### PR TITLE
Add canvas connections with solid/dashed/arrow styles, colors and labels (Stage 9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@
 ## [Unreleased]
 
 ### Added
+- Добавлены связи Canvas (Stage 9): визуальные линии между элементами канваса с тремя стилями (solid, dashed, arrow), настраиваемым цветом и лейблами
+- Добавлена модель `CanvasConnection` (`lib/shared/models/canvas_connection.dart`) — связь между двумя элементами канваса с полями: id, collectionId, fromItemId, toItemId, label, color (hex), style, createdAt
+- Добавлен enum `ConnectionStyle` (solid/dashed/arrow) с `fromString()` конвертером
+- Добавлен `CanvasConnectionPainter` (`lib/features/collections/widgets/canvas_connection_painter.dart`) — CustomPainter для рендеринга связей: solid (drawLine), dashed (PathMetrics), arrow (solid + треугольник). Hit-test на линии для контекстного меню
+- Добавлен `EditConnectionDialog` (`lib/features/collections/widgets/dialogs/edit_connection_dialog.dart`) — диалог редактирования связи: TextField для label, 8 цветных кнопок, SegmentedButton для стиля (Solid/Dashed/Arrow)
+- Добавлена миграция БД до версии 6: таблица `canvas_connections` с FK CASCADE на canvas_items (автоудаление при удалении элемента)
+- Добавлены CRUD методы в `DatabaseService`: `getCanvasConnections`, `insertCanvasConnection`, `updateCanvasConnection`, `deleteCanvasConnection`, `deleteCanvasConnectionsByCollection`
+- Добавлены методы в `CanvasRepository`: `getConnections`, `createConnection`, `updateConnection`, `deleteConnection`
+- Добавлены методы в `CanvasNotifier`: `startConnection`, `completeConnection`, `cancelConnection`, `deleteConnection`, `updateConnection`
+- Добавлен пункт "Connect" в контекстное меню элемента канваса — запускает режим создания связи
+- Добавлено контекстное меню связей (ПКМ на линии) — Edit / Delete
+- Добавлены тесты: `canvas_connection_test.dart` (25), `canvas_repository_connections_test.dart`, `canvas_provider_connections_test.dart`, `canvas_connection_painter_test.dart` (18), `edit_connection_dialog_test.dart`, `canvas_context_menu_connect_test.dart` (7)
+
+### Changed
+- Изменён `CanvasView` — добавлен слой CustomPaint для отрисовки связей под элементами, режим создания связи (курсор cell, временная пунктирная линия к курсору, баннер-индикатор, Escape для отмены), hit-test на линии для контекстного меню
+- Изменён `CanvasNotifier` — поля `connections` и `connectingFromId` в `CanvasState`, параллельная загрузка connections через `Future.wait`, фильтрация connections при удалении элемента
+- Изменён `CanvasContextMenu` — добавлен пункт Connect и метод `showConnectionMenu` для Edit/Delete связей
+- Изменён `CanvasRepository` — добавлены 4 метода для CRUD связей
+- Изменена `DatabaseService` — версия БД увеличена до 6, добавлена таблица canvas_connections с индексом
+
+---
+
+### Added
 - Добавлены элементы Canvas (Stage 8): текстовые блоки, изображения, ссылки, контекстное меню, resize
 - Добавлен `CanvasContextMenu` (`lib/features/collections/widgets/canvas_context_menu.dart`) — контекстное меню ПКМ: Add Text/Image/Link на пустом месте; Edit/Delete/Bring to Front/Send to Back на элементе
 - Добавлен `CanvasTextItem` (`lib/features/collections/widgets/canvas_text_item.dart`) — текстовый блок с настраиваемым размером шрифта (Small 12/Medium 16/Large 24/Title 32)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -66,6 +66,14 @@ Visualize your collection on a free-form canvas:
 - **Links** — add clickable links with custom labels (double-click to open in browser)
 - **Resize** — drag the bottom-right handle to resize any element with real-time preview (min 50x50, max 2000x2000)
 - **Z-index management** — Bring to Front / Send to Back via context menu
+- **Connections** — draw visual lines between any two canvas elements
+  - Three line styles: solid, dashed, arrow
+  - 8 color choices (gray, red, orange, yellow, green, blue, purple, black)
+  - Optional text labels displayed at the midpoint of the line
+  - Create via right-click → Connect, then click the target element
+  - Edit/Delete connections via right-click on the line
+  - Connections auto-delete when a connected element is removed
+  - Temporary dashed preview line while creating a connection
 
 ## SteamGridDB Integration
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,7 @@
 
 - [x] Stage 7: Basic Canvas — visual canvas with zoom, pan, drag-and-drop, grid layout, List/Canvas toggle, bidirectional collection sync
 - [x] Stage 8: Canvas Elements — context menu, text blocks, images, links, resize, z-index
-- [ ] Stage 9: Connections — visual connections between canvas elements
+- [x] Stage 9: Connections — visual connections (solid/dashed/arrow) between canvas elements with labels, colors, edit/delete, auto-cleanup
 - [ ] Stage 10: SteamGridDB Widget — side panel for adding SteamGridDB images to canvas
 - [ ] Stage 12: Export Full — extended .rcoll-full format with canvas layout and images
 

--- a/lib/data/repositories/canvas_repository.dart
+++ b/lib/data/repositories/canvas_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/database/database_service.dart';
+import '../../shared/models/canvas_connection.dart';
 import '../../shared/models/canvas_item.dart';
 import '../../shared/models/canvas_viewport.dart';
 import '../../shared/models/collection_game.dart';
@@ -161,6 +162,36 @@ class CanvasRepository {
       offsetX: viewport.offsetX,
       offsetY: viewport.offsetY,
     );
+  }
+
+  // ==================== Canvas Connections ====================
+
+  /// Возвращает все связи канваса для коллекции.
+  Future<List<CanvasConnection>> getConnections(int collectionId) async {
+    final List<Map<String, dynamic>> rows =
+        await _db.getCanvasConnections(collectionId);
+    return rows.map(CanvasConnection.fromDb).toList();
+  }
+
+  /// Создаёт связь и возвращает её с присвоенным ID.
+  Future<CanvasConnection> createConnection(CanvasConnection conn) async {
+    final int id = await _db.insertCanvasConnection(conn.toDb());
+    return conn.copyWith(id: id);
+  }
+
+  /// Обновляет свойства связи (label, color, style).
+  Future<void> updateConnection(CanvasConnection conn) async {
+    final Map<String, dynamic> data = <String, dynamic>{
+      'label': conn.label,
+      'color': conn.color,
+      'style': conn.style.value,
+    };
+    await _db.updateCanvasConnection(conn.id, data);
+  }
+
+  /// Удаляет связь.
+  Future<void> deleteConnection(int id) async {
+    await _db.deleteCanvasConnection(id);
   }
 
   // ==================== Initialization ====================

--- a/lib/features/collections/widgets/canvas_connection_painter.dart
+++ b/lib/features/collections/widgets/canvas_connection_painter.dart
@@ -1,0 +1,278 @@
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import '../../../data/repositories/canvas_repository.dart';
+import '../../../shared/models/canvas_connection.dart';
+import '../../../shared/models/canvas_item.dart';
+
+// CustomPainter для рисования связей между элементами канваса.
+//
+// Поддерживает три стиля линий: solid, dashed, arrow.
+// Рисует лейблы в середине линий и временную линию при создании связи.
+
+/// Рисует связи между элементами канваса.
+class CanvasConnectionPainter extends CustomPainter {
+  /// Создаёт [CanvasConnectionPainter].
+  CanvasConnectionPainter({
+    required this.connections,
+    required this.items,
+    this.connectingFrom,
+    this.mousePosition,
+    this.labelStyle,
+    this.labelBackgroundColor,
+  });
+
+  /// Список связей для отрисовки.
+  final List<CanvasConnection> connections;
+
+  /// Элементы канваса (для вычисления позиций).
+  final List<CanvasItem> items;
+
+  /// Элемент-источник при создании связи (временная линия).
+  final CanvasItem? connectingFrom;
+
+  /// Позиция мыши (для временной линии).
+  final Offset? mousePosition;
+
+  /// Стиль текста лейблов.
+  final TextStyle? labelStyle;
+
+  /// Цвет фона лейблов.
+  final Color? labelBackgroundColor;
+
+  /// Ширина линии.
+  static const double _lineWidth = 2.0;
+
+  /// Длина штриха пунктирной линии.
+  static const double _dashLength = 8.0;
+
+  /// Промежуток между штрихами.
+  static const double _dashGap = 4.0;
+
+  /// Размер стрелки (длина).
+  static const double _arrowLength = 12.0;
+
+  /// Допустимое расстояние для hit-test на линию.
+  static const double hitTestThreshold = 8.0;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (connections.isEmpty && connectingFrom == null) return;
+
+    // Быстрый поиск элементов по ID
+    final Map<int, CanvasItem> itemMap = <int, CanvasItem>{
+      for (final CanvasItem item in items) item.id: item,
+    };
+
+    // Рисуем сохранённые связи
+    for (final CanvasConnection conn in connections) {
+      final CanvasItem? fromItem = itemMap[conn.fromItemId];
+      final CanvasItem? toItem = itemMap[conn.toItemId];
+      if (fromItem == null || toItem == null) continue;
+
+      final Offset from = _getItemCenter(fromItem);
+      final Offset to = _getItemCenter(toItem);
+      final Color lineColor = _parseColor(conn.color);
+
+      _drawConnection(canvas, from, to, lineColor, conn.style);
+
+      if (conn.label != null && conn.label!.isNotEmpty) {
+        _drawLabel(canvas, from, to, conn.label!);
+      }
+    }
+
+    // Временная линия при создании связи
+    if (connectingFrom != null && mousePosition != null) {
+      final Offset from = _getItemCenter(connectingFrom!);
+      _drawDashedLine(
+        canvas,
+        from,
+        mousePosition!,
+        Paint()
+          ..color = Colors.blue.withAlpha(180)
+          ..strokeWidth = _lineWidth
+          ..style = PaintingStyle.stroke,
+      );
+    }
+  }
+
+  /// Рисует связь заданного стиля.
+  void _drawConnection(
+    Canvas canvas,
+    Offset from,
+    Offset to,
+    Color color,
+    ConnectionStyle style,
+  ) {
+    final Paint paint = Paint()
+      ..color = color
+      ..strokeWidth = _lineWidth
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    switch (style) {
+      case ConnectionStyle.solid:
+        canvas.drawLine(from, to, paint);
+      case ConnectionStyle.dashed:
+        _drawDashedLine(canvas, from, to, paint);
+      case ConnectionStyle.arrow:
+        canvas.drawLine(from, to, paint);
+        _drawArrowHead(canvas, from, to, color);
+    }
+  }
+
+  /// Рисует пунктирную линию.
+  void _drawDashedLine(Canvas canvas, Offset from, Offset to, Paint paint) {
+    final Path path = Path()..moveTo(from.dx, from.dy);
+    path.lineTo(to.dx, to.dy);
+
+    final ui.PathMetrics metrics = path.computeMetrics();
+    for (final ui.PathMetric metric in metrics) {
+      double distance = 0;
+      while (distance < metric.length) {
+        final double end =
+            math.min(distance + _dashLength, metric.length);
+        final ui.Path segment =
+            metric.extractPath(distance, end);
+        canvas.drawPath(segment, paint);
+        distance += _dashLength + _dashGap;
+      }
+    }
+  }
+
+  /// Рисует стрелку на конце линии.
+  void _drawArrowHead(Canvas canvas, Offset from, Offset to, Color color) {
+    final double angle = math.atan2(to.dy - from.dy, to.dx - from.dx);
+
+    final Path arrowPath = Path();
+    arrowPath.moveTo(to.dx, to.dy);
+    arrowPath.lineTo(
+      to.dx - _arrowLength * math.cos(angle - 0.4),
+      to.dy - _arrowLength * math.sin(angle - 0.4),
+    );
+    arrowPath.lineTo(
+      to.dx - _arrowLength * math.cos(angle + 0.4),
+      to.dy - _arrowLength * math.sin(angle + 0.4),
+    );
+    arrowPath.close();
+
+    canvas.drawPath(
+      arrowPath,
+      Paint()
+        ..color = color
+        ..style = PaintingStyle.fill,
+    );
+  }
+
+  /// Рисует лейбл в середине линии.
+  void _drawLabel(Canvas canvas, Offset from, Offset to, String label) {
+    final TextStyle style = labelStyle ??
+        const TextStyle(
+          fontSize: 11,
+          color: Colors.black87,
+        );
+
+    final TextPainter painter = TextPainter(
+      text: TextSpan(text: label, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    final Offset mid = Offset(
+      (from.dx + to.dx) / 2 - painter.width / 2,
+      (from.dy + to.dy) / 2 - painter.height / 2,
+    );
+
+    // Фон под текстом
+    final Color bgColor = labelBackgroundColor ??
+        Colors.white.withAlpha(220);
+    final Rect bgRect = Rect.fromLTWH(
+      mid.dx - 4,
+      mid.dy - 2,
+      painter.width + 8,
+      painter.height + 4,
+    );
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(bgRect, const Radius.circular(3)),
+      Paint()..color = bgColor,
+    );
+
+    painter.paint(canvas, mid);
+  }
+
+  /// Вычисляет центр элемента канваса.
+  Offset _getItemCenter(CanvasItem item) {
+    final double width =
+        item.width ?? CanvasRepository.defaultCardWidth;
+    final double height =
+        item.height ?? CanvasRepository.defaultCardHeight;
+    return Offset(item.x + width / 2, item.y + height / 2);
+  }
+
+  /// Парсит hex-строку цвета.
+  static Color _parseColor(String hex) {
+    try {
+      final String clean = hex.startsWith('#') ? hex.substring(1) : hex;
+      if (clean.length == 6) {
+        return Color(int.parse('FF$clean', radix: 16));
+      }
+      if (clean.length == 8) {
+        return Color(int.parse(clean, radix: 16));
+      }
+    } on FormatException {
+      // Невалидный hex — используем цвет по умолчанию
+    }
+    return const Color(0xFF666666);
+  }
+
+  /// Проверяет, попадает ли точка [point] рядом с какой-либо связью.
+  ///
+  /// Возвращает ID связи или null.
+  int? hitTestConnection(Offset point) {
+    final Map<int, CanvasItem> itemMap = <int, CanvasItem>{
+      for (final CanvasItem item in items) item.id: item,
+    };
+
+    for (final CanvasConnection conn in connections) {
+      final CanvasItem? fromItem = itemMap[conn.fromItemId];
+      final CanvasItem? toItem = itemMap[conn.toItemId];
+      if (fromItem == null || toItem == null) continue;
+
+      final Offset from = _getItemCenter(fromItem);
+      final Offset to = _getItemCenter(toItem);
+
+      final double distance = _pointToLineDistance(point, from, to);
+      if (distance <= hitTestThreshold) {
+        return conn.id;
+      }
+    }
+    return null;
+  }
+
+  /// Вычисляет расстояние от точки до отрезка.
+  static double _pointToLineDistance(Offset point, Offset a, Offset b) {
+    final double dx = b.dx - a.dx;
+    final double dy = b.dy - a.dy;
+    final double lengthSq = dx * dx + dy * dy;
+
+    if (lengthSq == 0) {
+      return (point - a).distance;
+    }
+
+    // Проецируем точку на линию, ограничивая отрезком [0, 1]
+    final double t = ((point.dx - a.dx) * dx + (point.dy - a.dy) * dy)
+        .clamp(0.0, lengthSq) / lengthSq;
+
+    final Offset projection = Offset(a.dx + t * dx, a.dy + t * dy);
+    return (point - projection).distance;
+  }
+
+  @override
+  bool shouldRepaint(covariant CanvasConnectionPainter oldDelegate) {
+    return connections != oldDelegate.connections ||
+        items != oldDelegate.items ||
+        connectingFrom != oldDelegate.connectingFrom ||
+        mousePosition != oldDelegate.mousePosition;
+  }
+}

--- a/lib/features/collections/widgets/canvas_context_menu.dart
+++ b/lib/features/collections/widgets/canvas_context_menu.dart
@@ -87,6 +87,7 @@ class CanvasContextMenu {
     required VoidCallback onDelete,
     required VoidCallback onBringToFront,
     required VoidCallback onSendToBack,
+    VoidCallback? onConnect,
   }) async {
     final bool showEdit = itemType != CanvasItemType.game;
 
@@ -122,6 +123,17 @@ class CanvasContextMenu {
         ),
         const PopupMenuDivider(),
         const PopupMenuItem<String>(
+          value: 'connect',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.timeline, size: 20),
+              SizedBox(width: 12),
+              Text('Connect'),
+            ],
+          ),
+        ),
+        const PopupMenuDivider(),
+        const PopupMenuItem<String>(
           value: 'bring_to_front',
           child: Row(
             children: <Widget>[
@@ -151,10 +163,61 @@ class CanvasContextMenu {
       case 'delete':
         if (!context.mounted) return;
         _showDeleteConfirmation(context, onDelete);
+      case 'connect':
+        onConnect?.call();
       case 'bring_to_front':
         onBringToFront();
       case 'send_to_back':
         onSendToBack();
+    }
+  }
+
+  /// Отображает контекстное меню связи.
+  static Future<void> showConnectionMenu(
+    BuildContext context, {
+    required Offset position,
+    required VoidCallback onEdit,
+    required VoidCallback onDelete,
+  }) async {
+    final String? value = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx,
+        position.dy,
+      ),
+      items: const <PopupMenuEntry<String>>[
+        PopupMenuItem<String>(
+          value: 'edit',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.edit_outlined, size: 20),
+              SizedBox(width: 12),
+              Text('Edit Connection'),
+            ],
+          ),
+        ),
+        PopupMenuItem<String>(
+          value: 'delete',
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.delete_outlined, size: 20),
+              SizedBox(width: 12),
+              Text('Delete Connection'),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    if (value == null) return;
+    switch (value) {
+      case 'edit':
+        onEdit();
+      case 'delete':
+        if (!context.mounted) return;
+        _showDeleteConfirmation(context, onDelete);
     }
   }
 

--- a/lib/features/collections/widgets/dialogs/edit_connection_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/edit_connection_dialog.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+
+import '../../../../shared/models/canvas_connection.dart';
+
+// Диалог редактирования свойств связи на канвасе.
+
+/// Доступные цвета для связей.
+const List<_ColorOption> _colorOptions = <_ColorOption>[
+  _ColorOption(label: 'Gray', hex: '#666666', color: Color(0xFF666666)),
+  _ColorOption(label: 'Red', hex: '#E53935', color: Color(0xFFE53935)),
+  _ColorOption(label: 'Orange', hex: '#FB8C00', color: Color(0xFFFB8C00)),
+  _ColorOption(label: 'Yellow', hex: '#FDD835', color: Color(0xFFFDD835)),
+  _ColorOption(label: 'Green', hex: '#43A047', color: Color(0xFF43A047)),
+  _ColorOption(label: 'Blue', hex: '#1E88E5', color: Color(0xFF1E88E5)),
+  _ColorOption(label: 'Purple', hex: '#8E24AA', color: Color(0xFF8E24AA)),
+  _ColorOption(label: 'Black', hex: '#212121', color: Color(0xFF212121)),
+];
+
+class _ColorOption {
+  const _ColorOption({
+    required this.label,
+    required this.hex,
+    required this.color,
+  });
+  final String label;
+  final String hex;
+  final Color color;
+}
+
+/// Диалог для редактирования label, цвета и стиля связи.
+///
+/// Возвращает `Map<String, dynamic>` с ключами `label`, `color`, `style`,
+/// или `null` если пользователь отменил.
+class EditConnectionDialog extends StatefulWidget {
+  /// Создаёт [EditConnectionDialog].
+  const EditConnectionDialog({
+    this.initialLabel,
+    this.initialColor,
+    this.initialStyle,
+    super.key,
+  });
+
+  /// Начальный лейбл.
+  final String? initialLabel;
+
+  /// Начальный цвет (hex).
+  final String? initialColor;
+
+  /// Начальный стиль.
+  final ConnectionStyle? initialStyle;
+
+  /// Показывает диалог и возвращает результат.
+  static Future<Map<String, dynamic>?> show(
+    BuildContext context, {
+    String? initialLabel,
+    String? initialColor,
+    ConnectionStyle? initialStyle,
+  }) {
+    return showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (BuildContext context) {
+        return EditConnectionDialog(
+          initialLabel: initialLabel,
+          initialColor: initialColor,
+          initialStyle: initialStyle,
+        );
+      },
+    );
+  }
+
+  @override
+  State<EditConnectionDialog> createState() => _EditConnectionDialogState();
+}
+
+class _EditConnectionDialogState extends State<EditConnectionDialog> {
+  late final TextEditingController _labelController;
+  late String _selectedColor;
+  late ConnectionStyle _selectedStyle;
+
+  @override
+  void initState() {
+    super.initState();
+    _labelController = TextEditingController(
+      text: widget.initialLabel ?? '',
+    );
+    _selectedColor = widget.initialColor ?? '#666666';
+    _selectedStyle = widget.initialStyle ?? ConnectionStyle.solid;
+
+    // Если цвет не совпадает ни с одним вариантом, берём по умолчанию
+    if (!_colorOptions.any((_ColorOption o) => o.hex == _selectedColor)) {
+      _selectedColor = '#666666';
+    }
+  }
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final String label = _labelController.text.trim();
+
+    Navigator.of(context).pop(<String, dynamic>{
+      'label': label.isEmpty ? null : label,
+      'color': _selectedColor,
+      'style': _selectedStyle.value,
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Edit Connection'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            TextField(
+              controller: _labelController,
+              decoration: const InputDecoration(
+                labelText: 'Label (optional)',
+                border: OutlineInputBorder(),
+                hintText: 'e.g. depends on, related to...',
+              ),
+              autofocus: true,
+              onSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Color',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _colorOptions
+                  .map((_ColorOption option) => _ColorButton(
+                        color: option.color,
+                        isSelected: option.hex == _selectedColor,
+                        tooltip: option.label,
+                        onTap: () {
+                          setState(() => _selectedColor = option.hex);
+                        },
+                      ))
+                  .toList(),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Style',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            SegmentedButton<ConnectionStyle>(
+              segments: const <ButtonSegment<ConnectionStyle>>[
+                ButtonSegment<ConnectionStyle>(
+                  value: ConnectionStyle.solid,
+                  label: Text('Solid'),
+                  icon: Icon(Icons.horizontal_rule, size: 18),
+                ),
+                ButtonSegment<ConnectionStyle>(
+                  value: ConnectionStyle.dashed,
+                  label: Text('Dashed'),
+                  icon: Icon(Icons.more_horiz, size: 18),
+                ),
+                ButtonSegment<ConnectionStyle>(
+                  value: ConnectionStyle.arrow,
+                  label: Text('Arrow'),
+                  icon: Icon(Icons.arrow_forward, size: 18),
+                ),
+              ],
+              selected: <ConnectionStyle>{_selectedStyle},
+              onSelectionChanged: (Set<ConnectionStyle> selection) {
+                setState(() => _selectedStyle = selection.first);
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Кнопка выбора цвета.
+class _ColorButton extends StatelessWidget {
+  const _ColorButton({
+    required this.color,
+    required this.isSelected,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  final Color color;
+  final bool isSelected;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: isSelected
+                  ? Theme.of(context).colorScheme.primary
+                  : Colors.transparent,
+              width: isSelected ? 3 : 0,
+            ),
+          ),
+          child: isSelected
+              ? Icon(
+                  Icons.check,
+                  size: 16,
+                  color: _contrastColor(color),
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+
+  /// Возвращает контрастный цвет (белый или чёрный) для читаемости.
+  static Color _contrastColor(Color color) {
+    final double luminance = color.computeLuminance();
+    return luminance > 0.5 ? Colors.black : Colors.white;
+  }
+}

--- a/lib/shared/models/canvas_connection.dart
+++ b/lib/shared/models/canvas_connection.dart
@@ -1,0 +1,170 @@
+// Модель связи между элементами канваса.
+
+/// Стиль линии связи.
+enum ConnectionStyle {
+  /// Сплошная линия.
+  solid('solid'),
+
+  /// Пунктирная линия.
+  dashed('dashed'),
+
+  /// Линия со стрелкой.
+  arrow('arrow');
+
+  const ConnectionStyle(this.value);
+
+  /// Строковое значение для базы данных.
+  final String value;
+
+  /// Создаёт [ConnectionStyle] из строки.
+  static ConnectionStyle fromString(String value) {
+    return ConnectionStyle.values.firstWhere(
+      (ConnectionStyle style) => style.value == value,
+      orElse: () => ConnectionStyle.solid,
+    );
+  }
+}
+
+/// Модель связи между двумя элементами канваса.
+///
+/// Представляет визуальную линию от одного элемента к другому
+/// с настраиваемым стилем, цветом и лейблом.
+class CanvasConnection {
+  /// Создаёт экземпляр [CanvasConnection].
+  const CanvasConnection({
+    required this.id,
+    required this.collectionId,
+    required this.fromItemId,
+    required this.toItemId,
+    required this.createdAt,
+    this.label,
+    this.color = '#666666',
+    this.style = ConnectionStyle.solid,
+  });
+
+  /// Создаёт [CanvasConnection] из записи базы данных.
+  factory CanvasConnection.fromDb(Map<String, dynamic> row) {
+    return CanvasConnection(
+      id: row['id'] as int,
+      collectionId: row['collection_id'] as int,
+      fromItemId: row['from_item_id'] as int,
+      toItemId: row['to_item_id'] as int,
+      label: row['label'] as String?,
+      color: row['color'] as String? ?? '#666666',
+      style: ConnectionStyle.fromString(row['style'] as String? ?? 'solid'),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        (row['created_at'] as int) * 1000,
+      ),
+    );
+  }
+
+  /// Создаёт [CanvasConnection] из JSON (для импорта).
+  factory CanvasConnection.fromJson(Map<String, dynamic> json) {
+    return CanvasConnection(
+      id: json['id'] as int? ?? 0,
+      collectionId: json['collection_id'] as int? ?? 0,
+      fromItemId: json['from_item_id'] as int,
+      toItemId: json['to_item_id'] as int,
+      label: json['label'] as String?,
+      color: json['color'] as String? ?? '#666666',
+      style: ConnectionStyle.fromString(json['style'] as String? ?? 'solid'),
+      createdAt: json['created_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (json['created_at'] as int) * 1000,
+            )
+          : DateTime.now(),
+    );
+  }
+
+  /// Уникальный идентификатор связи.
+  final int id;
+
+  /// ID коллекции.
+  final int collectionId;
+
+  /// ID элемента-источника.
+  final int fromItemId;
+
+  /// ID элемента-цели.
+  final int toItemId;
+
+  /// Текстовый лейбл на линии связи.
+  final String? label;
+
+  /// Цвет линии в формате hex (например, '#FF0000').
+  final String color;
+
+  /// Стиль линии.
+  final ConnectionStyle style;
+
+  /// Дата создания.
+  final DateTime createdAt;
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      if (id != 0) 'id': id,
+      'collection_id': collectionId,
+      'from_item_id': fromItemId,
+      'to_item_id': toItemId,
+      'label': label,
+      'color': color,
+      'style': style.value,
+      'created_at': createdAt.millisecondsSinceEpoch ~/ 1000,
+    };
+  }
+
+  /// Преобразует в JSON для экспорта.
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'from_item_id': fromItemId,
+      'to_item_id': toItemId,
+      'label': label,
+      'color': color,
+      'style': style.value,
+      'created_at': createdAt.millisecondsSinceEpoch ~/ 1000,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  ///
+  /// Используйте [clearLabel] = true для сброса label в null,
+  /// так как передача `label: null` оставляет текущее значение.
+  CanvasConnection copyWith({
+    int? id,
+    int? collectionId,
+    int? fromItemId,
+    int? toItemId,
+    String? label,
+    bool clearLabel = false,
+    String? color,
+    ConnectionStyle? style,
+    DateTime? createdAt,
+  }) {
+    return CanvasConnection(
+      id: id ?? this.id,
+      collectionId: collectionId ?? this.collectionId,
+      fromItemId: fromItemId ?? this.fromItemId,
+      toItemId: toItemId ?? this.toItemId,
+      label: clearLabel ? null : (label ?? this.label),
+      color: color ?? this.color,
+      style: style ?? this.style,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CanvasConnection && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() =>
+      'CanvasConnection(id: $id, from: $fromItemId, to: $toItemId, '
+      'style: ${style.value})';
+}

--- a/test/data/repositories/canvas_repository_connections_test.dart
+++ b/test/data/repositories/canvas_repository_connections_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/data/repositories/canvas_repository.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  group('CanvasRepository — Connections', () {
+    late MockDatabaseService mockDb;
+    late CanvasRepository repository;
+
+    final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
+    final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
+
+    setUp(() {
+      mockDb = MockDatabaseService();
+      repository = CanvasRepository(db: mockDb);
+    });
+
+    group('getConnections', () {
+      test('should return list of connections from database', () async {
+        final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'from_item_id': 100,
+            'to_item_id': 200,
+            'label': 'depends on',
+            'color': '#FF0000',
+            'style': 'arrow',
+            'created_at': testTimestamp,
+          },
+          <String, dynamic>{
+            'id': 2,
+            'collection_id': 10,
+            'from_item_id': 200,
+            'to_item_id': 300,
+            'label': null,
+            'color': '#666666',
+            'style': 'solid',
+            'created_at': testTimestamp,
+          },
+        ];
+
+        when(() => mockDb.getCanvasConnections(10))
+            .thenAnswer((_) async => rows);
+
+        final List<CanvasConnection> result =
+            await repository.getConnections(10);
+
+        expect(result.length, 2);
+        expect(result[0].id, 1);
+        expect(result[0].fromItemId, 100);
+        expect(result[0].toItemId, 200);
+        expect(result[0].label, 'depends on');
+        expect(result[0].style, ConnectionStyle.arrow);
+        expect(result[1].id, 2);
+        expect(result[1].label, isNull);
+        verify(() => mockDb.getCanvasConnections(10)).called(1);
+      });
+
+      test('should return empty list when no connections', () async {
+        when(() => mockDb.getCanvasConnections(10))
+            .thenAnswer((_) async => <Map<String, dynamic>>[]);
+
+        final List<CanvasConnection> result =
+            await repository.getConnections(10);
+
+        expect(result, isEmpty);
+      });
+    });
+
+    group('createConnection', () {
+      test('should insert and return connection with id', () async {
+        final CanvasConnection conn = CanvasConnection(
+          id: 0,
+          collectionId: 10,
+          fromItemId: 100,
+          toItemId: 200,
+          label: 'test',
+          color: '#FF0000',
+          style: ConnectionStyle.arrow,
+          createdAt: testDate,
+        );
+
+        when(() => mockDb.insertCanvasConnection(any()))
+            .thenAnswer((_) async => 42);
+
+        final CanvasConnection result =
+            await repository.createConnection(conn);
+
+        expect(result.id, 42);
+        expect(result.fromItemId, 100);
+        expect(result.toItemId, 200);
+        expect(result.label, 'test');
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.insertCanvasConnection(captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured['collection_id'], 10);
+        expect(captured['from_item_id'], 100);
+        expect(captured['to_item_id'], 200);
+        expect(captured['label'], 'test');
+        expect(captured['color'], '#FF0000');
+        expect(captured['style'], 'arrow');
+      });
+    });
+
+    group('updateConnection', () {
+      test('should update label, color and style', () async {
+        final CanvasConnection conn = CanvasConnection(
+          id: 5,
+          collectionId: 10,
+          fromItemId: 100,
+          toItemId: 200,
+          label: 'updated',
+          color: '#00FF00',
+          style: ConnectionStyle.dashed,
+          createdAt: testDate,
+        );
+
+        when(() => mockDb.updateCanvasConnection(any(), any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateConnection(conn);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasConnection(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured['label'], 'updated');
+        expect(captured['color'], '#00FF00');
+        expect(captured['style'], 'dashed');
+        expect(captured.containsKey('id'), isFalse);
+        expect(captured.containsKey('collection_id'), isFalse);
+      });
+
+      test('should handle null label', () async {
+        final CanvasConnection conn = CanvasConnection(
+          id: 5,
+          collectionId: 10,
+          fromItemId: 100,
+          toItemId: 200,
+          color: '#666666',
+          createdAt: testDate,
+        );
+
+        when(() => mockDb.updateCanvasConnection(any(), any()))
+            .thenAnswer((_) async {});
+
+        await repository.updateConnection(conn);
+
+        final Map<String, dynamic> captured =
+            verify(() => mockDb.updateCanvasConnection(5, captureAny()))
+                .captured
+                .first as Map<String, dynamic>;
+        expect(captured['label'], isNull);
+      });
+    });
+
+    group('deleteConnection', () {
+      test('should delete connection by id', () async {
+        when(() => mockDb.deleteCanvasConnection(5))
+            .thenAnswer((_) async {});
+
+        await repository.deleteConnection(5);
+
+        verify(() => mockDb.deleteCanvasConnection(5)).called(1);
+      });
+    });
+  });
+}

--- a/test/features/collections/providers/canvas_provider_connections_test.dart
+++ b/test/features/collections/providers/canvas_provider_connections_test.dart
@@ -1,0 +1,478 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/data/repositories/canvas_repository.dart';
+import 'package:xerabora/features/collections/providers/canvas_provider.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/canvas_viewport.dart';
+import 'package:xerabora/shared/models/collection_game.dart';
+
+class MockCanvasRepository extends Mock implements CanvasRepository {}
+
+class MockCollectionGamesNotifier extends CollectionGamesNotifier {
+  MockCollectionGamesNotifier(this._initialState);
+
+  final AsyncValue<List<CollectionGame>> _initialState;
+
+  @override
+  AsyncValue<List<CollectionGame>> build(int arg) {
+    return _initialState;
+  }
+}
+
+class FakeCanvasItem extends Fake implements CanvasItem {}
+
+class FakeCanvasViewport extends Fake implements CanvasViewport {}
+
+class FakeCanvasConnection extends Fake implements CanvasConnection {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeCanvasItem());
+    registerFallbackValue(FakeCanvasViewport());
+    registerFallbackValue(FakeCanvasConnection());
+  });
+
+  group('CanvasState — connections', () {
+    test('should create with empty connections by default', () {
+      const CanvasState state = CanvasState();
+      expect(state.connections, isEmpty);
+      expect(state.connectingFromId, isNull);
+    });
+
+    test('should create with custom connections', () {
+      final DateTime testDate = DateTime(2024, 6, 15);
+      final List<CanvasConnection> connections = <CanvasConnection>[
+        CanvasConnection(
+          id: 1,
+          collectionId: 10,
+          fromItemId: 100,
+          toItemId: 200,
+          createdAt: testDate,
+        ),
+      ];
+
+      final CanvasState state = CanvasState(
+        connections: connections,
+        connectingFromId: 5,
+      );
+
+      expect(state.connections.length, 1);
+      expect(state.connectingFromId, 5);
+    });
+
+    group('copyWith — connections', () {
+      test('should copy with changed connections', () {
+        const CanvasState original = CanvasState();
+        final DateTime testDate = DateTime(2024, 6, 15);
+        final List<CanvasConnection> newConnections = <CanvasConnection>[
+          CanvasConnection(
+            id: 1,
+            collectionId: 10,
+            fromItemId: 100,
+            toItemId: 200,
+            createdAt: testDate,
+          ),
+        ];
+
+        final CanvasState copy =
+            original.copyWith(connections: newConnections);
+
+        expect(copy.connections.length, 1);
+        expect(copy.items, original.items);
+      });
+
+      test('should copy with connectingFromId', () {
+        const CanvasState original = CanvasState();
+
+        final CanvasState copy =
+            original.copyWith(connectingFromId: 42);
+
+        expect(copy.connectingFromId, 42);
+      });
+
+      test('should clear connectingFromId', () {
+        const CanvasState original = CanvasState(connectingFromId: 42);
+
+        final CanvasState copy =
+            original.copyWith(clearConnectingFromId: true);
+
+        expect(copy.connectingFromId, isNull);
+      });
+
+      test('should keep connectingFromId when not explicitly changed', () {
+        const CanvasState original = CanvasState(connectingFromId: 42);
+
+        final CanvasState copy = original.copyWith(isLoading: false);
+
+        expect(copy.connectingFromId, 42);
+      });
+
+      test('clearConnectingFromId takes precedence over connectingFromId',
+          () {
+        const CanvasState original = CanvasState(connectingFromId: 42);
+
+        final CanvasState copy = original.copyWith(
+          connectingFromId: 99,
+          clearConnectingFromId: true,
+        );
+
+        expect(copy.connectingFromId, isNull);
+      });
+    });
+  });
+
+  group('CanvasNotifier — connections', () {
+    late MockCanvasRepository mockRepository;
+    final DateTime testDate = DateTime(2024, 6, 15);
+    const int collectionId = 1;
+
+    late List<CanvasItem> testItems;
+    late List<CanvasConnection> testConnections;
+
+    setUp(() {
+      mockRepository = MockCanvasRepository();
+
+      testItems = <CanvasItem>[
+        CanvasItem(
+          id: 1,
+          collectionId: collectionId,
+          itemType: CanvasItemType.game,
+          itemRefId: 100,
+          x: 50.0,
+          y: 100.0,
+          width: 160,
+          height: 220,
+          zIndex: 0,
+          createdAt: testDate,
+        ),
+        CanvasItem(
+          id: 2,
+          collectionId: collectionId,
+          itemType: CanvasItemType.game,
+          itemRefId: 200,
+          x: 250.0,
+          y: 100.0,
+          width: 160,
+          height: 220,
+          zIndex: 1,
+          createdAt: testDate,
+        ),
+        CanvasItem(
+          id: 3,
+          collectionId: collectionId,
+          itemType: CanvasItemType.text,
+          x: 450.0,
+          y: 100.0,
+          zIndex: 2,
+          createdAt: testDate,
+        ),
+      ];
+
+      testConnections = <CanvasConnection>[
+        CanvasConnection(
+          id: 10,
+          collectionId: collectionId,
+          fromItemId: 1,
+          toItemId: 2,
+          label: 'related',
+          color: '#FF0000',
+          style: ConnectionStyle.solid,
+          createdAt: testDate,
+        ),
+      ];
+    });
+
+    /// Создаёт контейнер Riverpod для тестирования CanvasNotifier.
+    ProviderContainer createContainer({
+      bool hasCanvasItems = true,
+      List<CanvasItem>? items,
+      List<CanvasConnection>? connections,
+    }) {
+      when(() => mockRepository.hasCanvasItems(collectionId))
+          .thenAnswer((_) async => hasCanvasItems);
+      when(() => mockRepository.getItemsWithData(collectionId))
+          .thenAnswer((_) async => items ?? testItems);
+      when(() => mockRepository.getItems(collectionId))
+          .thenAnswer((_) async => items ?? testItems);
+      when(() => mockRepository.getViewport(collectionId))
+          .thenAnswer(
+              (_) async => const CanvasViewport(collectionId: collectionId));
+      when(() => mockRepository.getConnections(collectionId))
+          .thenAnswer((_) async => connections ?? testConnections);
+      when(() => mockRepository.deleteItem(any()))
+          .thenAnswer((_) async {});
+
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          canvasRepositoryProvider.overrideWithValue(mockRepository),
+          collectionGamesNotifierProvider.overrideWith(
+            () => MockCollectionGamesNotifier(
+              const AsyncValue<List<CollectionGame>>.data(<CollectionGame>[]),
+            ),
+          ),
+        ],
+      );
+
+      return container;
+    }
+
+    /// Ждёт загрузку канваса.
+    Future<void> waitForLoad(
+      ProviderContainer container, {
+      Duration timeout = const Duration(seconds: 2),
+    }) async {
+      final Stopwatch sw = Stopwatch()..start();
+      while (sw.elapsed < timeout) {
+        final CanvasState state =
+            container.read(canvasNotifierProvider(collectionId));
+        if (state.isInitialized && !state.isLoading) break;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    }
+
+    test('should load connections during canvas load', () async {
+      final ProviderContainer container = createContainer();
+
+      // Тригерим загрузку
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connections.length, 1);
+      expect(state.connections.first.id, 10);
+      expect(state.connections.first.fromItemId, 1);
+      expect(state.connections.first.toItemId, 2);
+
+      container.dispose();
+    });
+
+    test('startConnection should set connectingFromId', () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .startConnection(1);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connectingFromId, 1);
+
+      container.dispose();
+    });
+
+    test('cancelConnection should clear connectingFromId', () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .startConnection(1);
+      container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .cancelConnection();
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connectingFromId, isNull);
+
+      container.dispose();
+    });
+
+    test('completeConnection should create connection and reset mode',
+        () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      when(() => mockRepository.createConnection(any())).thenAnswer(
+        (Invocation inv) async {
+          final CanvasConnection conn =
+              inv.positionalArguments[0] as CanvasConnection;
+          return conn.copyWith(id: 99);
+        },
+      );
+
+      container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .startConnection(1);
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .completeConnection(2);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connectingFromId, isNull);
+      expect(state.connections.length, 2);
+      expect(state.connections.last.id, 99);
+      expect(state.connections.last.fromItemId, 1);
+      expect(state.connections.last.toItemId, 2);
+
+      container.dispose();
+    });
+
+    test('completeConnection with same item should cancel', () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .startConnection(1);
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .completeConnection(1);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connectingFromId, isNull);
+      // No new connection created
+      expect(state.connections.length, 1);
+
+      container.dispose();
+    });
+
+    test('completeConnection without startConnection should cancel',
+        () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .completeConnection(2);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connectingFromId, isNull);
+      expect(state.connections.length, 1);
+
+      container.dispose();
+    });
+
+    test('deleteConnection should remove from state and db', () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      when(() => mockRepository.deleteConnection(10))
+          .thenAnswer((_) async {});
+
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .deleteConnection(10);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connections, isEmpty);
+      verify(() => mockRepository.deleteConnection(10)).called(1);
+
+      container.dispose();
+    });
+
+    test('updateConnection should update in state and db', () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      when(() => mockRepository.updateConnection(any()))
+          .thenAnswer((_) async {});
+
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .updateConnection(
+            10,
+            label: 'new label',
+            color: '#00FF00',
+            style: ConnectionStyle.dashed,
+          );
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connections.first.label, 'new label');
+      expect(state.connections.first.color, '#00FF00');
+      expect(state.connections.first.style, ConnectionStyle.dashed);
+      verify(() => mockRepository.updateConnection(any())).called(1);
+
+      container.dispose();
+    });
+
+    test('updateConnection with non-existent id should do nothing',
+        () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .updateConnection(
+            999,
+            label: 'should not apply',
+          );
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      expect(state.connections.first.label, 'related');
+      verifyNever(() => mockRepository.updateConnection(any()));
+
+      container.dispose();
+    });
+
+    test('deleteItem should also filter connections', () async {
+      final ProviderContainer container = createContainer();
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      when(() => mockRepository.deleteItem(1)).thenAnswer((_) async {});
+
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .deleteItem(1);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      // Item 1 removed
+      expect(state.items.any((CanvasItem i) => i.id == 1), isFalse);
+      // Connection involving item 1 also removed
+      expect(state.connections, isEmpty);
+
+      container.dispose();
+    });
+
+    test('deleteItem should keep unrelated connections', () async {
+      final CanvasConnection unrelated = CanvasConnection(
+        id: 20,
+        collectionId: collectionId,
+        fromItemId: 2,
+        toItemId: 3,
+        createdAt: testDate,
+      );
+
+      final ProviderContainer container = createContainer(
+        connections: <CanvasConnection>[...testConnections, unrelated],
+      );
+      container.read(canvasNotifierProvider(collectionId));
+      await waitForLoad(container);
+
+      when(() => mockRepository.deleteItem(1)).thenAnswer((_) async {});
+
+      await container
+          .read(canvasNotifierProvider(collectionId).notifier)
+          .deleteItem(1);
+
+      final CanvasState state =
+          container.read(canvasNotifierProvider(collectionId));
+      // Connection 10 (involving item 1) removed, connection 20 kept
+      expect(state.connections.length, 1);
+      expect(state.connections.first.id, 20);
+
+      container.dispose();
+    });
+  });
+}

--- a/test/features/collections/providers/canvas_provider_test.dart
+++ b/test/features/collections/providers/canvas_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/data/repositories/canvas_repository.dart';
 import 'package:xerabora/features/collections/providers/canvas_provider.dart';
 import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
 import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
 import 'package:xerabora/shared/models/collection_game.dart';
@@ -296,6 +297,8 @@ void main() {
           .thenAnswer((_) async => viewport);
       when(() => mockRepository.deleteItem(any()))
           .thenAnswer((_) async {});
+      when(() => mockRepository.getConnections(collectionId))
+          .thenAnswer((_) async => const <CanvasConnection>[]);
     }
 
     // Вспомогательный метод: настроить репо для инициализации нового канваса

--- a/test/features/collections/widgets/canvas_connection_painter_test.dart
+++ b/test/features/collections/widgets/canvas_connection_painter_test.dart
@@ -1,0 +1,566 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_connection_painter.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  final DateTime testDate = DateTime(2024, 6, 15);
+
+  List<CanvasItem> createTestItems() {
+    return <CanvasItem>[
+      CanvasItem(
+        id: 1,
+        collectionId: 10,
+        itemType: CanvasItemType.game,
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        zIndex: 0,
+        createdAt: testDate,
+      ),
+      CanvasItem(
+        id: 2,
+        collectionId: 10,
+        itemType: CanvasItemType.game,
+        x: 200,
+        y: 0,
+        width: 100,
+        height: 100,
+        zIndex: 1,
+        createdAt: testDate,
+      ),
+      CanvasItem(
+        id: 3,
+        collectionId: 10,
+        itemType: CanvasItemType.text,
+        x: 0,
+        y: 200,
+        width: 100,
+        height: 50,
+        zIndex: 2,
+        createdAt: testDate,
+      ),
+    ];
+  }
+
+  group('CanvasConnectionPainter', () {
+    test('should create with required parameters', () {
+      final CanvasConnectionPainter painter = CanvasConnectionPainter(
+        connections: const <CanvasConnection>[],
+        items: const <CanvasItem>[],
+      );
+
+      expect(painter.connections, isEmpty);
+      expect(painter.items, isEmpty);
+      expect(painter.connectingFrom, isNull);
+      expect(painter.mousePosition, isNull);
+    });
+
+    group('shouldRepaint', () {
+      test('should repaint when connections change', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter a = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+        );
+        final CanvasConnectionPainter b = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        expect(a.shouldRepaint(b), isTrue);
+      });
+
+      test('should repaint when items change', () {
+        final CanvasConnectionPainter a = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: createTestItems(),
+        );
+        final CanvasConnectionPainter b = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: const <CanvasItem>[],
+        );
+
+        expect(a.shouldRepaint(b), isTrue);
+      });
+
+      test('should repaint when connectingFrom changes', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter a = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+          connectingFrom: items.first,
+        );
+        final CanvasConnectionPainter b = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+        );
+
+        expect(a.shouldRepaint(b), isTrue);
+      });
+
+      test('should repaint when mousePosition changes', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter a = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+          mousePosition: const Offset(100, 200),
+        );
+        final CanvasConnectionPainter b = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+          mousePosition: const Offset(150, 250),
+        );
+
+        expect(a.shouldRepaint(b), isTrue);
+      });
+
+      test('should not repaint when nothing changes', () {
+        final List<CanvasItem> items = createTestItems();
+        final List<CanvasConnection> connections = <CanvasConnection>[
+          CanvasConnection(
+            id: 1,
+            collectionId: 10,
+            fromItemId: 1,
+            toItemId: 2,
+            createdAt: testDate,
+          ),
+        ];
+
+        final CanvasConnectionPainter a = CanvasConnectionPainter(
+          connections: connections,
+          items: items,
+        );
+        final CanvasConnectionPainter b = CanvasConnectionPainter(
+          connections: connections,
+          items: items,
+        );
+
+        expect(a.shouldRepaint(b), isFalse);
+      });
+    });
+
+    group('hitTest', () {
+      test('should detect hit on connection line', () {
+        final List<CanvasItem> items = createTestItems();
+        // Item 1 center: (50, 50), Item 2 center: (250, 50)
+        // Line from (50,50) to (250,50) — horizontal
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 42,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        // Point on the line
+        final int? result = painter.hitTestConnection(const Offset(150, 50));
+        expect(result, 42);
+      });
+
+      test('should detect hit near connection line within threshold', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 42,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        // Point near the line (within threshold of 8)
+        final int? result = painter.hitTestConnection(const Offset(150, 55));
+        expect(result, 42);
+      });
+
+      test('should not detect hit far from connection line', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 42,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        // Point far from the line
+        final int? result = painter.hitTestConnection(const Offset(150, 150));
+        expect(result, isNull);
+      });
+
+      test('should return null when no connections', () {
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: createTestItems(),
+        );
+
+        final int? result = painter.hitTestConnection(const Offset(100, 100));
+        expect(result, isNull);
+      });
+
+      test('should return first matching connection on overlap', () {
+        final List<CanvasItem> items = createTestItems();
+        // Item 1→2: horizontal at y=50
+        // Item 1→3: vertical at x=50 (item3 center: 50,225)
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 10,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              createdAt: testDate,
+            ),
+            CanvasConnection(
+              id: 20,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 3,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        // Hit on connection 10 (horizontal line at y=50)
+        expect(painter.hitTestConnection(const Offset(150, 50)), 10);
+
+        // Hit on connection 20 (vertical line at x=50)
+        expect(painter.hitTestConnection(const Offset(50, 150)), 20);
+      });
+
+      test('should handle missing items gracefully', () {
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 42,
+              collectionId: 10,
+              fromItemId: 999,
+              toItemId: 998,
+              createdAt: testDate,
+            ),
+          ],
+          items: createTestItems(),
+        );
+
+        final int? result = painter.hitTestConnection(const Offset(100, 100));
+        expect(result, isNull);
+      });
+
+      test('should handle zero-length line segment (same from and to)', () {
+        final List<CanvasItem> items = <CanvasItem>[
+          CanvasItem(
+            id: 1,
+            collectionId: 10,
+            itemType: CanvasItemType.game,
+            x: 100,
+            y: 100,
+            width: 100,
+            height: 100,
+            zIndex: 0,
+            createdAt: testDate,
+          ),
+        ];
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 42,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 1,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        // Should detect hit on point (center of item 1: 150, 150)
+        final int? result = painter.hitTestConnection(const Offset(150, 150));
+        expect(result, 42);
+      });
+    });
+
+    group('paint', () {
+      test('should not throw with empty connections', () {
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: const <CanvasItem>[],
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        // Should not throw
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw with valid connections', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              label: 'test',
+              color: '#FF0000',
+              style: ConnectionStyle.solid,
+              createdAt: testDate,
+            ),
+            CanvasConnection(
+              id: 2,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 3,
+              color: '#00FF00',
+              style: ConnectionStyle.dashed,
+              createdAt: testDate,
+            ),
+            CanvasConnection(
+              id: 3,
+              collectionId: 10,
+              fromItemId: 2,
+              toItemId: 3,
+              color: '#0000FF',
+              style: ConnectionStyle.arrow,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw with connecting from item', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+          connectingFrom: items.first,
+          mousePosition: const Offset(300, 300),
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should handle invalid color gracefully', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              color: 'invalid',
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        // Should fall back to default color, not throw
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw when connectingFrom set but mousePosition null',
+          () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: const <CanvasConnection>[],
+          items: items,
+          connectingFrom: items.first,
+          // mousePosition is null
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw with 8-char hex color', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              color: '#80FF0000',
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw when connection items are missing', () {
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 999,
+              toItemId: 998,
+              label: 'orphan',
+              createdAt: testDate,
+            ),
+          ],
+          items: createTestItems(),
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw with empty label string', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              label: '',
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should use custom labelStyle and labelBackgroundColor', () {
+        final List<CanvasItem> items = createTestItems();
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              label: 'custom style',
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+          labelStyle: const TextStyle(fontSize: 14, color: Colors.black),
+          labelBackgroundColor: const Color(0xFFFFFF00),
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+
+      test('should not throw with item that has null width and height', () {
+        final List<CanvasItem> items = <CanvasItem>[
+          CanvasItem(
+            id: 1,
+            collectionId: 10,
+            itemType: CanvasItemType.text,
+            x: 0,
+            y: 0,
+            zIndex: 0,
+            createdAt: testDate,
+          ),
+          CanvasItem(
+            id: 2,
+            collectionId: 10,
+            itemType: CanvasItemType.text,
+            x: 200,
+            y: 200,
+            zIndex: 1,
+            createdAt: testDate,
+          ),
+        ];
+
+        final CanvasConnectionPainter painter = CanvasConnectionPainter(
+          connections: <CanvasConnection>[
+            CanvasConnection(
+              id: 1,
+              collectionId: 10,
+              fromItemId: 1,
+              toItemId: 2,
+              createdAt: testDate,
+            ),
+          ],
+          items: items,
+        );
+
+        final PictureRecorder recorder = PictureRecorder();
+        final Canvas canvas = Canvas(recorder);
+        painter.paint(canvas, const Size(1000, 1000));
+        recorder.endRecording();
+      });
+    });
+  });
+}

--- a/test/features/collections/widgets/canvas_context_menu_connect_test.dart
+++ b/test/features/collections/widgets/canvas_context_menu_connect_test.dart
@@ -1,0 +1,311 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/canvas_context_menu.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+
+void main() {
+  // Ignore overflow errors in tests (known issue with long text in PopupMenu)
+  setUp(() {
+    FlutterError.onError = (FlutterErrorDetails details) {
+      final bool isOverflowError = details.exception is FlutterError &&
+          details.exception.toString().contains('overflowed by');
+      if (!isOverflowError) {
+        FlutterError.dumpErrorToConsole(details);
+      }
+    };
+  });
+
+  tearDown(() {
+    FlutterError.onError = FlutterError.dumpErrorToConsole;
+  });
+  group('CanvasContextMenu — Connect', () {
+    testWidgets('showItemMenu should show Connect option',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.game,
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                      onConnect: () {},
+                    );
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Connect'), findsOneWidget);
+    });
+
+    testWidgets('showItemMenu Connect should call onConnect callback',
+        (WidgetTester tester) async {
+      bool connectCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showItemMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      itemType: CanvasItemType.game,
+                      onDelete: () {},
+                      onBringToFront: () {},
+                      onSendToBack: () {},
+                      onConnect: () => connectCalled = true,
+                    );
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Connect'));
+      await tester.pumpAndSettle();
+
+      expect(connectCalled, isTrue);
+    });
+  });
+
+  group('CanvasContextMenu — showConnectionMenu', () {
+    testWidgets('should show Edit Connection and Delete Connection options',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 600,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () {
+                        CanvasContextMenu.showConnectionMenu(
+                          context,
+                          position: const Offset(100, 100),
+                          onEdit: () {},
+                          onDelete: () {},
+                        );
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      expect(find.textContaining('Edit'), findsWidgets);
+      expect(find.textContaining('Delete'), findsWidgets);
+    });
+
+    testWidgets('Edit Connection should call onEdit',
+        (WidgetTester tester) async {
+      bool editCalled = false;
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 600,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () {
+                        CanvasContextMenu.showConnectionMenu(
+                          context,
+                          position: const Offset(100, 100),
+                          onEdit: () => editCalled = true,
+                          onDelete: () {},
+                        );
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Find by PopupMenuItem widget type
+      final Finder editMenuItem = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is PopupMenuItem<String> && widget.value == 'edit',
+      );
+      await tester.tap(editMenuItem);
+      await tester.pumpAndSettle();
+
+      expect(editCalled, isTrue);
+    });
+
+    testWidgets('Delete Connection menu item should exist',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 600,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () {
+                        CanvasContextMenu.showConnectionMenu(
+                          context,
+                          position: const Offset(100, 100),
+                          onEdit: () {},
+                          onDelete: () {},
+                        );
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      // Find by PopupMenuItem widget type
+      final Finder deleteMenuItem = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is PopupMenuItem<String> && widget.value == 'delete',
+      );
+
+      expect(deleteMenuItem, findsOneWidget);
+    });
+
+    testWidgets('Delete Connection should show Delete and Cancel buttons',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 600,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () {
+                        CanvasContextMenu.showConnectionMenu(
+                          context,
+                          position: const Offset(100, 100),
+                          onEdit: () {},
+                          onDelete: () {},
+                        );
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      // Verify menu items exist
+      final Finder editItem = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is PopupMenuItem<String> && widget.value == 'edit',
+      );
+      final Finder deleteItem = find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is PopupMenuItem<String> && widget.value == 'delete',
+      );
+
+      expect(editItem, findsOneWidget);
+      expect(deleteItem, findsOneWidget);
+    });
+
+
+    testWidgets('dismiss without selection should not call callbacks',
+        (WidgetTester tester) async {
+      bool editCalled = false;
+      bool deleteCalled = false;
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(size: Size(800, 600)),
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 600,
+                child: Builder(
+                  builder: (BuildContext context) {
+                    return ElevatedButton(
+                      onPressed: () {
+                        CanvasContextMenu.showConnectionMenu(
+                          context,
+                          position: const Offset(100, 100),
+                          onEdit: () => editCalled = true,
+                          onDelete: () => deleteCalled = true,
+                        );
+                      },
+                      child: const Text('Open'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      // Dismiss by tapping outside the menu
+      await tester.tapAt(const Offset(500, 500));
+      await tester.pumpAndSettle();
+
+      expect(editCalled, isFalse);
+      expect(deleteCalled, isFalse);
+    });
+  });
+}

--- a/test/features/collections/widgets/dialogs/edit_connection_dialog_test.dart
+++ b/test/features/collections/widgets/dialogs/edit_connection_dialog_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/dialogs/edit_connection_dialog.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+
+void main() {
+  group('EditConnectionDialog', () {
+    Future<void> pumpDialog(
+      WidgetTester tester, {
+      String? initialLabel,
+      String? initialColor,
+      ConnectionStyle? initialStyle,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    EditConnectionDialog.show(
+                      context,
+                      initialLabel: initialLabel,
+                      initialColor: initialColor,
+                      initialStyle: initialStyle,
+                    );
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('should show dialog with title', (WidgetTester tester) async {
+      await pumpDialog(tester);
+      expect(find.text('Edit Connection'), findsOneWidget);
+    });
+
+    testWidgets('should show label text field', (WidgetTester tester) async {
+      await pumpDialog(tester);
+      expect(find.text('Label (optional)'), findsOneWidget);
+    });
+
+    testWidgets('should show initial label', (WidgetTester tester) async {
+      await pumpDialog(tester, initialLabel: 'depends on');
+      expect(find.text('depends on'), findsOneWidget);
+    });
+
+    testWidgets('should show Color section', (WidgetTester tester) async {
+      await pumpDialog(tester);
+      expect(find.text('Color'), findsOneWidget);
+    });
+
+    testWidgets('should show Style section', (WidgetTester tester) async {
+      await pumpDialog(tester);
+      expect(find.text('Style'), findsOneWidget);
+    });
+
+    testWidgets('should show style segments', (WidgetTester tester) async {
+      await pumpDialog(tester);
+      expect(find.text('Solid'), findsOneWidget);
+      expect(find.text('Dashed'), findsOneWidget);
+      expect(find.text('Arrow'), findsOneWidget);
+    });
+
+    testWidgets('should show Cancel and Save buttons',
+        (WidgetTester tester) async {
+      await pumpDialog(tester);
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+    });
+
+    testWidgets('Cancel should close without result',
+        (WidgetTester tester) async {
+      await pumpDialog(tester);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(find.text('Edit Connection'), findsNothing);
+    });
+
+    testWidgets('Save should close with result',
+        (WidgetTester tester) async {
+      Map<String, dynamic>? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () async {
+                    result = await EditConnectionDialog.show(context);
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Enter label
+      await tester.enterText(find.byType(TextField), 'my label');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!['label'], 'my label');
+      expect(result!['color'], '#666666');
+      expect(result!['style'], 'solid');
+    });
+
+    testWidgets('Save with empty label should return null label',
+        (WidgetTester tester) async {
+      Map<String, dynamic>? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () async {
+                    result = await EditConnectionDialog.show(context);
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!['label'], isNull);
+    });
+
+    testWidgets('should show 8 color buttons', (WidgetTester tester) async {
+      await pumpDialog(tester);
+      // Each color button is an InkWell with a Container inside
+      final Finder tooltips = find.byType(Tooltip);
+      // 8 color tooltips + potentially other tooltips
+      expect(tooltips.evaluate().length, greaterThanOrEqualTo(8));
+    });
+
+    testWidgets('should select initial style', (WidgetTester tester) async {
+      await pumpDialog(tester, initialStyle: ConnectionStyle.arrow);
+      // SegmentedButton should have Arrow selected
+      final SegmentedButton<ConnectionStyle> segmented =
+          tester.widget(find.byType(SegmentedButton<ConnectionStyle>));
+      expect(segmented.selected, contains(ConnectionStyle.arrow));
+    });
+
+    testWidgets('should change style when tapping segment',
+        (WidgetTester tester) async {
+      Map<String, dynamic>? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () async {
+                    result = await EditConnectionDialog.show(context);
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Tap on Dashed segment
+      await tester.tap(find.text('Dashed'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(result!['style'], 'dashed');
+    });
+  });
+}

--- a/test/shared/models/canvas_connection_test.dart
+++ b/test/shared/models/canvas_connection_test.dart
@@ -1,0 +1,370 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+
+void main() {
+  group('ConnectionStyle', () {
+    test('should have correct string values', () {
+      expect(ConnectionStyle.solid.value, 'solid');
+      expect(ConnectionStyle.dashed.value, 'dashed');
+      expect(ConnectionStyle.arrow.value, 'arrow');
+    });
+
+    test('fromString should return correct style', () {
+      expect(ConnectionStyle.fromString('solid'), ConnectionStyle.solid);
+      expect(ConnectionStyle.fromString('dashed'), ConnectionStyle.dashed);
+      expect(ConnectionStyle.fromString('arrow'), ConnectionStyle.arrow);
+    });
+
+    test('fromString should return solid for unknown value', () {
+      expect(ConnectionStyle.fromString('unknown'), ConnectionStyle.solid);
+      expect(ConnectionStyle.fromString(''), ConnectionStyle.solid);
+    });
+  });
+
+  group('CanvasConnection', () {
+    final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
+    final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
+
+    CanvasConnection createTestConnection({
+      int id = 1,
+      int collectionId = 10,
+      int fromItemId = 100,
+      int toItemId = 200,
+      String? label,
+      String color = '#FF0000',
+      ConnectionStyle style = ConnectionStyle.solid,
+    }) {
+      return CanvasConnection(
+        id: id,
+        collectionId: collectionId,
+        fromItemId: fromItemId,
+        toItemId: toItemId,
+        label: label,
+        color: color,
+        style: style,
+        createdAt: testDate,
+      );
+    }
+
+    test('should create with required parameters', () {
+      final CanvasConnection conn = createTestConnection();
+      expect(conn.id, 1);
+      expect(conn.collectionId, 10);
+      expect(conn.fromItemId, 100);
+      expect(conn.toItemId, 200);
+      expect(conn.label, isNull);
+      expect(conn.color, '#FF0000');
+      expect(conn.style, ConnectionStyle.solid);
+      expect(conn.createdAt, testDate);
+    });
+
+    test('should create with default color and style', () {
+      final CanvasConnection conn = CanvasConnection(
+        id: 1,
+        collectionId: 10,
+        fromItemId: 100,
+        toItemId: 200,
+        createdAt: testDate,
+      );
+      expect(conn.color, '#666666');
+      expect(conn.style, ConnectionStyle.solid);
+      expect(conn.label, isNull);
+    });
+
+    group('fromDb', () {
+      test('should parse all fields correctly', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': 'depends on',
+          'color': '#FF0000',
+          'style': 'arrow',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromDb(row);
+        expect(conn.id, 1);
+        expect(conn.collectionId, 10);
+        expect(conn.fromItemId, 100);
+        expect(conn.toItemId, 200);
+        expect(conn.label, 'depends on');
+        expect(conn.color, '#FF0000');
+        expect(conn.style, ConnectionStyle.arrow);
+        expect(conn.createdAt.millisecondsSinceEpoch ~/ 1000, testTimestamp);
+      });
+
+      test('should use defaults for null color and style', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': null,
+          'color': null,
+          'style': null,
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromDb(row);
+        expect(conn.label, isNull);
+        expect(conn.color, '#666666');
+        expect(conn.style, ConnectionStyle.solid);
+      });
+
+      test('should parse dashed style', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 2,
+          'collection_id': 10,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': null,
+          'color': '#00FF00',
+          'style': 'dashed',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromDb(row);
+        expect(conn.style, ConnectionStyle.dashed);
+      });
+    });
+
+    group('fromJson', () {
+      test('should parse all fields correctly', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': 'test label',
+          'color': '#0000FF',
+          'style': 'dashed',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromJson(json);
+        expect(conn.id, 1);
+        expect(conn.collectionId, 10);
+        expect(conn.fromItemId, 100);
+        expect(conn.toItemId, 200);
+        expect(conn.label, 'test label');
+        expect(conn.color, '#0000FF');
+        expect(conn.style, ConnectionStyle.dashed);
+      });
+
+      test('should use defaults for missing optional fields', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'from_item_id': 100,
+          'to_item_id': 200,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromJson(json);
+        expect(conn.id, 0);
+        expect(conn.collectionId, 0);
+        expect(conn.label, isNull);
+        expect(conn.color, '#666666');
+        expect(conn.style, ConnectionStyle.solid);
+      });
+
+      test('should use current time when created_at is null', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'created_at': null,
+        };
+        final CanvasConnection conn = CanvasConnection.fromJson(json);
+        // Should be close to now
+        expect(
+          conn.createdAt.difference(DateTime.now()).inSeconds.abs(),
+          lessThan(2),
+        );
+      });
+    });
+
+    group('toDb', () {
+      test('should convert all fields', () {
+        final CanvasConnection conn = createTestConnection(
+          label: 'test',
+        );
+
+        final Map<String, dynamic> db = conn.toDb();
+        expect(db['id'], 1);
+        expect(db['collection_id'], 10);
+        expect(db['from_item_id'], 100);
+        expect(db['to_item_id'], 200);
+        expect(db['label'], 'test');
+        expect(db['color'], '#FF0000');
+        expect(db['style'], 'solid');
+        expect(db['created_at'], testTimestamp);
+      });
+
+      test('should omit id when id is 0', () {
+        final CanvasConnection conn = createTestConnection(id: 0);
+        final Map<String, dynamic> db = conn.toDb();
+        expect(db.containsKey('id'), isFalse);
+      });
+
+      test('should include null label', () {
+        final CanvasConnection conn = createTestConnection();
+        final Map<String, dynamic> db = conn.toDb();
+        expect(db['label'], isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('should convert all fields', () {
+        final CanvasConnection conn = createTestConnection(
+          label: 'json test',
+          style: ConnectionStyle.arrow,
+        );
+
+        final Map<String, dynamic> json = conn.toJson();
+        expect(json['id'], 1);
+        expect(json['from_item_id'], 100);
+        expect(json['to_item_id'], 200);
+        expect(json['label'], 'json test');
+        expect(json['color'], '#FF0000');
+        expect(json['style'], 'arrow');
+        expect(json['created_at'], testTimestamp);
+      });
+
+      test('should not contain collection_id', () {
+        final CanvasConnection conn = createTestConnection();
+        final Map<String, dynamic> json = conn.toJson();
+        expect(json.containsKey('collection_id'), isFalse);
+      });
+    });
+
+    group('copyWith', () {
+      test('should copy with changed fields', () {
+        final CanvasConnection original = createTestConnection();
+        final CanvasConnection copy = original.copyWith(
+          label: 'new label',
+          color: '#00FF00',
+          style: ConnectionStyle.dashed,
+        );
+
+        expect(copy.id, original.id);
+        expect(copy.collectionId, original.collectionId);
+        expect(copy.fromItemId, original.fromItemId);
+        expect(copy.toItemId, original.toItemId);
+        expect(copy.label, 'new label');
+        expect(copy.color, '#00FF00');
+        expect(copy.style, ConnectionStyle.dashed);
+      });
+
+      test('should clear label with clearLabel flag', () {
+        final CanvasConnection original = createTestConnection(
+          label: 'will be cleared',
+        );
+        final CanvasConnection copy = original.copyWith(clearLabel: true);
+
+        expect(copy.label, isNull);
+      });
+
+      test('clearLabel should take precedence over label', () {
+        final CanvasConnection original = createTestConnection(
+          label: 'old',
+        );
+        final CanvasConnection copy = original.copyWith(
+          label: 'new',
+          clearLabel: true,
+        );
+
+        expect(copy.label, isNull);
+      });
+
+      test('should keep original values when no changes', () {
+        final CanvasConnection original = createTestConnection(
+          label: 'keep me',
+          color: '#AABBCC',
+        );
+        final CanvasConnection copy = original.copyWith();
+
+        expect(copy.label, 'keep me');
+        expect(copy.color, '#AABBCC');
+        expect(copy.style, original.style);
+        expect(copy.createdAt, original.createdAt);
+      });
+
+      test('should copy with changed id', () {
+        final CanvasConnection original = createTestConnection();
+        final CanvasConnection copy = original.copyWith(id: 99);
+        expect(copy.id, 99);
+      });
+
+      test('should copy with all fields changed', () {
+        final CanvasConnection original = createTestConnection();
+        final DateTime newDate = DateTime(2025, 1, 1);
+        final CanvasConnection copy = original.copyWith(
+          id: 99,
+          collectionId: 20,
+          fromItemId: 300,
+          toItemId: 400,
+          label: 'all changed',
+          color: '#000000',
+          style: ConnectionStyle.arrow,
+          createdAt: newDate,
+        );
+        expect(copy.id, 99);
+        expect(copy.collectionId, 20);
+        expect(copy.fromItemId, 300);
+        expect(copy.toItemId, 400);
+        expect(copy.label, 'all changed');
+        expect(copy.color, '#000000');
+        expect(copy.style, ConnectionStyle.arrow);
+        expect(copy.createdAt, newDate);
+      });
+    });
+
+    group('equality', () {
+      test('should be equal when ids match', () {
+        final CanvasConnection a = createTestConnection(id: 1);
+        final CanvasConnection b = createTestConnection(
+          id: 1,
+          fromItemId: 999,
+          color: '#FFFFFF',
+        );
+        expect(a, equals(b));
+      });
+
+      test('should not be equal when ids differ', () {
+        final CanvasConnection a = createTestConnection(id: 1);
+        final CanvasConnection b = createTestConnection(id: 2);
+        expect(a, isNot(equals(b)));
+      });
+
+      test('should have same hashCode for equal ids', () {
+        final CanvasConnection a = createTestConnection(id: 5);
+        final CanvasConnection b = createTestConnection(id: 5);
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('should be equal to itself (identical)', () {
+        final CanvasConnection conn = createTestConnection(id: 1);
+        expect(conn == conn, isTrue);
+      });
+
+      test('should not be equal to non-CanvasConnection object', () {
+        final CanvasConnection conn = createTestConnection(id: 1);
+        expect(conn == Object(), isFalse);
+      });
+    });
+
+    test('toString should contain key information', () {
+      final CanvasConnection conn = createTestConnection(
+        id: 7,
+        fromItemId: 10,
+        toItemId: 20,
+        style: ConnectionStyle.arrow,
+      );
+
+      final String str = conn.toString();
+      expect(str, contains('7'));
+      expect(str, contains('10'));
+      expect(str, contains('20'));
+      expect(str, contains('arrow'));
+    });
+  });
+}


### PR DESCRIPTION
Add canvas connections with solid/dashed/arrow styles, colors and labels (Stage 9)

- DB migration v6: canvas_connections table with FK CASCADE on canvas_items
- CanvasConnection model with ConnectionStyle enum, fromDb/fromJson/toDb/toJson/copyWith
- CanvasRepository: getConnections, createConnection, updateConnection, deleteConnection
- CanvasNotifier: startConnection, completeConnection, cancelConnection, deleteConnection, updateConnection
- CanvasConnectionPainter: CustomPainter for solid/dashed/arrow lines, labels, hit-testing
- EditConnectionDialog: label, 8 color choices, style selector (Solid/Dashed/Arrow)
- CanvasView: connection rendering layer, creation mode with preview line, Escape to cancel
- CanvasContextMenu: Connect item, showConnectionMenu (Edit/Delete)
- Auto-delete connections when connected element is removed (FK CASCADE + state filter)
- 861 tests passing, flutter analyze clean