### PR TITLE
Add SteamGridDB image panel for canvas (Stage 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@
 ## [Unreleased]
 
 ### Added
+- Добавлена боковая панель SteamGridDB для канваса (Stage 10): поиск игр и добавление изображений (grids, heroes, logos, icons) прямо на канвас
+- Добавлен провайдер `SteamGridDbPanelNotifier` (`lib/features/collections/providers/steamgriddb_panel_provider.dart`) — NotifierProvider.family по collectionId. Управление поиском игр, выбором типа изображений, in-memory кэш результатов API по ключу `gameId:imageType`
+- Добавлен enum `SteamGridDbImageType` (grids/heroes/logos/icons) с отображаемыми лейблами
+- Добавлен виджет `SteamGridDbPanel` (`lib/features/collections/widgets/steamgriddb_panel.dart`) — боковая панель 320px: заголовок, поле поиска (автозаполнение из названия коллекции), предупреждение об отсутствии API ключа, результаты поиска (ListView.builder с verified иконкой), SegmentedButton выбора типа, сетка thumbnail-ов (GridView.builder + CachedNetworkImage). Клик на изображение добавляет его на канвас
+- Добавлена кнопка FAB "SteamGridDB Images" на тулбар канваса (иконка image_search, только в режиме редактирования)
+- Добавлен пункт "Find images..." в контекстное меню пустого места канваса (с разделителем, только в режиме редактирования)
+- Добавлены тесты: `steamgriddb_panel_provider_test.dart` (29), `steamgriddb_panel_test.dart` (28), обновлены `canvas_view_test.dart` (+4), `canvas_context_menu_test.dart` (+3) — всего 64 теста Stage 10
+
+### Changed
+- Изменён `CollectionScreen` — канвас обёрнут в Row с AnimatedContainer (200ms, easeInOut) для анимированного открытия/закрытия панели, `.select((s) => s.isOpen)` для минимизации rebuild. Метод `_addSteamGridDbImage()` масштабирует изображение до max 300px по ширине с сохранением пропорций
+- Изменён `CanvasView` — добавлена кнопка FAB SteamGridDB перед существующими Center view и Reset positions, передаётся `onFindImages` callback в контекстное меню
+- Изменён `CanvasContextMenu.showCanvasMenu()` — добавлен необязательный параметр `onFindImages` и пункт "Find images..." с PopupMenuDivider
+
+---
+
+### Added
 - Добавлены связи Canvas (Stage 9): визуальные линии между элементами канваса с тремя стилями (solid, dashed, arrow), настраиваемым цветом и лейблами
 - Добавлена модель `CanvasConnection` (`lib/shared/models/canvas_connection.dart`) — связь между двумя элементами канваса с полями: id, collectionId, fromItemId, toItemId, label, color (hex), style, createdAt
 - Добавлен enum `ConnectionStyle` (solid/dashed/arrow) с `fromString()` конвертером

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -74,6 +74,13 @@ Visualize your collection on a free-form canvas:
   - Edit/Delete connections via right-click on the line
   - Connections auto-delete when a connected element is removed
   - Temporary dashed preview line while creating a connection
+- **SteamGridDB Image Panel** — side panel for browsing and adding SteamGridDB images to canvas
+  - Search games by name (auto-fills from collection name)
+  - Browse 4 image types: Grids (box art), Heroes (banners), Logos, Icons
+  - Click any thumbnail to add it to the canvas center (scaled to max 300px width)
+  - In-memory cache for API results (no re-fetching on tab switch)
+  - Toggle via FAB button or right-click "Find images..."
+  - Warning when SteamGridDB API key is not configured
 
 ## SteamGridDB Integration
 
@@ -82,6 +89,7 @@ Access high-quality game artwork from SteamGridDB:
 - Browse grid images (box art)
 - Browse hero images (banners)
 - Browse logos and icons
+- Add images directly to canvas from the side panel
 - Debug panel for testing API endpoints (dev builds only)
 
 ## Offline Mode

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@
 - [x] Stage 7: Basic Canvas — visual canvas with zoom, pan, drag-and-drop, grid layout, List/Canvas toggle, bidirectional collection sync
 - [x] Stage 8: Canvas Elements — context menu, text blocks, images, links, resize, z-index
 - [x] Stage 9: Connections — visual connections (solid/dashed/arrow) between canvas elements with labels, colors, edit/delete, auto-cleanup
-- [ ] Stage 10: SteamGridDB Widget — side panel for adding SteamGridDB images to canvas
+- [x] Stage 10: SteamGridDB Widget — side panel for adding SteamGridDB images to canvas
 - [ ] Stage 12: Export Full — extended .rcoll-full format with canvas layout and images
 
 ## Future Plans

--- a/lib/features/collections/providers/steamgriddb_panel_provider.dart
+++ b/lib/features/collections/providers/steamgriddb_panel_provider.dart
@@ -1,0 +1,264 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/steamgriddb_api.dart';
+import '../../../shared/models/steamgriddb_game.dart';
+import '../../../shared/models/steamgriddb_image.dart';
+import '../../settings/providers/settings_provider.dart';
+
+/// Тип изображений SteamGridDB для фильтрации в панели.
+enum SteamGridDbImageType {
+  /// Обложки (box art).
+  grids('Grids'),
+
+  /// Баннеры.
+  heroes('Heroes'),
+
+  /// Логотипы.
+  logos('Logos'),
+
+  /// Иконки.
+  icons('Icons');
+
+  const SteamGridDbImageType(this.label);
+
+  /// Отображаемое название.
+  final String label;
+}
+
+/// Состояние боковой панели SteamGridDB.
+class SteamGridDbPanelState {
+  /// Создаёт экземпляр [SteamGridDbPanelState].
+  const SteamGridDbPanelState({
+    this.isOpen = false,
+    this.searchTerm = '',
+    this.searchResults = const <SteamGridDbGame>[],
+    this.selectedGame,
+    this.selectedImageType = SteamGridDbImageType.grids,
+    this.images = const <SteamGridDbImage>[],
+    this.isSearching = false,
+    this.isLoadingImages = false,
+    this.searchError,
+    this.imageError,
+    this.imageCache = const <String, List<SteamGridDbImage>>{},
+  });
+
+  /// Открыта ли панель.
+  final bool isOpen;
+
+  /// Текущий поисковый запрос.
+  final String searchTerm;
+
+  /// Результаты поиска игр.
+  final List<SteamGridDbGame> searchResults;
+
+  /// Выбранная игра (null = показываем результаты поиска).
+  final SteamGridDbGame? selectedGame;
+
+  /// Выбранный тип изображений.
+  final SteamGridDbImageType selectedImageType;
+
+  /// Текущие изображения для отображения.
+  final List<SteamGridDbImage> images;
+
+  /// Идёт поиск игр.
+  final bool isSearching;
+
+  /// Идёт загрузка изображений.
+  final bool isLoadingImages;
+
+  /// Ошибка при поиске.
+  final String? searchError;
+
+  /// Ошибка при загрузке изображений.
+  final String? imageError;
+
+  /// Кэш изображений по ключу "$gameId:$imageType".
+  final Map<String, List<SteamGridDbImage>> imageCache;
+
+  /// Создаёт копию с изменёнными полями.
+  SteamGridDbPanelState copyWith({
+    bool? isOpen,
+    String? searchTerm,
+    List<SteamGridDbGame>? searchResults,
+    SteamGridDbGame? selectedGame,
+    bool clearSelectedGame = false,
+    SteamGridDbImageType? selectedImageType,
+    List<SteamGridDbImage>? images,
+    bool? isSearching,
+    bool? isLoadingImages,
+    String? searchError,
+    bool clearSearchError = false,
+    String? imageError,
+    bool clearImageError = false,
+    Map<String, List<SteamGridDbImage>>? imageCache,
+  }) {
+    return SteamGridDbPanelState(
+      isOpen: isOpen ?? this.isOpen,
+      searchTerm: searchTerm ?? this.searchTerm,
+      searchResults: searchResults ?? this.searchResults,
+      selectedGame: clearSelectedGame
+          ? null
+          : (selectedGame ?? this.selectedGame),
+      selectedImageType: selectedImageType ?? this.selectedImageType,
+      images: images ?? this.images,
+      isSearching: isSearching ?? this.isSearching,
+      isLoadingImages: isLoadingImages ?? this.isLoadingImages,
+      searchError: clearSearchError ? null : (searchError ?? this.searchError),
+      imageError: clearImageError ? null : (imageError ?? this.imageError),
+      imageCache: imageCache ?? this.imageCache,
+    );
+  }
+}
+
+/// Провайдер для управления боковой панелью SteamGridDB.
+final NotifierProviderFamily<SteamGridDbPanelNotifier, SteamGridDbPanelState,
+        int> steamGridDbPanelProvider =
+    NotifierProvider.family<SteamGridDbPanelNotifier, SteamGridDbPanelState,
+        int>(
+  SteamGridDbPanelNotifier.new,
+);
+
+/// Notifier для управления состоянием боковой панели SteamGridDB.
+class SteamGridDbPanelNotifier
+    extends FamilyNotifier<SteamGridDbPanelState, int> {
+  late SteamGridDbApi _api;
+
+  @override
+  SteamGridDbPanelState build(int arg) {
+    _api = ref.watch(steamGridDbApiProvider);
+    return const SteamGridDbPanelState();
+  }
+
+  /// Переключает видимость панели.
+  void togglePanel() {
+    state = state.copyWith(isOpen: !state.isOpen);
+  }
+
+  /// Открывает панель.
+  void openPanel() {
+    state = state.copyWith(isOpen: true);
+  }
+
+  /// Закрывает панель.
+  void closePanel() {
+    state = state.copyWith(isOpen: false);
+  }
+
+  /// Ищет игры по названию.
+  Future<void> searchGames(String term) async {
+    final String trimmedTerm = term.trim();
+    if (trimmedTerm.isEmpty) return;
+
+    final SettingsState settings = ref.read(settingsNotifierProvider);
+    if (!settings.hasSteamGridDbKey) {
+      state = state.copyWith(
+        searchError: 'SteamGridDB API key not set',
+        clearSearchError: false,
+      );
+      return;
+    }
+
+    state = state.copyWith(
+      isSearching: true,
+      clearSearchError: true,
+      searchTerm: trimmedTerm,
+      clearSelectedGame: true,
+      images: const <SteamGridDbImage>[],
+    );
+
+    try {
+      final List<SteamGridDbGame> results = await _api.searchGames(trimmedTerm);
+      state = state.copyWith(
+        searchResults: results,
+        isSearching: false,
+      );
+    } on SteamGridDbApiException catch (e) {
+      state = state.copyWith(
+        searchError: e.message,
+        isSearching: false,
+      );
+    }
+  }
+
+  /// Выбирает игру и загружает изображения по умолчанию (grids).
+  Future<void> selectGame(SteamGridDbGame game) async {
+    state = state.copyWith(
+      selectedGame: game,
+      selectedImageType: SteamGridDbImageType.grids,
+      images: const <SteamGridDbImage>[],
+      clearImageError: true,
+    );
+    await _loadImages();
+  }
+
+  /// Очищает выбор игры, возвращаясь к результатам поиска.
+  void clearGameSelection() {
+    state = state.copyWith(
+      clearSelectedGame: true,
+      images: const <SteamGridDbImage>[],
+      clearImageError: true,
+    );
+  }
+
+  /// Выбирает тип изображений и загружает их.
+  Future<void> selectImageType(SteamGridDbImageType type) async {
+    state = state.copyWith(
+      selectedImageType: type,
+      images: const <SteamGridDbImage>[],
+      clearImageError: true,
+    );
+    await _loadImages();
+  }
+
+  /// Возвращает ключ кэша для пары (gameId, imageType).
+  String _cacheKey(int gameId, SteamGridDbImageType type) {
+    return '$gameId:${type.name}';
+  }
+
+  /// Загружает изображения для выбранной игры и типа.
+  Future<void> _loadImages() async {
+    final SteamGridDbGame? game = state.selectedGame;
+    if (game == null) return;
+
+    final String key = _cacheKey(game.id, state.selectedImageType);
+
+    // Проверяем кэш
+    final List<SteamGridDbImage>? cached = state.imageCache[key];
+    if (cached != null) {
+      state = state.copyWith(images: cached);
+      return;
+    }
+
+    state = state.copyWith(isLoadingImages: true, clearImageError: true);
+
+    try {
+      final List<SteamGridDbImage> results;
+      switch (state.selectedImageType) {
+        case SteamGridDbImageType.grids:
+          results = await _api.getGrids(game.id);
+        case SteamGridDbImageType.heroes:
+          results = await _api.getHeroes(game.id);
+        case SteamGridDbImageType.logos:
+          results = await _api.getLogos(game.id);
+        case SteamGridDbImageType.icons:
+          results = await _api.getIcons(game.id);
+      }
+
+      // Сохраняем в кэш
+      final Map<String, List<SteamGridDbImage>> updatedCache =
+          Map<String, List<SteamGridDbImage>>.of(state.imageCache);
+      updatedCache[key] = results;
+
+      state = state.copyWith(
+        images: results,
+        isLoadingImages: false,
+        imageCache: updatedCache,
+      );
+    } on SteamGridDbApiException catch (e) {
+      state = state.copyWith(
+        imageError: e.message,
+        isLoadingImages: false,
+      );
+    }
+  }
+}

--- a/lib/features/collections/widgets/canvas_context_menu.dart
+++ b/lib/features/collections/widgets/canvas_context_menu.dart
@@ -21,6 +21,7 @@ class CanvasContextMenu {
     required VoidCallback onAddText,
     required VoidCallback onAddImage,
     required VoidCallback onAddLink,
+    VoidCallback? onFindImages,
   }) async {
     final String? value = await showMenu<String>(
       context: context,
@@ -61,6 +62,19 @@ class CanvasContextMenu {
             ],
           ),
         ),
+        if (onFindImages != null) ...<PopupMenuEntry<String>>[
+          const PopupMenuDivider(),
+          const PopupMenuItem<String>(
+            value: 'find_images',
+            child: Row(
+              children: <Widget>[
+                Icon(Icons.image_search, size: 20),
+                SizedBox(width: 12),
+                Text('Find images...'),
+              ],
+            ),
+          ),
+        ],
       ],
     );
 
@@ -72,6 +86,8 @@ class CanvasContextMenu {
         onAddImage();
       case 'add_link':
         onAddLink();
+      case 'find_images':
+        onFindImages?.call();
     }
   }
 

--- a/lib/features/collections/widgets/canvas_view.dart
+++ b/lib/features/collections/widgets/canvas_view.dart
@@ -17,6 +17,7 @@ import 'dialogs/add_image_dialog.dart';
 import 'dialogs/add_link_dialog.dart';
 import 'dialogs/add_text_dialog.dart';
 import 'dialogs/edit_connection_dialog.dart';
+import '../providers/steamgriddb_panel_provider.dart';
 
 // Виджет канваса для визуального размещения элементов коллекции.
 //
@@ -147,6 +148,12 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
       onAddText: () => _handleAddText(canvasX, canvasY),
       onAddImage: () => _handleAddImage(canvasX, canvasY),
       onAddLink: () => _handleAddLink(canvasX, canvasY),
+      onFindImages: widget.isEditable
+          ? () => ref
+              .read(
+                  steamGridDbPanelProvider(widget.collectionId).notifier)
+              .openPanel()
+          : null,
     );
   }
 
@@ -543,6 +550,23 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
+                  // Поиск изображений SteamGridDB
+                  if (widget.isEditable)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: FloatingActionButton.small(
+                        heroTag: 'canvas_steamgriddb',
+                        onPressed: () {
+                          ref
+                              .read(steamGridDbPanelProvider(
+                                      widget.collectionId)
+                                  .notifier)
+                              .togglePanel();
+                        },
+                        tooltip: 'SteamGridDB Images',
+                        child: const Icon(Icons.image_search),
+                      ),
+                    ),
                   // Центрировать вид на элементах
                   FloatingActionButton.small(
                     heroTag: 'canvas_reset_view',

--- a/lib/features/collections/widgets/steamgriddb_panel.dart
+++ b/lib/features/collections/widgets/steamgriddb_panel.dart
@@ -1,0 +1,481 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../shared/models/steamgriddb_game.dart';
+import '../../../shared/models/steamgriddb_image.dart';
+import '../../settings/providers/settings_provider.dart';
+import '../providers/steamgriddb_panel_provider.dart';
+
+/// Боковая панель для поиска и добавления SteamGridDB-изображений на канвас.
+class SteamGridDbPanel extends ConsumerStatefulWidget {
+  /// Создаёт [SteamGridDbPanel].
+  const SteamGridDbPanel({
+    required this.collectionId,
+    required this.collectionName,
+    required this.onAddImage,
+    super.key,
+  });
+
+  /// ID коллекции.
+  final int collectionId;
+
+  /// Название коллекции (для автозаполнения поиска).
+  final String collectionName;
+
+  /// Колбэк при добавлении изображения на канвас.
+  final void Function(SteamGridDbImage image) onAddImage;
+
+  @override
+  ConsumerState<SteamGridDbPanel> createState() => _SteamGridDbPanelState();
+}
+
+class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
+  final TextEditingController _searchController = TextEditingController();
+  bool _hasPreFilled = false;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _preFillSearchIfNeeded(SteamGridDbPanelState panelState) {
+    if (_hasPreFilled) return;
+    if (panelState.searchResults.isEmpty &&
+        panelState.searchTerm.isEmpty &&
+        widget.collectionName.isNotEmpty) {
+      _searchController.text = widget.collectionName;
+    }
+    _hasPreFilled = true;
+  }
+
+  void _performSearch() {
+    final String term = _searchController.text.trim();
+    if (term.isEmpty) return;
+    ref
+        .read(steamGridDbPanelProvider(widget.collectionId).notifier)
+        .searchGames(term);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SteamGridDbPanelState panelState =
+        ref.watch(steamGridDbPanelProvider(widget.collectionId));
+    final SettingsState settings = ref.watch(settingsNotifierProvider);
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    _preFillSearchIfNeeded(panelState);
+
+    return Container(
+      width: 320,
+      color: colorScheme.surface,
+      child: Column(
+        children: <Widget>[
+          // Заголовок
+          _buildHeader(colorScheme, theme),
+          const Divider(height: 1),
+
+          // Поиск
+          _buildSearchBar(colorScheme),
+
+          // Предупреждение об отсутствии ключа
+          if (!settings.hasSteamGridDbKey)
+            _buildNoApiKeyWarning(colorScheme, theme),
+
+          // Заголовок выбранной игры
+          if (panelState.selectedGame != null)
+            _buildGameHeader(panelState.selectedGame!, colorScheme, theme),
+
+          // Селектор типа изображений
+          if (panelState.selectedGame != null)
+            _buildImageTypeSelector(panelState, colorScheme),
+
+          // Основной контент
+          Expanded(
+            child: _buildContent(panelState, settings, colorScheme, theme),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(ColorScheme colorScheme, ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: <Widget>[
+          Icon(Icons.image_search, color: colorScheme.primary, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'SteamGridDB',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, size: 20),
+            tooltip: 'Close panel',
+            onPressed: () => ref
+                .read(steamGridDbPanelProvider(widget.collectionId).notifier)
+                .closePanel(),
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar(ColorScheme colorScheme) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: TextField(
+        controller: _searchController,
+        decoration: InputDecoration(
+          hintText: 'Search game...',
+          isDense: true,
+          border: const OutlineInputBorder(),
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          suffixIcon: IconButton(
+            icon: const Icon(Icons.search, size: 20),
+            tooltip: 'Search',
+            onPressed: _performSearch,
+          ),
+        ),
+        textInputAction: TextInputAction.search,
+        onSubmitted: (_) => _performSearch(),
+      ),
+    );
+  }
+
+  Widget _buildNoApiKeyWarning(ColorScheme colorScheme, ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Card(
+        color: colorScheme.errorContainer,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.warning_amber, color: colorScheme.error, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'SteamGridDB API key not set. Configure it in Settings.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onErrorContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGameHeader(
+    SteamGridDbGame game,
+    ColorScheme colorScheme,
+    ThemeData theme,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Row(
+        children: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.arrow_back, size: 20),
+            tooltip: 'Back to search',
+            onPressed: () {
+              ref
+                  .read(
+                      steamGridDbPanelProvider(widget.collectionId).notifier)
+                  .clearGameSelection();
+            },
+            visualDensity: VisualDensity.compact,
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              game.name,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (game.verified)
+            Icon(Icons.verified, size: 16, color: colorScheme.primary),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImageTypeSelector(
+    SteamGridDbPanelState panelState,
+    ColorScheme colorScheme,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: SegmentedButton<SteamGridDbImageType>(
+        segments: SteamGridDbImageType.values
+            .map(
+              (SteamGridDbImageType type) => ButtonSegment<SteamGridDbImageType>(
+                value: type,
+                label: Text(
+                  type.label,
+                  style: const TextStyle(fontSize: 12),
+                ),
+              ),
+            )
+            .toList(),
+        selected: <SteamGridDbImageType>{panelState.selectedImageType},
+        onSelectionChanged: (Set<SteamGridDbImageType> selection) {
+          ref
+              .read(steamGridDbPanelProvider(widget.collectionId).notifier)
+              .selectImageType(selection.first);
+        },
+        style: ButtonStyle(
+          visualDensity: VisualDensity.compact,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(horizontal: 8),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(
+    SteamGridDbPanelState panelState,
+    SettingsState settings,
+    ColorScheme colorScheme,
+    ThemeData theme,
+  ) {
+    // Загрузка поиска
+    if (panelState.isSearching) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Загрузка изображений
+    if (panelState.isLoadingImages) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Ошибка поиска
+    if (panelState.searchError != null) {
+      return _buildError(panelState.searchError!, colorScheme, theme);
+    }
+
+    // Ошибка загрузки изображений
+    if (panelState.imageError != null) {
+      return _buildError(panelState.imageError!, colorScheme, theme);
+    }
+
+    // Если выбрана игра — показать сетку изображений
+    if (panelState.selectedGame != null) {
+      return _buildImageGrid(panelState, colorScheme, theme);
+    }
+
+    // Результаты поиска
+    if (panelState.searchResults.isNotEmpty) {
+      return _buildSearchResults(panelState, colorScheme, theme);
+    }
+
+    // Пустое состояние
+    return _buildEmptyState(colorScheme, theme);
+  }
+
+  Widget _buildError(
+    String message,
+    ColorScheme colorScheme,
+    ThemeData theme,
+  ) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.error_outline, size: 48, color: colorScheme.error),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.error,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchResults(
+    SteamGridDbPanelState panelState,
+    ColorScheme colorScheme,
+    ThemeData theme,
+  ) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      itemCount: panelState.searchResults.length,
+      itemBuilder: (BuildContext context, int index) {
+        final SteamGridDbGame game = panelState.searchResults[index];
+        return ListTile(
+          dense: true,
+          title: Text(
+            game.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: game.verified
+              ? Icon(Icons.verified, size: 16, color: colorScheme.primary)
+              : null,
+          onTap: () {
+            ref
+                .read(steamGridDbPanelProvider(widget.collectionId).notifier)
+                .selectGame(game);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildImageGrid(
+    SteamGridDbPanelState panelState,
+    ColorScheme colorScheme,
+    ThemeData theme,
+  ) {
+    if (panelState.images.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            'No images found',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return GridView.builder(
+      padding: const EdgeInsets.all(8),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 8,
+        crossAxisSpacing: 8,
+        childAspectRatio: 0.75,
+      ),
+      itemCount: panelState.images.length,
+      itemBuilder: (BuildContext context, int index) {
+        final SteamGridDbImage image = panelState.images[index];
+        return _ImageThumbnailCard(
+          image: image,
+          colorScheme: colorScheme,
+          theme: theme,
+          onTap: () => widget.onAddImage(image),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState(ColorScheme colorScheme, ThemeData theme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.image_search,
+              size: 48,
+              color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Search for a game to browse images',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Карточка-превью изображения SteamGridDB.
+class _ImageThumbnailCard extends StatelessWidget {
+  const _ImageThumbnailCard({
+    required this.image,
+    required this.colorScheme,
+    required this.theme,
+    required this.onTap,
+  });
+
+  final SteamGridDbImage image;
+  final ColorScheme colorScheme;
+  final ThemeData theme;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: '${image.dimensions} • ${image.style}'
+          '${image.author != null ? ' • by ${image.author}' : ''}',
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Expanded(
+                child: CachedNetworkImage(
+                  imageUrl: image.thumb,
+                  fit: BoxFit.cover,
+                  placeholder: (BuildContext context, String url) => Container(
+                    color: colorScheme.surfaceContainerHighest,
+                    child: const Center(
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                  errorWidget:
+                      (BuildContext context, String url, Object error) =>
+                          Container(
+                    color: colorScheme.surfaceContainerHighest,
+                    child: Icon(
+                      Icons.broken_image_outlined,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                color: colorScheme.surfaceContainerLow,
+                child: Text(
+                  image.dimensions,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/collections/providers/steamgriddb_panel_provider_test.dart
+++ b/test/features/collections/providers/steamgriddb_panel_provider_test.dart
@@ -1,0 +1,590 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/steamgriddb_api.dart';
+import 'package:xerabora/features/collections/providers/steamgriddb_panel_provider.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/shared/models/steamgriddb_game.dart';
+import 'package:xerabora/shared/models/steamgriddb_image.dart';
+
+// Моки
+class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
+
+const int testCollectionId = 10;
+
+const SteamGridDbGame testGame = SteamGridDbGame(
+  id: 123,
+  name: 'Chrono Trigger',
+  verified: true,
+);
+
+const SteamGridDbGame testGame2 = SteamGridDbGame(
+  id: 456,
+  name: 'Super Metroid',
+);
+
+const SteamGridDbImage testImage1 = SteamGridDbImage(
+  id: 1,
+  score: 10,
+  style: 'alternate',
+  url: 'https://example.com/grid1.png',
+  thumb: 'https://example.com/grid1_thumb.png',
+  width: 600,
+  height: 900,
+);
+
+const SteamGridDbImage testImage2 = SteamGridDbImage(
+  id: 2,
+  score: 5,
+  style: 'blurred',
+  url: 'https://example.com/grid2.png',
+  thumb: 'https://example.com/grid2_thumb.png',
+  width: 460,
+  height: 215,
+);
+
+const SettingsState settingsWithKey = SettingsState(
+  steamGridDbApiKey: 'test-api-key',
+);
+
+const SettingsState settingsWithoutKey = SettingsState();
+
+void main() {
+  late MockSteamGridDbApi mockApi;
+
+  setUp(() {
+    mockApi = MockSteamGridDbApi();
+  });
+
+  ProviderContainer createContainer({
+    SettingsState settings = settingsWithKey,
+  }) {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        steamGridDbApiProvider.overrideWithValue(mockApi),
+        settingsNotifierProvider.overrideWith(
+          () => _FakeSettingsNotifier(settings),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SteamGridDbPanelState', () {
+    test('should create with default values', () {
+      const SteamGridDbPanelState state = SteamGridDbPanelState();
+
+      expect(state.isOpen, false);
+      expect(state.searchTerm, '');
+      expect(state.searchResults, isEmpty);
+      expect(state.selectedGame, isNull);
+      expect(state.selectedImageType, SteamGridDbImageType.grids);
+      expect(state.images, isEmpty);
+      expect(state.isSearching, false);
+      expect(state.isLoadingImages, false);
+      expect(state.searchError, isNull);
+      expect(state.imageError, isNull);
+      expect(state.imageCache, isEmpty);
+    });
+
+    group('copyWith', () {
+      test('should copy with changed isOpen', () {
+        const SteamGridDbPanelState original = SteamGridDbPanelState();
+        final SteamGridDbPanelState copy = original.copyWith(isOpen: true);
+
+        expect(copy.isOpen, true);
+        expect(copy.searchTerm, original.searchTerm);
+      });
+
+      test('should copy with changed selectedGame', () {
+        const SteamGridDbPanelState original = SteamGridDbPanelState();
+        final SteamGridDbPanelState copy =
+            original.copyWith(selectedGame: testGame);
+
+        expect(copy.selectedGame, testGame);
+      });
+
+      test('should clear selectedGame', () {
+        final SteamGridDbPanelState withGame =
+            const SteamGridDbPanelState().copyWith(selectedGame: testGame);
+        final SteamGridDbPanelState cleared =
+            withGame.copyWith(clearSelectedGame: true);
+
+        expect(cleared.selectedGame, isNull);
+      });
+
+      test('should clear searchError', () {
+        final SteamGridDbPanelState withError =
+            const SteamGridDbPanelState().copyWith(searchError: 'Error');
+        final SteamGridDbPanelState cleared =
+            withError.copyWith(clearSearchError: true);
+
+        expect(cleared.searchError, isNull);
+      });
+
+      test('should clear imageError', () {
+        final SteamGridDbPanelState withError =
+            const SteamGridDbPanelState().copyWith(imageError: 'Error');
+        final SteamGridDbPanelState cleared =
+            withError.copyWith(clearImageError: true);
+
+        expect(cleared.imageError, isNull);
+      });
+
+      test('should preserve all values when no changes specified', () {
+        final SteamGridDbPanelState original = const SteamGridDbPanelState(
+          isOpen: true,
+          searchTerm: 'test',
+          searchResults: <SteamGridDbGame>[testGame],
+          selectedImageType: SteamGridDbImageType.heroes,
+          images: <SteamGridDbImage>[testImage1],
+          isSearching: true,
+          isLoadingImages: true,
+          searchError: 'err',
+          imageError: 'img err',
+        ).copyWith(selectedGame: testGame);
+        final SteamGridDbPanelState copy = original.copyWith();
+
+        expect(copy.isOpen, original.isOpen);
+        expect(copy.searchTerm, original.searchTerm);
+        expect(copy.searchResults, original.searchResults);
+        expect(copy.selectedGame, original.selectedGame);
+        expect(copy.selectedImageType, original.selectedImageType);
+        expect(copy.images, original.images);
+        expect(copy.isSearching, original.isSearching);
+        expect(copy.isLoadingImages, original.isLoadingImages);
+        expect(copy.searchError, original.searchError);
+        expect(copy.imageError, original.imageError);
+        expect(copy.imageCache, original.imageCache);
+      });
+
+      test('should copy with all fields', () {
+        const SteamGridDbPanelState original = SteamGridDbPanelState();
+        final SteamGridDbPanelState copy = original.copyWith(
+          isOpen: true,
+          searchTerm: 'test',
+          searchResults: const <SteamGridDbGame>[testGame],
+          selectedGame: testGame,
+          selectedImageType: SteamGridDbImageType.heroes,
+          images: const <SteamGridDbImage>[testImage1],
+          isSearching: true,
+          isLoadingImages: true,
+          searchError: 'search error',
+          imageError: 'image error',
+          imageCache: const <String, List<SteamGridDbImage>>{
+            '123:grids': <SteamGridDbImage>[testImage1],
+          },
+        );
+
+        expect(copy.isOpen, true);
+        expect(copy.searchTerm, 'test');
+        expect(copy.searchResults, hasLength(1));
+        expect(copy.selectedGame, testGame);
+        expect(copy.selectedImageType, SteamGridDbImageType.heroes);
+        expect(copy.images, hasLength(1));
+        expect(copy.isSearching, true);
+        expect(copy.isLoadingImages, true);
+        expect(copy.searchError, 'search error');
+        expect(copy.imageError, 'image error');
+        expect(copy.imageCache, hasLength(1));
+      });
+    });
+  });
+
+  group('SteamGridDbImageType', () {
+    test('should have correct labels', () {
+      expect(SteamGridDbImageType.grids.label, 'Grids');
+      expect(SteamGridDbImageType.heroes.label, 'Heroes');
+      expect(SteamGridDbImageType.logos.label, 'Logos');
+      expect(SteamGridDbImageType.icons.label, 'Icons');
+    });
+
+    test('should have 4 values', () {
+      expect(SteamGridDbImageType.values, hasLength(4));
+    });
+  });
+
+  group('SteamGridDbPanelNotifier', () {
+    group('initial state', () {
+      test('should return default state', () {
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+
+        expect(state.isOpen, false);
+        expect(state.searchResults, isEmpty);
+        expect(state.selectedGame, isNull);
+      });
+    });
+
+    group('togglePanel', () {
+      test('should open panel when closed', () {
+        final ProviderContainer container = createContainer();
+        container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .togglePanel();
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.isOpen, true);
+      });
+
+      test('should close panel when open', () {
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        notifier.togglePanel(); // open
+        notifier.togglePanel(); // close
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.isOpen, false);
+      });
+    });
+
+    group('openPanel', () {
+      test('should set isOpen to true', () {
+        final ProviderContainer container = createContainer();
+        container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .openPanel();
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.isOpen, true);
+      });
+    });
+
+    group('closePanel', () {
+      test('should set isOpen to false', () {
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        notifier.openPanel();
+        notifier.closePanel();
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.isOpen, false);
+      });
+    });
+
+    group('searchGames', () {
+      test('should search and return results', () async {
+        when(() => mockApi.searchGames('Chrono')).thenAnswer(
+          (_) async => const <SteamGridDbGame>[testGame],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.searchGames('Chrono');
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.searchResults, hasLength(1));
+        expect(state.searchResults.first.name, 'Chrono Trigger');
+        expect(state.isSearching, false);
+        expect(state.searchError, isNull);
+        expect(state.searchTerm, 'Chrono');
+      });
+
+      test('should trim search term', () async {
+        when(() => mockApi.searchGames('Chrono')).thenAnswer(
+          (_) async => const <SteamGridDbGame>[testGame],
+        );
+
+        final ProviderContainer container = createContainer();
+        await container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .searchGames('  Chrono  ');
+
+        verify(() => mockApi.searchGames('Chrono')).called(1);
+      });
+
+      test('should ignore empty search term', () async {
+        final ProviderContainer container = createContainer();
+        await container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .searchGames('   ');
+
+        verifyNever(() => mockApi.searchGames(any()));
+      });
+
+      test('should clear selected game on new search', () async {
+        when(() => mockApi.searchGames(any())).thenAnswer(
+          (_) async => const <SteamGridDbGame>[testGame],
+        );
+        when(() => mockApi.getGrids(any())).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        // Сначала выбираем игру
+        await notifier.searchGames('Chrono');
+        await notifier.selectGame(testGame);
+
+        // Новый поиск должен сбросить выбор
+        await notifier.searchGames('Metroid');
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.selectedGame, isNull);
+        expect(state.images, isEmpty);
+      });
+
+      test('should set searchError on API exception', () async {
+        when(() => mockApi.searchGames('test')).thenThrow(
+          const SteamGridDbApiException('Rate limit exceeded'),
+        );
+
+        final ProviderContainer container = createContainer();
+        await container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .searchGames('test');
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.searchError, 'Rate limit exceeded');
+        expect(state.isSearching, false);
+      });
+
+      test('should set error when API key not set', () async {
+        final ProviderContainer container =
+            createContainer(settings: settingsWithoutKey);
+        await container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .searchGames('test');
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.searchError, 'SteamGridDB API key not set');
+        verifyNever(() => mockApi.searchGames(any()));
+      });
+    });
+
+    group('selectGame', () {
+      test('should set selected game and load grids', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async =>
+              const <SteamGridDbImage>[testImage1, testImage2],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.selectedGame, testGame);
+        expect(state.selectedImageType, SteamGridDbImageType.grids);
+        expect(state.images, hasLength(2));
+        expect(state.isLoadingImages, false);
+      });
+
+      test('should cache loaded images', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.imageCache.containsKey('123:grids'), true);
+        expect(state.imageCache['123:grids'], hasLength(1));
+      });
+
+      test('should set imageError on API exception', () async {
+        when(() => mockApi.getGrids(123)).thenThrow(
+          const SteamGridDbApiException('Game not found'),
+        );
+
+        final ProviderContainer container = createContainer();
+        await container
+            .read(steamGridDbPanelProvider(testCollectionId).notifier)
+            .selectGame(testGame);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.imageError, 'Game not found');
+        expect(state.isLoadingImages, false);
+      });
+    });
+
+    group('clearGameSelection', () {
+      test('should clear selected game and images', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+        notifier.clearGameSelection();
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.selectedGame, isNull);
+        expect(state.images, isEmpty);
+        expect(state.imageError, isNull);
+      });
+    });
+
+    group('selectImageType', () {
+      test('should change image type and load images', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+        when(() => mockApi.getHeroes(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage2],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+        await notifier.selectImageType(SteamGridDbImageType.heroes);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.selectedImageType, SteamGridDbImageType.heroes);
+        expect(state.images, hasLength(1));
+        expect(state.images.first.id, 2);
+      });
+
+      test('should use cache on second call with same type', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+        when(() => mockApi.getHeroes(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage2],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame); // Loads grids
+        await notifier.selectImageType(SteamGridDbImageType.heroes); // Loads heroes
+        await notifier.selectImageType(SteamGridDbImageType.grids); // Should use cache
+
+        // getGrids вызван только 1 раз (при selectGame), а не 2
+        verify(() => mockApi.getGrids(123)).called(1);
+      });
+
+      test('should load logos', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[],
+        );
+        when(() => mockApi.getLogos(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+        await notifier.selectImageType(SteamGridDbImageType.logos);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.images, hasLength(1));
+        verify(() => mockApi.getLogos(123)).called(1);
+      });
+
+      test('should load icons', () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[],
+        );
+        when(() => mockApi.getIcons(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage2],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+        await notifier.selectImageType(SteamGridDbImageType.icons);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.images, hasLength(1));
+        verify(() => mockApi.getIcons(123)).called(1);
+      });
+    });
+
+    group('_loadImages edge cases', () {
+      test('should do nothing when no game selected', () async {
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        // selectImageType без selectGame — _loadImages должен вернуть early
+        // Нет выбранной игры, вызываем selectImageType напрямую
+        await notifier.selectImageType(SteamGridDbImageType.heroes);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.images, isEmpty);
+        expect(state.isLoadingImages, false);
+        verifyNever(() => mockApi.getHeroes(any()));
+      });
+    });
+
+    group('image cache', () {
+      test('should cache results for different game/type combinations',
+          () async {
+        when(() => mockApi.getGrids(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage1],
+        );
+        when(() => mockApi.getHeroes(123)).thenAnswer(
+          (_) async => const <SteamGridDbImage>[testImage2],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        await notifier.selectGame(testGame);
+        await notifier.selectImageType(SteamGridDbImageType.heroes);
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.imageCache, hasLength(2));
+        expect(state.imageCache.containsKey('123:grids'), true);
+        expect(state.imageCache.containsKey('123:heroes'), true);
+      });
+    });
+  });
+}
+
+/// Фейковый SettingsNotifier для тестов.
+class _FakeSettingsNotifier extends SettingsNotifier {
+  _FakeSettingsNotifier(this._initialState);
+
+  final SettingsState _initialState;
+
+  @override
+  SettingsState build() {
+    return _initialState;
+  }
+}

--- a/test/features/collections/widgets/canvas_context_menu_test.dart
+++ b/test/features/collections/widgets/canvas_context_menu_test.dart
@@ -141,6 +141,99 @@ void main() {
       );
 
       testWidgets(
+        'должен показать пункт Find images когда onFindImages передан',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () {},
+                      onAddImage: () {},
+                      onAddLink: () {},
+                      onFindImages: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Find images...'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'не должен показывать Find images когда onFindImages не передан',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () {},
+                      onAddImage: () {},
+                      onAddLink: () {},
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Find images...'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'должен вызвать onFindImages при выборе Find images',
+        (WidgetTester tester) async {
+          bool called = false;
+
+          await tester.pumpWidget(buildTestApp(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    CanvasContextMenu.showCanvasMenu(
+                      context,
+                      position: const Offset(100, 100),
+                      onAddText: () {},
+                      onAddImage: () {},
+                      onAddLink: () {},
+                      onFindImages: () => called = true,
+                    );
+                  },
+                  child: const Text('Open Menu'),
+                );
+              },
+            ),
+          ));
+
+          await tester.tap(find.text('Open Menu'));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Find images...'));
+          await tester.pumpAndSettle();
+
+          expect(called, true);
+        },
+      );
+
+      testWidgets(
         'должен ничего не делать при закрытии меню без выбора',
         (WidgetTester tester) async {
           bool textCalled = false;

--- a/test/features/collections/widgets/steamgriddb_panel_test.dart
+++ b/test/features/collections/widgets/steamgriddb_panel_test.dart
@@ -1,0 +1,472 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/providers/steamgriddb_panel_provider.dart';
+import 'package:xerabora/features/collections/widgets/steamgriddb_panel.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/shared/models/steamgriddb_game.dart';
+import 'package:xerabora/shared/models/steamgriddb_image.dart';
+
+const int testCollectionId = 10;
+
+const SteamGridDbGame testGame = SteamGridDbGame(
+  id: 123,
+  name: 'Chrono Trigger',
+  verified: true,
+);
+
+const SteamGridDbImage testImage1 = SteamGridDbImage(
+  id: 1,
+  score: 10,
+  style: 'alternate',
+  url: 'https://example.com/grid1.png',
+  thumb: 'https://example.com/grid1_thumb.png',
+  width: 600,
+  height: 900,
+);
+
+const SteamGridDbImage testImage2 = SteamGridDbImage(
+  id: 2,
+  score: 5,
+  style: 'blurred',
+  url: 'https://example.com/grid2.png',
+  thumb: 'https://example.com/grid2_thumb.png',
+  width: 460,
+  height: 215,
+);
+
+const SettingsState settingsWithKey = SettingsState(
+  steamGridDbApiKey: 'test-key',
+);
+
+const SettingsState settingsWithoutKey = SettingsState();
+
+/// Тестовый notifier для SteamGridDB панели.
+class TestSteamGridDbPanelNotifier extends SteamGridDbPanelNotifier {
+  TestSteamGridDbPanelNotifier(this._initialState);
+
+  final SteamGridDbPanelState _initialState;
+
+  @override
+  SteamGridDbPanelState build(int arg) {
+    return _initialState;
+  }
+}
+
+void _noopAddImage(SteamGridDbImage _) {}
+
+Widget buildTestWidget({
+  required SteamGridDbPanelState panelState,
+  SettingsState settings = settingsWithKey,
+  void Function(SteamGridDbImage)? onAddImage,
+}) {
+  return ProviderScope(
+    overrides: <Override>[
+      steamGridDbPanelProvider.overrideWith(
+        () => TestSteamGridDbPanelNotifier(panelState),
+      ),
+      settingsNotifierProvider.overrideWith(
+        () => _FakeSettingsNotifier(settings),
+      ),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 320,
+          height: 600,
+          child: SteamGridDbPanel(
+            collectionId: testCollectionId,
+            collectionName: 'SNES Classics',
+            onAddImage: onAddImage ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('SteamGridDbPanel', () {
+    group('header', () {
+      testWidgets('should display SteamGridDB title', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.text('SteamGridDB'), findsOneWidget);
+      });
+
+      testWidgets('should have close button', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.byIcon(Icons.close), findsOneWidget);
+      });
+
+      testWidgets('should have image_search icon', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.byIcon(Icons.image_search), findsAtLeast(1));
+      });
+    });
+
+    group('search bar', () {
+      testWidgets('should display search text field', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.byType(TextField), findsOneWidget);
+      });
+
+      testWidgets('should have search hint text', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.text('Search game...'), findsOneWidget);
+      });
+
+      testWidgets('should have search icon button', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.byIcon(Icons.search), findsOneWidget);
+      });
+
+      testWidgets('should pre-fill with collection name', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        final TextField textField =
+            tester.widget<TextField>(find.byType(TextField));
+        expect(textField.controller?.text, 'SNES Classics');
+      });
+
+      testWidgets('should not pre-fill when collection name is empty',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(ProviderScope(
+          overrides: <Override>[
+            steamGridDbPanelProvider.overrideWith(
+              () => TestSteamGridDbPanelNotifier(
+                  const SteamGridDbPanelState(isOpen: true)),
+            ),
+            settingsNotifierProvider.overrideWith(
+              () => _FakeSettingsNotifier(settingsWithKey),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 320,
+                height: 600,
+                child: SteamGridDbPanel(
+                  collectionId: testCollectionId,
+                  collectionName: '',
+                  onAddImage: _noopAddImage,
+                ),
+              ),
+            ),
+          ),
+        ));
+
+        final TextField textField =
+            tester.widget<TextField>(find.byType(TextField));
+        expect(textField.controller?.text, '');
+      });
+
+      testWidgets('should not pre-fill when search results exist',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            searchTerm: 'Chrono',
+            searchResults: <SteamGridDbGame>[testGame],
+          ),
+        ));
+
+        final TextField textField =
+            tester.widget<TextField>(find.byType(TextField));
+        // Не должен перезаписывать — уже есть результаты
+        expect(textField.controller?.text, isNot('SNES Classics'));
+      });
+    });
+
+    group('no API key warning', () {
+      testWidgets('should show warning when API key not set',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+          settings: settingsWithoutKey,
+        ));
+
+        expect(find.text('SteamGridDB API key not set. Configure it in Settings.'),
+            findsOneWidget);
+        expect(find.byIcon(Icons.warning_amber), findsOneWidget);
+      });
+
+      testWidgets('should not show warning when API key is set',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+          settings: settingsWithKey,
+        ));
+
+        expect(find.byIcon(Icons.warning_amber), findsNothing);
+      });
+    });
+
+    group('search results', () {
+      testWidgets('should display search results as list tiles',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            searchTerm: 'Chrono',
+            searchResults: <SteamGridDbGame>[
+              testGame,
+              SteamGridDbGame(id: 456, name: 'Chrono Cross'),
+            ],
+          ),
+        ));
+
+        expect(find.text('Chrono Trigger'), findsOneWidget);
+        expect(find.text('Chrono Cross'), findsOneWidget);
+      });
+
+      testWidgets('should not show verified icon for non-verified games',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            searchTerm: 'test',
+            searchResults: <SteamGridDbGame>[
+              SteamGridDbGame(id: 999, name: 'Unverified Game'),
+            ],
+          ),
+        ));
+
+        expect(find.byIcon(Icons.verified), findsNothing);
+      });
+
+      testWidgets('should show verified icon for verified games',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            searchTerm: 'test',
+            searchResults: <SteamGridDbGame>[testGame],
+          ),
+        ));
+
+        expect(find.byIcon(Icons.verified), findsOneWidget);
+      });
+    });
+
+    group('loading states', () {
+      testWidgets('should show spinner when searching',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            isSearching: true,
+          ),
+        ));
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('should show spinner when loading images',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            isLoadingImages: true,
+          ),
+        ));
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+    });
+
+    group('error states', () {
+      testWidgets('should display search error',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            searchError: 'Rate limit exceeded',
+          ),
+        ));
+
+        expect(find.text('Rate limit exceeded'), findsOneWidget);
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      });
+
+      testWidgets('should display image error',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            imageError: 'Game not found',
+          ),
+        ));
+
+        expect(find.text('Game not found'), findsOneWidget);
+      });
+    });
+
+    group('game header', () {
+      testWidgets('should show selected game name',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[testImage1],
+          ),
+        ));
+
+        expect(find.text('Chrono Trigger'), findsOneWidget);
+      });
+
+      testWidgets('should show back button when game selected',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[testImage1],
+          ),
+        ));
+
+        expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+      });
+    });
+
+    group('image type selector', () {
+      testWidgets('should show segmented button when game selected',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[testImage1],
+          ),
+        ));
+
+        expect(find.byType(SegmentedButton<SteamGridDbImageType>),
+            findsOneWidget);
+        expect(find.text('Grids'), findsOneWidget);
+        expect(find.text('Heroes'), findsOneWidget);
+        expect(find.text('Logos'), findsOneWidget);
+        expect(find.text('Icons'), findsOneWidget);
+      });
+
+      testWidgets('should not show segmented button without game',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.byType(SegmentedButton<SteamGridDbImageType>),
+            findsNothing);
+      });
+    });
+
+    group('image grid', () {
+      testWidgets('should display image thumbnails',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[testImage1, testImage2],
+          ),
+        ));
+
+        expect(find.byType(GridView), findsOneWidget);
+        expect(find.byType(CachedNetworkImage), findsNWidgets(2));
+      });
+
+      testWidgets('should show dimensions on thumbnails',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[testImage1],
+          ),
+        ));
+
+        expect(find.text('600x900'), findsOneWidget);
+      });
+
+      testWidgets('should show no images found when empty',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[],
+          ),
+        ));
+
+        expect(find.text('No images found'), findsOneWidget);
+      });
+
+      testWidgets('should call onAddImage when image tapped',
+          (WidgetTester tester) async {
+        SteamGridDbImage? addedImage;
+
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(
+            isOpen: true,
+            selectedGame: testGame,
+            images: <SteamGridDbImage>[testImage1],
+          ),
+          onAddImage: (SteamGridDbImage image) => addedImage = image,
+        ));
+
+        // Нажимаем на карточку изображения (InkWell внутри Card)
+        await tester.tap(find.byType(InkWell).last);
+        await tester.pump();
+
+        expect(addedImage, isNotNull);
+        expect(addedImage!.id, 1);
+        expect(addedImage!.url, 'https://example.com/grid1.png');
+      });
+    });
+
+    group('empty state', () {
+      testWidgets('should show empty state when no results',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          panelState: const SteamGridDbPanelState(isOpen: true),
+        ));
+
+        expect(find.text('Search for a game to browse images'), findsOneWidget);
+      });
+    });
+  });
+}
+
+/// Фейковый SettingsNotifier для тестов.
+class _FakeSettingsNotifier extends SettingsNotifier {
+  _FakeSettingsNotifier(this._initialState);
+
+  final SettingsState _initialState;
+
+  @override
+  SettingsState build() {
+    return _initialState;
+  }
+}


### PR DESCRIPTION
 Summary

  - Добавлена боковая панель SteamGridDB (320px) для канваса — поиск игр и добавление изображений (grids, heroes, logos, icons) прямо на канвас
  - Новый SteamGridDbPanelNotifier (NotifierProvider.family по collectionId) с in-memory кэшем результатов API по ключу gameId:imageType
  - Интеграция в канвас: FAB-кнопка на тулбаре, пункт "Find images..." в контекстном меню, анимированное открытие/закрытие панели (AnimatedContainer 200ms)
