### PR TITLE
Add canvas elements, context menu, resize and fix drag/resize feedbac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@
 ## [Unreleased]
 
 ### Added
+- Добавлены элементы Canvas (Stage 8): текстовые блоки, изображения, ссылки, контекстное меню, resize
+- Добавлен `CanvasContextMenu` (`lib/features/collections/widgets/canvas_context_menu.dart`) — контекстное меню ПКМ: Add Text/Image/Link на пустом месте; Edit/Delete/Bring to Front/Send to Back на элементе
+- Добавлен `CanvasTextItem` (`lib/features/collections/widgets/canvas_text_item.dart`) — текстовый блок с настраиваемым размером шрифта (Small 12/Medium 16/Large 24/Title 32)
+- Добавлен `CanvasImageItem` (`lib/features/collections/widgets/canvas_image_item.dart`) — изображение по URL (CachedNetworkImage) или из файла (base64)
+- Добавлен `CanvasLinkItem` (`lib/features/collections/widgets/canvas_link_item.dart`) — ссылка с иконкой, double-click открывает в браузере через url_launcher
+- Добавлен `AddTextDialog` (`lib/features/collections/widgets/dialogs/add_text_dialog.dart`) — диалог создания/редактирования текста
+- Добавлен `AddImageDialog` (`lib/features/collections/widgets/dialogs/add_image_dialog.dart`) — диалог добавления изображения (URL/файл)
+- Добавлен `AddLinkDialog` (`lib/features/collections/widgets/dialogs/add_link_dialog.dart`) — диалог добавления/редактирования ссылки
+- Добавлен resize handle для всех элементов канваса (14x14, правый нижний угол, мин. 50x50, макс. 2000x2000)
+- Добавлены методы `addTextItem`, `addImageItem`, `addLinkItem`, `updateItemData`, `updateItemSize` в `CanvasNotifier`
+- Добавлен метод `updateItemData` в `CanvasRepository` для обновления JSON data элемента
+- Добавлена зависимость `url_launcher: ^6.2.0`
+- Добавлены тесты: `canvas_context_menu_test.dart` (10), `canvas_text_item_test.dart` (8), `canvas_image_item_test.dart` (8), `canvas_link_item_test.dart` (9), `add_text_dialog_test.dart` (9), `add_link_dialog_test.dart` (11), `add_image_dialog_test.dart` (14), + 16 тестов для новых методов canvas_provider + 2 теста updateItemData в canvas_repository — всего 87 тестов Stage 8
+
+### Changed
+- Изменён `CanvasView` — добавлено контекстное меню (ПКМ), resize handle, рендеринг text/image/link элементов вместо SizedBox.shrink()
+- Изменён `CanvasNotifier` — добавлены 5 методов для управления текстом, изображениями, ссылками и размерами
+- Изменён `CanvasRepository` — добавлен метод `updateItemData` для обновления JSON-данных элемента
+
+### Fixed
+- Исправлен баг визуальной обратной связи при перетаскивании: элементы теперь двигаются в реальном времени вместо прыжка при отпускании мыши (замена `ValueNotifier + Transform.translate` на `setState + Positioned`)
+- Исправлен баг визуальной обратной связи при ресайзе: размер элемента обновляется в реальном времени при перетаскивании handle
+- Текстовые блоки на канвасе отображаются без фона — убран Container с цветом и бордером
+- Добавлены типоспецифичные размеры по умолчанию: text 200x100, image 200x200, link 200x48 (ранее все типы использовали 150x200)
+- Виджеты `CanvasImageItem`, `CanvasLinkItem` заменили фиксированные SizedBox на `SizedBox.expand()` для корректного ресайза
+
+---
+
 - Добавлен базовый Canvas — визуальный холст для свободного размещения элементов коллекции (Stage 7)
 - Добавлена миграция БД до версии 5: таблицы `canvas_items` и `canvas_viewport` с FK CASCADE и индексами
 - Добавлена модель `CanvasItem` (`lib/shared/models/canvas_item.dart`) с enum `CanvasItemType` (game/text/image/link)

--- a/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -40,5 +40,10 @@ public final class GeneratedPluginRegistrant {
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin sqflite_android, com.tekartik.sqflite.SqflitePlugin", e);
     }
+    try {
+      flutterEngine.getPlugins().add(new io.flutter.plugins.urllauncher.UrlLauncherPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin url_launcher_android, io.flutter.plugins.urllauncher.UrlLauncherPlugin", e);
+    }
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,13 +82,25 @@ lib/
 | `lib/features/collections/widgets/status_dropdown.dart` | **Выпадающий список статусов**. Компактный и полный режим |
 | `lib/features/collections/widgets/canvas_view.dart` | **Canvas View**. InteractiveViewer с зумом 0.3–3.0x, панорамированием, drag-and-drop (абсолютное отслеживание позиции). Фоновая сетка (CustomPainter), автоцентрирование |
 | `lib/features/collections/widgets/canvas_game_card.dart` | **Карточка игры на канвасе**. Компактная карточка 160x220px с обложкой и названием. RepaintBoundary для оптимизации |
+| `lib/features/collections/widgets/canvas_context_menu.dart` | **Контекстное меню канваса**. ПКМ на пустом месте: Add Text/Image/Link. ПКМ на элементе: Edit/Delete/Bring to Front/Send to Back. Delete с диалогом подтверждения |
+| `lib/features/collections/widgets/canvas_text_item.dart` | **Текстовый блок на канвасе**. Настраиваемый fontSize (12/16/24/32). Container с padding, фоном surfaceContainerLow |
+| `lib/features/collections/widgets/canvas_image_item.dart` | **Изображение на канвасе**. URL (CachedNetworkImage) или base64 (Image.memory). Card с Clip.antiAlias, размер по умолчанию 200x200 |
+| `lib/features/collections/widgets/canvas_link_item.dart` | **Ссылка на канвасе**. Card с иконкой и подчёркнутым текстом. Double-tap → url_launcher. Размер по умолчанию 200x48 |
+
+#### Диалоги
+
+| Файл | Назначение |
+|------|------------|
+| `lib/features/collections/widgets/dialogs/add_text_dialog.dart` | **Диалог текста**. TextField (multiline) + DropdownButtonFormField (Small/Medium/Large/Title). Возвращает {content, fontSize} |
+| `lib/features/collections/widgets/dialogs/add_image_dialog.dart` | **Диалог изображения**. SegmentedButton (URL/File). URL: TextField + CachedNetworkImage preview. File: FilePicker + base64. Возвращает {url} или {base64, mimeType} |
+| `lib/features/collections/widgets/dialogs/add_link_dialog.dart` | **Диалог ссылки**. TextField URL (валидация http/https) + Label (optional). Возвращает {url, label} |
 
 #### Провайдеры
 
 | Файл | Назначение |
 |------|------------|
 | `lib/features/collections/providers/collections_provider.dart` | **State management коллекций**. `collectionsProvider` — список. `collectionGamesNotifierProvider` — игры в коллекции с CRUD |
-| `lib/features/collections/providers/canvas_provider.dart` | **State management канваса**. `canvasNotifierProvider` — NotifierProvider.family по collectionId. Методы: moveItem, updateViewport, addItem, deleteItem, bringToFront, sendToBack, removeGameItem. Debounced save (300ms position, 500ms viewport). Двусторонняя синхронизация с коллекцией через `ref.listen` |
+| `lib/features/collections/providers/canvas_provider.dart` | **State management канваса**. `canvasNotifierProvider` — NotifierProvider.family по collectionId. Методы: moveItem, updateViewport, addItem, deleteItem, bringToFront, sendToBack, removeGameItem, addTextItem, addImageItem, addLinkItem, updateItemData, updateItemSize. Debounced save (300ms position, 500ms viewport). Двусторонняя синхронизация с коллекцией через `ref.listen` |
 
 ---
 
@@ -131,7 +143,7 @@ lib/
 |------|------------|
 | `lib/data/repositories/collection_repository.dart` | **Репозиторий коллекций**. CRUD коллекций и игр. Форки с snapshot. Статистика (CollectionStats) |
 | `lib/data/repositories/game_repository.dart` | **Репозиторий игр**. Поиск через API + кеширование в SQLite |
-| `lib/data/repositories/canvas_repository.dart` | **Репозиторий канваса**. CRUD для canvas_items и viewport. Методы: getItems, getItemsWithData (с joined Game), createItem, updateItem, updateItemPosition, updateItemSize, updateItemZIndex, deleteItem, hasCanvasItems, initializeCanvas (раскладка сеткой) |
+| `lib/data/repositories/canvas_repository.dart` | **Репозиторий канваса**. CRUD для canvas_items и viewport. Методы: getItems, getItemsWithData (с joined Game), createItem, updateItem, updateItemPosition, updateItemSize, updateItemData, updateItemZIndex, deleteItem, hasCanvasItems, initializeCanvas (раскладка сеткой) |
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -53,13 +53,19 @@ Found a collection you like? Fork it:
 
 Visualize your collection on a free-form canvas:
 - **Infinite canvas** with zoom (0.3x – 3.0x) and pan
-- **Drag-and-drop** game cards with precise cursor tracking
+- **Drag-and-drop** all elements with real-time visual feedback
 - **Dot grid background** for visual alignment
 - **Auto-layout** — new canvas initializes games in a 5-column grid
 - **Auto-sync** — adding or removing games in the collection automatically updates the canvas
 - **Persistent viewport** — zoom level and position are saved and restored
 - **Center view** and **Reset positions** controls
 - **List/Canvas toggle** — switch between traditional list and visual canvas via SegmentedButton
+- **Context menu** (right-click) — Add Text/Image/Link on empty space; Edit/Delete/Bring to Front/Send to Back on elements
+- **Text blocks** — add custom text with configurable font size (Small 12/Medium 16/Large 24/Title 32), transparent background
+- **Images** — add images from URL or local file (base64 encoded)
+- **Links** — add clickable links with custom labels (double-click to open in browser)
+- **Resize** — drag the bottom-right handle to resize any element with real-time preview (min 50x50, max 2000x2000)
+- **Z-index management** — Bring to Front / Send to Back via context menu
 
 ## SteamGridDB Integration
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@
 ## Canvas Development
 
 - [x] Stage 7: Basic Canvas — visual canvas with zoom, pan, drag-and-drop, grid layout, List/Canvas toggle, bidirectional collection sync
-- [ ] Stage 8: Canvas Elements — context menu, text blocks, images, links, resize, z-index
+- [x] Stage 8: Canvas Elements — context menu, text blocks, images, links, resize, z-index
 - [ ] Stage 9: Connections — visual connections between canvas elements
 - [ ] Stage 10: SteamGridDB Widget — side panel for adding SteamGridDB images to canvas
 - [ ] Stage 12: Export Full — extended .rcoll-full format with canvas layout and images

--- a/lib/data/repositories/canvas_repository.dart
+++ b/lib/data/repositories/canvas_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/database/database_service.dart';
@@ -111,6 +113,13 @@ class CanvasRepository {
     if (data.isNotEmpty) {
       await _db.updateCanvasItem(id, data);
     }
+  }
+
+  /// Обновляет дополнительные данные элемента (JSON).
+  Future<void> updateItemData(int id, Map<String, dynamic>? data) async {
+    await _db.updateCanvasItem(id, <String, dynamic>{
+      'data': data != null ? json.encode(data) : null,
+    });
   }
 
   /// Обновляет z-index элемента.

--- a/lib/features/collections/providers/canvas_provider.dart
+++ b/lib/features/collections/providers/canvas_provider.dart
@@ -394,6 +394,139 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
     );
   }
 
+  /// Добавляет текстовый блок на канвас.
+  Future<CanvasItem> addTextItem(
+    double x,
+    double y,
+    String content,
+    double fontSize,
+  ) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int maxZ = state.items.isEmpty
+        ? 0
+        : state.items
+              .map((CanvasItem item) => item.zIndex)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      itemType: CanvasItemType.text,
+      x: x,
+      y: y,
+      width: 200,
+      height: null,
+      zIndex: maxZ,
+      data: <String, dynamic>{
+        'content': content,
+        'fontSize': fontSize,
+      },
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    return addItem(item);
+  }
+
+  /// Добавляет изображение на канвас.
+  Future<CanvasItem> addImageItem(
+    double x,
+    double y,
+    Map<String, dynamic> imageData,
+  ) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int maxZ = state.items.isEmpty
+        ? 0
+        : state.items
+              .map((CanvasItem item) => item.zIndex)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      itemType: CanvasItemType.image,
+      x: x,
+      y: y,
+      width: 200,
+      height: 200,
+      zIndex: maxZ,
+      data: imageData,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    return addItem(item);
+  }
+
+  /// Добавляет ссылку на канвас.
+  Future<CanvasItem> addLinkItem(
+    double x,
+    double y,
+    String url,
+    String label,
+  ) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int maxZ = state.items.isEmpty
+        ? 0
+        : state.items
+              .map((CanvasItem item) => item.zIndex)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      itemType: CanvasItemType.link,
+      x: x,
+      y: y,
+      width: 200,
+      height: 48,
+      zIndex: maxZ,
+      data: <String, dynamic>{
+        'url': url,
+        'label': label,
+      },
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    return addItem(item);
+  }
+
+  /// Обновляет дополнительные данные элемента.
+  Future<void> updateItemData(
+    int itemId,
+    Map<String, dynamic> data,
+  ) async {
+    await _repository.updateItemData(itemId, data);
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(data: data);
+        }
+        return item;
+      }).toList(),
+    );
+  }
+
+  /// Обновляет размеры элемента.
+  ///
+  /// Обновляет state мгновенно, сохраняет в БД.
+  Future<void> updateItemSize(
+    int itemId, {
+    required double width,
+    required double height,
+  }) async {
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(width: width, height: height);
+        }
+        return item;
+      }).toList(),
+    );
+    await _repository.updateItemSize(itemId, width: width, height: height);
+  }
+
   /// Перемещает элемент на передний план (максимальный z-index).
   Future<void> bringToFront(int itemId) async {
     if (state.items.isEmpty) return;

--- a/lib/features/collections/widgets/canvas_context_menu.dart
+++ b/lib/features/collections/widgets/canvas_context_menu.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/canvas_item.dart';
+
+// Контекстные меню для канваса.
+//
+// Статические методы для отображения контекстного меню пустого места
+// канваса и контекстного меню элемента.
+
+/// Утилитарный класс для контекстных меню канваса.
+class CanvasContextMenu {
+  CanvasContextMenu._();
+
+  /// Отображает контекстное меню пустого места на канвасе.
+  ///
+  /// [position] — экранные координаты клика ПКМ.
+  /// Колбэки вызываются при выборе соответствующего пункта.
+  static Future<void> showCanvasMenu(
+    BuildContext context, {
+    required Offset position,
+    required VoidCallback onAddText,
+    required VoidCallback onAddImage,
+    required VoidCallback onAddLink,
+  }) async {
+    final String? value = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: <PopupMenuEntry<String>>[
+        const PopupMenuItem<String>(
+          value: 'add_text',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.text_fields, size: 20),
+              SizedBox(width: 12),
+              Text('Add Text'),
+            ],
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'add_image',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.image_outlined, size: 20),
+              SizedBox(width: 12),
+              Text('Add Image'),
+            ],
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'add_link',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.link, size: 20),
+              SizedBox(width: 12),
+              Text('Add Link'),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    if (value == null) return;
+    switch (value) {
+      case 'add_text':
+        onAddText();
+      case 'add_image':
+        onAddImage();
+      case 'add_link':
+        onAddLink();
+    }
+  }
+
+  /// Отображает контекстное меню элемента канваса.
+  ///
+  /// [itemType] определяет, показывать ли пункт Edit.
+  /// Edit доступен для text, image и link (но не для game).
+  static Future<void> showItemMenu(
+    BuildContext context, {
+    required Offset position,
+    required CanvasItemType itemType,
+    VoidCallback? onEdit,
+    required VoidCallback onDelete,
+    required VoidCallback onBringToFront,
+    required VoidCallback onSendToBack,
+  }) async {
+    final bool showEdit = itemType != CanvasItemType.game;
+
+    final String? value = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: <PopupMenuEntry<String>>[
+        if (showEdit)
+          const PopupMenuItem<String>(
+            value: 'edit',
+            child: Row(
+              children: <Widget>[
+                Icon(Icons.edit_outlined, size: 20),
+                SizedBox(width: 12),
+                Text('Edit'),
+              ],
+            ),
+          ),
+        const PopupMenuItem<String>(
+          value: 'delete',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.delete_outlined, size: 20),
+              SizedBox(width: 12),
+              Text('Delete'),
+            ],
+          ),
+        ),
+        const PopupMenuDivider(),
+        const PopupMenuItem<String>(
+          value: 'bring_to_front',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.flip_to_front, size: 20),
+              SizedBox(width: 12),
+              Text('Bring to Front'),
+            ],
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'send_to_back',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.flip_to_back, size: 20),
+              SizedBox(width: 12),
+              Text('Send to Back'),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    if (value == null) return;
+    switch (value) {
+      case 'edit':
+        onEdit?.call();
+      case 'delete':
+        if (!context.mounted) return;
+        _showDeleteConfirmation(context, onDelete);
+      case 'bring_to_front':
+        onBringToFront();
+      case 'send_to_back':
+        onSendToBack();
+    }
+  }
+
+  /// Показывает диалог подтверждения удаления.
+  static Future<void> _showDeleteConfirmation(
+    BuildContext context,
+    VoidCallback onConfirm,
+  ) async {
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Delete element'),
+          content: const Text(
+            'Are you sure you want to delete this element?',
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Delete'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed == true) {
+      onConfirm();
+    }
+  }
+}

--- a/lib/features/collections/widgets/canvas_image_item.dart
+++ b/lib/features/collections/widgets/canvas_image_item.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/canvas_item.dart';
+
+// Виджет изображения на канвасе.
+//
+// Поддерживает два формата данных:
+// - {url: String} — сетевое изображение через CachedNetworkImage
+// - {base64: String, mimeType: String} — локальное изображение
+
+/// Изображение на канвасе.
+class CanvasImageItem extends StatelessWidget {
+  /// Создаёт [CanvasImageItem].
+  const CanvasImageItem({required this.item, super.key});
+
+  /// Элемент канваса с данными изображения.
+  final CanvasItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, dynamic>? data = item.data;
+    final String? url = data?['url'] as String?;
+    final String? base64Data = data?['base64'] as String?;
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    Widget imageWidget;
+
+    if (url != null && url.isNotEmpty) {
+      imageWidget = CachedNetworkImage(
+        imageUrl: url,
+        fit: BoxFit.cover,
+        placeholder: (BuildContext context, String url) => Center(
+          child: Icon(
+            Icons.image_outlined,
+            size: 32,
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        errorWidget:
+            (BuildContext context, String url, Object error) => Center(
+          child: Icon(
+            Icons.broken_image_outlined,
+            size: 32,
+            color: colorScheme.error,
+          ),
+        ),
+      );
+    } else if (base64Data != null && base64Data.isNotEmpty) {
+      final Uint8List bytes = base64Decode(base64Data);
+      imageWidget = Image.memory(
+        bytes,
+        fit: BoxFit.cover,
+        errorBuilder:
+            (BuildContext context, Object error, StackTrace? stackTrace) =>
+                Center(
+          child: Icon(
+            Icons.broken_image_outlined,
+            size: 32,
+            color: colorScheme.error,
+          ),
+        ),
+      );
+    } else {
+      imageWidget = Center(
+        child: Icon(
+          Icons.image_not_supported_outlined,
+          size: 32,
+          color: colorScheme.onSurfaceVariant,
+        ),
+      );
+    }
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      margin: EdgeInsets.zero,
+      child: SizedBox.expand(
+        child: imageWidget,
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/canvas_link_item.dart
+++ b/lib/features/collections/widgets/canvas_link_item.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../shared/models/canvas_item.dart';
+
+// Виджет ссылки на канвасе.
+//
+// Отображает карточку с иконкой ссылки и текстом.
+// Данные хранятся в CanvasItem.data: {url: String, label: String}.
+
+/// Ссылка на канвасе.
+class CanvasLinkItem extends StatelessWidget {
+  /// Создаёт [CanvasLinkItem].
+  const CanvasLinkItem({required this.item, super.key});
+
+  /// Элемент канваса с данными ссылки.
+  final CanvasItem item;
+
+  Future<void> _openUrl() async {
+    final String? url = item.data?['url'] as String?;
+    if (url == null || url.isEmpty) return;
+
+    final Uri uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, dynamic>? data = item.data;
+    final String label = data?['label'] as String? ??
+        data?['url'] as String? ??
+        'Link';
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    return GestureDetector(
+      onDoubleTap: _openUrl,
+      child: Card(
+        margin: EdgeInsets.zero,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: <Widget>[
+              Icon(
+                Icons.link,
+                size: 20,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.primary,
+                    decoration: TextDecoration.underline,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/canvas_text_item.dart
+++ b/lib/features/collections/widgets/canvas_text_item.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/canvas_item.dart';
+
+// Виджет текстового блока на канвасе.
+//
+// Отображает текст с настраиваемым размером шрифта.
+// Данные хранятся в CanvasItem.data: {content: String, fontSize: double}.
+
+/// Текстовый блок на канвасе.
+class CanvasTextItem extends StatelessWidget {
+  /// Создаёт [CanvasTextItem].
+  const CanvasTextItem({required this.item, super.key});
+
+  /// Элемент канваса с данными текста.
+  final CanvasItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<String, dynamic>? data = item.data;
+    final String content =
+        data?['content'] as String? ?? '';
+    final double fontSize =
+        (data?['fontSize'] as num?)?.toDouble() ?? 16;
+
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Text(
+        content,
+        style: TextStyle(
+          fontSize: fontSize,
+          color: colorScheme.onSurface,
+        ),
+        overflow: TextOverflow.clip,
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/dialogs/add_image_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/add_image_dialog.dart
@@ -1,0 +1,246 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+// Диалог добавления изображения на канвас.
+//
+// Поддерживает два режима: URL и локальный файл (base64).
+
+/// Способ добавления изображения.
+enum _ImageSource {
+  url,
+  file,
+}
+
+/// Диалог для добавления изображения на канвас.
+///
+/// Возвращает `Map<String, dynamic>` с ключом `url` (для URL)
+/// или `base64` + `mimeType` (для файла), или `null` при отмене.
+class AddImageDialog extends StatefulWidget {
+  /// Создаёт [AddImageDialog].
+  const AddImageDialog({this.initialUrl, super.key});
+
+  /// Начальный URL (для редактирования).
+  final String? initialUrl;
+
+  /// Показывает диалог и возвращает результат.
+  static Future<Map<String, dynamic>?> show(
+    BuildContext context, {
+    String? initialUrl,
+  }) {
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (BuildContext context) {
+        return AddImageDialog(initialUrl: initialUrl);
+      },
+    );
+  }
+
+  @override
+  State<AddImageDialog> createState() => _AddImageDialogState();
+}
+
+class _AddImageDialogState extends State<AddImageDialog> {
+  late final TextEditingController _urlController;
+  _ImageSource _source = _ImageSource.url;
+  String? _filePath;
+  String? _fileName;
+  String? _base64Data;
+  String? _mimeType;
+
+  bool get _isEditing => widget.initialUrl != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController = TextEditingController(text: widget.initialUrl ?? '');
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  bool get _canSubmit {
+    switch (_source) {
+      case _ImageSource.url:
+        final String url = _urlController.text.trim();
+        return url.startsWith('http://') || url.startsWith('https://');
+      case _ImageSource.file:
+        return _base64Data != null;
+    }
+  }
+
+  Future<void> _pickFile() async {
+    final FilePickerResult? result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+    );
+
+    if (result == null || result.files.isEmpty) return;
+
+    final PlatformFile file = result.files.first;
+    if (file.path == null) return;
+
+    final File ioFile = File(file.path!);
+    final List<int> bytes = await ioFile.readAsBytes();
+    final String base64String = base64Encode(bytes);
+
+    // Определяем MIME-тип по расширению
+    final String ext = file.extension?.toLowerCase() ?? '';
+    final String mimeType = switch (ext) {
+      'png' => 'image/png',
+      'jpg' || 'jpeg' => 'image/jpeg',
+      'gif' => 'image/gif',
+      'webp' => 'image/webp',
+      'bmp' => 'image/bmp',
+      _ => 'image/png',
+    };
+
+    setState(() {
+      _filePath = file.path;
+      _fileName = file.name;
+      _base64Data = base64String;
+      _mimeType = mimeType;
+    });
+  }
+
+  void _submit() {
+    if (!_canSubmit) return;
+
+    switch (_source) {
+      case _ImageSource.url:
+        Navigator.of(context).pop(<String, dynamic>{
+          'url': _urlController.text.trim(),
+        });
+      case _ImageSource.file:
+        Navigator.of(context).pop(<String, dynamic>{
+          'base64': _base64Data,
+          'mimeType': _mimeType,
+        });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return AlertDialog(
+      title: Text(_isEditing ? 'Edit Image' : 'Add Image'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            // Выбор источника
+            if (!_isEditing) ...<Widget>[
+              SegmentedButton<_ImageSource>(
+                segments: const <ButtonSegment<_ImageSource>>[
+                  ButtonSegment<_ImageSource>(
+                    value: _ImageSource.url,
+                    label: Text('From URL'),
+                    icon: Icon(Icons.link),
+                  ),
+                  ButtonSegment<_ImageSource>(
+                    value: _ImageSource.file,
+                    label: Text('From File'),
+                    icon: Icon(Icons.folder_open),
+                  ),
+                ],
+                selected: <_ImageSource>{_source},
+                onSelectionChanged: (Set<_ImageSource> selected) {
+                  setState(() => _source = selected.first);
+                },
+              ),
+              const SizedBox(height: 16),
+            ],
+
+            // URL ввод
+            if (_source == _ImageSource.url) ...<Widget>[
+              TextField(
+                controller: _urlController,
+                decoration: const InputDecoration(
+                  labelText: 'Image URL',
+                  hintText: 'https://example.com/image.png',
+                  border: OutlineInputBorder(),
+                ),
+                autofocus: true,
+                onChanged: (_) => setState(() {}),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 12),
+              // Превью
+              if (_urlController.text.trim().startsWith('http'))
+                SizedBox(
+                  height: 150,
+                  child: Center(
+                    child: CachedNetworkImage(
+                      imageUrl: _urlController.text.trim(),
+                      fit: BoxFit.contain,
+                      placeholder: (BuildContext context, String url) =>
+                          const CircularProgressIndicator(),
+                      errorWidget: (BuildContext context, String url,
+                              Object error) =>
+                          Icon(
+                        Icons.broken_image_outlined,
+                        size: 48,
+                        color: theme.colorScheme.error,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+
+            // Файл
+            if (_source == _ImageSource.file) ...<Widget>[
+              if (_fileName != null) ...<Widget>[
+                Text(
+                  _fileName!,
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 8),
+                if (_filePath != null)
+                  SizedBox(
+                    height: 150,
+                    child: Center(
+                      child: Image.file(
+                        File(_filePath!),
+                        fit: BoxFit.contain,
+                        errorBuilder: (BuildContext context, Object error,
+                                StackTrace? stackTrace) =>
+                            Icon(
+                          Icons.broken_image_outlined,
+                          size: 48,
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
+                    ),
+                  ),
+                const SizedBox(height: 8),
+              ],
+              OutlinedButton.icon(
+                onPressed: _pickFile,
+                icon: const Icon(Icons.folder_open),
+                label: Text(_fileName != null ? 'Choose Another' : 'Choose File'),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _canSubmit ? _submit : null,
+          child: Text(_isEditing ? 'Save' : 'Add'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/collections/widgets/dialogs/add_link_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/add_link_dialog.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+// Диалог добавления/редактирования ссылки на канвасе.
+
+/// Диалог для ввода URL и метки ссылки.
+///
+/// Возвращает `Map<String, dynamic>` с ключами `url` и `label`,
+/// или `null` если пользователь отменил.
+class AddLinkDialog extends StatefulWidget {
+  /// Создаёт [AddLinkDialog].
+  const AddLinkDialog({
+    this.initialUrl,
+    this.initialLabel,
+    super.key,
+  });
+
+  /// Начальный URL (для редактирования).
+  final String? initialUrl;
+
+  /// Начальная метка (для редактирования).
+  final String? initialLabel;
+
+  /// Показывает диалог и возвращает результат.
+  static Future<Map<String, dynamic>?> show(
+    BuildContext context, {
+    String? initialUrl,
+    String? initialLabel,
+  }) {
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (BuildContext context) {
+        return AddLinkDialog(
+          initialUrl: initialUrl,
+          initialLabel: initialLabel,
+        );
+      },
+    );
+  }
+
+  @override
+  State<AddLinkDialog> createState() => _AddLinkDialogState();
+}
+
+class _AddLinkDialogState extends State<AddLinkDialog> {
+  late final TextEditingController _urlController;
+  late final TextEditingController _labelController;
+  bool get _isEditing => widget.initialUrl != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController = TextEditingController(text: widget.initialUrl ?? '');
+    _labelController = TextEditingController(text: widget.initialLabel ?? '');
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _labelController.dispose();
+    super.dispose();
+  }
+
+  bool get _canSubmit {
+    final String url = _urlController.text.trim();
+    return url.startsWith('http://') || url.startsWith('https://');
+  }
+
+  void _submit() {
+    if (!_canSubmit) return;
+
+    final String url = _urlController.text.trim();
+    final String label = _labelController.text.trim();
+
+    Navigator.of(context).pop(<String, dynamic>{
+      'url': url,
+      'label': label.isNotEmpty ? label : url,
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(_isEditing ? 'Edit Link' : 'Add Link'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            TextField(
+              controller: _urlController,
+              decoration: const InputDecoration(
+                labelText: 'URL',
+                hintText: 'https://example.com',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: true,
+              onChanged: (_) => setState(() {}),
+              onSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _labelController,
+              decoration: const InputDecoration(
+                labelText: 'Label (optional)',
+                hintText: 'My Link',
+                border: OutlineInputBorder(),
+              ),
+              onSubmitted: (_) => _submit(),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _canSubmit ? _submit : null,
+          child: Text(_isEditing ? 'Save' : 'Add'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/collections/widgets/dialogs/add_text_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/add_text_dialog.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+// Диалог добавления/редактирования текстового блока на канвасе.
+
+/// Диалог для ввода текста и выбора размера шрифта.
+///
+/// Возвращает `Map<String, dynamic>` с ключами `content` и `fontSize`,
+/// или `null` если пользователь отменил.
+class AddTextDialog extends StatefulWidget {
+  /// Создаёт [AddTextDialog].
+  const AddTextDialog({
+    this.initialContent,
+    this.initialFontSize,
+    super.key,
+  });
+
+  /// Начальный текст (для редактирования).
+  final String? initialContent;
+
+  /// Начальный размер шрифта (для редактирования).
+  final double? initialFontSize;
+
+  /// Показывает диалог и возвращает результат.
+  static Future<Map<String, dynamic>?> show(
+    BuildContext context, {
+    String? initialContent,
+    double? initialFontSize,
+  }) {
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (BuildContext context) {
+        return AddTextDialog(
+          initialContent: initialContent,
+          initialFontSize: initialFontSize,
+        );
+      },
+    );
+  }
+
+  @override
+  State<AddTextDialog> createState() => _AddTextDialogState();
+}
+
+/// Доступные размеры шрифта.
+const List<_FontSizeOption> _fontSizeOptions = <_FontSizeOption>[
+  _FontSizeOption(label: 'Small', size: 12),
+  _FontSizeOption(label: 'Medium', size: 16),
+  _FontSizeOption(label: 'Large', size: 24),
+  _FontSizeOption(label: 'Title', size: 32),
+];
+
+class _FontSizeOption {
+  const _FontSizeOption({required this.label, required this.size});
+  final String label;
+  final double size;
+}
+
+class _AddTextDialogState extends State<AddTextDialog> {
+  late final TextEditingController _contentController;
+  late double _selectedFontSize;
+  bool get _isEditing => widget.initialContent != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _contentController = TextEditingController(
+      text: widget.initialContent ?? '',
+    );
+    _selectedFontSize = widget.initialFontSize ?? 16;
+    // Если initialFontSize не совпадает ни с одним вариантом, берём ближайший
+    if (!_fontSizeOptions.any(
+      (_FontSizeOption o) => o.size == _selectedFontSize,
+    )) {
+      _selectedFontSize = 16;
+    }
+  }
+
+  @override
+  void dispose() {
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final String content = _contentController.text.trim();
+    if (content.isEmpty) return;
+
+    Navigator.of(context).pop(<String, dynamic>{
+      'content': content,
+      'fontSize': _selectedFontSize,
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(_isEditing ? 'Edit Text' : 'Add Text'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            TextField(
+              controller: _contentController,
+              decoration: const InputDecoration(
+                labelText: 'Text content',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+              ),
+              maxLines: 5,
+              minLines: 2,
+              autofocus: true,
+              onSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<double>(
+              initialValue: _selectedFontSize,
+              decoration: const InputDecoration(
+                labelText: 'Font size',
+                border: OutlineInputBorder(),
+              ),
+              items: _fontSizeOptions
+                  .map(
+                    (_FontSizeOption option) => DropdownMenuItem<double>(
+                      value: option.size,
+                      child: Text('${option.label} (${option.size.toInt()}px)'),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (double? value) {
+                if (value != null) {
+                  setState(() => _selectedFontSize = value);
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: Text(_isEditing ? 'Save' : 'Add'),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -813,6 +813,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.6"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,9 @@ dependencies:
   # File Operations
   file_picker: ^6.1.1
 
+  # URL
+  url_launcher: ^6.2.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/data/repositories/canvas_repository_test.dart
+++ b/test/data/repositories/canvas_repository_test.dart
@@ -367,6 +367,37 @@ void main() {
       });
     });
 
+    group('updateItemData', () {
+      test('should encode data as JSON and update database', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemData(
+          5,
+          <String, dynamic>{'content': 'Hello', 'fontSize': 16.0},
+        );
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured['data'], '{"content":"Hello","fontSize":16.0}');
+      });
+
+      test('should set data to null when data is null', () async {
+        when(() => mockDb.updateCanvasItem(5, any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateItemData(5, null);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasItem(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured['data'], isNull);
+      });
+    });
+
     group('updateItemZIndex', () {
       test('should update z_index in database', () async {
         when(() => mockDb.updateCanvasItem(5, any()))

--- a/test/features/collections/widgets/canvas_context_menu_test.dart
+++ b/test/features/collections/widgets/canvas_context_menu_test.dart
@@ -1,0 +1,507 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_context_menu.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  group('CanvasContextMenu', () {
+    Widget buildTestApp({required Widget child}) {
+      return MaterialApp(home: Scaffold(body: child));
+    }
+
+    group('showCanvasMenu', () {
+      testWidgets(
+        'должен показать меню с пунктами Add Text, Add Image, Add Link',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () {},
+                      onAddImage: () {},
+                      onAddLink: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Add Text'), findsOneWidget);
+          expect(find.text('Add Image'), findsOneWidget);
+          expect(find.text('Add Link'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onAddText при выборе Add Text',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () => called = true,
+                      onAddImage: () {},
+                      onAddLink: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Add Text'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onAddImage при выборе Add Image',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () {},
+                      onAddImage: () => called = true,
+                      onAddLink: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Add Image'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onAddLink при выборе Add Link',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () {},
+                      onAddImage: () {},
+                      onAddLink: () => called = true,
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Add Link'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
+        'должен ничего не делать при закрытии меню без выбора',
+        (WidgetTester tester) async {
+          bool textCalled = false;
+          bool imageCalled = false;
+          bool linkCalled = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () => textCalled = true,
+                      onAddImage: () => imageCalled = true,
+                      onAddLink: () => linkCalled = true,
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+
+          // Закрываем тапом вне меню
+          await tester.tapAt(const Offset(10, 10));
+          await tester.pumpAndSettle();
+
+          expect(textCalled, false);
+          expect(imageCalled, false);
+          expect(linkCalled, false);
+        },
+      );
+    });
+
+    group('showItemMenu', () {
+      testWidgets(
+        'должен показать Edit для типа text',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.text,
+                      onEdit: () {},
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Edit'), findsOneWidget);
+          expect(find.text('Delete'), findsOneWidget);
+          expect(find.text('Bring to Front'), findsOneWidget);
+          expect(find.text('Send to Back'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'не должен показывать Edit для типа game',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.game,
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Edit'), findsNothing);
+          expect(find.text('Delete'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен показывать Edit для типов image и link',
+        (WidgetTester tester) async {
+          for (final CanvasItemType type in <CanvasItemType>[
+            CanvasItemType.image,
+            CanvasItemType.link,
+          ]) {
+            await tester.pumpWidget(buildTestApp(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: () {
+                      CanvasContextMenu.showItemMenu(
+                        context,
+                        position: const Offset(100, 100),
+                        itemType: type,
+                        onEdit: () {},
+                        onDelete: () {},
+                        onBringToFront: () {},
+                        onSendToBack: () {},
+                      );
+                    },
+                    child: const Text('Open Menu'),
+                  );
+                },
+              ),
+            ));
+
+            await tester.tap(find.text('Open Menu'));
+            await tester.pumpAndSettle();
+
+            expect(find.text('Edit'), findsOneWidget,
+                reason: 'Edit should be shown for $type');
+
+            // Close menu
+            await tester.tapAt(const Offset(10, 10));
+            await tester.pumpAndSettle();
+          }
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onEdit при выборе Edit',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.text,
+                      onEdit: () => called = true,
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Edit'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
+        'должен показать диалог подтверждения при выборе Delete',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.text,
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Delete'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Delete element'), findsOneWidget);
+          expect(
+            find.text('Are you sure you want to delete this element?'),
+            findsOneWidget,
+          );
+          expect(find.text('Cancel'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onDelete при подтверждении удаления',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.text,
+                      onDelete: () => called = true,
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Delete'));
+          await tester.pumpAndSettle();
+
+          // Подтверждаем удаление (FilledButton 'Delete' в диалоге)
+          await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
+        'не должен вызывать onDelete при отмене удаления',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.text,
+                      onDelete: () => called = true,
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Delete'));
+          await tester.pumpAndSettle();
+
+          // Отменяем удаление
+          await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+          await tester.pumpAndSettle();
+
+          expect(called, false);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onBringToFront при выборе Bring to Front',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.game,
+                      onDelete: () {},
+                      onBringToFront: () => called = true,
+                      onSendToBack: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Bring to Front'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onSendToBack при выборе Send to Back',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.game,
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () => called = true,
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Send to Back'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+    });
+  });
+}

--- a/test/features/collections/widgets/canvas_image_item_test.dart
+++ b/test/features/collections/widgets/canvas_image_item_test.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_image_item.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  group('CanvasImageItem', () {
+    final DateTime testDate = DateTime(2024, 6, 15);
+
+    CanvasItem createImageItem({
+      Map<String, dynamic>? data,
+      double? width,
+      double? height,
+    }) {
+      return CanvasItem(
+        id: 1,
+        collectionId: 10,
+        itemType: CanvasItemType.image,
+        x: 100,
+        y: 100,
+        width: width,
+        height: height,
+        data: data,
+        createdAt: testDate,
+      );
+    }
+
+    Widget buildWidget(CanvasItem item) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 400,
+            child: CanvasImageItem(item: item),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'должен показать Card',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{'url': 'https://example.com/image.png'},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byType(Card), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать placeholder иконку когда data null',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(data: null);
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать placeholder иконку когда data пустой',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать placeholder иконку когда url пустой',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{'url': ''},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать Image.memory для base64 данных',
+      (WidgetTester tester) async {
+        // Создаём минимальный PNG (1x1 пиксель)
+        final String base64Png = base64Encode(<int>[
+          0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+          0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+          0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+          0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+          0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT chunk
+          0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+          0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC,
+          0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, // IEND chunk
+          0x44, 0xAE, 0x42, 0x60, 0x82,
+        ]);
+
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{
+            'base64': base64Png,
+            'mimeType': 'image/png',
+          },
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byType(Image), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен использовать SizedBox.expand для заполнения родителя',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{'url': 'https://example.com/image.png'},
+          width: null,
+          height: null,
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        // SizedBox.expand() внутри Card — расширяется до размеров родителя
+        final SizedBox sizedBox = tester.widget<SizedBox>(
+          find.descendant(
+            of: find.byType(Card),
+            matching: find.byType(SizedBox),
+          ).first,
+        );
+        expect(sizedBox.width, double.infinity);
+        expect(sizedBox.height, double.infinity);
+      },
+    );
+
+    testWidgets(
+      'должен рендерить Card с изображением при custom размерах',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{'url': 'https://example.com/image.png'},
+          width: 300,
+          height: 150,
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        // Card рендерится (размеры задаются родителем Positioned)
+        expect(find.byType(Card), findsOneWidget);
+        // SizedBox.expand внутри
+        final SizedBox sizedBox = tester.widget<SizedBox>(
+          find.descendant(
+            of: find.byType(Card),
+            matching: find.byType(SizedBox),
+          ).first,
+        );
+        expect(sizedBox.width, double.infinity);
+        expect(sizedBox.height, double.infinity);
+      },
+    );
+
+    testWidgets(
+      'должен иметь clipBehavior antiAlias на Card',
+      (WidgetTester tester) async {
+        final CanvasItem item = createImageItem(
+          data: <String, dynamic>{'url': 'https://example.com/image.png'},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        final Card card = tester.widget<Card>(find.byType(Card));
+        expect(card.clipBehavior, Clip.antiAlias);
+      },
+    );
+  });
+}

--- a/test/features/collections/widgets/canvas_link_item_test.dart
+++ b/test/features/collections/widgets/canvas_link_item_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_link_item.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  group('CanvasLinkItem', () {
+    final DateTime testDate = DateTime(2024, 6, 15);
+
+    CanvasItem createLinkItem({
+      Map<String, dynamic>? data,
+      double? width,
+      double? height,
+    }) {
+      return CanvasItem(
+        id: 1,
+        collectionId: 10,
+        itemType: CanvasItemType.link,
+        x: 100,
+        y: 100,
+        width: width,
+        height: height,
+        data: data,
+        createdAt: testDate,
+      );
+    }
+
+    Widget buildWidget(CanvasItem item) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 400,
+            child: CanvasLinkItem(item: item),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'должен показать Card',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'Example',
+          },
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byType(Card), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен отображать label',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'My Website',
+          },
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.text('My Website'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показывать url если label отсутствует',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{'url': 'https://example.com'},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.text('https://example.com'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показывать "Link" если data null',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(data: null);
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.text('Link'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показывать иконку ссылки',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'Test',
+          },
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byIcon(Icons.link), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен рендерить Card без явного SizedBox (размер от родителя)',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'Test',
+          },
+          width: null,
+          height: null,
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        // Card рендерится, размеры определяются родителем Positioned
+        expect(find.byType(Card), findsOneWidget);
+        // Row внутри Card содержит иконку и текст
+        expect(find.byIcon(Icons.link), findsOneWidget);
+        expect(find.text('Test'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен рендерить Card при custom размерах',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'Test',
+          },
+          width: 300,
+          height: 60,
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        // Card рендерится (размеры задаются родителем Positioned)
+        expect(find.byType(Card), findsOneWidget);
+        expect(find.text('Test'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен содержать GestureDetector для doubleTap',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'Test',
+          },
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.byType(GestureDetector), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен иметь подчёркнутый текст',
+      (WidgetTester tester) async {
+        final CanvasItem item = createLinkItem(
+          data: <String, dynamic>{
+            'url': 'https://example.com',
+            'label': 'Underlined',
+          },
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        final Text textWidget =
+            tester.widget<Text>(find.text('Underlined'));
+        expect(textWidget.style?.decoration, TextDecoration.underline);
+      },
+    );
+  });
+}

--- a/test/features/collections/widgets/canvas_text_item_test.dart
+++ b/test/features/collections/widgets/canvas_text_item_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_text_item.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  group('CanvasTextItem', () {
+    final DateTime testDate = DateTime(2024, 6, 15);
+
+    CanvasItem createTextItem({
+      Map<String, dynamic>? data,
+      double? width,
+    }) {
+      return CanvasItem(
+        id: 1,
+        collectionId: 10,
+        itemType: CanvasItemType.text,
+        x: 100,
+        y: 100,
+        width: width,
+        data: data,
+        createdAt: testDate,
+      );
+    }
+
+    Widget buildWidget(CanvasItem item) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 300,
+            height: 300,
+            child: CanvasTextItem(item: item),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'должен отображать текст из data.content',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'Hello World', 'fontSize': 16.0},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.text('Hello World'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен использовать fontSize из data',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'Big Text', 'fontSize': 32.0},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        final Text textWidget = tester.widget<Text>(find.text('Big Text'));
+        expect(textWidget.style?.fontSize, 32.0);
+      },
+    );
+
+    testWidgets(
+      'должен использовать fontSize 16 по умолчанию когда fontSize отсутствует',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'Default Size'},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        final Text textWidget = tester.widget<Text>(find.text('Default Size'));
+        expect(textWidget.style?.fontSize, 16.0);
+      },
+    );
+
+    testWidgets(
+      'должен отображать пустую строку когда data null',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(data: null);
+
+        await tester.pumpWidget(buildWidget(item));
+
+        // Пустой Text виджет существует
+        expect(find.byType(Text), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен рендерить текст при заданном width',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'Test'},
+          width: 300,
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.text('Test'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен рендерить текст без явного width',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'Default Width'},
+          width: null,
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        expect(find.text('Default Width'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен иметь padding 8',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'Padded'},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        final Padding padding = tester.widget<Padding>(
+          find.ancestor(
+            of: find.text('Padded'),
+            matching: find.byType(Padding),
+          ).first,
+        );
+        expect(padding.padding, const EdgeInsets.all(8));
+      },
+    );
+
+    testWidgets(
+      'должен отображать текст без фона',
+      (WidgetTester tester) async {
+        final CanvasItem item = createTextItem(
+          data: <String, dynamic>{'content': 'No Background'},
+        );
+
+        await tester.pumpWidget(buildWidget(item));
+
+        // Виджет использует Padding, а не Container с декорацией
+        expect(
+          find.ancestor(
+            of: find.text('No Background'),
+            matching: find.byType(Padding),
+          ),
+          findsWidgets,
+        );
+        // Нет Container с BoxDecoration (фоном)
+        final Finder containerFinder = find.ancestor(
+          of: find.text('No Background'),
+          matching: find.byWidgetPredicate(
+            (Widget widget) =>
+                widget is Container && widget.decoration != null,
+          ),
+        );
+        expect(containerFinder, findsNothing);
+      },
+    );
+  });
+}

--- a/test/features/collections/widgets/canvas_view_test.dart
+++ b/test/features/collections/widgets/canvas_view_test.dart
@@ -444,7 +444,7 @@ void main() {
       );
 
       testWidgets(
-        'должен создавать SizedBox.shrink для элемента типа image',
+        'должен отображать элемент типа image как Card',
         (WidgetTester tester) async {
           final CanvasState normalState = CanvasState(
             isLoading: false,
@@ -462,12 +462,13 @@ void main() {
           await tester.pump();
 
           expect(find.byType(InteractiveViewer), findsOneWidget);
-          expect(find.byType(Card), findsNothing);
+          // CanvasImageItem содержит Card
+          expect(find.byType(Card), findsOneWidget);
         },
       );
 
       testWidgets(
-        'должен создавать SizedBox.shrink для элемента типа link',
+        'должен отображать элемент типа link как Card',
         (WidgetTester tester) async {
           final CanvasState normalState = CanvasState(
             isLoading: false,
@@ -485,12 +486,13 @@ void main() {
           await tester.pump();
 
           expect(find.byType(InteractiveViewer), findsOneWidget);
-          expect(find.byType(Card), findsNothing);
+          // CanvasLinkItem содержит Card
+          expect(find.byType(Card), findsOneWidget);
         },
       );
 
       testWidgets(
-        'должен показывать смешанные типы — только game отображает карточку',
+        'должен показывать смешанные типы — все типы отображаются',
         (WidgetTester tester) async {
           final CanvasState normalState = CanvasState(
             isLoading: false,
@@ -522,10 +524,9 @@ void main() {
           await tester.pumpWidget(buildTestWidget(canvasState: normalState));
           await tester.pump();
 
-          // Только одна карточка для game
           expect(find.text('Zelda'), findsOneWidget);
-          // Один Card от CanvasGameCard
-          expect(find.byType(Card), findsOneWidget);
+          // 2 Card: один от CanvasGameCard, один от CanvasImageItem
+          expect(find.byType(Card), findsNWidgets(2));
         },
       );
     });
@@ -676,6 +677,84 @@ void main() {
           await tester.pump();
 
           expect(find.byType(LayoutBuilder), findsOneWidget);
+        },
+      );
+    });
+
+    group('resize handle', () {
+      testWidgets(
+        'должен показывать resize handle когда isEditable=true',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(canvasState: normalState, isEditable: true),
+          );
+          await tester.pump();
+
+          // Resize handle содержит иконку drag_handle
+          expect(find.byIcon(Icons.drag_handle), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'не должен показывать resize handle когда isEditable=false',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(canvasState: normalState, isEditable: false),
+          );
+          await tester.pump();
+
+          // Resize handle НЕ рендерится
+          expect(find.byIcon(Icons.drag_handle), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'должен оборачивать дочерний виджет в SizedBox.expand',
+        (WidgetTester tester) async {
+          final CanvasState normalState = CanvasState(
+            isLoading: false,
+            isInitialized: true,
+            items: <CanvasItem>[
+              createTestItem(
+                id: 1,
+                game: const Game(id: 100, name: 'Test Game'),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(buildTestWidget(canvasState: normalState));
+          await tester.pump();
+
+          // SizedBox.expand имеет width=infinity, height=infinity
+          final Finder expandedBoxes = find.byWidgetPredicate(
+            (Widget widget) =>
+                widget is SizedBox &&
+                widget.width == double.infinity &&
+                widget.height == double.infinity,
+          );
+          expect(expandedBoxes, findsWidgets);
         },
       );
     });

--- a/test/features/collections/widgets/dialogs/add_image_dialog_test.dart
+++ b/test/features/collections/widgets/dialogs/add_image_dialog_test.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/dialogs/add_image_dialog.dart';
+
+void main() {
+  group('AddImageDialog', () {
+    Widget buildTestApp({
+      required void Function(Map<String, dynamic>? result) onResult,
+      String? initialUrl,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  final Map<String, dynamic>? result =
+                      await AddImageDialog.show(
+                    context,
+                    initialUrl: initialUrl,
+                  );
+                  onResult(result);
+                },
+                child: const Text('Open'),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'должен показать заголовок "Add Image" для нового элемента',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Add Image'), findsOneWidget);
+        expect(find.text('Add'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать заголовок "Edit Image" когда initialUrl указан',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialUrl: 'https://example.com/image.png',
+        ));
+        await tester.tap(find.text('Open'));
+        // CachedNetworkImage показывает CircularProgressIndicator,
+        // который не даёт pumpAndSettle завершиться — используем pump.
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Edit Image'), findsOneWidget);
+        expect(find.text('Save'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать SegmentedButton с "From URL" и "From File" для нового элемента',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byWidgetPredicate(
+            (Widget widget) => widget.runtimeType.toString().startsWith('SegmentedButton'),
+          ),
+          findsOneWidget,
+        );
+        expect(find.text('From URL'), findsOneWidget);
+        expect(find.text('From File'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'не должен показывать SegmentedButton когда initialUrl указан',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialUrl: 'https://example.com/image.png',
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          find.byWidgetPredicate(
+            (Widget widget) => widget.runtimeType.toString().startsWith('SegmentedButton'),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'должен показать TextField с лейблом "Image URL" в режиме URL',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TextField), findsOneWidget);
+        expect(find.text('Image URL'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен отключить кнопку Add когда URL пустой',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNull);
+      },
+    );
+
+    testWidgets(
+      'должен отключить кнопку Add когда URL не начинается с http:// или https://',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField),
+          'ftp://example.com/image.png',
+        );
+        await tester.pumpAndSettle();
+
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNull);
+      },
+    );
+
+    testWidgets(
+      'должен включить кнопку Add когда URL начинается с https://',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField),
+          'https://example.com/image.png',
+        );
+        // CachedNetworkImage превью вызывает бесконечную анимацию
+        await tester.pump();
+        await tester.pump();
+
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'должен включить кнопку Add когда URL начинается с http://',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField),
+          'http://example.com/image.png',
+        );
+        // CachedNetworkImage превью вызывает бесконечную анимацию
+        await tester.pump();
+        await tester.pump();
+
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'должен вернуть map с url при нажатии Add с валидным URL',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField),
+          'https://example.com/image.png',
+        );
+        await tester.pump();
+        await tester.pump();
+
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNotNull);
+        expect(result!['url'], 'https://example.com/image.png');
+      },
+    );
+
+    testWidgets(
+      'должен вернуть null при нажатии Cancel',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result = <String, dynamic>{'marker': true};
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNull);
+      },
+    );
+
+    testWidgets(
+      'должен заполнить initialUrl в TextField',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialUrl: 'https://example.com/image.png',
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pump();
+        await tester.pump();
+
+        final TextField textField = tester.widget<TextField>(
+          find.byType(TextField),
+        );
+        expect(textField.controller?.text, 'https://example.com/image.png');
+      },
+    );
+
+    testWidgets(
+      'должен показать кнопку "Choose File" в режиме файла',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        // Переключаемся на режим файла
+        await tester.tap(find.text('From File'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Choose File'), findsOneWidget);
+        // TextField не должен быть виден в режиме файла
+        expect(find.byType(TextField), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'должен обрезать пробелы в URL при submit',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField),
+          '  https://example.com/image.png  ',
+        );
+        await tester.pump();
+        await tester.pump();
+
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNotNull);
+        expect(result!['url'], 'https://example.com/image.png');
+      },
+    );
+  });
+}

--- a/test/features/collections/widgets/dialogs/add_link_dialog_test.dart
+++ b/test/features/collections/widgets/dialogs/add_link_dialog_test.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/dialogs/add_link_dialog.dart';
+
+void main() {
+  group('AddLinkDialog', () {
+    Widget buildTestApp({
+      required void Function(Map<String, dynamic>? result) onResult,
+      String? initialUrl,
+      String? initialLabel,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  final Map<String, dynamic>? result =
+                      await AddLinkDialog.show(
+                    context,
+                    initialUrl: initialUrl,
+                    initialLabel: initialLabel,
+                  );
+                  onResult(result);
+                },
+                child: const Text('Open'),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'должен показать заголовок "Add Link" для нового элемента',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Add Link'), findsOneWidget);
+        // FilledButton disabled (no valid URL)
+        expect(find.text('Add'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать заголовок "Edit Link" при редактировании',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialUrl: 'https://example.com',
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit Link'), findsOneWidget);
+        expect(find.text('Save'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен заполнить initial URL и label',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialUrl: 'https://example.com',
+          initialLabel: 'My Site',
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        // URL может быть в TextField и hint — проверяем через контроллер
+        final TextField urlField = tester.widget<TextField>(
+          find.byType(TextField).first,
+        );
+        expect(urlField.controller?.text, 'https://example.com');
+        expect(find.text('My Site'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен вернуть url и label при нажатии Add',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        // Вводим URL
+        await tester.enterText(
+          find.byType(TextField).first,
+          'https://example.com',
+        );
+        await tester.pumpAndSettle();
+
+        // Вводим label
+        await tester.enterText(
+          find.byType(TextField).last,
+          'Example',
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNotNull);
+        expect(result!['url'], 'https://example.com');
+        expect(result!['label'], 'Example');
+      },
+    );
+
+    testWidgets(
+      'должен использовать URL как label если label пустой',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          'https://example.com',
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result!['label'], 'https://example.com');
+      },
+    );
+
+    testWidgets(
+      'должен вернуть null при нажатии Cancel',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result = <String, dynamic>{'marker': true};
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNull);
+      },
+    );
+
+    testWidgets(
+      'должен отключать кнопку Add когда URL невалидный',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        // Вводим невалидный URL
+        await tester.enterText(
+          find.byType(TextField).first,
+          'not-a-url',
+        );
+        await tester.pumpAndSettle();
+
+        // Кнопка Add disabled
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNull);
+      },
+    );
+
+    testWidgets(
+      'должен включать кнопку Add когда URL начинается с https://',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          'https://example.com',
+        );
+        await tester.pumpAndSettle();
+
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'должен включать кнопку Add когда URL начинается с http://',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          'http://example.com',
+        );
+        await tester.pumpAndSettle();
+
+        final FilledButton addButton = tester.widget<FilledButton>(
+          find.byType(FilledButton),
+        );
+        expect(addButton.onPressed, isNotNull);
+      },
+    );
+
+    testWidgets(
+      'должен обрезать пробелы в URL и label',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          '  https://example.com  ',
+        );
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).last,
+          '  My Label  ',
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result!['url'], 'https://example.com');
+        expect(result!['label'], 'My Label');
+      },
+    );
+
+    testWidgets(
+      'должен показать 2 TextField — URL и Label',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TextField), findsNWidgets(2));
+        expect(find.text('URL'), findsOneWidget);
+        expect(find.text('Label (optional)'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/features/collections/widgets/dialogs/add_text_dialog_test.dart
+++ b/test/features/collections/widgets/dialogs/add_text_dialog_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/dialogs/add_text_dialog.dart';
+
+void main() {
+  group('AddTextDialog', () {
+    Widget buildTestApp({
+      required void Function(Map<String, dynamic>? result) onResult,
+      String? initialContent,
+      double? initialFontSize,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  final Map<String, dynamic>? result =
+                      await AddTextDialog.show(
+                    context,
+                    initialContent: initialContent,
+                    initialFontSize: initialFontSize,
+                  );
+                  onResult(result);
+                },
+                child: const Text('Open'),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'должен показать заголовок "Add Text" для нового элемента',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Add Text'), findsOneWidget);
+        expect(find.text('Add'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен показать заголовок "Edit Text" при редактировании',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialContent: 'Existing text',
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Edit Text'), findsOneWidget);
+        expect(find.text('Save'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен заполнить initial content',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(
+          onResult: (_) {},
+          initialContent: 'Hello World',
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Hello World'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен вернуть данные при нажатии Add',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          'New Text',
+        );
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNotNull);
+        expect(result!['content'], 'New Text');
+        expect(result!['fontSize'], 16.0); // default Medium
+      },
+    );
+
+    testWidgets(
+      'должен вернуть null при нажатии Cancel',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result = <String, dynamic>{'marker': true};
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        expect(result, isNull);
+      },
+    );
+
+    testWidgets(
+      'не должен submit когда текст пустой',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        // Поле пустое, нажимаем Add
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        // Диалог всё ещё открыт (submit не сработал)
+        expect(find.text('Add Text'), findsOneWidget);
+        expect(result, isNull);
+      },
+    );
+
+    testWidgets(
+      'должен обрезать пробелы в тексте',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextField).first,
+          '  Trimmed Text  ',
+        );
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        expect(result!['content'], 'Trimmed Text');
+      },
+    );
+
+    testWidgets(
+      'должен иметь dropdown с 4 вариантами размера шрифта',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestApp(onResult: (_) {}));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DropdownButtonFormField<double>), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'должен сбрасывать нестандартный initialFontSize на 16',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+          initialContent: 'Test',
+          initialFontSize: 99.0, // Нестандартный размер
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+
+        expect(result!['fontSize'], 16.0); // Сброшен на default
+      },
+    );
+
+    testWidgets(
+      'должен использовать initialFontSize если он валидный',
+      (WidgetTester tester) async {
+        Map<String, dynamic>? result;
+
+        await tester.pumpWidget(buildTestApp(
+          onResult: (Map<String, dynamic>? r) => result = r,
+          initialContent: 'Test',
+          initialFontSize: 32.0, // Title
+        ));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+
+        expect(result!['fontSize'], 32.0);
+      },
+    );
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
…k (Stage 8)

Stage 8 adds text blocks, images, links, context menu (right-click), resize handles and z-index management to the canvas. Fixes real-time visual feedback for drag and resize by replacing ValueNotifier + Transform.translate with setState + Positioned. Text blocks now render without background. Type-specific default sizes for all element types.