### PR TITLE
Add platform logos and offline image caching

### DIFF
--- a/lib/core/api/igdb_api.dart
+++ b/lib/core/api/igdb_api.dart
@@ -168,7 +168,7 @@ class IgdbApi {
               'Authorization': 'Bearer $_accessToken',
             },
           ),
-          data: 'fields id,name,abbreviation; limit $limit; offset $offset;',
+          data: 'fields id,name,abbreviation,platform_logo.image_id; limit $limit; offset $offset;',
         );
 
         if (response.statusCode != 200 || response.data == null) {

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -43,7 +43,7 @@ class DatabaseService {
     return databaseFactoryFfi.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 3,
+        version: 4,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {
@@ -67,6 +67,7 @@ class DatabaseService {
         id INTEGER PRIMARY KEY,
         name TEXT NOT NULL,
         abbreviation TEXT,
+        logo_image_id TEXT,
         synced_at INTEGER
       )
     ''');
@@ -143,6 +144,10 @@ class DatabaseService {
     if (oldVersion < 3) {
       await _createCollectionsTable(db);
       await _createCollectionGamesTable(db);
+    }
+    if (oldVersion < 4) {
+      // Добавляем колонку logo_image_id для хранения логотипов платформ
+      await db.execute('ALTER TABLE platforms ADD COLUMN logo_image_id TEXT');
     }
   }
 

--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -1,0 +1,268 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Ключи для SharedPreferences.
+class _CacheKeys {
+  static const String customCachePath = 'image_cache_path';
+  static const String cacheEnabled = 'image_cache_enabled';
+}
+
+/// Типы изображений для кэширования.
+enum ImageType {
+  /// Логотипы платформ.
+  platformLogo('platform_logos'),
+
+  /// Обложки игр.
+  gameCover('game_covers');
+
+  const ImageType(this.folder);
+
+  /// Имя папки для данного типа.
+  final String folder;
+}
+
+/// Провайдер сервиса кэширования изображений.
+final Provider<ImageCacheService> imageCacheServiceProvider =
+    Provider<ImageCacheService>((Ref ref) {
+  return ImageCacheService();
+});
+
+/// Сервис для локального кэширования изображений.
+///
+/// Поддерживает кэширование логотипов платформ и обложек игр.
+/// При включённом кэшировании изображения сохраняются локально
+/// и используются в оффлайн режиме.
+class ImageCacheService {
+  final Dio _dio = Dio();
+
+  /// Возвращает базовый путь к директории кэша.
+  Future<String> getBaseCachePath() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? customPath = prefs.getString(_CacheKeys.customCachePath);
+
+    if (customPath != null && customPath.isNotEmpty) {
+      return customPath;
+    }
+
+    // Путь по умолчанию
+    final Directory appDir = await getApplicationDocumentsDirectory();
+    return p.join(appDir.path, 'xerabora', 'image_cache');
+  }
+
+  /// Возвращает путь к директории для конкретного типа изображений.
+  Future<String> getCachePath(ImageType type) async {
+    final String basePath = await getBaseCachePath();
+    return p.join(basePath, type.folder);
+  }
+
+  /// Устанавливает кастомный путь к кэшу.
+  Future<void> setCachePath(String path) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_CacheKeys.customCachePath, path);
+  }
+
+  /// Сбрасывает путь к кэшу на значение по умолчанию.
+  Future<void> resetCachePath() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_CacheKeys.customCachePath);
+  }
+
+  /// Возвращает включено ли кэширование.
+  Future<bool> isCacheEnabled() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_CacheKeys.cacheEnabled) ?? false;
+  }
+
+  /// Устанавливает состояние кэширования.
+  Future<void> setCacheEnabled(bool enabled) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_CacheKeys.cacheEnabled, enabled);
+  }
+
+  /// Возвращает путь к локальному файлу изображения.
+  Future<String> getLocalImagePath(ImageType type, String imageId) async {
+    final String cachePath = await getCachePath(type);
+    return p.join(cachePath, '$imageId.png');
+  }
+
+  /// Проверяет есть ли изображение в кэше.
+  Future<bool> isImageCached(ImageType type, String imageId) async {
+    final String path = await getLocalImagePath(type, imageId);
+    return File(path).existsSync();
+  }
+
+  /// Возвращает результат получения изображения.
+  ///
+  /// Логика:
+  /// - Кэширование выключено: возвращает удалённый URL
+  /// - Кэширование включено + файл есть: возвращает локальный путь
+  /// - Кэширование включено + файла нет: isMissing = true (ресурс повреждён)
+  Future<ImageResult> getImageUri({
+    required ImageType type,
+    required String imageId,
+    required String remoteUrl,
+  }) async {
+    final bool enabled = await isCacheEnabled();
+
+    if (!enabled) {
+      // Кэширование выключено - используем удалённый URL
+      return ImageResult(uri: remoteUrl, isLocal: false, isMissing: false);
+    }
+
+    // Кэширование включено - проверяем локальный файл
+    final String localPath = await getLocalImagePath(type, imageId);
+    final File file = File(localPath);
+
+    if (file.existsSync()) {
+      return ImageResult(uri: localPath, isLocal: true, isMissing: false);
+    }
+
+    // Файл отсутствует - ресурс повреждён
+    return const ImageResult(uri: null, isLocal: true, isMissing: true);
+  }
+
+  /// Скачивает изображение в кэш.
+  Future<bool> downloadImage({
+    required ImageType type,
+    required String imageId,
+    required String remoteUrl,
+  }) async {
+    try {
+      final String localPath = await getLocalImagePath(type, imageId);
+      final File file = File(localPath);
+
+      // Создаём директорию если не существует
+      final Directory dir = file.parent;
+      if (!dir.existsSync()) {
+        await dir.create(recursive: true);
+      }
+
+      // Скачиваем файл
+      await _dio.download(remoteUrl, localPath);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /// Скачивает список изображений.
+  ///
+  /// Возвращает количество успешно скачанных.
+  Future<int> downloadImages({
+    required ImageType type,
+    required List<ImageDownloadTask> tasks,
+    void Function(int current, int total)? onProgress,
+  }) async {
+    int downloaded = 0;
+    for (int i = 0; i < tasks.length; i++) {
+      final ImageDownloadTask task = tasks[i];
+      final bool success = await downloadImage(
+        type: type,
+        imageId: task.imageId,
+        remoteUrl: task.remoteUrl,
+      );
+      if (success) downloaded++;
+      onProgress?.call(i + 1, tasks.length);
+    }
+    return downloaded;
+  }
+
+  /// Очищает весь кэш изображений.
+  Future<void> clearCache() async {
+    final String basePath = await getBaseCachePath();
+    final Directory dir = Directory(basePath);
+
+    if (dir.existsSync()) {
+      await dir.delete(recursive: true);
+    }
+  }
+
+  /// Очищает кэш для конкретного типа изображений.
+  Future<void> clearCacheForType(ImageType type) async {
+    final String cachePath = await getCachePath(type);
+    final Directory dir = Directory(cachePath);
+
+    if (dir.existsSync()) {
+      await dir.delete(recursive: true);
+    }
+  }
+
+  /// Возвращает размер кэша в байтах.
+  Future<int> getCacheSize() async {
+    final String basePath = await getBaseCachePath();
+    final Directory dir = Directory(basePath);
+
+    if (!dir.existsSync()) return 0;
+
+    int size = 0;
+    await for (final FileSystemEntity entity in dir.list(recursive: true)) {
+      if (entity is File) {
+        size += await entity.length();
+      }
+    }
+    return size;
+  }
+
+  /// Возвращает количество файлов в кэше.
+  Future<int> getCachedCount() async {
+    final String basePath = await getBaseCachePath();
+    final Directory dir = Directory(basePath);
+
+    if (!dir.existsSync()) return 0;
+
+    int count = 0;
+    await for (final FileSystemEntity entity in dir.list(recursive: true)) {
+      if (entity is File && entity.path.endsWith('.png')) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /// Форматирует размер в читаемый вид.
+  String formatSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}
+
+/// Результат получения изображения.
+class ImageResult {
+  /// Создаёт [ImageResult].
+  const ImageResult({
+    required this.uri,
+    required this.isLocal,
+    required this.isMissing,
+  });
+
+  /// URI изображения (локальный путь или удалённый URL).
+  /// null если изображение отсутствует.
+  final String? uri;
+
+  /// true если используется локальный файл.
+  final bool isLocal;
+
+  /// true если локальный файл отсутствует (кэш повреждён).
+  final bool isMissing;
+}
+
+/// Задача для скачивания изображения.
+class ImageDownloadTask {
+  /// Создаёт [ImageDownloadTask].
+  const ImageDownloadTask({
+    required this.imageId,
+    required this.remoteUrl,
+  });
+
+  /// ID изображения (имя файла без расширения).
+  final String imageId;
+
+  /// URL для скачивания.
+  final String remoteUrl;
+}

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/game.dart';
 import '../../../shared/models/platform.dart';
+import '../../../shared/widgets/cached_image.dart' as app_cached;
 import '../../collections/providers/collections_provider.dart';
 import '../providers/game_search_provider.dart';
 import '../widgets/game_card.dart';
@@ -276,7 +278,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               final String platformName =
                   platform?.displayName ?? 'Platform $id';
               return ListTile(
-                leading: const Icon(Icons.videogame_asset),
+                leading: _buildPlatformLogo(platform),
                 title: Text(platformName),
                 onTap: () => Navigator.of(context).pop(id),
               );
@@ -291,6 +293,22 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         ],
       ),
     );
+  }
+
+  Widget _buildPlatformLogo(Platform? platform) {
+    if (platform?.logoUrl != null && platform?.logoImageId != null) {
+      return app_cached.CachedImage(
+        imageType: ImageType.platformLogo,
+        imageId: platform!.logoImageId!,
+        remoteUrl: platform.logoUrl!,
+        width: 32,
+        height: 32,
+        fit: BoxFit.contain,
+        placeholder: const Icon(Icons.videogame_asset, size: 24),
+        errorWidget: const Icon(Icons.videogame_asset, size: 24),
+      );
+    }
+    return const Icon(Icons.videogame_asset, size: 24);
   }
 
   void _showGameDetails(Game game) {

--- a/lib/features/search/widgets/platform_filter_sheet.dart
+++ b/lib/features/search/widgets/platform_filter_sheet.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/services/image_cache_service.dart';
 import '../../../shared/models/platform.dart';
+import '../../../shared/widgets/cached_image.dart' as app_cached;
 
 /// BottomSheet для выбора платформ с поиском.
 ///
 /// Позволяет фильтровать список платформ по названию
 /// и выбирать несколько платформ через чекбоксы.
-class PlatformFilterSheet extends StatefulWidget {
+class PlatformFilterSheet extends ConsumerStatefulWidget {
   /// Создаёт [PlatformFilterSheet].
   const PlatformFilterSheet({
     required this.platforms,
@@ -25,10 +28,10 @@ class PlatformFilterSheet extends StatefulWidget {
   final void Function(List<int> selectedIds) onApply;
 
   @override
-  State<PlatformFilterSheet> createState() => _PlatformFilterSheetState();
+  ConsumerState<PlatformFilterSheet> createState() => _PlatformFilterSheetState();
 }
 
-class _PlatformFilterSheetState extends State<PlatformFilterSheet> {
+class _PlatformFilterSheetState extends ConsumerState<PlatformFilterSheet> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocus = FocusNode();
 
@@ -204,15 +207,18 @@ class _PlatformFilterSheetState extends State<PlatformFilterSheet> {
                         final bool isSelected =
                             _selectedIds.contains(platform.id);
 
-                        return CheckboxListTile(
-                          value: isSelected,
-                          onChanged: (_) => _togglePlatform(platform.id),
+                        return ListTile(
+                          leading: _buildPlatformLogo(platform),
                           title: Text(platform.name),
                           subtitle: platform.abbreviation != null
                               ? Text(platform.abbreviation!)
                               : null,
+                          trailing: Checkbox(
+                            value: isSelected,
+                            onChanged: (_) => _togglePlatform(platform.id),
+                          ),
                           dense: true,
-                          controlAffinity: ListTileControlAffinity.leading,
+                          onTap: () => _togglePlatform(platform.id),
                         );
                       },
                     ),
@@ -257,6 +263,22 @@ class _PlatformFilterSheetState extends State<PlatformFilterSheet> {
         );
       },
     );
+  }
+
+  Widget _buildPlatformLogo(Platform platform) {
+    if (platform.logoUrl != null && platform.logoImageId != null) {
+      return app_cached.CachedImage(
+        imageType: ImageType.platformLogo,
+        imageId: platform.logoImageId!,
+        remoteUrl: platform.logoUrl!,
+        width: 32,
+        height: 32,
+        fit: BoxFit.contain,
+        placeholder: const Icon(Icons.devices, size: 24),
+        errorWidget: const Icon(Icons.devices, size: 24),
+      );
+    }
+    return const Icon(Icons.devices, size: 24);
   }
 
   Widget _buildEmptyState(ThemeData theme, ColorScheme colorScheme) {

--- a/lib/shared/models/platform.dart
+++ b/lib/shared/models/platform.dart
@@ -7,15 +7,24 @@ class Platform {
     required this.id,
     required this.name,
     this.abbreviation,
+    this.logoImageId,
     this.syncedAt,
   });
 
   /// Создаёт [Platform] из JSON ответа IGDB API.
   factory Platform.fromJson(Map<String, dynamic> json) {
+    // platform_logo может быть объектом с image_id при использовании field expansion
+    String? logoImageId;
+    final dynamic platformLogo = json['platform_logo'];
+    if (platformLogo is Map<String, dynamic>) {
+      logoImageId = platformLogo['image_id'] as String?;
+    }
+
     return Platform(
       id: json['id'] as int,
       name: json['name'] as String,
       abbreviation: json['abbreviation'] as String?,
+      logoImageId: logoImageId,
       syncedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
   }
@@ -26,6 +35,7 @@ class Platform {
       id: row['id'] as int,
       name: row['name'] as String,
       abbreviation: row['abbreviation'] as String?,
+      logoImageId: row['logo_image_id'] as String?,
       syncedAt: row['synced_at'] as int?,
     );
   }
@@ -39,8 +49,16 @@ class Platform {
   /// Сокращённое название (например, "SNES", "PS1").
   final String? abbreviation;
 
+  /// ID изображения логотипа в IGDB.
+  final String? logoImageId;
+
   /// Время последней синхронизации с IGDB (Unix timestamp).
   final int? syncedAt;
+
+  /// URL логотипа платформы (размер cover_big: 227x320).
+  String? get logoUrl => logoImageId != null
+      ? 'https://images.igdb.com/igdb/image/upload/t_cover_big/$logoImageId.png'
+      : null;
 
   /// Возвращает отображаемое имя (сокращение или полное название).
   String get displayName => abbreviation ?? name;
@@ -63,6 +81,7 @@ class Platform {
       'id': id,
       'name': name,
       'abbreviation': abbreviation,
+      'logo_image_id': logoImageId,
       'synced_at': syncedAt,
     };
   }
@@ -81,12 +100,14 @@ class Platform {
     int? id,
     String? name,
     String? abbreviation,
+    String? logoImageId,
     int? syncedAt,
   }) {
     return Platform(
       id: id ?? this.id,
       name: name ?? this.name,
       abbreviation: abbreviation ?? this.abbreviation,
+      logoImageId: logoImageId ?? this.logoImageId,
       syncedAt: syncedAt ?? this.syncedAt,
     );
   }

--- a/lib/shared/widgets/cached_image.dart
+++ b/lib/shared/widgets/cached_image.dart
@@ -1,0 +1,157 @@
+import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/image_cache_service.dart';
+
+/// Виджет для отображения кэшированных изображений.
+///
+/// Автоматически определяет источник изображения:
+/// - Если кэширование выключено: загружает из сети
+/// - Если кэширование включено: показывает локальный файл
+/// - Если файл отсутствует при включённом кэше: показывает ошибку
+class CachedImage extends ConsumerWidget {
+  /// Создаёт [CachedImage].
+  const CachedImage({
+    required this.imageType,
+    required this.imageId,
+    required this.remoteUrl,
+    this.width,
+    this.height,
+    this.fit = BoxFit.contain,
+    this.placeholder,
+    this.errorWidget,
+    this.onMissingCache,
+    super.key,
+  });
+
+  /// Тип изображения (платформа или обложка).
+  final ImageType imageType;
+
+  /// ID изображения для кэша.
+  final String imageId;
+
+  /// URL для загрузки из сети.
+  final String remoteUrl;
+
+  /// Ширина изображения.
+  final double? width;
+
+  /// Высота изображения.
+  final double? height;
+
+  /// Способ масштабирования.
+  final BoxFit fit;
+
+  /// Виджет-заглушка при загрузке.
+  final Widget? placeholder;
+
+  /// Виджет при ошибке.
+  final Widget? errorWidget;
+
+  /// Callback при отсутствии локального файла (кэш повреждён).
+  final VoidCallback? onMissingCache;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ImageCacheService cacheService = ref.read(imageCacheServiceProvider);
+
+    return FutureBuilder<ImageResult>(
+      future: cacheService.getImageUri(
+        type: imageType,
+        imageId: imageId,
+        remoteUrl: remoteUrl,
+      ),
+      builder: (BuildContext context, AsyncSnapshot<ImageResult> snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return _buildPlaceholder();
+        }
+
+        final ImageResult? result = snapshot.data;
+        if (result == null) {
+          return _buildError(context);
+        }
+
+        // Кэш повреждён - показываем ошибку и уведомляем
+        if (result.isMissing) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            onMissingCache?.call();
+          });
+          return _buildMissingCacheError(context);
+        }
+
+        // Локальный файл
+        if (result.isLocal && result.uri != null) {
+          return Image.file(
+            File(result.uri!),
+            width: width,
+            height: height,
+            fit: fit,
+            errorBuilder: (BuildContext ctx, Object error, StackTrace? stack) {
+              return _buildError(context);
+            },
+          );
+        }
+
+        // Удалённый URL
+        if (result.uri != null) {
+          return CachedNetworkImage(
+            imageUrl: result.uri!,
+            width: width,
+            height: height,
+            fit: fit,
+            placeholder: (BuildContext ctx, String url) => _buildPlaceholder(),
+            errorWidget: (BuildContext ctx, String url, Object error) =>
+                _buildError(context),
+          );
+        }
+
+        return _buildError(context);
+      },
+    );
+  }
+
+  Widget _buildPlaceholder() {
+    if (placeholder != null) return placeholder!;
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: const Center(
+        child: SizedBox(
+          width: 24,
+          height: 24,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context) {
+    if (errorWidget != null) return errorWidget!;
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Icon(
+        Icons.broken_image,
+        color: Theme.of(context).colorScheme.error,
+        size: 24,
+      ),
+    );
+  }
+
+  Widget _buildMissingCacheError(BuildContext context) {
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Icon(
+        Icons.cloud_off,
+        color: Theme.of(context).colorScheme.error,
+        size: 24,
+      ),
+    );
+  }
+}

--- a/test/features/search/widgets/platform_filter_sheet_test.dart
+++ b/test/features/search/widgets/platform_filter_sheet_test.dart
@@ -92,11 +92,11 @@ void main() {
 
         expect(find.text('PC Windows'), findsOneWidget);
         // Проверяем что subtitle отсутствует (нет Text с abbreviation)
-        final Finder tile = find.byType(CheckboxListTile);
+        final Finder tile = find.byType(ListTile);
         expect(tile, findsOneWidget);
 
-        final CheckboxListTile checkboxTile = tester.widget<CheckboxListTile>(tile);
-        expect(checkboxTile.subtitle, isNull);
+        final ListTile listTile = tester.widget<ListTile>(tile);
+        expect(listTile.subtitle, isNull);
       });
 
       testWidgets('должен показывать кнопки Cancel и Apply', (WidgetTester tester) async {
@@ -271,30 +271,18 @@ void main() {
         expect(find.text('2 selected'), findsOneWidget);
 
         // Проверяем что чекбоксы отмечены
-        final Finder checkboxes = find.byType(CheckboxListTile);
-        final CheckboxListTile ps5Tile = tester.widget<CheckboxListTile>(
-          find.ancestor(
-            of: find.text('PlayStation 5'),
-            matching: checkboxes,
-          ),
-        );
-        expect(ps5Tile.value, isTrue);
+        // Находим ListTile для каждой платформы и проверяем trailing Checkbox
+        final List<Checkbox> checkboxWidgets = tester.widgetList<Checkbox>(
+          find.byType(Checkbox),
+        ).toList();
 
-        final CheckboxListTile switchTile = tester.widget<CheckboxListTile>(
-          find.ancestor(
-            of: find.text('Nintendo Switch'),
-            matching: checkboxes,
-          ),
-        );
-        expect(switchTile.value, isTrue);
-
-        final CheckboxListTile xboxTile = tester.widget<CheckboxListTile>(
-          find.ancestor(
-            of: find.text('Xbox Series X'),
-            matching: checkboxes,
-          ),
-        );
-        expect(xboxTile.value, isFalse);
+        // Порядок: PS5 (id:1), Xbox (id:2), Switch (id:3)
+        // PS5 (index 0) - выбран
+        expect(checkboxWidgets[0].value, isTrue);
+        // Xbox (index 1) - не выбран
+        expect(checkboxWidgets[1].value, isFalse);
+        // Switch (index 2) - выбран
+        expect(checkboxWidgets[2].value, isTrue);
       });
     });
 

--- a/test/shared/models/platform_test.dart
+++ b/test/shared/models/platform_test.dart
@@ -6,6 +6,7 @@ void main() {
     const int testId = 1;
     const String testName = 'Super Nintendo Entertainment System';
     const String testAbbreviation = 'SNES';
+    const String testLogoImageId = 'pl6b';
     const int testSyncedAt = 1700000000;
 
     group('constructor', () {
@@ -26,12 +27,14 @@ void main() {
           id: testId,
           name: testName,
           abbreviation: testAbbreviation,
+          logoImageId: testLogoImageId,
           syncedAt: testSyncedAt,
         );
 
         expect(platform.id, equals(testId));
         expect(platform.name, equals(testName));
         expect(platform.abbreviation, equals(testAbbreviation));
+        expect(platform.logoImageId, equals(testLogoImageId));
         expect(platform.syncedAt, equals(testSyncedAt));
       });
     });
@@ -65,6 +68,59 @@ void main() {
         expect(platform.name, equals(testName));
         expect(platform.abbreviation, isNull);
       });
+
+      test('должен парсить platform_logo с image_id', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': testId,
+          'name': testName,
+          'platform_logo': <String, dynamic>{
+            'id': 123,
+            'image_id': testLogoImageId,
+          },
+        };
+
+        final Platform platform = Platform.fromJson(json);
+
+        expect(platform.logoImageId, equals(testLogoImageId));
+      });
+
+      test('должен установить null logoImageId когда platform_logo отсутствует', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': testId,
+          'name': testName,
+        };
+
+        final Platform platform = Platform.fromJson(json);
+
+        expect(platform.logoImageId, isNull);
+      });
+
+      test('должен установить null logoImageId когда platform_logo не Map', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': testId,
+          'name': testName,
+          'platform_logo': 123, // просто ID, не объект
+        };
+
+        final Platform platform = Platform.fromJson(json);
+
+        expect(platform.logoImageId, isNull);
+      });
+
+      test('должен установить null logoImageId когда image_id отсутствует в platform_logo', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': testId,
+          'name': testName,
+          'platform_logo': <String, dynamic>{
+            'id': 123,
+            // image_id отсутствует
+          },
+        };
+
+        final Platform platform = Platform.fromJson(json);
+
+        expect(platform.logoImageId, isNull);
+      });
     });
 
     group('fromDb', () {
@@ -73,6 +129,7 @@ void main() {
           'id': testId,
           'name': testName,
           'abbreviation': testAbbreviation,
+          'logo_image_id': testLogoImageId,
           'synced_at': testSyncedAt,
         };
 
@@ -81,6 +138,7 @@ void main() {
         expect(platform.id, equals(testId));
         expect(platform.name, equals(testName));
         expect(platform.abbreviation, equals(testAbbreviation));
+        expect(platform.logoImageId, equals(testLogoImageId));
         expect(platform.syncedAt, equals(testSyncedAt));
       });
 
@@ -89,6 +147,7 @@ void main() {
           'id': testId,
           'name': testName,
           'abbreviation': null,
+          'logo_image_id': null,
           'synced_at': null,
         };
 
@@ -97,6 +156,7 @@ void main() {
         expect(platform.id, equals(testId));
         expect(platform.name, equals(testName));
         expect(platform.abbreviation, isNull);
+        expect(platform.logoImageId, isNull);
         expect(platform.syncedAt, isNull);
       });
     });
@@ -107,6 +167,7 @@ void main() {
           id: testId,
           name: testName,
           abbreviation: testAbbreviation,
+          logoImageId: testLogoImageId,
           syncedAt: testSyncedAt,
         );
 
@@ -115,6 +176,7 @@ void main() {
         expect(result['id'], equals(testId));
         expect(result['name'], equals(testName));
         expect(result['abbreviation'], equals(testAbbreviation));
+        expect(result['logo_image_id'], equals(testLogoImageId));
         expect(result['synced_at'], equals(testSyncedAt));
       });
 
@@ -127,6 +189,7 @@ void main() {
         final Map<String, dynamic> result = platform.toDb();
 
         expect(result['abbreviation'], isNull);
+        expect(result['logo_image_id'], isNull);
         expect(result['synced_at'], isNull);
       });
     });
@@ -145,6 +208,30 @@ void main() {
         expect(result['name'], equals(testName));
         expect(result['abbreviation'], equals(testAbbreviation));
         expect(result.containsKey('synced_at'), isFalse);
+      });
+    });
+
+    group('logoUrl', () {
+      test('должен вернуть URL когда logoImageId есть', () {
+        const Platform platform = Platform(
+          id: testId,
+          name: testName,
+          logoImageId: testLogoImageId,
+        );
+
+        expect(
+          platform.logoUrl,
+          equals('https://images.igdb.com/igdb/image/upload/t_cover_big/$testLogoImageId.png'),
+        );
+      });
+
+      test('должен вернуть null когда logoImageId отсутствует', () {
+        const Platform platform = Platform(
+          id: testId,
+          name: testName,
+        );
+
+        expect(platform.logoUrl, isNull);
       });
     });
 
@@ -257,11 +344,20 @@ void main() {
         expect(copy.syncedAt, equals(9999));
       });
 
+      test('должен создать копию с изменённым logoImageId', () {
+        const Platform original = Platform(id: testId, name: testName);
+
+        final Platform copy = original.copyWith(logoImageId: 'newlogo');
+
+        expect(copy.logoImageId, equals('newlogo'));
+      });
+
       test('должен сохранить все поля при пустом copyWith', () {
         const Platform original = Platform(
           id: testId,
           name: testName,
           abbreviation: testAbbreviation,
+          logoImageId: testLogoImageId,
           syncedAt: testSyncedAt,
         );
 
@@ -270,6 +366,7 @@ void main() {
         expect(copy.id, equals(original.id));
         expect(copy.name, equals(original.name));
         expect(copy.abbreviation, equals(original.abbreviation));
+        expect(copy.logoImageId, equals(original.logoImageId));
         expect(copy.syncedAt, equals(original.syncedAt));
       });
     });

--- a/test/shared/widgets/cached_image_test.dart
+++ b/test/shared/widgets/cached_image_test.dart
@@ -1,0 +1,339 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:xerabora/core/services/image_cache_service.dart';
+import 'package:xerabora/shared/widgets/cached_image.dart';
+
+class MockImageCacheService extends Mock implements ImageCacheService {}
+
+void main() {
+  late MockImageCacheService mockCacheService;
+
+  setUpAll(() {
+    registerFallbackValue(ImageType.platformLogo);
+  });
+
+  setUp(() {
+    mockCacheService = MockImageCacheService();
+  });
+
+  Widget buildTestWidget({
+    required Widget child,
+    double? constrainedWidth,
+    double? constrainedHeight,
+  }) {
+    return ProviderScope(
+      overrides: <Override>[
+        imageCacheServiceProvider.overrideWithValue(mockCacheService),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: constrainedWidth != null || constrainedHeight != null
+              ? SizedBox(
+                  width: constrainedWidth,
+                  height: constrainedHeight,
+                  child: child,
+                )
+              : child,
+        ),
+      ),
+    );
+  }
+
+  group('CachedImage', () {
+    group('missing cache error', () {
+      testWidgets('должен показывать иконку cloud_off при отсутствии кэша',
+          (WidgetTester tester) async {
+        // Arrange
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => const ImageResult(
+              uri: null,
+              isLocal: true,
+              isMissing: true,
+            ));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+      });
+
+      testWidgets('не должен вызывать overflow при размере 32x32',
+          (WidgetTester tester) async {
+        // Arrange
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => const ImageResult(
+              uri: null,
+              isLocal: true,
+              isMissing: true,
+            ));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          constrainedWidth: 32,
+          constrainedHeight: 32,
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert - проверяем что нет overflow ошибок
+        expect(tester.takeException(), isNull);
+        expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+      });
+
+      testWidgets('не должен вызывать overflow при размере 24x24',
+          (WidgetTester tester) async {
+        // Arrange
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => const ImageResult(
+              uri: null,
+              isLocal: true,
+              isMissing: true,
+            ));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          constrainedWidth: 24,
+          constrainedHeight: 24,
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 24,
+            height: 24,
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(tester.takeException(), isNull);
+        expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+      });
+
+      testWidgets('должен вызывать onMissingCache callback',
+          (WidgetTester tester) async {
+        // Arrange
+        bool callbackCalled = false;
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => const ImageResult(
+              uri: null,
+              isLocal: true,
+              isMissing: true,
+            ));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          child: CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+            onMissingCache: () {
+              callbackCalled = true;
+            },
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(callbackCalled, isTrue);
+      });
+    });
+
+    group('placeholder', () {
+      testWidgets('должен показывать CircularProgressIndicator при загрузке',
+          (WidgetTester tester) async {
+        // Arrange - Future никогда не завершается (Completer без complete)
+        final Completer<ImageResult> completer = Completer<ImageResult>();
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) => completer.future);
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+          ),
+        ));
+        // Не вызываем pumpAndSettle - оставляем в состоянии загрузки
+
+        // Assert
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('должен показывать кастомный placeholder',
+          (WidgetTester tester) async {
+        // Arrange
+        final Completer<ImageResult> completer = Completer<ImageResult>();
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) => completer.future);
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+            placeholder: Icon(Icons.hourglass_empty),
+          ),
+        ));
+
+        // Assert
+        expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+
+      testWidgets('не должен вызывать overflow при размере 32x32',
+          (WidgetTester tester) async {
+        // Arrange
+        final Completer<ImageResult> completer = Completer<ImageResult>();
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) => completer.future);
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          constrainedWidth: 32,
+          constrainedHeight: 32,
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+          ),
+        ));
+
+        // Assert
+        expect(tester.takeException(), isNull);
+      });
+    });
+
+    group('error state', () {
+      testWidgets('должен показывать broken_image при null result',
+          (WidgetTester tester) async {
+        // Arrange - возвращаем ошибку через Future.error
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => throw Exception('Test error'));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.byIcon(Icons.broken_image), findsOneWidget);
+      });
+
+      testWidgets('должен показывать кастомный errorWidget',
+          (WidgetTester tester) async {
+        // Arrange
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => throw Exception('Test error'));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+            errorWidget: Icon(Icons.error_outline),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.byIcon(Icons.broken_image), findsNothing);
+      });
+
+      testWidgets('не должен вызывать overflow при размере 32x32',
+          (WidgetTester tester) async {
+        // Arrange
+        when(() => mockCacheService.getImageUri(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => throw Exception('Test error'));
+
+        // Act
+        await tester.pumpWidget(buildTestWidget(
+          constrainedWidth: 32,
+          constrainedHeight: 32,
+          child: const CachedImage(
+            imageType: ImageType.platformLogo,
+            imageId: 'test_id',
+            remoteUrl: 'https://example.com/image.png',
+            width: 32,
+            height: 32,
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        // Assert
+        expect(tester.takeException(), isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Fetch platform_logo.image_id from IGDB API
- Add logoImageId field and logoUrl getter to Platform model
- Database migration v4 for logo_image_id column
- Create ImageCacheService for offline image storage
- Add CachedImage widget with local/remote source detection
- Settings: Offline mode toggle, cache folder picker, clear cache
- Update PlatformFilterSheet and SearchScreen to use CachedImage
- Add tests for CachedImage (overflow protection)
- Update devchange.md with implementation details