### PR TITLE
Add basic Canvas view with zoom, pan, drag-and-drop (Stage 7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 dev.md
+/canvas-dev.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@
 ## [Unreleased]
 
 ### Added
+- Добавлен базовый Canvas — визуальный холст для свободного размещения элементов коллекции (Stage 7)
+- Добавлена миграция БД до версии 5: таблицы `canvas_items` и `canvas_viewport` с FK CASCADE и индексами
+- Добавлена модель `CanvasItem` (`lib/shared/models/canvas_item.dart`) с enum `CanvasItemType` (game/text/image/link)
+- Добавлена модель `CanvasViewport` (`lib/shared/models/canvas_viewport.dart`) — хранение зума и позиции камеры
+- Добавлен `CanvasRepository` (`lib/data/repositories/canvas_repository.dart`) — CRUD для canvas_items и viewport, инициализация сеткой
+- Добавлен `CanvasNotifier` (`lib/features/collections/providers/canvas_provider.dart`) — state management канваса с debounced save (300ms position, 500ms viewport), двусторонняя синхронизация с коллекцией (реактивная через `ref.listen`)
+- Добавлен `CanvasView` (`lib/features/collections/widgets/canvas_view.dart`) — InteractiveViewer с зумом 0.3–3.0x, drag-and-drop с абсолютным отслеживанием позиции, фоновая сетка, автоцентрирование
+- Добавлен `CanvasGameCard` (`lib/features/collections/widgets/canvas_game_card.dart`) — компактная карточка игры с обложкой и названием
+- Добавлен переключатель List/Canvas в `CollectionScreen` через `SegmentedButton`
+- Добавлены CRUD методы в `DatabaseService`: `getCanvasItems`, `insertCanvasItem`, `updateCanvasItem`, `deleteCanvasItem`, `deleteCanvasItemByRef`, `deleteCanvasItemsByCollection`, `getCanvasItemCount`, `getCanvasViewport`, `upsertCanvasViewport`
+- Добавлены тесты: `canvas_item_test.dart` (24), `canvas_viewport_test.dart` (17), `canvas_repository_test.dart` (27), `canvas_provider_test.dart` (45), `canvas_game_card_test.dart` (6), `canvas_view_test.dart` (30) — всего 149 тестов для Stage 7
+
+### Changed
+- Изменён `DatabaseService` — версия БД увеличена до 5, добавлены таблицы canvas_items и canvas_viewport
+- Изменён `CollectionScreen` — добавлен SegmentedButton для переключения между List и Canvas режимами, синхронизация удаления игр с канвасом
+- Оптимизирован `CanvasView` — кеширование `Theme.of(context)`, параллельная загрузка items и viewport
+
+### Fixed
+- Исправлен баг drag-and-drop: карточки двигались быстрее курсора из-за конфликта жестов InteractiveViewer и GestureDetector (переход на абсолютное отслеживание через `globalPosition`, блокировка `panEnabled` при drag)
+
+---
+
 - Добавлен API клиент SteamGridDB (`lib/core/api/steamgriddb_api.dart`): поиск игр, загрузка grids, heroes, logos, icons с Bearer token авторизацией
 - Добавлена модель `SteamGridDbGame` (`lib/shared/models/steamgriddb_game.dart`) — результат поиска игры в SteamGridDB
 - Добавлена модель `SteamGridDbImage` (`lib/shared/models/steamgriddb_image.dart`) — изображение из SteamGridDB (grids, heroes, logos, icons)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -49,6 +49,18 @@ Found a collection you like? Fork it:
 - Add or remove games
 - Revert to original anytime
 
+## Canvas View
+
+Visualize your collection on a free-form canvas:
+- **Infinite canvas** with zoom (0.3x – 3.0x) and pan
+- **Drag-and-drop** game cards with precise cursor tracking
+- **Dot grid background** for visual alignment
+- **Auto-layout** — new canvas initializes games in a 5-column grid
+- **Auto-sync** — adding or removing games in the collection automatically updates the canvas
+- **Persistent viewport** — zoom level and position are saved and restored
+- **Center view** and **Reset positions** controls
+- **List/Canvas toggle** — switch between traditional list and visual canvas via SegmentedButton
+
 ## SteamGridDB Integration
 
 Access high-quality game artwork from SteamGridDB:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,6 +13,14 @@
 - [x] Offline image caching
 - [x] Platform logos
 
+## Canvas Development
+
+- [x] Stage 7: Basic Canvas — visual canvas with zoom, pan, drag-and-drop, grid layout, List/Canvas toggle, bidirectional collection sync
+- [ ] Stage 8: Canvas Elements — context menu, text blocks, images, links, resize, z-index
+- [ ] Stage 9: Connections — visual connections between canvas elements
+- [ ] Stage 10: SteamGridDB Widget — side panel for adding SteamGridDB images to canvas
+- [ ] Stage 12: Export Full — extended .rcoll-full format with canvas layout and images
+
 ## Future Plans
 
 ### RetroAchievements Integration

--- a/lib/data/repositories/canvas_repository.dart
+++ b/lib/data/repositories/canvas_repository.dart
@@ -1,0 +1,213 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/database/database_service.dart';
+import '../../shared/models/canvas_item.dart';
+import '../../shared/models/canvas_viewport.dart';
+import '../../shared/models/collection_game.dart';
+import '../../shared/models/game.dart';
+
+/// Провайдер для репозитория канваса.
+final Provider<CanvasRepository> canvasRepositoryProvider =
+    Provider<CanvasRepository>((Ref ref) {
+  return CanvasRepository(
+    db: ref.watch(databaseServiceProvider),
+  );
+});
+
+/// Репозиторий для работы с элементами канваса.
+///
+/// Управляет CRUD операциями для canvas_items и canvas_viewport.
+class CanvasRepository {
+  /// Создаёт экземпляр [CanvasRepository].
+  CanvasRepository({required DatabaseService db}) : _db = db;
+
+  final DatabaseService _db;
+
+  /// Ширина карточки по умолчанию.
+  static const double defaultCardWidth = 160;
+
+  /// Высота карточки по умолчанию.
+  static const double defaultCardHeight = 220;
+
+  /// Отступ между карточками в сетке.
+  static const double gridGap = 24;
+
+  /// Количество колонок при авторазмещении.
+  static const int gridColumns = 5;
+
+  /// X координата центра канваса для размещения элементов.
+  static const double initialCenterX = 2500.0;
+
+  /// Y координата центра канваса для размещения элементов.
+  static const double initialCenterY = 2500.0;
+
+  // ==================== Canvas Items ====================
+
+  /// Возвращает все элементы канваса для коллекции.
+  Future<List<CanvasItem>> getItems(int collectionId) async {
+    final List<Map<String, dynamic>> rows =
+        await _db.getCanvasItems(collectionId);
+    return rows.map(CanvasItem.fromDb).toList();
+  }
+
+  /// Возвращает элементы канваса с подгруженными данными игр.
+  Future<List<CanvasItem>> getItemsWithData(int collectionId) async {
+    final List<CanvasItem> items = await getItems(collectionId);
+    if (items.isEmpty) return items;
+
+    // Собираем ID игр для подгрузки
+    final List<int> gameIds = items
+        .where((CanvasItem item) =>
+            item.itemType == CanvasItemType.game && item.itemRefId != null)
+        .map((CanvasItem item) => item.itemRefId!)
+        .toList();
+
+    if (gameIds.isEmpty) return items;
+
+    final List<Game> games = await _db.getGamesByIds(gameIds);
+    final Map<int, Game> gamesMap = <int, Game>{
+      for (final Game g in games) g.id: g,
+    };
+
+    return items.map((CanvasItem item) {
+      if (item.itemType == CanvasItemType.game && item.itemRefId != null) {
+        return item.copyWith(game: gamesMap[item.itemRefId]);
+      }
+      return item;
+    }).toList();
+  }
+
+  /// Создаёт элемент канваса и возвращает его с присвоенным ID.
+  Future<CanvasItem> createItem(CanvasItem item) async {
+    final int id = await _db.insertCanvasItem(item.toDb());
+    return item.copyWith(id: id);
+  }
+
+  /// Обновляет элемент канваса.
+  Future<void> updateItem(CanvasItem item) async {
+    final Map<String, dynamic> dbData = item.toDb();
+    dbData.remove('id');
+    await _db.updateCanvasItem(item.id, dbData);
+  }
+
+  /// Обновляет позицию элемента на канвасе.
+  Future<void> updateItemPosition(
+    int id, {
+    required double x,
+    required double y,
+  }) async {
+    await _db.updateCanvasItem(id, <String, dynamic>{'x': x, 'y': y});
+  }
+
+  /// Обновляет размеры элемента.
+  Future<void> updateItemSize(
+    int id, {
+    double? width,
+    double? height,
+  }) async {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (width != null) data['width'] = width;
+    if (height != null) data['height'] = height;
+    if (data.isNotEmpty) {
+      await _db.updateCanvasItem(id, data);
+    }
+  }
+
+  /// Обновляет z-index элемента.
+  Future<void> updateItemZIndex(int id, int zIndex) async {
+    await _db.updateCanvasItem(id, <String, dynamic>{'z_index': zIndex});
+  }
+
+  /// Удаляет элемент канваса.
+  Future<void> deleteItem(int id) async {
+    await _db.deleteCanvasItem(id);
+  }
+
+  /// Удаляет элемент канваса, связанный с игрой (по igdbId).
+  Future<void> deleteGameItem(int collectionId, int igdbId) async {
+    await _db.deleteCanvasItemByRef(collectionId, igdbId);
+  }
+
+  /// Проверяет, есть ли элементы канваса для коллекции.
+  Future<bool> hasCanvasItems(int collectionId) async {
+    final int count = await _db.getCanvasItemCount(collectionId);
+    return count > 0;
+  }
+
+  // ==================== Canvas Viewport ====================
+
+  /// Возвращает состояние viewport для коллекции.
+  Future<CanvasViewport?> getViewport(int collectionId) async {
+    final Map<String, dynamic>? row =
+        await _db.getCanvasViewport(collectionId);
+    if (row == null) return null;
+    return CanvasViewport.fromDb(row);
+  }
+
+  /// Сохраняет состояние viewport.
+  Future<void> saveViewport(CanvasViewport viewport) async {
+    await _db.upsertCanvasViewport(
+      collectionId: viewport.collectionId,
+      scale: viewport.scale,
+      offsetX: viewport.offsetX,
+      offsetY: viewport.offsetY,
+    );
+  }
+
+  // ==================== Initialization ====================
+
+  /// Инициализирует канвас для коллекции, размещая игры сеткой по центру.
+  ///
+  /// Вызывается при первом открытии Canvas View.
+  /// Сетка центрируется вокруг [initialCenterX], [initialCenterY].
+  Future<List<CanvasItem>> initializeCanvas(
+    int collectionId,
+    List<CollectionGame> games,
+  ) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final List<CanvasItem> createdItems = <CanvasItem>[];
+
+    if (games.isEmpty) {
+      await saveViewport(CanvasViewport(collectionId: collectionId));
+      return createdItems;
+    }
+
+    // Рассчитываем размеры сетки для центрирования
+    final int cols =
+        games.length < gridColumns ? games.length : gridColumns;
+    final int rowCount = (games.length + cols - 1) ~/ cols;
+    final double gridWidth = cols * (defaultCardWidth + gridGap) - gridGap;
+    final double gridHeight =
+        rowCount * (defaultCardHeight + gridGap) - gridGap;
+    final double startX = initialCenterX - gridWidth / 2;
+    final double startY = initialCenterY - gridHeight / 2;
+
+    for (int i = 0; i < games.length; i++) {
+      final int col = i % cols;
+      final int row = i ~/ cols;
+      final double x = startX + col * (defaultCardWidth + gridGap);
+      final double y = startY + row * (defaultCardHeight + gridGap);
+
+      final CanvasItem item = CanvasItem(
+        id: 0,
+        collectionId: collectionId,
+        itemType: CanvasItemType.game,
+        itemRefId: games[i].igdbId,
+        x: x,
+        y: y,
+        width: defaultCardWidth,
+        height: defaultCardHeight,
+        zIndex: i,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+      );
+
+      final CanvasItem created = await createItem(item);
+      createdItems.add(created.copyWith(game: games[i].game));
+    }
+
+    // Создаём viewport по умолчанию
+    await saveViewport(CanvasViewport(collectionId: collectionId));
+
+    return createdItems;
+  }
+}

--- a/lib/features/collections/providers/canvas_provider.dart
+++ b/lib/features/collections/providers/canvas_provider.dart
@@ -1,0 +1,436 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../data/repositories/canvas_repository.dart';
+import '../../../shared/models/canvas_item.dart';
+import '../../../shared/models/canvas_viewport.dart';
+import '../../../shared/models/collection_game.dart';
+import 'collections_provider.dart';
+
+/// Состояние канваса для коллекции.
+class CanvasState {
+  /// Создаёт экземпляр [CanvasState].
+  const CanvasState({
+    this.items = const <CanvasItem>[],
+    this.viewport = CanvasViewport.defaultValue,
+    this.isLoading = true,
+    this.isInitialized = false,
+    this.error,
+  });
+
+  /// Элементы на канвасе.
+  final List<CanvasItem> items;
+
+  /// Состояние viewport (зум, позиция камеры).
+  final CanvasViewport viewport;
+
+  /// Загружается ли канвас.
+  final bool isLoading;
+
+  /// Инициализирован ли канвас (данные загружены).
+  final bool isInitialized;
+
+  /// Ошибка при загрузке.
+  final String? error;
+
+  /// Создаёт копию с изменёнными полями.
+  CanvasState copyWith({
+    List<CanvasItem>? items,
+    CanvasViewport? viewport,
+    bool? isLoading,
+    bool? isInitialized,
+    String? error,
+  }) {
+    return CanvasState(
+      items: items ?? this.items,
+      viewport: viewport ?? this.viewport,
+      isLoading: isLoading ?? this.isLoading,
+      isInitialized: isInitialized ?? this.isInitialized,
+      error: error,
+    );
+  }
+}
+
+/// Провайдер для управления канвасом конкретной коллекции.
+final NotifierProviderFamily<CanvasNotifier, CanvasState, int>
+    canvasNotifierProvider =
+    NotifierProvider.family<CanvasNotifier, CanvasState, int>(
+  CanvasNotifier.new,
+);
+
+/// Notifier для управления состоянием канваса.
+class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
+  late CanvasRepository _repository;
+  late int _collectionId;
+  Timer? _viewportSaveTimer;
+  Timer? _positionSaveTimer;
+
+  @override
+  CanvasState build(int arg) {
+    _collectionId = arg;
+    _repository = ref.watch(canvasRepositoryProvider);
+
+    ref.onDispose(() {
+      _viewportSaveTimer?.cancel();
+      _positionSaveTimer?.cancel();
+    });
+
+    // Реактивная синхронизация: при изменении списка игр коллекции
+    // автоматически добавляем/удаляем элементы канваса
+    ref.listen<AsyncValue<List<CollectionGame>>>(
+      collectionGamesNotifierProvider(_collectionId),
+      (AsyncValue<List<CollectionGame>>? previous,
+          AsyncValue<List<CollectionGame>> next) {
+        if (state.isInitialized && !state.isLoading && next.hasValue) {
+          _syncAndReload();
+        }
+      },
+    );
+
+    // Запускаем загрузку после инициализации state
+    Future<void>.microtask(_loadCanvas);
+
+    return const CanvasState();
+  }
+
+  Future<void> _loadCanvas() async {
+    try {
+      final bool hasItems = await _repository.hasCanvasItems(_collectionId);
+
+      if (!hasItems) {
+        // Первый запуск — инициализируем канвас из игр коллекции
+        await _initializeFromGames();
+      } else {
+        // Синхронизация: удаляем сиротские элементы канваса
+        await _syncCanvasWithGames();
+
+        // Загружаем элементы и viewport параллельно
+        final (List<CanvasItem> items, CanvasViewport? viewport) =
+            await (_repository.getItemsWithData(_collectionId),
+                _repository.getViewport(_collectionId)).wait;
+
+        state = state.copyWith(
+          items: items,
+          viewport: viewport ??
+              CanvasViewport(collectionId: _collectionId),
+          isLoading: false,
+          isInitialized: true,
+        );
+      }
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  Future<void> _initializeFromGames() async {
+    try {
+      final AsyncValue<List<CollectionGame>> gamesAsync =
+          ref.read(collectionGamesNotifierProvider(_collectionId));
+      final List<CollectionGame> games =
+          gamesAsync.valueOrNull ?? <CollectionGame>[];
+
+      final List<CanvasItem> items =
+          await _repository.initializeCanvas(_collectionId, games);
+
+      state = state.copyWith(
+        items: items,
+        viewport: CanvasViewport(collectionId: _collectionId),
+        isLoading: false,
+        isInitialized: true,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Синхронизирует канвас с играми и перезагружает элементы.
+  ///
+  /// Вызывается реактивно при изменении списка игр коллекции.
+  Future<void> _syncAndReload() async {
+    try {
+      await _syncCanvasWithGames();
+      final List<CanvasItem> items =
+          await _repository.getItemsWithData(_collectionId);
+      state = state.copyWith(items: items);
+    } catch (_) {
+      // Ошибки синхронизации не критичны — при следующем открытии
+      // канваса данные будут синхронизированы в _loadCanvas
+    }
+  }
+
+  /// Синхронизирует элементы канваса с текущими играми коллекции.
+  ///
+  /// Двусторонняя синхронизация:
+  /// - Удаляет элементы канваса для игр, удалённых из коллекции
+  /// - Создаёт элементы канваса для новых игр в коллекции
+  Future<void> _syncCanvasWithGames() async {
+    final AsyncValue<List<CollectionGame>> gamesAsync =
+        ref.read(collectionGamesNotifierProvider(_collectionId));
+    final List<CollectionGame>? games = gamesAsync.valueOrNull;
+
+    // Если игры ещё не загружены — пропускаем синхронизацию
+    if (games == null) return;
+
+    final Set<int> currentIgdbIds =
+        games.map((CollectionGame g) => g.igdbId).toSet();
+
+    final List<CanvasItem> canvasItems =
+        await _repository.getItems(_collectionId);
+
+    // Удаляем сиротские элементы (игра удалена из коллекции)
+    for (final CanvasItem item in canvasItems) {
+      if (item.itemType == CanvasItemType.game &&
+          item.itemRefId != null &&
+          !currentIgdbIds.contains(item.itemRefId)) {
+        await _repository.deleteItem(item.id);
+      }
+    }
+
+    // Добавляем недостающие элементы (игра добавлена в коллекцию)
+    final Set<int> canvasIgdbIds = canvasItems
+        .where((CanvasItem item) =>
+            item.itemType == CanvasItemType.game && item.itemRefId != null)
+        .map((CanvasItem item) => item.itemRefId!)
+        .toSet();
+
+    final List<CollectionGame> missingGames = games
+        .where((CollectionGame g) => !canvasIgdbIds.contains(g.igdbId))
+        .toList();
+
+    if (missingGames.isEmpty) return;
+
+    // Позиция для новых элементов: ниже существующих
+    double maxY = CanvasRepository.initialCenterY;
+    for (final CanvasItem item in canvasItems) {
+      final double bottom =
+          item.y + (item.height ?? CanvasRepository.defaultCardHeight);
+      if (bottom > maxY) maxY = bottom;
+    }
+
+    final double startY = canvasItems.isEmpty
+        ? CanvasRepository.initialCenterY -
+            CanvasRepository.defaultCardHeight / 2
+        : maxY + CanvasRepository.gridGap;
+
+    final int cols = missingGames.length < CanvasRepository.gridColumns
+        ? missingGames.length
+        : CanvasRepository.gridColumns;
+    final double gridWidth =
+        cols * (CanvasRepository.defaultCardWidth + CanvasRepository.gridGap) -
+            CanvasRepository.gridGap;
+    final double startX = CanvasRepository.initialCenterX - gridWidth / 2;
+
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int baseZIndex = canvasItems.isEmpty
+        ? 0
+        : canvasItems
+                .map((CanvasItem item) => item.zIndex)
+                .reduce((int a, int b) => a > b ? a : b) +
+            1;
+
+    for (int i = 0; i < missingGames.length; i++) {
+      final int col = i % cols;
+      final int row = i ~/ cols;
+      final double x = startX +
+          col * (CanvasRepository.defaultCardWidth + CanvasRepository.gridGap);
+      final double y = startY +
+          row *
+              (CanvasRepository.defaultCardHeight + CanvasRepository.gridGap);
+
+      final CanvasItem item = CanvasItem(
+        id: 0,
+        collectionId: _collectionId,
+        itemType: CanvasItemType.game,
+        itemRefId: missingGames[i].igdbId,
+        x: x,
+        y: y,
+        width: CanvasRepository.defaultCardWidth,
+        height: CanvasRepository.defaultCardHeight,
+        zIndex: baseZIndex + i,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+      );
+
+      await _repository.createItem(item);
+    }
+  }
+
+  /// Удаляет элемент игры с канваса по igdbId.
+  ///
+  /// Обновляет state мгновенно и удаляет из БД.
+  void removeGameItem(int igdbId) {
+    state = state.copyWith(
+      items: state.items
+          .where((CanvasItem item) =>
+              !(item.itemType == CanvasItemType.game &&
+                  item.itemRefId == igdbId))
+          .toList(),
+    );
+    _repository.deleteGameItem(_collectionId, igdbId);
+  }
+
+  /// Обновляет канвас (перезагрузка из БД).
+  Future<void> refresh() async {
+    state = state.copyWith(isLoading: true, error: null);
+    await _loadCanvas();
+  }
+
+  /// Перемещает элемент на канвасе.
+  ///
+  /// Обновляет state мгновенно, сохраняет в БД с debounce.
+  void moveItem(int itemId, double x, double y) {
+    // Локальное обновление
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(x: x, y: y);
+        }
+        return item;
+      }).toList(),
+    );
+
+    // Debounced сохранение в БД
+    _positionSaveTimer?.cancel();
+    _positionSaveTimer = Timer(const Duration(milliseconds: 300), () {
+      _repository.updateItemPosition(itemId, x: x, y: y);
+    });
+  }
+
+  /// Обновляет viewport (зум и позицию камеры).
+  ///
+  /// Сохраняет в БД с debounce.
+  void updateViewport(double scale, double offsetX, double offsetY) {
+    final CanvasViewport newViewport = CanvasViewport(
+      collectionId: _collectionId,
+      scale: scale,
+      offsetX: offsetX,
+      offsetY: offsetY,
+    );
+
+    state = state.copyWith(viewport: newViewport);
+
+    // Debounced сохранение
+    _viewportSaveTimer?.cancel();
+    _viewportSaveTimer = Timer(const Duration(milliseconds: 500), () {
+      _repository.saveViewport(newViewport);
+    });
+  }
+
+  /// Сбрасывает viewport в значение по умолчанию (scale=1, offset=0,0).
+  void resetViewport() {
+    final CanvasViewport defaultViewport = CanvasViewport(
+      collectionId: _collectionId,
+    );
+
+    state = state.copyWith(viewport: defaultViewport);
+
+    _viewportSaveTimer?.cancel();
+    _repository.saveViewport(defaultViewport);
+  }
+
+  /// Сбрасывает позиции всех элементов в сетку по центру канваса.
+  ///
+  /// [viewportWidth] — ширина видимой области для расчёта колонок.
+  /// Элементы центрируются вокруг [CanvasRepository.initialCenterX],
+  /// [CanvasRepository.initialCenterY].
+  Future<void> resetPositions(double viewportWidth) async {
+    final List<CanvasItem> items = state.items;
+    if (items.isEmpty) return;
+
+    const double cardW = CanvasRepository.defaultCardWidth;
+    const double cardH = CanvasRepository.defaultCardHeight;
+    const double gap = CanvasRepository.gridGap;
+
+    // Рассчитываем количество колонок по ширине видимой области
+    final int columns =
+        ((viewportWidth + gap) / (cardW + gap)).floor().clamp(1, items.length);
+    final int rowCount = (items.length + columns - 1) ~/ columns;
+
+    // Центрируем сетку вокруг центра канваса
+    final double gridWidth = columns * (cardW + gap) - gap;
+    final double gridHeight = rowCount * (cardH + gap) - gap;
+    final double startX =
+        CanvasRepository.initialCenterX - gridWidth / 2;
+    final double startY =
+        CanvasRepository.initialCenterY - gridHeight / 2;
+
+    final List<CanvasItem> updated = <CanvasItem>[];
+    for (int i = 0; i < items.length; i++) {
+      final int col = i % columns;
+      final int row = i ~/ columns;
+      final double x = startX + col * (cardW + gap);
+      final double y = startY + row * (cardH + gap);
+
+      final CanvasItem item = items[i].copyWith(x: x, y: y, zIndex: 0);
+      updated.add(item);
+      _repository.updateItemPosition(item.id, x: x, y: y);
+    }
+
+    state = state.copyWith(items: updated);
+  }
+
+  /// Добавляет элемент на канвас.
+  Future<CanvasItem> addItem(CanvasItem item) async {
+    final CanvasItem created = await _repository.createItem(item);
+    state = state.copyWith(
+      items: <CanvasItem>[...state.items, created],
+    );
+    return created;
+  }
+
+  /// Удаляет элемент с канваса.
+  Future<void> deleteItem(int itemId) async {
+    await _repository.deleteItem(itemId);
+    state = state.copyWith(
+      items: state.items
+          .where((CanvasItem item) => item.id != itemId)
+          .toList(),
+    );
+  }
+
+  /// Перемещает элемент на передний план (максимальный z-index).
+  Future<void> bringToFront(int itemId) async {
+    if (state.items.isEmpty) return;
+
+    final int maxZ = state.items
+        .map((CanvasItem item) => item.zIndex)
+        .reduce((int a, int b) => a > b ? a : b);
+    final int newZ = maxZ + 1;
+
+    await _repository.updateItemZIndex(itemId, newZ);
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(zIndex: newZ);
+        }
+        return item;
+      }).toList(),
+    );
+  }
+
+  /// Перемещает элемент на задний план (минимальный z-index).
+  Future<void> sendToBack(int itemId) async {
+    if (state.items.isEmpty) return;
+
+    final int minZ = state.items
+        .map((CanvasItem item) => item.zIndex)
+        .reduce((int a, int b) => a < b ? a : b);
+    final int newZ = minZ - 1;
+
+    await _repository.updateItemZIndex(itemId, newZ);
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(zIndex: newZ);
+        }
+        return item;
+      }).toList(),
+    );
+  }
+}

--- a/lib/features/collections/widgets/canvas_game_card.dart
+++ b/lib/features/collections/widgets/canvas_game_card.dart
@@ -1,0 +1,87 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/canvas_item.dart';
+
+/// Карточка игры на канвасе.
+///
+/// Отображает обложку, название и платформу в компактном виде.
+class CanvasGameCard extends StatelessWidget {
+  /// Создаёт [CanvasGameCard].
+  const CanvasGameCard({
+    required this.item,
+    super.key,
+  });
+
+  /// Элемент канваса с данными игры.
+  final CanvasItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+    final String? coverUrl = item.game?.coverUrl;
+    final String gameName = item.game?.name ?? 'Unknown Game';
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      elevation: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          // Обложка
+          Expanded(
+            child: coverUrl != null
+                ? CachedNetworkImage(
+                    imageUrl: coverUrl,
+                    fit: BoxFit.cover,
+                    placeholder: (BuildContext ctx, String url) => Container(
+                      color: colorScheme.surfaceContainerHighest,
+                      child: const Center(
+                        child: SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                      ),
+                    ),
+                    errorWidget:
+                        (BuildContext ctx, String url, Object error) =>
+                            Container(
+                      color: colorScheme.surfaceContainerHighest,
+                      child: Icon(
+                        Icons.videogame_asset,
+                        size: 32,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  )
+                : Container(
+                    color: colorScheme.surfaceContainerHighest,
+                    child: Icon(
+                      Icons.videogame_asset,
+                      size: 32,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+          ),
+
+          // Название
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+            color: colorScheme.surfaceContainerLow,
+            child: Text(
+              gameName,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: colorScheme.onSurface,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/canvas_view.dart
+++ b/lib/features/collections/widgets/canvas_view.dart
@@ -1,0 +1,483 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../data/repositories/canvas_repository.dart';
+import '../../../shared/models/canvas_item.dart';
+import '../providers/canvas_provider.dart';
+import 'canvas_game_card.dart';
+
+// Виджет канваса для визуального размещения элементов коллекции.
+//
+// Поддерживает зум (0.3x–3.0x), панорамирование и перетаскивание элементов.
+// Канвас расширяется автоматически под контент. Элементы размещаются
+// по центру канваса, чтобы можно было перемещать их во все стороны.
+class CanvasView extends ConsumerStatefulWidget {
+  /// Создаёт [CanvasView].
+  const CanvasView({
+    required this.collectionId,
+    required this.isEditable,
+    super.key,
+  });
+
+  /// ID коллекции.
+  final int collectionId;
+
+  /// Можно ли редактировать (перемещать элементы).
+  final bool isEditable;
+
+  @override
+  ConsumerState<CanvasView> createState() => _CanvasViewState();
+}
+
+class _CanvasViewState extends ConsumerState<CanvasView> {
+  final TransformationController _transformationController =
+      TransformationController();
+
+  /// Минимальный зум.
+  static const double _minScale = 0.3;
+
+  /// Максимальный зум.
+  static const double _maxScale = 3.0;
+
+  /// Минимальный размер канваса.
+  static const double _minCanvasSize = 5000.0;
+
+  /// Буфер за последним элементом.
+  static const double _canvasBuffer = 1000.0;
+
+  /// Флаг: начальное центрирование вида уже выполнено.
+  bool _hasScrolledToItems = false;
+
+  /// Флаг: элемент перетаскивается (блокирует пан InteractiveViewer).
+  bool _isItemDragging = false;
+
+  void _onItemDragStateChanged({required bool isDragging}) {
+    setState(() => _isItemDragging = isDragging);
+  }
+
+  @override
+  void dispose() {
+    _transformationController.dispose();
+    super.dispose();
+  }
+
+  /// Центрирует вид на элементах канваса.
+  void _centerViewOnItems(
+    double viewportWidth,
+    double viewportHeight,
+    List<CanvasItem> items,
+  ) {
+    if (items.isEmpty) return;
+
+    double minX = double.infinity;
+    double minY = double.infinity;
+    double maxX = double.negativeInfinity;
+    double maxY = double.negativeInfinity;
+
+    for (final CanvasItem item in items) {
+      if (item.x < minX) minX = item.x;
+      if (item.y < minY) minY = item.y;
+      final double right =
+          item.x + (item.width ?? CanvasRepository.defaultCardWidth);
+      final double bottom =
+          item.y + (item.height ?? CanvasRepository.defaultCardHeight);
+      if (right > maxX) maxX = right;
+      if (bottom > maxY) maxY = bottom;
+    }
+
+    final double contentCenterX = (minX + maxX) / 2;
+    final double contentCenterY = (minY + maxY) / 2;
+
+    _transformationController.value = Matrix4.identity()
+      ..translateByDouble(
+        viewportWidth / 2 - contentCenterX,
+        viewportHeight / 2 - contentCenterY,
+        0.0,
+        1.0,
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final CanvasState canvasState =
+        ref.watch(canvasNotifierProvider(widget.collectionId));
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    if (canvasState.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (canvasState.error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.error_outline,
+              size: 48,
+              color: colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Failed to load canvas',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () {
+                ref
+                    .read(
+                        canvasNotifierProvider(widget.collectionId).notifier)
+                    .refresh();
+              },
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (canvasState.items.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.dashboard_outlined,
+              size: 64,
+              color: colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Canvas is empty',
+              style: theme.textTheme.titleMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Add games to the collection first',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final List<CanvasItem> sortedItems =
+        List<CanvasItem>.from(canvasState.items)
+          ..sort(
+              (CanvasItem a, CanvasItem b) => a.zIndex.compareTo(b.zIndex));
+
+    // Размер канваса: подстраивается под контент
+    double canvasWidth = _minCanvasSize;
+    double canvasHeight = _minCanvasSize;
+    for (final CanvasItem item in canvasState.items) {
+      final double right = item.x +
+          (item.width ?? CanvasRepository.defaultCardWidth) +
+          _canvasBuffer;
+      final double bottom = item.y +
+          (item.height ?? CanvasRepository.defaultCardHeight) +
+          _canvasBuffer;
+      if (right > canvasWidth) canvasWidth = right;
+      if (bottom > canvasHeight) canvasHeight = bottom;
+    }
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double viewportWidth = constraints.maxWidth;
+        final double viewportHeight = constraints.maxHeight;
+
+        // При первой загрузке центрируем вид на элементах
+        if (!_hasScrolledToItems && canvasState.isInitialized) {
+          _hasScrolledToItems = true;
+          SchedulerBinding.instance.addPostFrameCallback((_) {
+            _centerViewOnItems(
+              viewportWidth,
+              viewportHeight,
+              canvasState.items,
+            );
+          });
+        }
+
+        return Stack(
+          children: <Widget>[
+            // Канвас с зумом и панорамированием
+            InteractiveViewer(
+              transformationController: _transformationController,
+              constrained: false,
+              panEnabled: !_isItemDragging,
+              minScale: _minScale,
+              maxScale: _maxScale,
+              child: SizedBox(
+                width: canvasWidth,
+                height: canvasHeight,
+                child: CustomPaint(
+                  painter: _CanvasGridPainter(
+                    color: colorScheme.outlineVariant.withAlpha(60),
+                  ),
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: <Widget>[
+                      for (final CanvasItem item in sortedItems)
+                        _buildCanvasItem(item),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            // Кнопки управления (поверх канваса, фиксированы)
+            Positioned(
+              right: 16,
+              bottom: 16,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  // Центрировать вид на элементах
+                  FloatingActionButton.small(
+                    heroTag: 'canvas_reset_view',
+                    onPressed: () {
+                      _centerViewOnItems(
+                        viewportWidth,
+                        viewportHeight,
+                        canvasState.items,
+                      );
+                    },
+                    tooltip: 'Center view',
+                    child: const Icon(Icons.fit_screen),
+                  ),
+                  const SizedBox(height: 8),
+                  // Сброс позиций всех элементов в сетку
+                  FloatingActionButton.small(
+                    heroTag: 'canvas_reset_positions',
+                    onPressed: () {
+                      ref
+                          .read(canvasNotifierProvider(widget.collectionId)
+                              .notifier)
+                          .resetPositions(viewportWidth);
+                      // Центрируем вид после сброса
+                      SchedulerBinding.instance.addPostFrameCallback((_) {
+                        final List<CanvasItem> items = ref
+                            .read(
+                                canvasNotifierProvider(widget.collectionId))
+                            .items;
+                        _centerViewOnItems(
+                          viewportWidth,
+                          viewportHeight,
+                          items,
+                        );
+                      });
+                    },
+                    tooltip: 'Reset positions',
+                    child: const Icon(Icons.grid_view),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildCanvasItem(CanvasItem item) {
+    switch (item.itemType) {
+      case CanvasItemType.game:
+        return _DraggableCanvasItem(
+          key: ValueKey<int>(item.id),
+          item: item,
+          isEditable: widget.isEditable,
+          collectionId: widget.collectionId,
+          transformationController: _transformationController,
+          onDragStateChanged: _onItemDragStateChanged,
+          child: CanvasGameCard(
+            item: item,
+          ),
+        );
+      // Остальные типы будут в Stage 8
+      case CanvasItemType.text:
+      case CanvasItemType.image:
+      case CanvasItemType.link:
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+/// Обёртка для перетаскиваемых элементов канваса.
+///
+/// Во время drag позиция обновляется через [ValueNotifier] —
+/// пересобирается только [Transform.translate], а дочерний виджет
+/// полностью кэшируется через `child` параметр [ListenableBuilder].
+///
+/// Используется абсолютное отслеживание позиции (globalPosition)
+/// вместо накопления инкрементальных дельт. При старте drag
+/// InteractiveViewer отключает пан через callback, чтобы избежать
+/// двойного смещения.
+class _DraggableCanvasItem extends ConsumerStatefulWidget {
+  const _DraggableCanvasItem({
+    required this.item,
+    required this.isEditable,
+    required this.collectionId,
+    required this.transformationController,
+    required this.onDragStateChanged,
+    required this.child,
+    super.key,
+  });
+
+  final CanvasItem item;
+  final bool isEditable;
+  final int collectionId;
+  final TransformationController transformationController;
+
+  /// Callback для уведомления родителя о начале/конце drag.
+  final void Function({required bool isDragging}) onDragStateChanged;
+
+  final Widget child;
+
+  @override
+  ConsumerState<_DraggableCanvasItem> createState() =>
+      _DraggableCanvasItemState();
+}
+
+class _DraggableCanvasItemState extends ConsumerState<_DraggableCanvasItem> {
+  final ValueNotifier<Offset> _dragDelta =
+      ValueNotifier<Offset>(Offset.zero);
+  bool _isDragging = false;
+
+  /// Глобальная позиция указателя при старте перетаскивания.
+  Offset _panStartGlobal = Offset.zero;
+
+  double get _itemWidth =>
+      widget.item.width ?? CanvasRepository.defaultCardWidth;
+  double get _itemHeight =>
+      widget.item.height ?? CanvasRepository.defaultCardHeight;
+
+  @override
+  void dispose() {
+    _dragDelta.dispose();
+    super.dispose();
+  }
+
+  void _onPanStart(DragStartDetails details) {
+    if (!widget.isEditable) return;
+    _panStartGlobal = details.globalPosition;
+    _dragDelta.value = Offset.zero;
+    setState(() => _isDragging = true);
+    widget.onDragStateChanged(isDragging: true);
+  }
+
+  void _onPanUpdate(DragUpdateDetails details) {
+    if (!_isDragging) return;
+
+    // Вычисляем полное смещение от стартовой позиции (в экранных координатах),
+    // затем делим на масштаб для перевода в координаты канваса.
+    final double scale =
+        widget.transformationController.value.getMaxScaleOnAxis();
+    final Offset totalGlobalDelta =
+        details.globalPosition - _panStartGlobal;
+    _dragDelta.value = Offset(
+      totalGlobalDelta.dx / scale,
+      totalGlobalDelta.dy / scale,
+    );
+  }
+
+  void _onPanEnd(DragEndDetails details) {
+    if (!_isDragging) return;
+
+    final double newX = widget.item.x + _dragDelta.value.dx;
+    final double newY = widget.item.y + _dragDelta.value.dy;
+
+    ref
+        .read(canvasNotifierProvider(widget.collectionId).notifier)
+        .moveItem(widget.item.id, newX, newY);
+
+    _dragDelta.value = Offset.zero;
+    setState(() => _isDragging = false);
+    widget.onDragStateChanged(isDragging: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Color shadowColor =
+        Theme.of(context).colorScheme.shadow.withAlpha(80);
+
+    return Positioned(
+      left: widget.item.x,
+      top: widget.item.y,
+      width: _itemWidth,
+      height: _itemHeight,
+      child: MouseRegion(
+        cursor: _isDragging
+            ? SystemMouseCursors.grabbing
+            : SystemMouseCursors.grab,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onPanStart: _onPanStart,
+          onPanUpdate: _onPanUpdate,
+          onPanEnd: _onPanEnd,
+          child: ListenableBuilder(
+            listenable: _dragDelta,
+            builder: (BuildContext context, Widget? child) {
+              return Transform.translate(
+                offset: _dragDelta.value,
+                child: child,
+              );
+            },
+            child: RepaintBoundary(
+              child: AnimatedOpacity(
+                opacity: _isDragging ? 0.8 : 1.0,
+                duration: const Duration(milliseconds: 150),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  decoration: BoxDecoration(
+                    boxShadow: _isDragging
+                        ? <BoxShadow>[
+                            BoxShadow(
+                              color: shadowColor,
+                              blurRadius: 12,
+                              offset: const Offset(0, 4),
+                            ),
+                          ]
+                        : null,
+                  ),
+                  child: widget.child,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Рисует фоновую сетку на канвасе.
+class _CanvasGridPainter extends CustomPainter {
+  _CanvasGridPainter({required this.color});
+
+  final Color color;
+
+  static const double _gridStep = 50.0;
+  static const double _dotRadius = 1.5;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    for (double x = 0; x < size.width; x += _gridStep) {
+      for (double y = 0; y < size.height; y += _gridStep) {
+        canvas.drawCircle(Offset(x, y), _dotRadius, paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_CanvasGridPainter oldDelegate) =>
+      color != oldDelegate.color;
+}

--- a/lib/shared/models/canvas_item.dart
+++ b/lib/shared/models/canvas_item.dart
@@ -1,0 +1,213 @@
+import 'dart:convert';
+
+import 'game.dart';
+
+/// Тип элемента на канвасе.
+enum CanvasItemType {
+  /// Карточка игры.
+  game('game'),
+
+  /// Текстовый блок.
+  text('text'),
+
+  /// Изображение.
+  image('image'),
+
+  /// Ссылка.
+  link('link');
+
+  const CanvasItemType(this.value);
+
+  /// Строковое значение для базы данных.
+  final String value;
+
+  /// Создаёт [CanvasItemType] из строки.
+  static CanvasItemType fromString(String value) {
+    return CanvasItemType.values.firstWhere(
+      (CanvasItemType type) => type.value == value,
+      orElse: () => CanvasItemType.game,
+    );
+  }
+}
+
+/// Модель элемента на канвасе коллекции.
+///
+/// Представляет любой объект, размещённый на канвасе:
+/// игровую карточку, текст, изображение или ссылку.
+class CanvasItem {
+  /// Создаёт экземпляр [CanvasItem].
+  const CanvasItem({
+    required this.id,
+    required this.collectionId,
+    required this.itemType,
+    required this.x,
+    required this.y,
+    required this.createdAt,
+    this.itemRefId,
+    this.width,
+    this.height,
+    this.zIndex = 0,
+    this.data,
+    this.game,
+  });
+
+  /// Создаёт [CanvasItem] из записи базы данных.
+  factory CanvasItem.fromDb(Map<String, dynamic> row) {
+    final String? dataString = row['data'] as String?;
+    Map<String, dynamic>? parsedData;
+    if (dataString != null && dataString.isNotEmpty) {
+      parsedData =
+          json.decode(dataString) as Map<String, dynamic>;
+    }
+
+    return CanvasItem(
+      id: row['id'] as int,
+      collectionId: row['collection_id'] as int,
+      itemType: CanvasItemType.fromString(row['item_type'] as String),
+      itemRefId: row['item_ref_id'] as int?,
+      x: (row['x'] as num).toDouble(),
+      y: (row['y'] as num).toDouble(),
+      width: (row['width'] as num?)?.toDouble(),
+      height: (row['height'] as num?)?.toDouble(),
+      zIndex: row['z_index'] as int? ?? 0,
+      data: parsedData,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        (row['created_at'] as int) * 1000,
+      ),
+    );
+  }
+
+  /// Создаёт [CanvasItem] из JSON (для импорта).
+  factory CanvasItem.fromJson(Map<String, dynamic> json) {
+    return CanvasItem(
+      id: json['id'] as int? ?? 0,
+      collectionId: json['collection_id'] as int? ?? 0,
+      itemType: CanvasItemType.fromString(json['type'] as String? ?? 'game'),
+      itemRefId: json['refId'] as int?,
+      x: (json['x'] as num).toDouble(),
+      y: (json['y'] as num).toDouble(),
+      width: (json['width'] as num?)?.toDouble(),
+      height: (json['height'] as num?)?.toDouble(),
+      zIndex: json['z_index'] as int? ?? 0,
+      data: json['data'] as Map<String, dynamic>?,
+      createdAt: json['created_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (json['created_at'] as int) * 1000,
+            )
+          : DateTime.now(),
+    );
+  }
+
+  /// Уникальный идентификатор элемента.
+  final int id;
+
+  /// ID коллекции.
+  final int collectionId;
+
+  /// Тип элемента.
+  final CanvasItemType itemType;
+
+  /// ID связанного объекта (igdb_id для game, null для остальных).
+  final int? itemRefId;
+
+  /// Позиция X на канвасе.
+  final double x;
+
+  /// Позиция Y на канвасе.
+  final double y;
+
+  /// Ширина элемента.
+  final double? width;
+
+  /// Высота элемента.
+  final double? height;
+
+  /// Слой отображения (z-index).
+  final int zIndex;
+
+  /// Дополнительные данные (JSON).
+  final Map<String, dynamic>? data;
+
+  /// Дата создания.
+  final DateTime createdAt;
+
+  /// Данные игры (joined, не сохраняются в БД).
+  final Game? game;
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      if (id != 0) 'id': id,
+      'collection_id': collectionId,
+      'item_type': itemType.value,
+      'item_ref_id': itemRefId,
+      'x': x,
+      'y': y,
+      'width': width,
+      'height': height,
+      'z_index': zIndex,
+      'data': data != null ? json.encode(data) : null,
+      'created_at': createdAt.millisecondsSinceEpoch ~/ 1000,
+    };
+  }
+
+  /// Преобразует в JSON для экспорта.
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'type': itemType.value,
+      'refId': itemRefId,
+      'x': x,
+      'y': y,
+      'width': width,
+      'height': height,
+      'z_index': zIndex,
+      'data': data,
+      'created_at': createdAt.millisecondsSinceEpoch ~/ 1000,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  CanvasItem copyWith({
+    int? id,
+    int? collectionId,
+    CanvasItemType? itemType,
+    int? itemRefId,
+    double? x,
+    double? y,
+    double? width,
+    double? height,
+    int? zIndex,
+    Map<String, dynamic>? data,
+    DateTime? createdAt,
+    Game? game,
+  }) {
+    return CanvasItem(
+      id: id ?? this.id,
+      collectionId: collectionId ?? this.collectionId,
+      itemType: itemType ?? this.itemType,
+      itemRefId: itemRefId ?? this.itemRefId,
+      x: x ?? this.x,
+      y: y ?? this.y,
+      width: width ?? this.width,
+      height: height ?? this.height,
+      zIndex: zIndex ?? this.zIndex,
+      data: data ?? this.data,
+      createdAt: createdAt ?? this.createdAt,
+      game: game ?? this.game,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CanvasItem && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() =>
+      'CanvasItem(id: $id, type: ${itemType.value}, x: $x, y: $y)';
+}

--- a/lib/shared/models/canvas_viewport.dart
+++ b/lib/shared/models/canvas_viewport.dart
@@ -1,0 +1,101 @@
+/// Модель состояния viewport канваса.
+///
+/// Хранит позицию камеры и уровень масштабирования
+/// для восстановления при повторном открытии канваса.
+class CanvasViewport {
+  /// Создаёт экземпляр [CanvasViewport].
+  const CanvasViewport({
+    required this.collectionId,
+    this.scale = 1.0,
+    this.offsetX = 0.0,
+    this.offsetY = 0.0,
+  });
+
+  /// Создаёт [CanvasViewport] из записи базы данных.
+  factory CanvasViewport.fromDb(Map<String, dynamic> row) {
+    return CanvasViewport(
+      collectionId: row['collection_id'] as int,
+      scale: (row['scale'] as num?)?.toDouble() ?? 1.0,
+      offsetX: (row['offset_x'] as num?)?.toDouble() ?? 0.0,
+      offsetY: (row['offset_y'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  /// Создаёт [CanvasViewport] из JSON (для импорта).
+  factory CanvasViewport.fromJson(
+    Map<String, dynamic> json, {
+    int collectionId = 0,
+  }) {
+    return CanvasViewport(
+      collectionId: collectionId,
+      scale: (json['scale'] as num?)?.toDouble() ?? 1.0,
+      offsetX: (json['offsetX'] as num?)?.toDouble() ?? 0.0,
+      offsetY: (json['offsetY'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  /// ID коллекции.
+  final int collectionId;
+
+  /// Уровень масштабирования.
+  final double scale;
+
+  /// Смещение по X.
+  final double offsetX;
+
+  /// Смещение по Y.
+  final double offsetY;
+
+  /// Viewport по умолчанию (используется для новых канвасов).
+  static const CanvasViewport defaultValue = CanvasViewport(
+    collectionId: 0,
+  );
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'collection_id': collectionId,
+      'scale': scale,
+      'offset_x': offsetX,
+      'offset_y': offsetY,
+    };
+  }
+
+  /// Преобразует в JSON для экспорта.
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'scale': scale,
+      'offsetX': offsetX,
+      'offsetY': offsetY,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  CanvasViewport copyWith({
+    int? collectionId,
+    double? scale,
+    double? offsetX,
+    double? offsetY,
+  }) {
+    return CanvasViewport(
+      collectionId: collectionId ?? this.collectionId,
+      scale: scale ?? this.scale,
+      offsetX: offsetX ?? this.offsetX,
+      offsetY: offsetY ?? this.offsetY,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CanvasViewport && other.collectionId == collectionId;
+  }
+
+  @override
+  int get hashCode => collectionId.hashCode;
+
+  @override
+  String toString() =>
+      'CanvasViewport(collectionId: $collectionId, scale: $scale, '
+      'offset: ($offsetX, $offsetY))';
+}

--- a/test/data/repositories/canvas_repository_test.dart
+++ b/test/data/repositories/canvas_repository_test.dart
@@ -1,0 +1,596 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/data/repositories/canvas_repository.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/canvas_viewport.dart';
+import 'package:xerabora/shared/models/collection_game.dart';
+import 'package:xerabora/shared/models/game.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  group('CanvasRepository', () {
+    late MockDatabaseService mockDb;
+    late CanvasRepository repository;
+
+    final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
+    final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
+
+    setUp(() {
+      mockDb = MockDatabaseService();
+      repository = CanvasRepository(db: mockDb);
+    });
+
+    group('constants', () {
+      test('should have correct default values', () {
+        expect(CanvasRepository.defaultCardWidth, 160);
+        expect(CanvasRepository.defaultCardHeight, 220);
+        expect(CanvasRepository.gridGap, 24);
+        expect(CanvasRepository.gridColumns, 5);
+      });
+    });
+
+    group('getItems', () {
+      test('should return list of canvas items from database', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'item_type': 'game',
+            'item_ref_id': 100,
+            'x': 50.0,
+            'y': 100.0,
+            'width': 160.0,
+            'height': 220.0,
+            'z_index': 0,
+            'data': null,
+            'created_at': testTimestamp,
+          },
+          <String, dynamic>{
+            'id': 2,
+            'collection_id': 10,
+            'item_type': 'text',
+            'item_ref_id': null,
+            'x': 200.0,
+            'y': 300.0,
+            'width': null,
+            'height': null,
+            'z_index': 1,
+            'data': '{"content":"Hello"}',
+            'created_at': testTimestamp,
+          },
+        ];
+
+        when(() => mockDb.getCanvasItems(10)).thenAnswer((_) async => rows);
+
+        final List<CanvasItem> result = await repository.getItems(10);
+
+        expect(result.length, 2);
+        expect(result[0].id, 1);
+        expect(result[0].itemType, CanvasItemType.game);
+        expect(result[1].id, 2);
+        expect(result[1].itemType, CanvasItemType.text);
+        verify(() => mockDb.getCanvasItems(10)).called(1);
+      });
+
+      test('should return empty list when no items', () async {
+        when(() => mockDb.getCanvasItems(10))
+            .thenAnswer((_) async => <Map<String, dynamic>>[]);
+
+        final List<CanvasItem> result = await repository.getItems(10);
+
+        expect(result, isEmpty);
+      });
+    });
+
+    group('getItemsWithData', () {
+      test('should return items with joined game data', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'item_type': 'game',
+            'item_ref_id': 100,
+            'x': 50.0,
+            'y': 100.0,
+            'width': 160.0,
+            'height': 220.0,
+            'z_index': 0,
+            'data': null,
+            'created_at': testTimestamp,
+          },
+        ];
+
+        const Game testGame = Game(id: 100, name: 'Test Game');
+
+        when(() => mockDb.getCanvasItems(10)).thenAnswer((_) async => rows);
+        when(() => mockDb.getGamesByIds(<int>[100]))
+            .thenAnswer((_) async => <Game>[testGame]);
+
+        final List<CanvasItem> result = await repository.getItemsWithData(10);
+
+        expect(result.length, 1);
+        expect(result[0].game, isNotNull);
+        expect(result[0].game!.name, 'Test Game');
+        verify(() => mockDb.getGamesByIds(<int>[100])).called(1);
+      });
+
+      test('should return empty list when no items', () async {
+        when(() => mockDb.getCanvasItems(10))
+            .thenAnswer((_) async => <Map<String, dynamic>>[]);
+
+        final List<CanvasItem> result = await repository.getItemsWithData(10);
+
+        expect(result, isEmpty);
+      });
+
+      test('should skip game lookup when no game items', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'item_type': 'text',
+            'item_ref_id': null,
+            'x': 50.0,
+            'y': 100.0,
+            'width': null,
+            'height': null,
+            'z_index': 0,
+            'data': '{"content":"Hello"}',
+            'created_at': testTimestamp,
+          },
+        ];
+
+        when(() => mockDb.getCanvasItems(10)).thenAnswer((_) async => rows);
+
+        final List<CanvasItem> result = await repository.getItemsWithData(10);
+
+        expect(result.length, 1);
+        verifyNever(() => mockDb.getGamesByIds(any()));
+      });
+
+      test('should handle game items with null itemRefId', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'item_type': 'game',
+            'item_ref_id': null,
+            'x': 50.0,
+            'y': 100.0,
+            'width': 160.0,
+            'height': 220.0,
+            'z_index': 0,
+            'data': null,
+            'created_at': testTimestamp,
+          },
+        ];
+
+        when(() => mockDb.getCanvasItems(10)).thenAnswer((_) async => rows);
+
+        final List<CanvasItem> result = await repository.getItemsWithData(10);
+
+        expect(result.length, 1);
+        expect(result[0].game, isNull);
+        verifyNever(() => mockDb.getGamesByIds(any()));
+      });
+
+      test('should handle mixed game and non-game items', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'item_type': 'game',
+            'item_ref_id': 100,
+            'x': 50.0,
+            'y': 100.0,
+            'width': 160.0,
+            'height': 220.0,
+            'z_index': 0,
+            'data': null,
+            'created_at': testTimestamp,
+          },
+          <String, dynamic>{
+            'id': 2,
+            'collection_id': 10,
+            'item_type': 'text',
+            'item_ref_id': null,
+            'x': 200.0,
+            'y': 300.0,
+            'width': null,
+            'height': null,
+            'z_index': 1,
+            'data': '{"content":"Hello"}',
+            'created_at': testTimestamp,
+          },
+        ];
+
+        const Game testGame = Game(id: 100, name: 'Test Game');
+
+        when(() => mockDb.getCanvasItems(10)).thenAnswer((_) async => rows);
+        when(() => mockDb.getGamesByIds(<int>[100]))
+            .thenAnswer((_) async => <Game>[testGame]);
+
+        final List<CanvasItem> result = await repository.getItemsWithData(10);
+
+        expect(result.length, 2);
+        expect(result[0].game, isNotNull);
+        expect(result[0].game!.name, 'Test Game');
+        expect(result[1].game, isNull);
+        expect(result[1].itemType, CanvasItemType.text);
+      });
+
+      test('should handle missing game in database', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'item_type': 'game',
+            'item_ref_id': 999,
+            'x': 50.0,
+            'y': 100.0,
+            'width': 160.0,
+            'height': 220.0,
+            'z_index': 0,
+            'data': null,
+            'created_at': testTimestamp,
+          },
+        ];
+
+        when(() => mockDb.getCanvasItems(10)).thenAnswer((_) async => rows);
+        when(() => mockDb.getGamesByIds(<int>[999]))
+            .thenAnswer((_) async => <Game>[]);
+
+        final List<CanvasItem> result = await repository.getItemsWithData(10);
+
+        expect(result.length, 1);
+        expect(result[0].game, isNull);
+      });
+    });
+
+    group('createItem', () {
+      test('should insert item and return with assigned id', () async {
+        final CanvasItem item = CanvasItem(
+          id: 0,
+          collectionId: 10,
+          itemType: CanvasItemType.game,
+          itemRefId: 100,
+          x: 50.0,
+          y: 100.0,
+          width: 160.0,
+          height: 220.0,
+          zIndex: 0,
+          createdAt: testDate,
+        );
+
+        when(() => mockDb.insertCanvasItem(any())).thenAnswer((_) async => 42);
+
+        final CanvasItem result = await repository.createItem(item);
+
+        expect(result.id, 42);
+        expect(result.collectionId, 10);
+        verify(() => mockDb.insertCanvasItem(any())).called(1);
+      });
+    });
+
+    group('updateItem', () {
+      test('should update item in database without id field', () async {
+        final CanvasItem item = CanvasItem(
+          id: 5,
+          collectionId: 10,
+          itemType: CanvasItemType.game,
+          itemRefId: 100,
+          x: 200.0,
+          y: 300.0,
+          width: 160.0,
+          height: 220.0,
+          zIndex: 1,
+          createdAt: testDate,
+        );
+
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItem(item);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured.containsKey('id'), false);
+        expect(captured['x'], 200.0);
+        expect(captured['y'], 300.0);
+      });
+    });
+
+    group('updateItemPosition', () {
+      test('should update only x and y in database', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemPosition(5, x: 300.0, y: 400.0);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured, <String, dynamic>{'x': 300.0, 'y': 400.0});
+      });
+    });
+
+    group('updateItemSize', () {
+      test('should update width and height', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemSize(5, width: 200.0, height: 300.0);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured['width'], 200.0);
+        expect(captured['height'], 300.0);
+      });
+
+      test('should update only width when height is null', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemSize(5, width: 200.0);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured, <String, dynamic>{'width': 200.0});
+      });
+
+      test('should update only height when width is null', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemSize(5, height: 300.0);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured, <String, dynamic>{'height': 300.0});
+      });
+
+      test('should not call database when both are null', () async {
+        await repository.updateItemSize(5);
+
+        verifyNever(() => mockDb.updateCanvasItem(any(), any()));
+      });
+    });
+
+    group('updateItemZIndex', () {
+      test('should update z_index in database', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemZIndex(5, 10);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured, <String, dynamic>{'z_index': 10});
+      });
+    });
+
+    group('deleteItem', () {
+      test('should delete item from database', () async {
+        when(() => mockDb.deleteCanvasItem(5)).thenAnswer((_) async {});
+
+        await repository.deleteItem(5);
+
+        verify(() => mockDb.deleteCanvasItem(5)).called(1);
+      });
+    });
+
+    group('deleteGameItem', () {
+      test('should delete game item by collection and igdb id', () async {
+        when(() => mockDb.deleteCanvasItemByRef(10, 100))
+            .thenAnswer((_) async {});
+
+        await repository.deleteGameItem(10, 100);
+
+        verify(() => mockDb.deleteCanvasItemByRef(10, 100)).called(1);
+      });
+    });
+
+    group('hasCanvasItems', () {
+      test('should return true when items exist', () async {
+        when(() => mockDb.getCanvasItemCount(10)).thenAnswer((_) async => 3);
+
+        final bool result = await repository.hasCanvasItems(10);
+
+        expect(result, true);
+      });
+
+      test('should return false when no items', () async {
+        when(() => mockDb.getCanvasItemCount(10)).thenAnswer((_) async => 0);
+
+        final bool result = await repository.hasCanvasItems(10);
+
+        expect(result, false);
+      });
+    });
+
+    group('getViewport', () {
+      test('should return viewport from database', () async {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'collection_id': 10,
+          'scale': 1.5,
+          'offset_x': -100.0,
+          'offset_y': -200.0,
+        };
+
+        when(() => mockDb.getCanvasViewport(10)).thenAnswer((_) async => row);
+
+        final CanvasViewport? result = await repository.getViewport(10);
+
+        expect(result, isNotNull);
+        expect(result!.collectionId, 10);
+        expect(result.scale, 1.5);
+        expect(result.offsetX, -100.0);
+        expect(result.offsetY, -200.0);
+      });
+
+      test('should return null when viewport not found', () async {
+        when(() => mockDb.getCanvasViewport(10)).thenAnswer((_) async => null);
+
+        final CanvasViewport? result = await repository.getViewport(10);
+
+        expect(result, isNull);
+      });
+    });
+
+    group('saveViewport', () {
+      test('should upsert viewport to database', () async {
+        const CanvasViewport viewport = CanvasViewport(
+          collectionId: 10,
+          scale: 2.0,
+          offsetX: -50.0,
+          offsetY: -75.0,
+        );
+
+        when(() => mockDb.upsertCanvasViewport(
+              collectionId: 10,
+              scale: 2.0,
+              offsetX: -50.0,
+              offsetY: -75.0,
+            )).thenAnswer((_) async {});
+
+        await repository.saveViewport(viewport);
+
+        verify(() => mockDb.upsertCanvasViewport(
+              collectionId: 10,
+              scale: 2.0,
+              offsetX: -50.0,
+              offsetY: -75.0,
+            )).called(1);
+      });
+    });
+
+    group('initializeCanvas', () {
+      test('should create canvas items in grid layout', () async {
+        final List<CollectionGame> games = <CollectionGame>[
+          CollectionGame(
+            id: 1,
+            collectionId: 10,
+            igdbId: 100,
+            platformId: 18,
+            status: GameStatus.notStarted,
+            addedAt: testDate,
+          ),
+          CollectionGame(
+            id: 2,
+            collectionId: 10,
+            igdbId: 200,
+            platformId: 18,
+            status: GameStatus.notStarted,
+            addedAt: testDate,
+          ),
+        ];
+
+        int insertCallCount = 0;
+        when(() => mockDb.insertCanvasItem(any())).thenAnswer((_) async {
+          insertCallCount++;
+          return insertCallCount;
+        });
+        when(() => mockDb.upsertCanvasViewport(
+              collectionId: any(named: 'collectionId'),
+              scale: any(named: 'scale'),
+              offsetX: any(named: 'offsetX'),
+              offsetY: any(named: 'offsetY'),
+            )).thenAnswer((_) async {});
+
+        final List<CanvasItem> result =
+            await repository.initializeCanvas(10, games);
+
+        expect(result.length, 2);
+        expect(result[0].id, 1);
+        expect(result[0].itemRefId, 100);
+        // 2 games → cols=2, gridWidth=344, startX=2500-172=2328
+        // gridHeight=220, startY=2500-110=2390
+        expect(result[0].x, 2328.0);
+        expect(result[0].y, 2390.0);
+        expect(result[1].id, 2);
+        expect(result[1].itemRefId, 200);
+        expect(result[1].x, 2512.0); // 2328 + 1 * (160 + 24)
+        expect(result[1].y, 2390.0);
+        verify(() => mockDb.insertCanvasItem(any())).called(2);
+        verify(() => mockDb.upsertCanvasViewport(
+              collectionId: 10,
+              scale: 1.0,
+              offsetX: 0.0,
+              offsetY: 0.0,
+            )).called(1);
+      });
+
+      test('should wrap to next row after gridColumns', () async {
+        // Create 6 games (should wrap at column 5)
+        final List<CollectionGame> games = List<CollectionGame>.generate(
+          6,
+          (int i) => CollectionGame(
+            id: i + 1,
+            collectionId: 10,
+            igdbId: (i + 1) * 100,
+            platformId: 18,
+            status: GameStatus.notStarted,
+            addedAt: testDate,
+          ),
+        );
+
+        int insertCallCount = 0;
+        when(() => mockDb.insertCanvasItem(any())).thenAnswer((_) async {
+          insertCallCount++;
+          return insertCallCount;
+        });
+        when(() => mockDb.upsertCanvasViewport(
+              collectionId: any(named: 'collectionId'),
+              scale: any(named: 'scale'),
+              offsetX: any(named: 'offsetX'),
+              offsetY: any(named: 'offsetY'),
+            )).thenAnswer((_) async {});
+
+        final List<CanvasItem> result =
+            await repository.initializeCanvas(10, games);
+
+        expect(result.length, 6);
+        // 6 games → cols=5, gridWidth=896, startX=2500-448=2052
+        // gridHeight=464, startY=2500-232=2268
+        // Item at index 5: col = 5 % 5 = 0, row = 5 ~/ 5 = 1
+        expect(result[5].x, 2052.0); // startX + 0 * 184
+        expect(result[5].y, 2512.0); // 2268 + 1 * (220 + 24)
+      });
+
+      test('should handle empty games list', () async {
+        when(() => mockDb.upsertCanvasViewport(
+              collectionId: any(named: 'collectionId'),
+              scale: any(named: 'scale'),
+              offsetX: any(named: 'offsetX'),
+              offsetY: any(named: 'offsetY'),
+            )).thenAnswer((_) async {});
+
+        final List<CanvasItem> result =
+            await repository.initializeCanvas(10, <CollectionGame>[]);
+
+        expect(result, isEmpty);
+        verifyNever(() => mockDb.insertCanvasItem(any()));
+        // Should still create default viewport
+        verify(() => mockDb.upsertCanvasViewport(
+              collectionId: 10,
+              scale: 1.0,
+              offsetX: 0.0,
+              offsetY: 0.0,
+            )).called(1);
+      });
+    });
+  });
+}

--- a/test/features/collections/providers/canvas_provider_test.dart
+++ b/test/features/collections/providers/canvas_provider_test.dart
@@ -1,0 +1,1547 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/data/repositories/canvas_repository.dart';
+import 'package:xerabora/features/collections/providers/canvas_provider.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/canvas_viewport.dart';
+import 'package:xerabora/shared/models/collection_game.dart';
+
+// Моки
+class MockCanvasRepository extends Mock implements CanvasRepository {}
+
+class MockCollectionGamesNotifier extends CollectionGamesNotifier {
+  MockCollectionGamesNotifier(this._initialState);
+
+  final AsyncValue<List<CollectionGame>> _initialState;
+
+  @override
+  AsyncValue<List<CollectionGame>> build(int arg) {
+    return _initialState;
+  }
+
+  void emitState(AsyncValue<List<CollectionGame>> newState) {
+    state = newState;
+  }
+}
+
+// Фейковые классы для registerFallbackValue
+class FakeCanvasItem extends Fake implements CanvasItem {}
+
+class FakeCanvasViewport extends Fake implements CanvasViewport {}
+
+void main() {
+  // Регистрация фейковых значений для mocktail
+  setUpAll(() {
+    registerFallbackValue(FakeCanvasItem());
+    registerFallbackValue(FakeCanvasViewport());
+  });
+
+  group('CanvasState', () {
+    test('should create with default values', () {
+      const CanvasState state = CanvasState();
+
+      expect(state.items, isEmpty);
+      expect(state.viewport, CanvasViewport.defaultValue);
+      expect(state.isLoading, true);
+      expect(state.isInitialized, false);
+      expect(state.error, isNull);
+    });
+
+    test('should create with custom values', () {
+      final DateTime testDate = DateTime(2024, 6, 15);
+      final List<CanvasItem> items = <CanvasItem>[
+        CanvasItem(
+          id: 1,
+          collectionId: 10,
+          itemType: CanvasItemType.game,
+          itemRefId: 100,
+          x: 50.0,
+          y: 100.0,
+          zIndex: 0,
+          createdAt: testDate,
+        ),
+      ];
+      const CanvasViewport viewport = CanvasViewport(
+        collectionId: 10,
+        scale: 1.5,
+        offsetX: -100.0,
+        offsetY: -200.0,
+      );
+
+      final CanvasState state = CanvasState(
+        items: items,
+        viewport: viewport,
+        isLoading: false,
+        isInitialized: true,
+        error: 'Some error',
+      );
+
+      expect(state.items.length, 1);
+      expect(state.viewport.scale, 1.5);
+      expect(state.isLoading, false);
+      expect(state.isInitialized, true);
+      expect(state.error, 'Some error');
+    });
+
+    group('copyWith', () {
+      test('should copy with changed items', () {
+        const CanvasState original = CanvasState();
+        final DateTime testDate = DateTime(2024, 6, 15);
+        final List<CanvasItem> newItems = <CanvasItem>[
+          CanvasItem(
+            id: 1,
+            collectionId: 10,
+            itemType: CanvasItemType.game,
+            x: 0,
+            y: 0,
+            zIndex: 0,
+            createdAt: testDate,
+          ),
+        ];
+
+        final CanvasState copy = original.copyWith(items: newItems);
+
+        expect(copy.items.length, 1);
+        expect(copy.isLoading, original.isLoading);
+        expect(copy.isInitialized, original.isInitialized);
+      });
+
+      test('should copy with changed viewport', () {
+        const CanvasState original = CanvasState();
+        const CanvasViewport newViewport = CanvasViewport(
+          collectionId: 5,
+          scale: 2.0,
+        );
+
+        final CanvasState copy = original.copyWith(viewport: newViewport);
+
+        expect(copy.viewport.scale, 2.0);
+        expect(copy.items, original.items);
+      });
+
+      test('should copy with changed loading state', () {
+        const CanvasState original = CanvasState();
+
+        final CanvasState copy = original.copyWith(
+          isLoading: false,
+          isInitialized: true,
+        );
+
+        expect(copy.isLoading, false);
+        expect(copy.isInitialized, true);
+      });
+
+      test('should clear error when copying with null error', () {
+        const CanvasState original = CanvasState(error: 'Some error');
+
+        final CanvasState copy = original.copyWith(isLoading: false);
+
+        // error defaults to null in copyWith when not explicitly passed
+        expect(copy.error, isNull);
+      });
+
+      test('should preserve error when explicitly passed', () {
+        const CanvasState original = CanvasState();
+
+        final CanvasState copy = original.copyWith(error: 'New error');
+
+        expect(copy.error, 'New error');
+      });
+
+      test('should keep original values when not specified', () {
+        final DateTime testDate = DateTime(2024, 6, 15);
+        final CanvasState original = CanvasState(
+          items: <CanvasItem>[
+            CanvasItem(
+              id: 1,
+              collectionId: 10,
+              itemType: CanvasItemType.game,
+              x: 0,
+              y: 0,
+              zIndex: 0,
+              createdAt: testDate,
+            ),
+          ],
+          viewport: const CanvasViewport(
+            collectionId: 10,
+            scale: 2.0,
+          ),
+          isLoading: false,
+          isInitialized: true,
+          error: 'Error',
+        );
+
+        final CanvasState copy = original.copyWith(error: 'Error');
+
+        expect(copy.items.length, original.items.length);
+        expect(copy.viewport.scale, original.viewport.scale);
+        expect(copy.isLoading, original.isLoading);
+        expect(copy.isInitialized, original.isInitialized);
+      });
+    });
+  });
+
+  group('CanvasNotifier', () {
+    late MockCanvasRepository mockRepository;
+    final DateTime testDate = DateTime(2024, 6, 15);
+    const int collectionId = 1;
+
+    // Вспомогательные данные для тестов
+    late List<CanvasItem> testItems;
+    late List<CollectionGame> testGames;
+
+    setUp(() {
+      mockRepository = MockCanvasRepository();
+
+      testItems = <CanvasItem>[
+        CanvasItem(
+          id: 1,
+          collectionId: collectionId,
+          itemType: CanvasItemType.game,
+          itemRefId: 100,
+          x: 50.0,
+          y: 100.0,
+          width: 160,
+          height: 220,
+          zIndex: 0,
+          createdAt: testDate,
+        ),
+        CanvasItem(
+          id: 2,
+          collectionId: collectionId,
+          itemType: CanvasItemType.game,
+          itemRefId: 200,
+          x: 250.0,
+          y: 100.0,
+          width: 160,
+          height: 220,
+          zIndex: 1,
+          createdAt: testDate,
+        ),
+        CanvasItem(
+          id: 3,
+          collectionId: collectionId,
+          itemType: CanvasItemType.game,
+          itemRefId: 300,
+          x: 450.0,
+          y: 100.0,
+          width: 160,
+          height: 220,
+          zIndex: 2,
+          createdAt: testDate,
+        ),
+      ];
+
+      testGames = <CollectionGame>[
+        CollectionGame(
+          id: 1,
+          collectionId: collectionId,
+          igdbId: 100,
+          platformId: 6,
+          status: GameStatus.notStarted,
+          addedAt: testDate,
+        ),
+        CollectionGame(
+          id: 2,
+          collectionId: collectionId,
+          igdbId: 200,
+          platformId: 6,
+          status: GameStatus.playing,
+          addedAt: testDate,
+        ),
+        CollectionGame(
+          id: 3,
+          collectionId: collectionId,
+          igdbId: 300,
+          platformId: 48,
+          status: GameStatus.completed,
+          addedAt: testDate,
+        ),
+      ];
+    });
+
+    // Вспомогательный метод для создания ProviderContainer
+    ProviderContainer createContainer({
+      AsyncValue<List<CollectionGame>>? gamesState,
+    }) {
+      final AsyncValue<List<CollectionGame>> initialGamesState = gamesState ??
+          AsyncData<List<CollectionGame>>(testGames);
+
+      return ProviderContainer(
+        overrides: <Override>[
+          canvasRepositoryProvider.overrideWithValue(mockRepository),
+          collectionGamesNotifierProvider
+              .overrideWith(() => MockCollectionGamesNotifier(initialGamesState)),
+        ],
+      );
+    }
+
+    // Вспомогательный метод: настроить репо для загрузки существующих элементов
+    void setupExistingCanvas({
+      List<CanvasItem>? items,
+      CanvasViewport? viewport,
+    }) {
+      final List<CanvasItem> effectiveItems = items ?? testItems;
+      when(() => mockRepository.hasCanvasItems(collectionId))
+          .thenAnswer((_) async => true);
+      when(() => mockRepository.getItems(collectionId))
+          .thenAnswer((_) async => effectiveItems);
+      when(() => mockRepository.getItemsWithData(collectionId))
+          .thenAnswer((_) async => effectiveItems);
+      when(() => mockRepository.getViewport(collectionId))
+          .thenAnswer((_) async => viewport);
+      when(() => mockRepository.deleteItem(any()))
+          .thenAnswer((_) async {});
+    }
+
+    // Вспомогательный метод: настроить репо для инициализации нового канваса
+    void setupNewCanvas({List<CollectionGame>? games}) {
+      final List<CollectionGame> effectiveGames = games ?? testGames;
+      when(() => mockRepository.hasCanvasItems(collectionId))
+          .thenAnswer((_) async => false);
+      when(() => mockRepository.initializeCanvas(collectionId, any()))
+          .thenAnswer((_) async {
+        final List<CanvasItem> created = <CanvasItem>[];
+        for (int i = 0; i < effectiveGames.length; i++) {
+          created.add(
+            CanvasItem(
+              id: i + 1,
+              collectionId: collectionId,
+              itemType: CanvasItemType.game,
+              itemRefId: effectiveGames[i].igdbId,
+              x: 100.0 + i * 184.0,
+              y: 100.0,
+              width: 160,
+              height: 220,
+              zIndex: i,
+              createdAt: testDate,
+            ),
+          );
+        }
+        return created;
+      });
+    }
+
+    group('build()', () {
+      test(
+        'должен загрузить существующие элементы канваса когда они есть в БД',
+        () async {
+          const CanvasViewport savedViewport = CanvasViewport(
+            collectionId: collectionId,
+            scale: 1.5,
+            offsetX: -100.0,
+            offsetY: -200.0,
+          );
+          setupExistingCanvas(viewport: savedViewport);
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          // Читаем state для запуска build()
+          final CanvasState initialState =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(initialState.isLoading, true);
+
+          // Ждём загрузки (Future.microtask)
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasState loadedState =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(loadedState.isLoading, false);
+          expect(loadedState.isInitialized, true);
+          expect(loadedState.items.length, 3);
+          expect(loadedState.viewport.scale, 1.5);
+          expect(loadedState.viewport.offsetX, -100.0);
+          expect(loadedState.error, isNull);
+
+          verify(() => mockRepository.hasCanvasItems(collectionId)).called(1);
+          verify(() => mockRepository.getItemsWithData(collectionId)).called(1);
+          verify(() => mockRepository.getViewport(collectionId)).called(1);
+        },
+      );
+
+      test(
+        'должен инициализировать канвас из игр когда элементов нет в БД',
+        () async {
+          setupNewCanvas();
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.isLoading, false);
+          expect(state.isInitialized, true);
+          expect(state.items.length, 3);
+          expect(state.error, isNull);
+          expect(state.viewport.collectionId, collectionId);
+
+          verify(
+            () => mockRepository.initializeCanvas(collectionId, any()),
+          ).called(1);
+        },
+      );
+
+      test(
+        'должен использовать viewport по умолчанию когда viewport null в БД',
+        () async {
+          setupExistingCanvas(viewport: null);
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.viewport.collectionId, collectionId);
+          expect(state.viewport.scale, 1.0);
+          expect(state.viewport.offsetX, 0.0);
+          expect(state.viewport.offsetY, 0.0);
+        },
+      );
+
+      test(
+        'должен установить ошибку когда загрузка канваса бросает исключение',
+        () async {
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenThrow(Exception('Database error'));
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.isLoading, false);
+          expect(state.error, contains('Database error'));
+        },
+      );
+
+      test(
+        'должен установить ошибку когда инициализация из игр бросает исключение',
+        () async {
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenAnswer((_) async => false);
+          when(() => mockRepository.initializeCanvas(collectionId, any()))
+              .thenThrow(Exception('Init error'));
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.isLoading, false);
+          expect(state.error, contains('Init error'));
+        },
+      );
+
+      test(
+        'должен инициализировать канвас с пустым списком игр когда игры ещё не загружены',
+        () async {
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenAnswer((_) async => false);
+          when(() => mockRepository.initializeCanvas(collectionId, any()))
+              .thenAnswer((_) async => <CanvasItem>[]);
+
+          final ProviderContainer container = createContainer(
+            gamesState:
+                const AsyncLoading<List<CollectionGame>>(),
+          );
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.isLoading, false);
+          expect(state.isInitialized, true);
+          expect(state.items, isEmpty);
+
+          verify(
+            () => mockRepository.initializeCanvas(
+              collectionId,
+              <CollectionGame>[],
+            ),
+          ).called(1);
+        },
+      );
+    });
+
+    group('_syncCanvasWithGames() через build/_loadCanvas', () {
+      test(
+        'должен удалить сиротские элементы канваса когда игры удалены из коллекции',
+        () async {
+          // В канвасе 3 элемента, но в коллекции только 2 игры (igdbId 100 и 200)
+          final List<CollectionGame> twoGames = <CollectionGame>[
+            testGames[0],
+            testGames[1],
+          ];
+          setupExistingCanvas();
+
+          final ProviderContainer container = createContainer(
+            gamesState: AsyncData<List<CollectionGame>>(twoGames),
+          );
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          // Элемент с itemRefId=300 должен быть удалён
+          verify(() => mockRepository.deleteItem(3)).called(1);
+        },
+      );
+
+      test(
+        'должен добавить недостающие элементы канваса когда игры добавлены в коллекцию',
+        () async {
+          // В канвасе 2 элемента, но в коллекции 3 игры (добавлена igdbId=400)
+          final List<CanvasItem> twoItems = <CanvasItem>[
+            testItems[0],
+            testItems[1],
+          ];
+          final List<CollectionGame> threeGames = <CollectionGame>[
+            ...testGames.sublist(0, 2),
+            CollectionGame(
+              id: 4,
+              collectionId: collectionId,
+              igdbId: 400,
+              platformId: 6,
+              status: GameStatus.planned,
+              addedAt: testDate,
+            ),
+          ];
+
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenAnswer((_) async => true);
+          when(() => mockRepository.getItems(collectionId))
+              .thenAnswer((_) async => twoItems);
+          when(() => mockRepository.getItemsWithData(collectionId))
+              .thenAnswer((_) async => twoItems);
+          when(() => mockRepository.getViewport(collectionId))
+              .thenAnswer((_) async => null);
+          when(() => mockRepository.createItem(any()))
+              .thenAnswer((Invocation invocation) async {
+            final CanvasItem item =
+                invocation.positionalArguments[0] as CanvasItem;
+            return item.copyWith(id: 10);
+          });
+
+          final ProviderContainer container = createContainer(
+            gamesState: AsyncData<List<CollectionGame>>(threeGames),
+          );
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          verify(() => mockRepository.createItem(any())).called(1);
+        },
+      );
+
+      test(
+        'должен пропустить синхронизацию когда игры ещё не загружены',
+        () async {
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenAnswer((_) async => true);
+          when(() => mockRepository.getItems(collectionId))
+              .thenAnswer((_) async => testItems);
+          when(() => mockRepository.getItemsWithData(collectionId))
+              .thenAnswer((_) async => testItems);
+          when(() => mockRepository.getViewport(collectionId))
+              .thenAnswer((_) async => null);
+
+          final ProviderContainer container = createContainer(
+            gamesState:
+                const AsyncLoading<List<CollectionGame>>(),
+          );
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          // getItems вызывается для syncCanvasWithGames, но т.к. games == null
+          // синхронизация пропускается и getItems НЕ вызывается
+          // (hasCanvasItems -> true -> _syncCanvasWithGames -> games == null -> return)
+          // Далее getItemsWithData вызывается для загрузки
+          verify(() => mockRepository.getItemsWithData(collectionId)).called(1);
+          verifyNever(() => mockRepository.deleteItem(any()));
+        },
+      );
+    });
+
+    group('removeGameItem()', () {
+      test(
+        'должен удалить элемент игры из state и БД когда вызван с igdbId',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.deleteGameItem(collectionId, any<int>()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.removeGameItem(200);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.items.length, 2);
+          expect(
+            state.items
+                .any((CanvasItem item) => item.itemRefId == 200),
+            false,
+          );
+
+          verify(
+            () => mockRepository.deleteGameItem(collectionId, 200),
+          ).called(1);
+        },
+      );
+
+      test(
+        'должен не менять state когда igdbId не найден',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.deleteGameItem(collectionId, any<int>()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.removeGameItem(999);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.items.length, 3);
+        },
+      );
+    });
+
+    group('refresh()', () {
+      test(
+        'должен перезагрузить канвас из БД когда вызван',
+        () async {
+          setupExistingCanvas();
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          // Первая загрузка завершена
+          expect(
+            container.read(canvasNotifierProvider(collectionId)).isLoading,
+            false,
+          );
+
+          // Настраиваем обновлённые данные
+          final List<CanvasItem> updatedItems = <CanvasItem>[testItems[0]];
+          when(() => mockRepository.getItemsWithData(collectionId))
+              .thenAnswer((_) async => updatedItems);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.refresh();
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.isLoading, false);
+          expect(state.items.length, 1);
+          expect(state.error, isNull);
+        },
+      );
+
+      test(
+        'должен установить isLoading в true перед загрузкой когда refresh вызван',
+        () async {
+          setupExistingCanvas();
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          // Делаем загрузку медленной чтобы проверить isLoading
+          final Completer<List<CanvasItem>> completer =
+              Completer<List<CanvasItem>>();
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenAnswer((_) async => true);
+          when(() => mockRepository.getItemsWithData(collectionId))
+              .thenAnswer((_) => completer.future);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+
+          // ignore: unawaited_futures
+          final Future<void> refreshFuture = notifier.refresh();
+
+          // Не завершаем completer, проверяем промежуточное состояние
+          // (refresh устанавливает isLoading=true синхронно, но hasCanvasItems
+          // тоже async, поэтому подождём microtask)
+          await Future<void>.delayed(Duration.zero);
+
+          // Завершаем загрузку
+          completer.complete(testItems);
+          await refreshFuture;
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.isLoading, false);
+        },
+      );
+
+      test(
+        'должен очистить предыдущую ошибку когда refresh вызван',
+        () async {
+          // Первая загрузка с ошибкой
+          when(() => mockRepository.hasCanvasItems(collectionId))
+              .thenThrow(Exception('First error'));
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            container.read(canvasNotifierProvider(collectionId)).error,
+            isNotNull,
+          );
+
+          // Настраиваем успешную загрузку
+          setupExistingCanvas();
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.refresh();
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.error, isNull);
+          expect(state.isLoading, false);
+          expect(state.isInitialized, true);
+        },
+      );
+    });
+
+    group('moveItem()', () {
+      test(
+        'должен обновить позицию элемента в state мгновенно когда вызван',
+        () async {
+          setupExistingCanvas();
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.moveItem(1, 999.0, 888.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem movedItem = state.items.firstWhere(
+            (CanvasItem item) => item.id == 1,
+          );
+          expect(movedItem.x, 999.0);
+          expect(movedItem.y, 888.0);
+        },
+      );
+
+      test(
+        'должен сохранить в БД с debounce когда moveItem вызван',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.moveItem(1, 100.0, 200.0);
+
+          // Сразу после вызова — БД ещё не вызвана (debounce 300ms)
+          verifyNever(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          );
+
+          // Ждём debounce
+          await Future<void>.delayed(const Duration(milliseconds: 350));
+
+          verify(
+            () => mockRepository.updateItemPosition(
+              1,
+              x: 100.0,
+              y: 200.0,
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'должен отменить предыдущий debounce когда moveItem вызван повторно',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+
+          // Быстрые последовательные перемещения
+          notifier.moveItem(1, 100.0, 200.0);
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          notifier.moveItem(1, 150.0, 250.0);
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          notifier.moveItem(1, 200.0, 300.0);
+
+          // Ждём debounce после последнего вызова
+          await Future<void>.delayed(const Duration(milliseconds: 350));
+
+          // Только последнее значение должно быть сохранено
+          verify(
+            () => mockRepository.updateItemPosition(
+              1,
+              x: 200.0,
+              y: 300.0,
+            ),
+          ).called(1);
+          // Промежуточные значения НЕ должны быть сохранены
+          verifyNever(
+            () => mockRepository.updateItemPosition(
+              1,
+              x: 100.0,
+              y: 200.0,
+            ),
+          );
+          verifyNever(
+            () => mockRepository.updateItemPosition(
+              1,
+              x: 150.0,
+              y: 250.0,
+            ),
+          );
+        },
+      );
+
+      test(
+        'должен не менять другие элементы когда перемещается один элемент',
+        () async {
+          setupExistingCanvas();
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.moveItem(1, 999.0, 888.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem unchanged = state.items.firstWhere(
+            (CanvasItem item) => item.id == 2,
+          );
+          expect(unchanged.x, 250.0);
+          expect(unchanged.y, 100.0);
+        },
+      );
+    });
+
+    group('updateViewport()', () {
+      test(
+        'должен обновить viewport в state мгновенно когда вызван',
+        () async {
+          setupExistingCanvas();
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.updateViewport(2.0, -100.0, -200.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.viewport.scale, 2.0);
+          expect(state.viewport.offsetX, -100.0);
+          expect(state.viewport.offsetY, -200.0);
+          expect(state.viewport.collectionId, collectionId);
+        },
+      );
+
+      test(
+        'должен сохранить viewport в БД с debounce когда вызван',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.saveViewport(any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.updateViewport(2.0, -100.0, -200.0);
+
+          // Сразу после вызова — не сохранено (debounce 500ms)
+          verifyNever(() => mockRepository.saveViewport(any()));
+
+          // Ждём debounce
+          await Future<void>.delayed(const Duration(milliseconds: 550));
+
+          verify(() => mockRepository.saveViewport(any())).called(1);
+        },
+      );
+
+      test(
+        'должен отменить предыдущий debounce когда updateViewport вызван повторно',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.saveViewport(any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+
+          notifier.updateViewport(1.5, -50.0, -50.0);
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+          notifier.updateViewport(2.0, -100.0, -200.0);
+
+          // Ждём debounce после последнего вызова
+          await Future<void>.delayed(const Duration(milliseconds: 550));
+
+          // Только один вызов
+          verify(() => mockRepository.saveViewport(any())).called(1);
+        },
+      );
+    });
+
+    group('resetViewport()', () {
+      test(
+        'должен сбросить viewport на значение по умолчанию когда вызван',
+        () async {
+          const CanvasViewport savedViewport = CanvasViewport(
+            collectionId: collectionId,
+            scale: 2.0,
+            offsetX: -500.0,
+            offsetY: -300.0,
+          );
+          setupExistingCanvas(viewport: savedViewport);
+          when(
+            () => mockRepository.saveViewport(any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          // Проверяем что viewport сохранён
+          expect(
+            container.read(canvasNotifierProvider(collectionId)).viewport.scale,
+            2.0,
+          );
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          notifier.resetViewport();
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.viewport.scale, 1.0);
+          expect(state.viewport.offsetX, 0.0);
+          expect(state.viewport.offsetY, 0.0);
+          expect(state.viewport.collectionId, collectionId);
+
+          // Должен сохранить в БД без debounce
+          verify(() => mockRepository.saveViewport(any())).called(1);
+        },
+      );
+    });
+
+    group('resetPositions()', () {
+      test(
+        'должен не менять state когда список элементов пуст',
+        () async {
+          setupExistingCanvas(items: <CanvasItem>[]);
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.resetPositions(1000.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.items, isEmpty);
+        },
+      );
+
+      test(
+        'должен расположить элементы сеткой по центру канваса когда вызван',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.resetPositions(1000.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+
+          // Все элементы должны иметь zIndex == 0 после сброса
+          for (final CanvasItem item in state.items) {
+            expect(item.zIndex, 0);
+          }
+
+          // Должен вызвать updateItemPosition для каждого элемента
+          verify(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          ).called(3);
+        },
+      );
+
+      test(
+        'должен рассчитать колонки по ширине viewport когда вызван',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+
+          // Узкий viewport — все элементы в одну колонку
+          await notifier.resetPositions(160.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+
+          // При одной колонке все x-координаты должны быть одинаковыми
+          final Set<double> uniqueX =
+              state.items.map((CanvasItem item) => item.x).toSet();
+          expect(uniqueX.length, 1);
+        },
+      );
+    });
+
+    group('addItem()', () {
+      test(
+        'должен добавить элемент в state и вернуть элемент с ID когда вызван',
+        () async {
+          setupExistingCanvas();
+
+          final CanvasItem newItem = CanvasItem(
+            id: 0,
+            collectionId: collectionId,
+            itemType: CanvasItemType.text,
+            x: 500.0,
+            y: 500.0,
+            zIndex: 10,
+            createdAt: testDate,
+          );
+
+          when(() => mockRepository.createItem(any()))
+              .thenAnswer((_) async => newItem.copyWith(id: 42));
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          final CanvasItem created = await notifier.addItem(newItem);
+
+          expect(created.id, 42);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.items.length, 4);
+          expect(
+            state.items.any((CanvasItem item) => item.id == 42),
+            true,
+          );
+
+          verify(() => mockRepository.createItem(any())).called(1);
+        },
+      );
+    });
+
+    group('deleteItem()', () {
+      test(
+        'должен удалить элемент из state и БД когда вызван с id',
+        () async {
+          setupExistingCanvas();
+          when(() => mockRepository.deleteItem(any()))
+              .thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            container
+                .read(canvasNotifierProvider(collectionId))
+                .items
+                .length,
+            3,
+          );
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.deleteItem(2);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.items.length, 2);
+          expect(
+            state.items.any((CanvasItem item) => item.id == 2),
+            false,
+          );
+
+          verify(() => mockRepository.deleteItem(2)).called(1);
+        },
+      );
+
+      test(
+        'должен не менять размер списка когда id не найден',
+        () async {
+          setupExistingCanvas();
+          when(() => mockRepository.deleteItem(any()))
+              .thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.deleteItem(999);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          // id==999 не найден — все 3 остались
+          expect(state.items.length, 3);
+        },
+      );
+    });
+
+    group('bringToFront()', () {
+      test(
+        'должен установить максимальный z-index + 1 когда вызван',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemZIndex(any(), any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.bringToFront(1);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem frontItem = state.items.firstWhere(
+            (CanvasItem item) => item.id == 1,
+          );
+
+          // Максимальный zIndex был 2, значит новый = 3
+          expect(frontItem.zIndex, 3);
+
+          verify(() => mockRepository.updateItemZIndex(1, 3)).called(1);
+        },
+      );
+
+      test(
+        'должен не менять state когда список элементов пуст',
+        () async {
+          setupExistingCanvas(items: <CanvasItem>[]);
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.bringToFront(1);
+
+          verifyNever(() => mockRepository.updateItemZIndex(any(), any()));
+        },
+      );
+
+      test(
+        'должен не менять другие элементы когда один перемещён на передний план',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemZIndex(any(), any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.bringToFront(1);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem item2 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 2,
+          );
+          final CanvasItem item3 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 3,
+          );
+          expect(item2.zIndex, 1);
+          expect(item3.zIndex, 2);
+        },
+      );
+    });
+
+    group('sendToBack()', () {
+      test(
+        'должен установить минимальный z-index - 1 когда вызван',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemZIndex(any(), any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.sendToBack(3);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem backItem = state.items.firstWhere(
+            (CanvasItem item) => item.id == 3,
+          );
+
+          // Минимальный zIndex был 0, значит новый = -1
+          expect(backItem.zIndex, -1);
+
+          verify(() => mockRepository.updateItemZIndex(3, -1)).called(1);
+        },
+      );
+
+      test(
+        'должен не менять state когда список элементов пуст',
+        () async {
+          setupExistingCanvas(items: <CanvasItem>[]);
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.sendToBack(3);
+
+          verifyNever(() => mockRepository.updateItemZIndex(any(), any()));
+        },
+      );
+
+      test(
+        'должен не менять другие элементы когда один отправлен на задний план',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemZIndex(any(), any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.sendToBack(3);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem item1 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 1,
+          );
+          final CanvasItem item2 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 2,
+          );
+          expect(item1.zIndex, 0);
+          expect(item2.zIndex, 1);
+        },
+      );
+    });
+
+    group('bringToFront() и sendToBack() последовательно', () {
+      test(
+        'должен корректно обрабатывать множественные перемещения по z-index',
+        () async {
+          setupExistingCanvas();
+          when(
+            () => mockRepository.updateItemZIndex(any(), any()),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+
+          // item1(z=0) -> front -> z=3
+          await notifier.bringToFront(1);
+          // item2(z=1) -> back -> z=-1
+          await notifier.sendToBack(2);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          final CanvasItem item1 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 1,
+          );
+          final CanvasItem item2 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 2,
+          );
+          final CanvasItem item3 = state.items.firstWhere(
+            (CanvasItem item) => item.id == 3,
+          );
+
+          expect(item1.zIndex, 3);
+          // Минимальный z-index после первого bringToFront: min(3,1,2) = 1
+          // sendToBack(2) -> 1 - 1 = 0
+          expect(item2.zIndex, 0);
+          expect(item3.zIndex, 2);
+        },
+      );
+    });
+
+    group('addItem() и deleteItem() вместе', () {
+      test(
+        'должен корректно добавить и затем удалить элемент',
+        () async {
+          setupExistingCanvas();
+          when(() => mockRepository.deleteItem(any()))
+              .thenAnswer((_) async {});
+
+          final CanvasItem newItem = CanvasItem(
+            id: 0,
+            collectionId: collectionId,
+            itemType: CanvasItemType.image,
+            x: 300.0,
+            y: 300.0,
+            zIndex: 5,
+            createdAt: testDate,
+          );
+
+          when(() => mockRepository.createItem(any()))
+              .thenAnswer((_) async => newItem.copyWith(id: 50));
+
+          final ProviderContainer container = createContainer();
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+
+          // Добавляем
+          await notifier.addItem(newItem);
+          expect(
+            container
+                .read(canvasNotifierProvider(collectionId))
+                .items
+                .length,
+            4,
+          );
+
+          // Удаляем
+          await notifier.deleteItem(50);
+          expect(
+            container
+                .read(canvasNotifierProvider(collectionId))
+                .items
+                .length,
+            3,
+          );
+        },
+      );
+    });
+
+    group('resetPositions() расчёт сетки', () {
+      test(
+        'должен расположить один элемент по центру канваса',
+        () async {
+          // Используем одну игру в коллекции, чтобы _syncCanvasWithGames
+          // не пыталась добавить недостающие элементы
+          final List<CanvasItem> singleItem = <CanvasItem>[testItems[0]];
+          final List<CollectionGame> singleGame = <CollectionGame>[
+            testGames[0],
+          ];
+          setupExistingCanvas(items: singleItem);
+          when(
+            () => mockRepository.updateItemPosition(
+              any(),
+              x: any(named: 'x'),
+              y: any(named: 'y'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final ProviderContainer container = createContainer(
+            gamesState: AsyncData<List<CollectionGame>>(singleGame),
+          );
+          addTearDown(container.dispose);
+
+          container.read(canvasNotifierProvider(collectionId));
+          await Future<void>.delayed(Duration.zero);
+
+          final CanvasNotifier notifier = container
+              .read(canvasNotifierProvider(collectionId).notifier);
+          await notifier.resetPositions(1000.0);
+
+          final CanvasState state =
+              container.read(canvasNotifierProvider(collectionId));
+          expect(state.items.length, 1);
+
+          // Один элемент — 1 колонка, gridWidth = cardW = 160
+          // startX = 2500 - 160/2 = 2420
+          // startY = 2500 - 220/2 = 2390
+          expect(state.items[0].x, 2500.0 - 160.0 / 2);
+          expect(state.items[0].y, 2500.0 - 220.0 / 2);
+        },
+      );
+    });
+  });
+}

--- a/test/features/collections/widgets/canvas_game_card_test.dart
+++ b/test/features/collections/widgets/canvas_game_card_test.dart
@@ -1,0 +1,110 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_game_card.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/game.dart';
+
+void main() {
+  group('CanvasGameCard', () {
+    final DateTime testDate = DateTime(2024, 6, 15);
+
+    CanvasItem createGameItem({
+      Game? game,
+    }) {
+      return CanvasItem(
+        id: 1,
+        collectionId: 10,
+        itemType: CanvasItemType.game,
+        itemRefId: 100,
+        x: 0,
+        y: 0,
+        width: 160,
+        height: 220,
+        zIndex: 0,
+        createdAt: testDate,
+        game: game,
+      );
+    }
+
+    Widget buildTestWidget(CanvasItem item) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 160,
+            height: 220,
+            child: CanvasGameCard(item: item),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('should display game name when game is set',
+        (WidgetTester tester) async {
+      final CanvasItem item = createGameItem(
+        game: const Game(
+          id: 100,
+          name: 'Super Mario Bros.',
+          coverUrl: 'https://images.igdb.com/test.jpg',
+        ),
+      );
+
+      await tester.pumpWidget(buildTestWidget(item));
+
+      expect(find.text('Super Mario Bros.'), findsOneWidget);
+    });
+
+    testWidgets('should display "Unknown Game" when game is null',
+        (WidgetTester tester) async {
+      final CanvasItem item = createGameItem();
+
+      await tester.pumpWidget(buildTestWidget(item));
+
+      expect(find.text('Unknown Game'), findsOneWidget);
+    });
+
+    testWidgets('should display placeholder icon when no cover URL',
+        (WidgetTester tester) async {
+      final CanvasItem item = createGameItem(
+        game: const Game(id: 100, name: 'Test Game'),
+      );
+
+      await tester.pumpWidget(buildTestWidget(item));
+
+      expect(find.byIcon(Icons.videogame_asset), findsOneWidget);
+    });
+
+    testWidgets('should use CachedNetworkImage when cover URL exists',
+        (WidgetTester tester) async {
+      final CanvasItem item = createGameItem(
+        game: const Game(
+          id: 100,
+          name: 'Test Game',
+          coverUrl: 'https://images.igdb.com/test.jpg',
+        ),
+      );
+
+      await tester.pumpWidget(buildTestWidget(item));
+
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+    });
+
+    testWidgets('should contain a Card widget', (WidgetTester tester) async {
+      final CanvasItem item = createGameItem();
+
+      await tester.pumpWidget(buildTestWidget(item));
+
+      expect(find.byType(Card), findsOneWidget);
+    });
+
+    testWidgets('should display game name with null name in game',
+        (WidgetTester tester) async {
+      // Game is null, so should show 'Unknown Game'
+      final CanvasItem item = createGameItem();
+
+      await tester.pumpWidget(buildTestWidget(item));
+
+      expect(find.text('Unknown Game'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/collections/widgets/canvas_view_test.dart
+++ b/test/features/collections/widgets/canvas_view_test.dart
@@ -1,0 +1,727 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/providers/canvas_provider.dart';
+import 'package:xerabora/features/collections/widgets/canvas_view.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/game.dart';
+
+// Тестовый notifier, который возвращает контролируемое состояние
+// без реальных async-операций (БД, репозиторий).
+class TestCanvasNotifier extends CanvasNotifier {
+  TestCanvasNotifier(this._testState);
+
+  final CanvasState _testState;
+
+  @override
+  CanvasState build(int arg) {
+    return _testState;
+  }
+
+  @override
+  Future<void> refresh() async {
+    // Не делаем ничего в тестах
+  }
+
+  @override
+  Future<void> resetPositions(double viewportWidth) async {
+    // Не делаем ничего в тестах
+  }
+}
+
+void main() {
+  final DateTime testDate = DateTime(2024, 6, 15);
+
+  const int testCollectionId = 1;
+
+  CanvasItem createTestItem({
+    int id = 1,
+    CanvasItemType itemType = CanvasItemType.game,
+    int? itemRefId = 100,
+    double x = 2500.0,
+    double y = 2500.0,
+    double? width = 160.0,
+    double? height = 220.0,
+    int zIndex = 0,
+    Game? game,
+  }) {
+    return CanvasItem(
+      id: id,
+      collectionId: testCollectionId,
+      itemType: itemType,
+      itemRefId: itemRefId,
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+      zIndex: zIndex,
+      createdAt: testDate,
+      game: game,
+    );
+  }
+
+  Widget buildTestWidget({
+    required CanvasState canvasState,
+    bool isEditable = true,
+  }) {
+    return ProviderScope(
+      overrides: <Override>[
+        canvasNotifierProvider
+            .overrideWith(() => TestCanvasNotifier(canvasState)),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: CanvasView(
+              collectionId: testCollectionId,
+              isEditable: isEditable,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('CanvasView', () {
+    group('состояние загрузки', () {
+      testWidgets(
+        'должен показывать CircularProgressIndicator когда isLoading=true',
+        (WidgetTester tester) async {
+          const CanvasState loadingState = CanvasState(
+            isLoading: true,
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: loadingState));
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          // Не должно быть InteractiveViewer в состоянии загрузки
+          expect(find.byType(InteractiveViewer), findsNothing);
+        },
+      );
+    });
+
+    group('состояние ошибки', () {
+      testWidgets(
+        'должен показывать иконку ошибки когда error!=null',
+        (WidgetTester tester) async {
+          const CanvasState errorState = CanvasState(
+            isLoading: false,
+            error: 'Database connection failed',
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: errorState));
+
+          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать текст "Failed to load canvas" когда error!=null',
+        (WidgetTester tester) async {
+          const CanvasState errorState = CanvasState(
+            isLoading: false,
+            error: 'Some error',
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: errorState));
+
+          expect(find.text('Failed to load canvas'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать кнопку Retry когда error!=null',
+        (WidgetTester tester) async {
+          const CanvasState errorState = CanvasState(
+            isLoading: false,
+            error: 'Some error',
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: errorState));
+
+          expect(find.text('Retry'), findsOneWidget);
+          expect(find.byType(TextButton), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'не должен показывать InteractiveViewer когда error!=null',
+        (WidgetTester tester) async {
+          const CanvasState errorState = CanvasState(
+            isLoading: false,
+            error: 'Some error',
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: errorState));
+
+          expect(find.byType(InteractiveViewer), findsNothing);
+        },
+      );
+    });
+
+    group('пустое состояние', () {
+      testWidgets(
+        'должен показывать "Canvas is empty" когда список items пуст',
+        (WidgetTester tester) async {
+          const CanvasState emptyState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: emptyState));
+
+          expect(find.text('Canvas is empty'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать иконку dashboard_outlined когда список items пуст',
+        (WidgetTester tester) async {
+          const CanvasState emptyState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: emptyState));
+
+          expect(find.byIcon(Icons.dashboard_outlined), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать подсказку "Add games to the collection first" когда пусто',
+        (WidgetTester tester) async {
+          const CanvasState emptyState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: emptyState));
+
+          expect(
+            find.text('Add games to the collection first'),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'не должен показывать InteractiveViewer когда список items пуст',
+        (WidgetTester tester) async {
+          const CanvasState emptyState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: emptyState));
+
+          expect(find.byType(InteractiveViewer), findsNothing);
+        },
+      );
+    });
+
+    group('нормальное состояние с элементами', () {
+      testWidgets(
+        'должен показывать InteractiveViewer когда есть элементы',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(InteractiveViewer), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать CustomPaint для фоновой сетки когда есть элементы',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(CustomPaint), findsWidgets);
+        },
+      );
+
+      testWidgets(
+        'должен показывать несколько карточек игр когда есть несколько элементов',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemRefId: 100,
+                game: const Game(id: 100, name: 'Game One'),
+              ),
+              createTestItem(
+                id: 2,
+                itemRefId: 200,
+                x: 2700.0,
+                zIndex: 1,
+                game: const Game(id: 200, name: 'Game Two'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.text('Game One'), findsOneWidget);
+          expect(find.text('Game Two'), findsOneWidget);
+        },
+      );
+    });
+
+    group('кнопки управления', () {
+      testWidgets(
+        'должен показывать FAB "Center view" когда есть элементы',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byIcon(Icons.fit_screen), findsOneWidget);
+          expect(find.byTooltip('Center view'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать FAB "Reset positions" когда есть элементы',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byIcon(Icons.grid_view), findsOneWidget);
+          expect(find.byTooltip('Reset positions'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать два FloatingActionButton когда есть элементы',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(FloatingActionButton), findsNWidgets(2));
+        },
+      );
+
+      testWidgets(
+        'не должен показывать FAB кнопки в состоянии загрузки',
+        (WidgetTester tester) async {
+          const CanvasState loadingState = CanvasState(
+            isLoading: true,
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: loadingState));
+
+          expect(find.byType(FloatingActionButton), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'не должен показывать FAB кнопки в состоянии ошибки',
+        (WidgetTester tester) async {
+          const CanvasState errorState = CanvasState(
+            isLoading: false,
+            error: 'Some error',
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: errorState));
+
+          expect(find.byType(FloatingActionButton), findsNothing);
+        },
+      );
+    });
+
+    group('_buildCanvasItem — типы элементов', () {
+      testWidgets(
+        'должен создавать CanvasGameCard для элемента типа game',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemType: CanvasItemType.game,
+                game: const Game(id: 100, name: 'Mario'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          // CanvasGameCard отображает Card с названием игры
+          expect(find.text('Mario'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен создавать SizedBox.shrink для элемента типа text',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemType: CanvasItemType.text,
+                itemRefId: null,
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          // InteractiveViewer должен быть, но без CanvasGameCard
+          expect(find.byType(InteractiveViewer), findsOneWidget);
+          // Нет ни одного Card (CanvasGameCard содержит Card)
+          expect(find.byType(Card), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'должен создавать SizedBox.shrink для элемента типа image',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemType: CanvasItemType.image,
+                itemRefId: null,
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(InteractiveViewer), findsOneWidget);
+          expect(find.byType(Card), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'должен создавать SizedBox.shrink для элемента типа link',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemType: CanvasItemType.link,
+                itemRefId: null,
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(InteractiveViewer), findsOneWidget);
+          expect(find.byType(Card), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'должен показывать смешанные типы — только game отображает карточку',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemType: CanvasItemType.game,
+                itemRefId: 100,
+                game: const Game(id: 100, name: 'Zelda'),
+              ),
+              createTestItem(
+                id: 2,
+                itemType: CanvasItemType.text,
+                itemRefId: null,
+                x: 2700.0,
+                zIndex: 1,
+              ),
+              createTestItem(
+                id: 3,
+                itemType: CanvasItemType.image,
+                itemRefId: null,
+                x: 2900.0,
+                zIndex: 2,
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          // Только одна карточка для game
+          expect(find.text('Zelda'), findsOneWidget);
+          // Один Card от CanvasGameCard
+          expect(find.byType(Card), findsOneWidget);
+        },
+      );
+    });
+
+    group('сортировка элементов', () {
+      testWidgets(
+        'должен отображать элементы отсортированные по zIndex',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                itemRefId: 100,
+                zIndex: 5,
+                game: const Game(id: 100, name: 'Game Z5'),
+              ),
+              createTestItem(
+                id: 2,
+                itemRefId: 200,
+                x: 2700.0,
+                zIndex: 1,
+                game: const Game(id: 200, name: 'Game Z1'),
+              ),
+              createTestItem(
+                id: 3,
+                itemRefId: 300,
+                x: 2900.0,
+                zIndex: 10,
+                game: const Game(id: 300, name: 'Game Z10'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          // Все три игры должны отображаться
+          expect(find.text('Game Z5'), findsOneWidget);
+          expect(find.text('Game Z1'), findsOneWidget);
+          expect(find.text('Game Z10'), findsOneWidget);
+        },
+      );
+    });
+
+    group('параметр isEditable', () {
+      testWidgets(
+        'должен рендерить канвас когда isEditable=false',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(canvasState: normalState, isEditable: false),
+          );
+          await tester.pump();
+
+          expect(find.byType(InteractiveViewer), findsOneWidget);
+          expect(find.text('Test Game'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен рендерить канвас когда isEditable=true',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(canvasState: normalState, isEditable: true),
+          );
+          await tester.pump();
+
+          expect(find.byType(InteractiveViewer), findsOneWidget);
+          expect(find.text('Test Game'), findsOneWidget);
+        },
+      );
+    });
+
+    group('приоритет состояний', () {
+      testWidgets(
+        'должен показывать загрузку а не ошибку когда isLoading=true и error!=null',
+        (WidgetTester tester) async {
+          // isLoading проверяется первым в build()
+          const CanvasState state = CanvasState(
+            isLoading: true,
+            error: 'Some error',
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: state));
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.text('Failed to load canvas'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'должен показывать ошибку а не пустой канвас когда error!=null и items пуст',
+        (WidgetTester tester) async {
+          // error проверяется вторым, до items.isEmpty
+          const CanvasState state = CanvasState(
+            isLoading: false,
+            error: 'Connection error',
+            items: <CanvasItem>[],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: state));
+
+          expect(find.text('Failed to load canvas'), findsOneWidget);
+          expect(find.text('Canvas is empty'), findsNothing);
+        },
+      );
+    });
+
+    group('LayoutBuilder и размеры', () {
+      testWidgets(
+        'должен использовать LayoutBuilder для определения размеров viewport',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(LayoutBuilder), findsOneWidget);
+        },
+      );
+    });
+
+    group('GestureDetector на элементах', () {
+      testWidgets(
+        'должен содержать GestureDetector для перетаскивания элементов',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(GestureDetector), findsWidgets);
+        },
+      );
+
+      testWidgets(
+        'должен содержать MouseRegion для курсора grab',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          expect(find.byType(MouseRegion), findsWidgets);
+        },
+      );
+    });
+  });
+}

--- a/test/shared/models/canvas_item_test.dart
+++ b/test/shared/models/canvas_item_test.dart
@@ -1,0 +1,379 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  group('CanvasItemType', () {
+    test('should have correct string values', () {
+      expect(CanvasItemType.game.value, 'game');
+      expect(CanvasItemType.text.value, 'text');
+      expect(CanvasItemType.image.value, 'image');
+      expect(CanvasItemType.link.value, 'link');
+    });
+
+    test('fromString should return correct type', () {
+      expect(CanvasItemType.fromString('game'), CanvasItemType.game);
+      expect(CanvasItemType.fromString('text'), CanvasItemType.text);
+      expect(CanvasItemType.fromString('image'), CanvasItemType.image);
+      expect(CanvasItemType.fromString('link'), CanvasItemType.link);
+    });
+
+    test('fromString should return game for unknown value', () {
+      expect(CanvasItemType.fromString('unknown'), CanvasItemType.game);
+      expect(CanvasItemType.fromString(''), CanvasItemType.game);
+    });
+  });
+
+  group('CanvasItem', () {
+    final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
+    final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
+
+    CanvasItem createTestItem({
+      int id = 1,
+      int collectionId = 10,
+      CanvasItemType itemType = CanvasItemType.game,
+      int? itemRefId = 100,
+      double x = 50.0,
+      double y = 100.0,
+      double? width = 160.0,
+      double? height = 220.0,
+      int zIndex = 0,
+      Map<String, dynamic>? data,
+    }) {
+      return CanvasItem(
+        id: id,
+        collectionId: collectionId,
+        itemType: itemType,
+        itemRefId: itemRefId,
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+        zIndex: zIndex,
+        data: data,
+        createdAt: testDate,
+      );
+    }
+
+    test('should create with required parameters', () {
+      final CanvasItem item = createTestItem();
+
+      expect(item.id, 1);
+      expect(item.collectionId, 10);
+      expect(item.itemType, CanvasItemType.game);
+      expect(item.itemRefId, 100);
+      expect(item.x, 50.0);
+      expect(item.y, 100.0);
+      expect(item.width, 160.0);
+      expect(item.height, 220.0);
+      expect(item.zIndex, 0);
+      expect(item.data, isNull);
+      expect(item.game, isNull);
+      expect(item.createdAt, testDate);
+    });
+
+    test('should create with data map', () {
+      final CanvasItem item = createTestItem(
+        itemType: CanvasItemType.text,
+        itemRefId: null,
+        data: <String, dynamic>{'content': 'Hello', 'fontSize': 16},
+      );
+
+      expect(item.data, isNotNull);
+      expect(item.data!['content'], 'Hello');
+      expect(item.data!['fontSize'], 16);
+    });
+
+    group('fromDb', () {
+      test('should parse game item from database row', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'item_type': 'game',
+          'item_ref_id': 100,
+          'x': 50.0,
+          'y': 100.0,
+          'width': 160.0,
+          'height': 220.0,
+          'z_index': 3,
+          'data': null,
+          'created_at': testTimestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromDb(row);
+
+        expect(item.id, 1);
+        expect(item.collectionId, 10);
+        expect(item.itemType, CanvasItemType.game);
+        expect(item.itemRefId, 100);
+        expect(item.x, 50.0);
+        expect(item.y, 100.0);
+        expect(item.width, 160.0);
+        expect(item.height, 220.0);
+        expect(item.zIndex, 3);
+        expect(item.data, isNull);
+      });
+
+      test('should parse item with JSON data', () {
+        final Map<String, dynamic> dataMap = <String, dynamic>{
+          'content': 'Test text',
+          'fontSize': 14,
+        };
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 2,
+          'collection_id': 10,
+          'item_type': 'text',
+          'item_ref_id': null,
+          'x': 200.0,
+          'y': 300.0,
+          'width': null,
+          'height': null,
+          'z_index': null,
+          'data': json.encode(dataMap),
+          'created_at': testTimestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromDb(row);
+
+        expect(item.itemType, CanvasItemType.text);
+        expect(item.itemRefId, isNull);
+        expect(item.width, isNull);
+        expect(item.zIndex, 0);
+        expect(item.data, isNotNull);
+        expect(item.data!['content'], 'Test text');
+        expect(item.data!['fontSize'], 14);
+      });
+
+      test('should handle empty string data', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 3,
+          'collection_id': 10,
+          'item_type': 'text',
+          'item_ref_id': null,
+          'x': 0.0,
+          'y': 0.0,
+          'width': null,
+          'height': null,
+          'z_index': 0,
+          'data': '',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromDb(row);
+
+        expect(item.data, isNull);
+      });
+
+      test('should handle integer x and y values', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'item_type': 'game',
+          'item_ref_id': 100,
+          'x': 50,
+          'y': 100,
+          'width': null,
+          'height': null,
+          'z_index': 0,
+          'data': null,
+          'created_at': testTimestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromDb(row);
+        expect(item.x, 50.0);
+        expect(item.y, 100.0);
+      });
+    });
+
+    group('toDb', () {
+      test('should serialize game item to database map', () {
+        final CanvasItem item = createTestItem();
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db['id'], 1);
+        expect(db['collection_id'], 10);
+        expect(db['item_type'], 'game');
+        expect(db['item_ref_id'], 100);
+        expect(db['x'], 50.0);
+        expect(db['y'], 100.0);
+        expect(db['width'], 160.0);
+        expect(db['height'], 220.0);
+        expect(db['z_index'], 0);
+        expect(db['data'], isNull);
+        expect(db['created_at'], testTimestamp);
+      });
+
+      test('should serialize data map as JSON string', () {
+        final CanvasItem item = createTestItem(
+          itemType: CanvasItemType.text,
+          data: <String, dynamic>{'content': 'Hello'},
+        );
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db['data'], isA<String>());
+        final Map<String, dynamic> parsed =
+            json.decode(db['data'] as String) as Map<String, dynamic>;
+        expect(parsed['content'], 'Hello');
+      });
+
+      test('should omit id when id is 0 (new item)', () {
+        final CanvasItem item = createTestItem(id: 0);
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db.containsKey('id'), false);
+      });
+    });
+
+    group('toJson', () {
+      test('should serialize for export', () {
+        final CanvasItem item = createTestItem();
+        final Map<String, dynamic> jsonMap = item.toJson();
+
+        expect(jsonMap['id'], 1);
+        expect(jsonMap['type'], 'game');
+        expect(jsonMap['refId'], 100);
+        expect(jsonMap['x'], 50.0);
+        expect(jsonMap['y'], 100.0);
+        expect(jsonMap['width'], 160.0);
+        expect(jsonMap['height'], 220.0);
+        expect(jsonMap['z_index'], 0);
+        expect(jsonMap['data'], isNull);
+        expect(jsonMap['created_at'], testTimestamp);
+      });
+
+      test('should include data map in export', () {
+        final CanvasItem item = createTestItem(
+          data: <String, dynamic>{'content': 'Test'},
+        );
+        final Map<String, dynamic> jsonMap = item.toJson();
+
+        expect(jsonMap['data'], isA<Map<String, dynamic>>());
+        expect((jsonMap['data'] as Map<String, dynamic>)['content'], 'Test');
+      });
+    });
+
+    group('fromJson', () {
+      test('should parse from export JSON', () {
+        final Map<String, dynamic> jsonMap = <String, dynamic>{
+          'id': 5,
+          'type': 'image',
+          'refId': null,
+          'x': 400,
+          'y': 100,
+          'width': 500,
+          'height': 400,
+          'data': <String, dynamic>{
+            'url': 'https://example.com/image.png',
+          },
+        };
+
+        final CanvasItem item = CanvasItem.fromJson(jsonMap);
+
+        expect(item.id, 5);
+        expect(item.itemType, CanvasItemType.image);
+        expect(item.itemRefId, isNull);
+        expect(item.x, 400.0);
+        expect(item.y, 100.0);
+        expect(item.data!['url'], 'https://example.com/image.png');
+      });
+
+      test('should use defaults for missing fields', () {
+        final Map<String, dynamic> jsonMap = <String, dynamic>{
+          'x': 0,
+          'y': 0,
+        };
+
+        final CanvasItem item = CanvasItem.fromJson(jsonMap);
+
+        expect(item.id, 0);
+        expect(item.collectionId, 0);
+        expect(item.itemType, CanvasItemType.game);
+        expect(item.zIndex, 0);
+      });
+
+      test('should parse created_at from JSON when present', () {
+        final int timestamp = testDate.millisecondsSinceEpoch ~/ 1000;
+        final Map<String, dynamic> jsonMap = <String, dynamic>{
+          'x': 0,
+          'y': 0,
+          'created_at': timestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromJson(jsonMap);
+
+        expect(
+          item.createdAt,
+          DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
+        );
+      });
+    });
+
+    group('copyWith', () {
+      test('should create copy with changed fields', () {
+        final CanvasItem original = createTestItem();
+        final CanvasItem copy = original.copyWith(
+          x: 200.0,
+          y: 300.0,
+          zIndex: 5,
+        );
+
+        expect(copy.id, original.id);
+        expect(copy.collectionId, original.collectionId);
+        expect(copy.x, 200.0);
+        expect(copy.y, 300.0);
+        expect(copy.zIndex, 5);
+        expect(copy.itemType, original.itemType);
+      });
+
+      test('should keep original values when not specified', () {
+        final CanvasItem original = createTestItem();
+        final CanvasItem copy = original.copyWith();
+
+        expect(copy.id, original.id);
+        expect(copy.x, original.x);
+        expect(copy.y, original.y);
+        expect(copy.zIndex, original.zIndex);
+      });
+    });
+
+    group('equality', () {
+      test('should be equal when id matches', () {
+        final CanvasItem item1 = createTestItem(id: 1, x: 0);
+        final CanvasItem item2 = createTestItem(id: 1, x: 100);
+
+        expect(item1, equals(item2));
+        expect(item1.hashCode, item2.hashCode);
+      });
+
+      test('should be equal to identical object', () {
+        final CanvasItem item = createTestItem(id: 1);
+
+        expect(item == item, true);
+      });
+
+      test('should not be equal when id differs', () {
+        final CanvasItem item1 = createTestItem(id: 1);
+        final CanvasItem item2 = createTestItem(id: 2);
+
+        expect(item1, isNot(equals(item2)));
+      });
+
+      test('should not be equal to non-CanvasItem object', () {
+        final CanvasItem item = createTestItem(id: 1);
+
+        expect(item == Object(), false);
+      });
+    });
+
+    test('toString should contain type and position', () {
+      final CanvasItem item = createTestItem();
+      final String str = item.toString();
+
+      expect(str, contains('id: 1'));
+      expect(str, contains('type: game'));
+      expect(str, contains('x: 50.0'));
+      expect(str, contains('y: 100.0'));
+    });
+  });
+}

--- a/test/shared/models/canvas_viewport_test.dart
+++ b/test/shared/models/canvas_viewport_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/canvas_viewport.dart';
+
+void main() {
+  group('CanvasViewport', () {
+    test('should create with default values', () {
+      const CanvasViewport viewport = CanvasViewport(collectionId: 1);
+
+      expect(viewport.collectionId, 1);
+      expect(viewport.scale, 1.0);
+      expect(viewport.offsetX, 0.0);
+      expect(viewport.offsetY, 0.0);
+    });
+
+    test('should create with custom values', () {
+      const CanvasViewport viewport = CanvasViewport(
+        collectionId: 5,
+        scale: 1.5,
+        offsetX: -100.0,
+        offsetY: -200.0,
+      );
+
+      expect(viewport.collectionId, 5);
+      expect(viewport.scale, 1.5);
+      expect(viewport.offsetX, -100.0);
+      expect(viewport.offsetY, -200.0);
+    });
+
+    test('defaultValue should have zero collectionId and default scale', () {
+      expect(CanvasViewport.defaultValue.collectionId, 0);
+      expect(CanvasViewport.defaultValue.scale, 1.0);
+      expect(CanvasViewport.defaultValue.offsetX, 0.0);
+      expect(CanvasViewport.defaultValue.offsetY, 0.0);
+    });
+
+    group('fromDb', () {
+      test('should parse from database row', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'collection_id': 3,
+          'scale': 2.0,
+          'offset_x': -50.0,
+          'offset_y': -75.0,
+        };
+
+        final CanvasViewport viewport = CanvasViewport.fromDb(row);
+
+        expect(viewport.collectionId, 3);
+        expect(viewport.scale, 2.0);
+        expect(viewport.offsetX, -50.0);
+        expect(viewport.offsetY, -75.0);
+      });
+
+      test('should use defaults for null values', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'collection_id': 1,
+          'scale': null,
+          'offset_x': null,
+          'offset_y': null,
+        };
+
+        final CanvasViewport viewport = CanvasViewport.fromDb(row);
+
+        expect(viewport.scale, 1.0);
+        expect(viewport.offsetX, 0.0);
+        expect(viewport.offsetY, 0.0);
+      });
+
+      test('should handle integer values for scale and offset', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'collection_id': 1,
+          'scale': 2,
+          'offset_x': -50,
+          'offset_y': 100,
+        };
+
+        final CanvasViewport viewport = CanvasViewport.fromDb(row);
+
+        expect(viewport.scale, 2.0);
+        expect(viewport.offsetX, -50.0);
+        expect(viewport.offsetY, 100.0);
+      });
+    });
+
+    group('fromJson', () {
+      test('should parse from export JSON', () {
+        final Map<String, dynamic> jsonMap = <String, dynamic>{
+          'scale': 1.5,
+          'offsetX': -100.0,
+          'offsetY': -200.0,
+        };
+
+        final CanvasViewport viewport =
+            CanvasViewport.fromJson(jsonMap, collectionId: 7);
+
+        expect(viewport.collectionId, 7);
+        expect(viewport.scale, 1.5);
+        expect(viewport.offsetX, -100.0);
+        expect(viewport.offsetY, -200.0);
+      });
+
+      test('should use defaults for missing fields', () {
+        final CanvasViewport viewport =
+            CanvasViewport.fromJson(<String, dynamic>{});
+
+        expect(viewport.collectionId, 0);
+        expect(viewport.scale, 1.0);
+        expect(viewport.offsetX, 0.0);
+        expect(viewport.offsetY, 0.0);
+      });
+    });
+
+    group('toDb', () {
+      test('should serialize to database map', () {
+        const CanvasViewport viewport = CanvasViewport(
+          collectionId: 3,
+          scale: 1.5,
+          offsetX: -100.0,
+          offsetY: -200.0,
+        );
+
+        final Map<String, dynamic> db = viewport.toDb();
+
+        expect(db['collection_id'], 3);
+        expect(db['scale'], 1.5);
+        expect(db['offset_x'], -100.0);
+        expect(db['offset_y'], -200.0);
+      });
+    });
+
+    group('toJson', () {
+      test('should serialize for export', () {
+        const CanvasViewport viewport = CanvasViewport(
+          collectionId: 3,
+          scale: 1.5,
+          offsetX: -100.0,
+          offsetY: -200.0,
+        );
+
+        final Map<String, dynamic> jsonMap = viewport.toJson();
+
+        expect(jsonMap['scale'], 1.5);
+        expect(jsonMap['offsetX'], -100.0);
+        expect(jsonMap['offsetY'], -200.0);
+        expect(jsonMap.containsKey('collection_id'), false);
+      });
+    });
+
+    group('copyWith', () {
+      test('should create copy with changed fields', () {
+        const CanvasViewport original = CanvasViewport(
+          collectionId: 1,
+          scale: 1.0,
+          offsetX: 0.0,
+          offsetY: 0.0,
+        );
+
+        final CanvasViewport copy = original.copyWith(
+          scale: 2.5,
+          offsetX: -300.0,
+        );
+
+        expect(copy.collectionId, 1);
+        expect(copy.scale, 2.5);
+        expect(copy.offsetX, -300.0);
+        expect(copy.offsetY, 0.0);
+      });
+
+      test('should keep original values when not specified', () {
+        const CanvasViewport original = CanvasViewport(
+          collectionId: 5,
+          scale: 1.5,
+          offsetX: -100.0,
+          offsetY: -200.0,
+        );
+
+        final CanvasViewport copy = original.copyWith();
+
+        expect(copy.collectionId, original.collectionId);
+        expect(copy.scale, original.scale);
+        expect(copy.offsetX, original.offsetX);
+        expect(copy.offsetY, original.offsetY);
+      });
+    });
+
+    group('equality', () {
+      test('should be equal when collectionId matches', () {
+        const CanvasViewport v1 = CanvasViewport(
+          collectionId: 1,
+          scale: 1.0,
+        );
+        const CanvasViewport v2 = CanvasViewport(
+          collectionId: 1,
+          scale: 2.0,
+        );
+
+        expect(v1, equals(v2));
+        expect(v1.hashCode, v2.hashCode);
+      });
+
+      test('should be equal to identical object', () {
+        const CanvasViewport viewport = CanvasViewport(collectionId: 1);
+
+        expect(viewport == viewport, true);
+      });
+
+      test('should not be equal when collectionId differs', () {
+        const CanvasViewport v1 = CanvasViewport(collectionId: 1);
+        const CanvasViewport v2 = CanvasViewport(collectionId: 2);
+
+        expect(v1, isNot(equals(v2)));
+      });
+
+      test('should not be equal to non-CanvasViewport object', () {
+        const CanvasViewport viewport = CanvasViewport(collectionId: 1);
+
+        expect(viewport == Object(), false);
+      });
+    });
+
+    test('toString should contain collection id and scale', () {
+      const CanvasViewport viewport = CanvasViewport(
+        collectionId: 3,
+        scale: 1.5,
+        offsetX: -100.0,
+        offsetY: -200.0,
+      );
+
+      final String str = viewport.toString();
+
+      expect(str, contains('collectionId: 3'));
+      expect(str, contains('scale: 1.5'));
+      expect(str, contains('-100.0'));
+      expect(str, contains('-200.0'));
+    });
+  });
+}


### PR DESCRIPTION
Visual canvas for free-form game card placement with InteractiveViewer (0.3x-3.0x zoom), absolute position tracking for precise drag, bidirectional collection-canvas sync via ref.listen, debounced DB persistence, and List/Canvas toggle in CollectionScreen. DB migrated to v5 with canvas_items and canvas_viewport tables. 149 tests for Stage 7 (674 total).