### PR TITLE
Add TMDB API integration for movies and TV shows (Stage 15)

### DIFF
--- a/lib/core/api/tmdb_api.dart
+++ b/lib/core/api/tmdb_api.dart
@@ -1,0 +1,567 @@
+// API клиент для TMDB (TheMovieDB).
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/models/movie.dart';
+import '../../shared/models/tv_season.dart';
+import '../../shared/models/tv_show.dart';
+
+/// Провайдер для TMDB API клиента.
+final Provider<TmdbApi> tmdbApiProvider = Provider<TmdbApi>((Ref ref) {
+  return TmdbApi();
+});
+
+/// Исключение при ошибках TMDB API.
+class TmdbApiException implements Exception {
+  /// Создаёт [TmdbApiException].
+  const TmdbApiException(this.message, {this.statusCode});
+
+  /// Сообщение об ошибке.
+  final String message;
+
+  /// HTTP код ответа (если есть).
+  final int? statusCode;
+
+  @override
+  String toString() => 'TmdbApiException: $message (status: $statusCode)';
+}
+
+/// Жанр из TMDB.
+class TmdbGenre {
+  /// Создаёт [TmdbGenre].
+  const TmdbGenre({required this.id, required this.name});
+
+  /// Создаёт [TmdbGenre] из JSON.
+  factory TmdbGenre.fromJson(Map<String, dynamic> json) {
+    return TmdbGenre(
+      id: json['id'] as int,
+      name: json['name'] as String,
+    );
+  }
+
+  /// ID жанра.
+  final int id;
+
+  /// Название жанра.
+  final String name;
+}
+
+/// Тип результата мультипоиска.
+enum TmdbMediaType {
+  /// Фильм.
+  movie,
+
+  /// Сериал.
+  tv,
+}
+
+/// Результат мультипоиска: фильм или сериал.
+class MultiSearchResult {
+  /// Создаёт [MultiSearchResult].
+  const MultiSearchResult({
+    required this.mediaType,
+    this.movie,
+    this.tvShow,
+  });
+
+  /// Тип медиа.
+  final TmdbMediaType mediaType;
+
+  /// Фильм (если mediaType == movie).
+  final Movie? movie;
+
+  /// Сериал (если mediaType == tv).
+  final TvShow? tvShow;
+}
+
+/// Клиент для работы с TMDB API v3.
+///
+/// Использует API Key (v3 auth) для аутентификации.
+/// Документация: https://developers.themoviedb.org/3
+class TmdbApi {
+  /// Создаёт экземпляр [TmdbApi].
+  TmdbApi({Dio? dio, this.language = 'ru-RU'}) : _dio = dio ?? Dio();
+
+  static const String _baseUrl = 'https://api.themoviedb.org/3';
+
+  final Dio _dio;
+
+  /// Язык для локализации ответов.
+  final String language;
+
+  String? _apiKey;
+
+  /// Устанавливает API ключ для аутентификации.
+  void setApiKey(String apiKey) {
+    _apiKey = apiKey;
+  }
+
+  /// Очищает API ключ.
+  void clearApiKey() {
+    _apiKey = null;
+  }
+
+  /// Проверяет валидность API ключа.
+  ///
+  /// Возвращает true, если ключ корректен.
+  Future<bool> validateApiKey(String apiKey) async {
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/configuration',
+        queryParameters: <String, dynamic>{
+          'api_key': apiKey,
+        },
+      );
+      return response.statusCode == 200;
+    } on DioException {
+      return false;
+    }
+  }
+
+  // ===== Фильмы =====
+
+  /// Ищет фильмы по названию.
+  ///
+  /// [query] — строка поиска.
+  /// [page] — номер страницы (по умолчанию 1).
+  ///
+  /// Возвращает список найденных фильмов.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<Movie>> searchMovies(String query, {int page = 1}) async {
+    _ensureApiKey();
+
+    if (query.trim().isEmpty) {
+      return <Movie>[];
+    }
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/search/movie',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+          'query': query.trim(),
+          'page': page,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to search movies',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> results = data['results'] as List<dynamic>;
+
+      return results
+          .map(
+              (dynamic item) => Movie.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to search movies');
+    }
+  }
+
+  /// Получает фильм по ID.
+  ///
+  /// Возвращает фильм или null, если не найден.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<Movie?> getMovie(int tmdbId) async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/movie/$tmdbId',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch movie',
+          statusCode: response.statusCode,
+        );
+      }
+
+      return Movie.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        return null;
+      }
+      throw _handleDioException(e, 'Failed to fetch movie');
+    }
+  }
+
+  /// Получает популярные фильмы.
+  ///
+  /// [page] — номер страницы (по умолчанию 1).
+  ///
+  /// Возвращает список популярных фильмов.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<Movie>> getPopularMovies({int page = 1}) async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/movie/popular',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+          'page': page,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch popular movies',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> results = data['results'] as List<dynamic>;
+
+      return results
+          .map(
+              (dynamic item) => Movie.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to fetch popular movies');
+    }
+  }
+
+  // ===== Сериалы =====
+
+  /// Ищет сериалы по названию.
+  ///
+  /// [query] — строка поиска.
+  /// [page] — номер страницы (по умолчанию 1).
+  ///
+  /// Возвращает список найденных сериалов.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<TvShow>> searchTvShows(String query, {int page = 1}) async {
+    _ensureApiKey();
+
+    if (query.trim().isEmpty) {
+      return <TvShow>[];
+    }
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/search/tv',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+          'query': query.trim(),
+          'page': page,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to search TV shows',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> results = data['results'] as List<dynamic>;
+
+      return results
+          .map((dynamic item) =>
+              TvShow.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to search TV shows');
+    }
+  }
+
+  /// Получает сериал по ID.
+  ///
+  /// Возвращает сериал или null, если не найден.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<TvShow?> getTvShow(int tmdbId) async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/tv/$tmdbId',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch TV show',
+          statusCode: response.statusCode,
+        );
+      }
+
+      return TvShow.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        return null;
+      }
+      throw _handleDioException(e, 'Failed to fetch TV show');
+    }
+  }
+
+  /// Получает сезоны сериала.
+  ///
+  /// Извлекает сезоны из деталей сериала.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<TvSeason>> getTvSeasons(int tmdbId) async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/tv/$tmdbId',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch TV show seasons',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> seasons = data['seasons'] as List<dynamic>? ?? <dynamic>[];
+
+      return seasons
+          .map((dynamic item) => TvSeason.fromJson(
+                item as Map<String, dynamic>,
+                showId: tmdbId,
+              ))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to fetch TV show seasons');
+    }
+  }
+
+  /// Получает популярные сериалы.
+  ///
+  /// [page] — номер страницы (по умолчанию 1).
+  ///
+  /// Возвращает список популярных сериалов.
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<TvShow>> getPopularTvShows({int page = 1}) async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/tv/popular',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+          'page': page,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch popular TV shows',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> results = data['results'] as List<dynamic>;
+
+      return results
+          .map((dynamic item) =>
+              TvShow.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to fetch popular TV shows');
+    }
+  }
+
+  // ===== Общее =====
+
+  /// Мультипоиск (фильмы + сериалы).
+  ///
+  /// [query] — строка поиска.
+  /// [page] — номер страницы (по умолчанию 1).
+  ///
+  /// Возвращает список результатов (фильмы и сериалы).
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<MultiSearchResult>> multiSearch(
+    String query, {
+    int page = 1,
+  }) async {
+    _ensureApiKey();
+
+    if (query.trim().isEmpty) {
+      return <MultiSearchResult>[];
+    }
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/search/multi',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+          'query': query.trim(),
+          'page': page,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to multi search',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> results = data['results'] as List<dynamic>;
+
+      final List<MultiSearchResult> searchResults = <MultiSearchResult>[];
+
+      for (final dynamic item in results) {
+        final Map<String, dynamic> json = item as Map<String, dynamic>;
+        final String? mediaType = json['media_type'] as String?;
+
+        if (mediaType == 'movie') {
+          searchResults.add(MultiSearchResult(
+            mediaType: TmdbMediaType.movie,
+            movie: Movie.fromJson(json),
+          ));
+        } else if (mediaType == 'tv') {
+          searchResults.add(MultiSearchResult(
+            mediaType: TmdbMediaType.tv,
+            tvShow: TvShow.fromJson(json),
+          ));
+        }
+        // Пропускаем 'person' и другие типы
+      }
+
+      return searchResults;
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to multi search');
+    }
+  }
+
+  /// Возвращает список жанров фильмов.
+  ///
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<TmdbGenre>> getMovieGenres() async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/genre/movie/list',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch movie genres',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> genres = data['genres'] as List<dynamic>;
+
+      return genres
+          .map((dynamic item) =>
+              TmdbGenre.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to fetch movie genres');
+    }
+  }
+
+  /// Возвращает список жанров сериалов.
+  ///
+  /// Throws [TmdbApiException] при ошибке запроса.
+  Future<List<TmdbGenre>> getTvGenres() async {
+    _ensureApiKey();
+
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        '$_baseUrl/genre/tv/list',
+        queryParameters: <String, dynamic>{
+          'api_key': _apiKey,
+          'language': language,
+        },
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw TmdbApiException(
+          'Failed to fetch TV genres',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+      final List<dynamic> genres = data['genres'] as List<dynamic>;
+
+      return genres
+          .map((dynamic item) =>
+              TmdbGenre.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _handleDioException(e, 'Failed to fetch TV genres');
+    }
+  }
+
+  /// Обрабатывает DioException и возвращает TmdbApiException.
+  TmdbApiException _handleDioException(
+    DioException e,
+    String defaultMessage,
+  ) {
+    final int? statusCode = e.response?.statusCode;
+    String message = defaultMessage;
+
+    if (statusCode == 401) {
+      message = 'Invalid API key';
+    } else if (statusCode == 404) {
+      message = 'Resource not found';
+    } else if (statusCode == 429) {
+      message = 'Rate limit exceeded. Please try again later';
+    } else if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.receiveTimeout) {
+      message = 'Connection timeout';
+    } else if (e.type == DioExceptionType.connectionError) {
+      message = 'No internet connection';
+    }
+
+    return TmdbApiException(message, statusCode: statusCode);
+  }
+
+  void _ensureApiKey() {
+    if (_apiKey == null) {
+      throw const TmdbApiException('API key not set');
+    }
+  }
+
+  /// Закрывает HTTP клиент.
+  void dispose() {
+    _dio.close();
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -39,11 +39,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   final TextEditingController _clientSecretController = TextEditingController();
   final TextEditingController _steamGridDbKeyController =
       TextEditingController();
+  final TextEditingController _tmdbKeyController = TextEditingController();
   final FocusNode _clientIdFocus = FocusNode();
   final FocusNode _clientSecretFocus = FocusNode();
 
   bool _obscureSecret = true;
   bool _obscureSteamGridDbKey = true;
+  bool _obscureTmdbKey = true;
 
   @override
   void initState() {
@@ -56,6 +58,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _clientIdController.text = settings.clientId ?? '';
     _clientSecretController.text = settings.clientSecret ?? '';
     _steamGridDbKeyController.text = settings.steamGridDbApiKey ?? '';
+    _tmdbKeyController.text = settings.tmdbApiKey ?? '';
   }
 
   @override
@@ -63,6 +66,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _clientIdController.dispose();
     _clientSecretController.dispose();
     _steamGridDbKeyController.dispose();
+    _tmdbKeyController.dispose();
     _clientIdFocus.dispose();
     _clientSecretFocus.dispose();
     super.dispose();
@@ -185,6 +189,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             _buildCacheSection(),
             const SizedBox(height: 24),
             _buildSteamGridDbSection(settings),
+            const SizedBox(height: 24),
+            _buildTmdbSection(settings),
             if (kDebugMode) ...<Widget>[
               const SizedBox(height: 24),
               _buildDeveloperToolsSection(settings),
@@ -652,6 +658,98 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     if (mounted) {
       _showSnackBar(
         apiKey.isEmpty ? 'API key cleared' : 'API key saved',
+        isError: false,
+      );
+    }
+  }
+
+  Widget _buildTmdbSection(SettingsState settings) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(Icons.movie,
+                    color: Theme.of(context).colorScheme.primary),
+                const SizedBox(width: 8),
+                Text(
+                  'TMDB API (Movies & TV)',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _tmdbKeyController,
+              decoration: InputDecoration(
+                labelText: 'API Key',
+                hintText: 'Enter your TMDB API key (v3)',
+                border: const OutlineInputBorder(),
+                prefixIcon: const Icon(Icons.vpn_key),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscureTmdbKey
+                        ? Icons.visibility
+                        : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscureTmdbKey = !_obscureTmdbKey;
+                    });
+                  },
+                ),
+              ),
+              obscureText: _obscureTmdbKey,
+              textInputAction: TextInputAction.done,
+              onSubmitted: (_) => _saveTmdbKey(),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: <Widget>[
+                Icon(
+                  settings.hasTmdbKey
+                      ? Icons.check_circle
+                      : Icons.help_outline,
+                  color: settings.hasTmdbKey ? Colors.green : Colors.grey,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  settings.hasTmdbKey ? 'API key saved' : 'No API key',
+                  style: TextStyle(
+                    color:
+                        settings.hasTmdbKey ? Colors.green : Colors.grey,
+                  ),
+                ),
+                const Spacer(),
+                SizedBox(
+                  width: 80,
+                  height: 40,
+                  child: FilledButton(
+                    onPressed: _saveTmdbKey,
+                    child: const Text('Save'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _saveTmdbKey() async {
+    final String apiKey = _tmdbKeyController.text.trim();
+    final SettingsNotifier notifier =
+        ref.read(settingsNotifierProvider.notifier);
+    await notifier.setTmdbApiKey(apiKey);
+
+    if (mounted) {
+      _showSnackBar(
+        apiKey.isEmpty ? 'TMDB API key cleared' : 'TMDB API key saved',
         isError: false,
       );
     }

--- a/lib/shared/models/movie.dart
+++ b/lib/shared/models/movie.dart
@@ -1,0 +1,198 @@
+// Модель фильма из TMDB.
+
+import 'dart:convert';
+
+/// Модель фильма из TMDB API.
+///
+/// Представляет фильм с метаданными из TheMovieDB.
+class Movie {
+  /// Создаёт экземпляр [Movie].
+  const Movie({
+    required this.tmdbId,
+    required this.title,
+    this.originalTitle,
+    this.posterUrl,
+    this.backdropUrl,
+    this.overview,
+    this.genres,
+    this.releaseYear,
+    this.rating,
+    this.runtime,
+    this.cachedAt,
+  });
+
+  /// Создаёт [Movie] из JSON ответа TMDB API.
+  factory Movie.fromJson(Map<String, dynamic> json) {
+    // Извлекаем URL постера
+    String? posterUrl;
+    final String? posterPath = json['poster_path'] as String?;
+    if (posterPath != null) {
+      posterUrl = 'https://image.tmdb.org/t/p/w500$posterPath';
+    }
+
+    // Извлекаем URL бэкдропа
+    String? backdropUrl;
+    final String? backdropPath = json['backdrop_path'] as String?;
+    if (backdropPath != null) {
+      backdropUrl = 'https://image.tmdb.org/t/p/w780$backdropPath';
+    }
+
+    // Извлекаем год из release_date (формат: "2010-07-16")
+    int? releaseYear;
+    final String? releaseDate = json['release_date'] as String?;
+    if (releaseDate != null && releaseDate.length >= 4) {
+      releaseYear = int.tryParse(releaseDate.substring(0, 4));
+    }
+
+    // Извлекаем жанры
+    List<String>? genres;
+    if (json['genres'] != null) {
+      final List<dynamic> genresList = json['genres'] as List<dynamic>;
+      genres = genresList
+          .map((dynamic g) => (g as Map<String, dynamic>)['name'] as String)
+          .toList();
+    } else if (json['genre_ids'] != null) {
+      // В результатах поиска приходят только ID жанров
+      final List<dynamic> genreIds = json['genre_ids'] as List<dynamic>;
+      genres = genreIds.map((dynamic id) => id.toString()).toList();
+    }
+
+    return Movie(
+      tmdbId: json['id'] as int,
+      title: json['title'] as String,
+      originalTitle: json['original_title'] as String?,
+      posterUrl: posterUrl,
+      backdropUrl: backdropUrl,
+      overview: json['overview'] as String?,
+      genres: genres,
+      releaseYear: releaseYear,
+      rating: (json['vote_average'] as num?)?.toDouble(),
+      runtime: json['runtime'] as int?,
+      cachedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+  }
+
+  /// Создаёт [Movie] из записи базы данных.
+  factory Movie.fromDb(Map<String, dynamic> row) {
+    List<String>? genres;
+    if (row['genres'] != null && (row['genres'] as String).isNotEmpty) {
+      genres = (jsonDecode(row['genres'] as String) as List<dynamic>)
+          .map((dynamic g) => g as String)
+          .toList();
+    }
+
+    return Movie(
+      tmdbId: row['tmdb_id'] as int,
+      title: row['title'] as String,
+      originalTitle: row['original_title'] as String?,
+      posterUrl: row['poster_url'] as String?,
+      backdropUrl: row['backdrop_url'] as String?,
+      overview: row['overview'] as String?,
+      genres: genres,
+      releaseYear: row['release_year'] as int?,
+      rating: row['rating'] as double?,
+      runtime: row['runtime'] as int?,
+      cachedAt: row['cached_at'] as int?,
+    );
+  }
+
+  /// Уникальный идентификатор фильма в TMDB.
+  final int tmdbId;
+
+  /// Название фильма (локализованное).
+  final String title;
+
+  /// Оригинальное название фильма.
+  final String? originalTitle;
+
+  /// URL постера фильма.
+  final String? posterUrl;
+
+  /// URL бэкдропа фильма.
+  final String? backdropUrl;
+
+  /// Описание фильма.
+  final String? overview;
+
+  /// Список жанров.
+  final List<String>? genres;
+
+  /// Год выхода.
+  final int? releaseYear;
+
+  /// Рейтинг TMDB (0-10).
+  final double? rating;
+
+  /// Длительность в минутах.
+  final int? runtime;
+
+  /// Время кеширования (Unix timestamp).
+  final int? cachedAt;
+
+  /// Возвращает отформатированный рейтинг.
+  String? get formattedRating {
+    if (rating == null) return null;
+    return rating!.toStringAsFixed(1);
+  }
+
+  /// Возвращает жанры в виде строки через запятую.
+  String? get genresString => genres?.join(', ');
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'tmdb_id': tmdbId,
+      'title': title,
+      'original_title': originalTitle,
+      'poster_url': posterUrl,
+      'backdrop_url': backdropUrl,
+      'overview': overview,
+      'genres': genres != null ? jsonEncode(genres) : null,
+      'release_year': releaseYear,
+      'rating': rating,
+      'runtime': runtime,
+      'cached_at': cachedAt,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  Movie copyWith({
+    int? tmdbId,
+    String? title,
+    String? originalTitle,
+    String? posterUrl,
+    String? backdropUrl,
+    String? overview,
+    List<String>? genres,
+    int? releaseYear,
+    double? rating,
+    int? runtime,
+    int? cachedAt,
+  }) {
+    return Movie(
+      tmdbId: tmdbId ?? this.tmdbId,
+      title: title ?? this.title,
+      originalTitle: originalTitle ?? this.originalTitle,
+      posterUrl: posterUrl ?? this.posterUrl,
+      backdropUrl: backdropUrl ?? this.backdropUrl,
+      overview: overview ?? this.overview,
+      genres: genres ?? this.genres,
+      releaseYear: releaseYear ?? this.releaseYear,
+      rating: rating ?? this.rating,
+      runtime: runtime ?? this.runtime,
+      cachedAt: cachedAt ?? this.cachedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Movie && other.tmdbId == tmdbId;
+  }
+
+  @override
+  int get hashCode => tmdbId.hashCode;
+
+  @override
+  String toString() => 'Movie(tmdbId: $tmdbId, title: $title)';
+}

--- a/lib/shared/models/tv_season.dart
+++ b/lib/shared/models/tv_season.dart
@@ -1,0 +1,110 @@
+// Модель сезона сериала из TMDB.
+
+/// Модель сезона сериала из TMDB API.
+///
+/// Представляет сезон сериала с метаданными.
+class TvSeason {
+  /// Создаёт экземпляр [TvSeason].
+  const TvSeason({
+    required this.tmdbShowId,
+    required this.seasonNumber,
+    this.name,
+    this.episodeCount,
+    this.posterUrl,
+    this.airDate,
+  });
+
+  /// Создаёт [TvSeason] из JSON ответа TMDB API.
+  factory TvSeason.fromJson(Map<String, dynamic> json, {required int showId}) {
+    String? posterUrl;
+    final String? posterPath = json['poster_path'] as String?;
+    if (posterPath != null) {
+      posterUrl = 'https://image.tmdb.org/t/p/w500$posterPath';
+    }
+
+    return TvSeason(
+      tmdbShowId: showId,
+      seasonNumber: json['season_number'] as int,
+      name: json['name'] as String?,
+      episodeCount: json['episode_count'] as int?,
+      posterUrl: posterUrl,
+      airDate: json['air_date'] as String?,
+    );
+  }
+
+  /// Создаёт [TvSeason] из записи базы данных.
+  factory TvSeason.fromDb(Map<String, dynamic> row) {
+    return TvSeason(
+      tmdbShowId: row['tmdb_show_id'] as int,
+      seasonNumber: row['season_number'] as int,
+      name: row['name'] as String?,
+      episodeCount: row['episode_count'] as int?,
+      posterUrl: row['poster_url'] as String?,
+      airDate: row['air_date'] as String?,
+    );
+  }
+
+  /// ID сериала в TMDB.
+  final int tmdbShowId;
+
+  /// Номер сезона.
+  final int seasonNumber;
+
+  /// Название сезона.
+  final String? name;
+
+  /// Количество эпизодов в сезоне.
+  final int? episodeCount;
+
+  /// URL постера сезона.
+  final String? posterUrl;
+
+  /// Дата выхода сезона (формат: "YYYY-MM-DD").
+  final String? airDate;
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'tmdb_show_id': tmdbShowId,
+      'season_number': seasonNumber,
+      'name': name,
+      'episode_count': episodeCount,
+      'poster_url': posterUrl,
+      'air_date': airDate,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  TvSeason copyWith({
+    int? tmdbShowId,
+    int? seasonNumber,
+    String? name,
+    int? episodeCount,
+    String? posterUrl,
+    String? airDate,
+  }) {
+    return TvSeason(
+      tmdbShowId: tmdbShowId ?? this.tmdbShowId,
+      seasonNumber: seasonNumber ?? this.seasonNumber,
+      name: name ?? this.name,
+      episodeCount: episodeCount ?? this.episodeCount,
+      posterUrl: posterUrl ?? this.posterUrl,
+      airDate: airDate ?? this.airDate,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TvSeason &&
+        other.tmdbShowId == tmdbShowId &&
+        other.seasonNumber == seasonNumber;
+  }
+
+  @override
+  int get hashCode => Object.hash(tmdbShowId, seasonNumber);
+
+  @override
+  String toString() =>
+      'TvSeason(showId: $tmdbShowId, season: $seasonNumber)';
+}

--- a/lib/shared/models/tv_show.dart
+++ b/lib/shared/models/tv_show.dart
@@ -1,0 +1,216 @@
+// Модель сериала из TMDB.
+
+import 'dart:convert';
+
+/// Модель сериала из TMDB API.
+///
+/// Представляет сериал с метаданными из TheMovieDB.
+class TvShow {
+  /// Создаёт экземпляр [TvShow].
+  const TvShow({
+    required this.tmdbId,
+    required this.title,
+    this.originalTitle,
+    this.posterUrl,
+    this.backdropUrl,
+    this.overview,
+    this.genres,
+    this.firstAirYear,
+    this.totalSeasons,
+    this.totalEpisodes,
+    this.rating,
+    this.status,
+    this.cachedAt,
+  });
+
+  /// Создаёт [TvShow] из JSON ответа TMDB API.
+  factory TvShow.fromJson(Map<String, dynamic> json) {
+    // Извлекаем URL постера
+    String? posterUrl;
+    final String? posterPath = json['poster_path'] as String?;
+    if (posterPath != null) {
+      posterUrl = 'https://image.tmdb.org/t/p/w500$posterPath';
+    }
+
+    // Извлекаем URL бэкдропа
+    String? backdropUrl;
+    final String? backdropPath = json['backdrop_path'] as String?;
+    if (backdropPath != null) {
+      backdropUrl = 'https://image.tmdb.org/t/p/w780$backdropPath';
+    }
+
+    // Извлекаем год из first_air_date (формат: "2008-01-20")
+    int? firstAirYear;
+    final String? firstAirDate = json['first_air_date'] as String?;
+    if (firstAirDate != null && firstAirDate.length >= 4) {
+      firstAirYear = int.tryParse(firstAirDate.substring(0, 4));
+    }
+
+    // Извлекаем жанры
+    List<String>? genres;
+    if (json['genres'] != null) {
+      final List<dynamic> genresList = json['genres'] as List<dynamic>;
+      genres = genresList
+          .map((dynamic g) => (g as Map<String, dynamic>)['name'] as String)
+          .toList();
+    } else if (json['genre_ids'] != null) {
+      final List<dynamic> genreIds = json['genre_ids'] as List<dynamic>;
+      genres = genreIds.map((dynamic id) => id.toString()).toList();
+    }
+
+    return TvShow(
+      tmdbId: json['id'] as int,
+      title: (json['name'] ?? json['title']) as String,
+      originalTitle:
+          (json['original_name'] ?? json['original_title']) as String?,
+      posterUrl: posterUrl,
+      backdropUrl: backdropUrl,
+      overview: json['overview'] as String?,
+      genres: genres,
+      firstAirYear: firstAirYear,
+      totalSeasons: json['number_of_seasons'] as int?,
+      totalEpisodes: json['number_of_episodes'] as int?,
+      rating: (json['vote_average'] as num?)?.toDouble(),
+      status: json['status'] as String?,
+      cachedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    );
+  }
+
+  /// Создаёт [TvShow] из записи базы данных.
+  factory TvShow.fromDb(Map<String, dynamic> row) {
+    List<String>? genres;
+    if (row['genres'] != null && (row['genres'] as String).isNotEmpty) {
+      genres = (jsonDecode(row['genres'] as String) as List<dynamic>)
+          .map((dynamic g) => g as String)
+          .toList();
+    }
+
+    return TvShow(
+      tmdbId: row['tmdb_id'] as int,
+      title: row['title'] as String,
+      originalTitle: row['original_title'] as String?,
+      posterUrl: row['poster_url'] as String?,
+      backdropUrl: row['backdrop_url'] as String?,
+      overview: row['overview'] as String?,
+      genres: genres,
+      firstAirYear: row['first_air_year'] as int?,
+      totalSeasons: row['total_seasons'] as int?,
+      totalEpisodes: row['total_episodes'] as int?,
+      rating: row['rating'] as double?,
+      status: row['status'] as String?,
+      cachedAt: row['cached_at'] as int?,
+    );
+  }
+
+  /// Уникальный идентификатор сериала в TMDB.
+  final int tmdbId;
+
+  /// Название сериала (локализованное).
+  final String title;
+
+  /// Оригинальное название сериала.
+  final String? originalTitle;
+
+  /// URL постера сериала.
+  final String? posterUrl;
+
+  /// URL бэкдропа сериала.
+  final String? backdropUrl;
+
+  /// Описание сериала.
+  final String? overview;
+
+  /// Список жанров.
+  final List<String>? genres;
+
+  /// Год начала показа.
+  final int? firstAirYear;
+
+  /// Общее количество сезонов.
+  final int? totalSeasons;
+
+  /// Общее количество эпизодов.
+  final int? totalEpisodes;
+
+  /// Рейтинг TMDB (0-10).
+  final double? rating;
+
+  /// Статус сериала (Returning Series, Ended, Canceled).
+  final String? status;
+
+  /// Время кеширования (Unix timestamp).
+  final int? cachedAt;
+
+  /// Возвращает отформатированный рейтинг.
+  String? get formattedRating {
+    if (rating == null) return null;
+    return rating!.toStringAsFixed(1);
+  }
+
+  /// Возвращает жанры в виде строки через запятую.
+  String? get genresString => genres?.join(', ');
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'tmdb_id': tmdbId,
+      'title': title,
+      'original_title': originalTitle,
+      'poster_url': posterUrl,
+      'backdrop_url': backdropUrl,
+      'overview': overview,
+      'genres': genres != null ? jsonEncode(genres) : null,
+      'first_air_year': firstAirYear,
+      'total_seasons': totalSeasons,
+      'total_episodes': totalEpisodes,
+      'rating': rating,
+      'status': status,
+      'cached_at': cachedAt,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  TvShow copyWith({
+    int? tmdbId,
+    String? title,
+    String? originalTitle,
+    String? posterUrl,
+    String? backdropUrl,
+    String? overview,
+    List<String>? genres,
+    int? firstAirYear,
+    int? totalSeasons,
+    int? totalEpisodes,
+    double? rating,
+    String? status,
+    int? cachedAt,
+  }) {
+    return TvShow(
+      tmdbId: tmdbId ?? this.tmdbId,
+      title: title ?? this.title,
+      originalTitle: originalTitle ?? this.originalTitle,
+      posterUrl: posterUrl ?? this.posterUrl,
+      backdropUrl: backdropUrl ?? this.backdropUrl,
+      overview: overview ?? this.overview,
+      genres: genres ?? this.genres,
+      firstAirYear: firstAirYear ?? this.firstAirYear,
+      totalSeasons: totalSeasons ?? this.totalSeasons,
+      totalEpisodes: totalEpisodes ?? this.totalEpisodes,
+      rating: rating ?? this.rating,
+      status: status ?? this.status,
+      cachedAt: cachedAt ?? this.cachedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TvShow && other.tmdbId == tmdbId;
+  }
+
+  @override
+  int get hashCode => tmdbId.hashCode;
+
+  @override
+  String toString() => 'TvShow(tmdbId: $tmdbId, title: $title)';
+}

--- a/test/core/api/tmdb_api_test.dart
+++ b/test/core/api/tmdb_api_test.dart
@@ -1,0 +1,1618 @@
+// Тесты для TMDB API клиента.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_season.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  late TmdbApi sut;
+  late MockDio mockDio;
+
+  const String testApiKey = 'test_api_key_123';
+
+  setUp(() {
+    mockDio = MockDio();
+    sut = TmdbApi(dio: mockDio);
+  });
+
+  tearDown(() {
+    sut.dispose();
+  });
+
+  // ===== Вспомогательные данные =====
+
+  Map<String, dynamic> createMovieJson({
+    int id = 550,
+    String title = 'Бойцовский клуб',
+    String? originalTitle = 'Fight Club',
+    String? posterPath = '/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg',
+    String? backdropPath = '/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg',
+    String? overview = 'Тест описание',
+    String? releaseDate = '1999-10-15',
+    double? voteAverage = 8.4,
+    int? runtime = 139,
+  }) {
+    return <String, dynamic>{
+      'id': id,
+      'title': title,
+      'original_title': originalTitle,
+      'poster_path': posterPath,
+      'backdrop_path': backdropPath,
+      'overview': overview,
+      'release_date': releaseDate,
+      'vote_average': voteAverage,
+      'runtime': runtime,
+      'genre_ids': <int>[18, 53],
+    };
+  }
+
+  Map<String, dynamic> createTvShowJson({
+    int id = 1396,
+    String name = 'Во все тяжкие',
+    String? originalName = 'Breaking Bad',
+    String? posterPath = '/ggFHVNu6YYI5L9pCfOacjizRGt.jpg',
+    String? backdropPath = '/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg',
+    String? overview = 'Сериал о химике',
+    String? firstAirDate = '2008-01-20',
+    int? numberOfSeasons = 5,
+    int? numberOfEpisodes = 62,
+    double? voteAverage = 8.9,
+    String? status = 'Ended',
+  }) {
+    return <String, dynamic>{
+      'id': id,
+      'name': name,
+      'original_name': originalName,
+      'poster_path': posterPath,
+      'backdrop_path': backdropPath,
+      'overview': overview,
+      'first_air_date': firstAirDate,
+      'number_of_seasons': numberOfSeasons,
+      'number_of_episodes': numberOfEpisodes,
+      'vote_average': voteAverage,
+      'status': status,
+      'genre_ids': <int>[18, 80],
+    };
+  }
+
+  Map<String, dynamic> createSeasonJson({
+    int seasonNumber = 1,
+    String? name = 'Сезон 1',
+    int? episodeCount = 7,
+    String? posterPath = '/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg',
+    String? airDate = '2008-01-20',
+  }) {
+    return <String, dynamic>{
+      'season_number': seasonNumber,
+      'name': name,
+      'episode_count': episodeCount,
+      'poster_path': posterPath,
+      'air_date': airDate,
+    };
+  }
+
+  // ===== TmdbApiException =====
+
+  group('TmdbApiException', () {
+    test('должен создать с сообщением', () {
+      const TmdbApiException exception = TmdbApiException('Test error');
+
+      expect(exception.message, equals('Test error'));
+      expect(exception.statusCode, isNull);
+    });
+
+    test('должен создать с сообщением и кодом', () {
+      const TmdbApiException exception = TmdbApiException(
+        'Test error',
+        statusCode: 401,
+      );
+
+      expect(exception.message, equals('Test error'));
+      expect(exception.statusCode, equals(401));
+    });
+
+    test('toString должен вернуть строковое представление', () {
+      const TmdbApiException exception = TmdbApiException(
+        'Test error',
+        statusCode: 401,
+      );
+
+      expect(
+        exception.toString(),
+        equals('TmdbApiException: Test error (status: 401)'),
+      );
+    });
+
+    test('toString должен вернуть null для statusCode если не задан', () {
+      const TmdbApiException exception = TmdbApiException('Test error');
+
+      expect(
+        exception.toString(),
+        equals('TmdbApiException: Test error (status: null)'),
+      );
+    });
+  });
+
+  // ===== TmdbGenre =====
+
+  group('TmdbGenre', () {
+    test('fromJson должен создать жанр из JSON', () {
+      final Map<String, dynamic> json = <String, dynamic>{
+        'id': 28,
+        'name': 'Action',
+      };
+
+      final TmdbGenre genre = TmdbGenre.fromJson(json);
+
+      expect(genre.id, equals(28));
+      expect(genre.name, equals('Action'));
+    });
+
+    test('fromJson должен создать жанр с русским названием', () {
+      final Map<String, dynamic> json = <String, dynamic>{
+        'id': 18,
+        'name': 'Драма',
+      };
+
+      final TmdbGenre genre = TmdbGenre.fromJson(json);
+
+      expect(genre.id, equals(18));
+      expect(genre.name, equals('Драма'));
+    });
+  });
+
+  // ===== TmdbApi =====
+
+  group('TmdbApi', () {
+    // ----- setApiKey / clearApiKey -----
+
+    group('setApiKey', () {
+      test('должен установить API ключ', () {
+        sut.setApiKey(testApiKey);
+
+        // Проверяем что после установки ключа можно вызвать метод
+        // без исключения о недостающем ключе
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('clearApiKey', () {
+      test('должен очистить API ключ', () {
+        sut.setApiKey(testApiKey);
+        sut.clearApiKey();
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+    });
+
+    // ----- _ensureApiKey -----
+
+    group('_ensureApiKey', () {
+      test('должен выбросить исключение если ключ не установлен', () {
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getMovie без ключа', () {
+        expect(
+          () => sut.getMovie(550),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getPopularMovies без ключа', () {
+        expect(
+          () => sut.getPopularMovies(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для searchTvShows без ключа', () {
+        expect(
+          () => sut.searchTvShows('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getTvShow без ключа', () {
+        expect(
+          () => sut.getTvShow(1396),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getTvSeasons без ключа', () {
+        expect(
+          () => sut.getTvSeasons(1396),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getPopularTvShows без ключа', () {
+        expect(
+          () => sut.getPopularTvShows(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для multiSearch без ключа', () {
+        expect(
+          () => sut.multiSearch('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getMovieGenres без ключа', () {
+        expect(
+          () => sut.getMovieGenres(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+
+      test('должен выбросить исключение для getTvGenres без ключа', () {
+        expect(
+          () => sut.getTvGenres(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'API key not set',
+          )),
+        );
+      });
+    });
+
+    // ----- validateApiKey -----
+
+    group('validateApiKey', () {
+      test('должен вернуть true при валидном ключе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{'images': <String, dynamic>{}},
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final bool result = await sut.validateApiKey(testApiKey);
+
+        expect(result, isTrue);
+      });
+
+      test('должен вернуть false при невалидном ключе (DioException)', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        final bool result = await sut.validateApiKey('invalid_key');
+
+        expect(result, isFalse);
+      });
+
+      test('должен вернуть false при ошибке соединения', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(),
+        ));
+
+        final bool result = await sut.validateApiKey(testApiKey);
+
+        expect(result, isFalse);
+      });
+    });
+
+    // ----- searchMovies -----
+
+    group('searchMovies', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть пустой список при пустом запросе', () async {
+        final List<Movie> result = await sut.searchMovies('');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть пустой список при запросе из пробелов', () async {
+        final List<Movie> result = await sut.searchMovies('   ');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть список фильмов при успешном ответе', () async {
+        final Map<String, dynamic> movie1 = createMovieJson();
+        final Map<String, dynamic> movie2 = createMovieJson(
+          id: 680,
+          title: 'Криминальное чтиво',
+          originalTitle: 'Pulp Fiction',
+          releaseDate: '1994-09-10',
+          voteAverage: 8.5,
+        );
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[movie1, movie2],
+                'total_results': 2,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<Movie> result = await sut.searchMovies('test');
+
+        expect(result, hasLength(2));
+        expect(result[0].tmdbId, equals(550));
+        expect(result[0].title, equals('Бойцовский клуб'));
+        expect(result[1].tmdbId, equals(680));
+        expect(result[1].title, equals('Криминальное чтиво'));
+      });
+
+      test('должен выбросить TmdbApiException при DioException 401', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при DioException 429', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 429,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Rate limit exceeded. Please try again later',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при таймауте', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Connection timeout',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при ошибке соединения', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'No internet connection',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при receiveTimeout', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.receiveTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Connection timeout',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getMovie -----
+
+    group('getMovie', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть фильм при успешном ответе', () async {
+        final Map<String, dynamic> movieJson = createMovieJson();
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: movieJson,
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final Movie? result = await sut.getMovie(550);
+
+        expect(result, isNotNull);
+        expect(result!.tmdbId, equals(550));
+        expect(result.title, equals('Бойцовский клуб'));
+        expect(result.originalTitle, equals('Fight Club'));
+        expect(result.releaseYear, equals(1999));
+        expect(result.rating, equals(8.4));
+        expect(result.runtime, equals(139));
+        expect(result.posterUrl, contains('/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg'));
+        expect(result.backdropUrl, contains('/hZkgoQYus5dXo3H8T7Uef6DNknx.jpg'));
+      });
+
+      test('должен вернуть null при 404', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 404,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        final Movie? result = await sut.getMovie(999999);
+
+        expect(result, isNull);
+      });
+
+      test('должен выбросить TmdbApiException при DioException 500', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 500,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getMovie(550),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при DioException 401', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getMovie(550),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getMovie(550),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getPopularMovies -----
+
+    group('getPopularMovies', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть список популярных фильмов', () async {
+        final Map<String, dynamic> movie1 = createMovieJson();
+        final Map<String, dynamic> movie2 = createMovieJson(
+          id: 680,
+          title: 'Криминальное чтиво',
+        );
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[movie1, movie2],
+                'total_results': 2,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<Movie> result = await sut.getPopularMovies();
+
+        expect(result, hasLength(2));
+        expect(result[0].tmdbId, equals(550));
+        expect(result[1].tmdbId, equals(680));
+      });
+
+      test('должен вернуть пустой список при пустых результатах', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+                'total_results': 0,
+                'total_pages': 0,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<Movie> result = await sut.getPopularMovies();
+
+        expect(result, isEmpty);
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getPopularMovies(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 503,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getPopularMovies(),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- searchTvShows -----
+
+    group('searchTvShows', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть пустой список при пустом запросе', () async {
+        final List<TvShow> result = await sut.searchTvShows('');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть пустой список при запросе из пробелов', () async {
+        final List<TvShow> result = await sut.searchTvShows('   ');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть список сериалов при успешном ответе', () async {
+        final Map<String, dynamic> tvShow1 = createTvShowJson();
+        final Map<String, dynamic> tvShow2 = createTvShowJson(
+          id: 1399,
+          name: 'Игра престолов',
+          originalName: 'Game of Thrones',
+          firstAirDate: '2011-04-17',
+          voteAverage: 8.4,
+        );
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[tvShow1, tvShow2],
+                'total_results': 2,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TvShow> result = await sut.searchTvShows('test');
+
+        expect(result, hasLength(2));
+        expect(result[0].tmdbId, equals(1396));
+        expect(result[0].title, equals('Во все тяжкие'));
+        expect(result[1].tmdbId, equals(1399));
+        expect(result[1].title, equals('Игра престолов'));
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchTvShows('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.searchTvShows('test'),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getTvShow -----
+
+    group('getTvShow', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть сериал при успешном ответе', () async {
+        final Map<String, dynamic> tvShowJson = createTvShowJson();
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: tvShowJson,
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final TvShow? result = await sut.getTvShow(1396);
+
+        expect(result, isNotNull);
+        expect(result!.tmdbId, equals(1396));
+        expect(result.title, equals('Во все тяжкие'));
+        expect(result.originalTitle, equals('Breaking Bad'));
+        expect(result.firstAirYear, equals(2008));
+        expect(result.totalSeasons, equals(5));
+        expect(result.totalEpisodes, equals(62));
+        expect(result.rating, equals(8.9));
+        expect(result.status, equals('Ended'));
+      });
+
+      test('должен вернуть null при 404', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 404,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        final TvShow? result = await sut.getTvShow(999999);
+
+        expect(result, isNull);
+      });
+
+      test('должен выбросить TmdbApiException при DioException 500', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 500,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getTvShow(1396),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getTvShow(1396),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getTvSeasons -----
+
+    group('getTvSeasons', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть список сезонов при успешном ответе', () async {
+        final Map<String, dynamic> season1 = createSeasonJson();
+        final Map<String, dynamic> season2 = createSeasonJson(
+          seasonNumber: 2,
+          name: 'Сезон 2',
+          episodeCount: 13,
+          airDate: '2009-03-08',
+        );
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'seasons': <Map<String, dynamic>>[season1, season2],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TvSeason> result = await sut.getTvSeasons(1396);
+
+        expect(result, hasLength(2));
+        expect(result[0].tmdbShowId, equals(1396));
+        expect(result[0].seasonNumber, equals(1));
+        expect(result[0].name, equals('Сезон 1'));
+        expect(result[0].episodeCount, equals(7));
+        expect(result[1].seasonNumber, equals(2));
+        expect(result[1].name, equals('Сезон 2'));
+        expect(result[1].episodeCount, equals(13));
+      });
+
+      test('должен вернуть пустой список если нет сезонов', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'id': 1396,
+                'name': 'Test Show',
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TvSeason> result = await sut.getTvSeasons(1396);
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть пустой список при пустом массиве сезонов', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'seasons': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TvSeason> result = await sut.getTvSeasons(1396);
+
+        expect(result, isEmpty);
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getTvSeasons(1396),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getTvSeasons(1396),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getPopularTvShows -----
+
+    group('getPopularTvShows', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть список популярных сериалов', () async {
+        final Map<String, dynamic> tvShow1 = createTvShowJson();
+        final Map<String, dynamic> tvShow2 = createTvShowJson(
+          id: 1399,
+          name: 'Игра престолов',
+        );
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[tvShow1, tvShow2],
+                'total_results': 2,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TvShow> result = await sut.getPopularTvShows();
+
+        expect(result, hasLength(2));
+        expect(result[0].tmdbId, equals(1396));
+        expect(result[1].tmdbId, equals(1399));
+      });
+
+      test('должен вернуть пустой список при пустых результатах', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TvShow> result = await sut.getPopularTvShows();
+
+        expect(result, isEmpty);
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 429,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getPopularTvShows(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Rate limit exceeded. Please try again later',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 503,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getPopularTvShows(),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- multiSearch -----
+
+    group('multiSearch', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть пустой список при пустом запросе', () async {
+        final List<MultiSearchResult> result = await sut.multiSearch('');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть пустой список при запросе из пробелов', () async {
+        final List<MultiSearchResult> result = await sut.multiSearch('   ');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен вернуть фильмы и сериалы, отфильтровав person', () async {
+        final Map<String, dynamic> movieResult = <String, dynamic>{
+          ...createMovieJson(),
+          'media_type': 'movie',
+        };
+        final Map<String, dynamic> tvResult = <String, dynamic>{
+          ...createTvShowJson(),
+          'media_type': 'tv',
+        };
+        final Map<String, dynamic> personResult = <String, dynamic>{
+          'id': 17419,
+          'name': 'Брэд Питт',
+          'media_type': 'person',
+        };
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[
+                  movieResult,
+                  tvResult,
+                  personResult,
+                ],
+                'total_results': 3,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<MultiSearchResult> result = await sut.multiSearch('test');
+
+        expect(result, hasLength(2));
+
+        // Первый результат - фильм
+        expect(result[0].mediaType, equals(TmdbMediaType.movie));
+        expect(result[0].movie, isNotNull);
+        expect(result[0].movie!.tmdbId, equals(550));
+        expect(result[0].tvShow, isNull);
+
+        // Второй результат - сериал
+        expect(result[1].mediaType, equals(TmdbMediaType.tv));
+        expect(result[1].tvShow, isNotNull);
+        expect(result[1].tvShow!.tmdbId, equals(1396));
+        expect(result[1].movie, isNull);
+      });
+
+      test('должен вернуть только фильмы если нет сериалов', () async {
+        final Map<String, dynamic> movieResult = <String, dynamic>{
+          ...createMovieJson(),
+          'media_type': 'movie',
+        };
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[movieResult],
+                'total_results': 1,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<MultiSearchResult> result = await sut.multiSearch('fight');
+
+        expect(result, hasLength(1));
+        expect(result[0].mediaType, equals(TmdbMediaType.movie));
+        expect(result[0].movie, isNotNull);
+      });
+
+      test('должен пропустить результаты с неизвестным media_type', () async {
+        final Map<String, dynamic> unknownResult = <String, dynamic>{
+          'id': 100,
+          'name': 'Unknown',
+          'media_type': 'collection',
+        };
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[unknownResult],
+                'total_results': 1,
+                'total_pages': 1,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<MultiSearchResult> result = await sut.multiSearch('test');
+
+        expect(result, isEmpty);
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.multiSearch('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.multiSearch('test'),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getMovieGenres -----
+
+    group('getMovieGenres', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть список жанров фильмов', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'genres': <Map<String, dynamic>>[
+                  <String, dynamic>{'id': 28, 'name': 'Боевик'},
+                  <String, dynamic>{'id': 12, 'name': 'Приключения'},
+                  <String, dynamic>{'id': 18, 'name': 'Драма'},
+                ],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TmdbGenre> result = await sut.getMovieGenres();
+
+        expect(result, hasLength(3));
+        expect(result[0].id, equals(28));
+        expect(result[0].name, equals('Боевик'));
+        expect(result[1].id, equals(12));
+        expect(result[1].name, equals('Приключения'));
+        expect(result[2].id, equals(18));
+        expect(result[2].name, equals('Драма'));
+      });
+
+      test('должен вернуть пустой список при пустых жанрах', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'genres': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TmdbGenre> result = await sut.getMovieGenres();
+
+        expect(result, isEmpty);
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getMovieGenres(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getMovieGenres(),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- getTvGenres -----
+
+    group('getTvGenres', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен вернуть список жанров сериалов', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'genres': <Map<String, dynamic>>[
+                  <String, dynamic>{'id': 10759, 'name': 'Боевик и Приключения'},
+                  <String, dynamic>{'id': 18, 'name': 'Драма'},
+                  <String, dynamic>{'id': 35, 'name': 'Комедия'},
+                ],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TmdbGenre> result = await sut.getTvGenres();
+
+        expect(result, hasLength(3));
+        expect(result[0].id, equals(10759));
+        expect(result[0].name, equals('Боевик и Приключения'));
+        expect(result[1].id, equals(18));
+        expect(result[1].name, equals('Драма'));
+        expect(result[2].id, equals(35));
+        expect(result[2].name, equals('Комедия'));
+      });
+
+      test('должен вернуть пустой список при пустых жанрах', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'genres': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final List<TmdbGenre> result = await sut.getTvGenres();
+
+        expect(result, isEmpty);
+      });
+
+      test('должен выбросить TmdbApiException при DioException', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 401,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getTvGenres(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Invalid API key',
+          )),
+        );
+      });
+
+      test('должен выбросить TmdbApiException при неуспешном статусе', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: null,
+              statusCode: 500,
+              requestOptions: RequestOptions(),
+            ));
+
+        expect(
+          () => sut.getTvGenres(),
+          throwsA(isA<TmdbApiException>()),
+        );
+      });
+    });
+
+    // ----- _handleDioException -----
+
+    group('_handleDioException через публичные методы', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('должен обработать 404 как Resource not found', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 404,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        // searchMovies не ловит 404 как getMovie, поэтому должен выбросить
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Resource not found',
+          )),
+        );
+      });
+
+      test('должен включить statusCode в исключение', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 429,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.statusCode,
+            'statusCode',
+            429,
+          )),
+        );
+      });
+
+      test('должен обработать connectionTimeout', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getPopularMovies(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Connection timeout',
+          )),
+        );
+      });
+
+      test('должен обработать receiveTimeout', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.receiveTimeout,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getPopularTvShows(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Connection timeout',
+          )),
+        );
+      });
+
+      test('должен обработать connectionError', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.getMovieGenres(),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'No internet connection',
+          )),
+        );
+      });
+
+      test('должен использовать defaultMessage для неизвестных ошибок', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          type: DioExceptionType.unknown,
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(
+          () => sut.searchMovies('test'),
+          throwsA(isA<TmdbApiException>().having(
+            (TmdbApiException e) => e.message,
+            'message',
+            'Failed to search movies',
+          )),
+        );
+      });
+    });
+
+    // ----- dispose -----
+
+    group('dispose', () {
+      test('должен закрыть Dio клиент', () {
+        when(() => mockDio.close()).thenReturn(null);
+
+        sut.dispose();
+
+        verify(() => mockDio.close()).called(1);
+      });
+    });
+
+    // ----- Конструктор -----
+
+    group('конструктор', () {
+      test('должен принимать кастомный language', () {
+        final TmdbApi apiWithLang = TmdbApi(dio: mockDio, language: 'en-US');
+
+        expect(apiWithLang.language, equals('en-US'));
+
+        apiWithLang.dispose();
+      });
+
+      test('должен использовать ru-RU по умолчанию', () {
+        expect(sut.language, equals('ru-RU'));
+      });
+    });
+  });
+}

--- a/test/features/settings/providers/settings_provider_test.dart
+++ b/test/features/settings/providers/settings_provider_test.dart
@@ -1,0 +1,350 @@
+// Тесты для SettingsNotifier — управление настройками IGDB, SteamGridDB, TMDB.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/core/api/igdb_api.dart';
+import 'package:xerabora/core/api/steamgriddb_api.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+
+// Моки
+class MockIgdbApi extends Mock implements IgdbApi {}
+
+class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
+
+class MockTmdbApi extends Mock implements TmdbApi {}
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  late MockIgdbApi mockIgdbApi;
+  late MockSteamGridDbApi mockSteamGridDbApi;
+  late MockTmdbApi mockTmdbApi;
+  late MockDatabaseService mockDbService;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    mockIgdbApi = MockIgdbApi();
+    mockSteamGridDbApi = MockSteamGridDbApi();
+    mockTmdbApi = MockTmdbApi();
+    mockDbService = MockDatabaseService();
+
+    // По умолчанию getPlatformCount возвращает 0
+    when(() => mockDbService.getPlatformCount()).thenAnswer((_) async => 0);
+  });
+
+  Future<ProviderContainer> createContainer({
+    Map<String, Object> initialPrefs = const <String, Object>{},
+  }) async {
+    SharedPreferences.setMockInitialValues(initialPrefs);
+    prefs = await SharedPreferences.getInstance();
+
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        igdbApiProvider.overrideWithValue(mockIgdbApi),
+        steamGridDbApiProvider.overrideWithValue(mockSteamGridDbApi),
+        tmdbApiProvider.overrideWithValue(mockTmdbApi),
+        databaseServiceProvider.overrideWithValue(mockDbService),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SettingsNotifier', () {
+    group('build / _loadFromPrefs', () {
+      test('должен загрузить TMDB ключ из prefs и установить в TmdbApi',
+          () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'tmdb_api_key': 'saved_tmdb_key',
+          },
+        );
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.tmdbApiKey, equals('saved_tmdb_key'));
+        verify(() => mockTmdbApi.setApiKey('saved_tmdb_key')).called(1);
+      });
+
+      test('не должен вызывать setApiKey на TmdbApi когда ключ отсутствует',
+          () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.tmdbApiKey, isNull);
+        verifyNever(() => mockTmdbApi.setApiKey(any()));
+      });
+
+      test('не должен вызывать setApiKey на TmdbApi когда ключ пустой',
+          () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'tmdb_api_key': '',
+          },
+        );
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.tmdbApiKey, equals(''));
+        verifyNever(() => mockTmdbApi.setApiKey(any()));
+      });
+
+      test('должен загрузить SteamGridDB ключ и установить в SteamGridDbApi',
+          () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'steamgriddb_api_key': 'saved_sgdb_key',
+          },
+        );
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.steamGridDbApiKey, equals('saved_sgdb_key'));
+        verify(() => mockSteamGridDbApi.setApiKey('saved_sgdb_key')).called(1);
+      });
+
+      test('должен загрузить все ключи из prefs одновременно', () async {
+        final int futureExpiry =
+            DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'igdb_client_id': 'cid',
+            'igdb_client_secret': 'csecret',
+            'igdb_access_token': 'token123',
+            'igdb_token_expires': futureExpiry,
+            'igdb_last_sync': 1700000000,
+            'steamgriddb_api_key': 'sgdb_key',
+            'tmdb_api_key': 'tmdb_key',
+          },
+        );
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.clientId, equals('cid'));
+        expect(state.clientSecret, equals('csecret'));
+        expect(state.accessToken, equals('token123'));
+        expect(state.tokenExpires, equals(futureExpiry));
+        expect(state.lastSync, equals(1700000000));
+        expect(state.steamGridDbApiKey, equals('sgdb_key'));
+        expect(state.tmdbApiKey, equals('tmdb_key'));
+
+        verify(() => mockIgdbApi.setCredentials(
+              clientId: 'cid',
+              accessToken: 'token123',
+            )).called(1);
+        verify(() => mockSteamGridDbApi.setApiKey('sgdb_key')).called(1);
+        verify(() => mockTmdbApi.setApiKey('tmdb_key')).called(1);
+      });
+    });
+
+    group('setTmdbApiKey', () {
+      test('должен сохранить ключ в prefs и обновить состояние', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setTmdbApiKey('new_tmdb_key');
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.tmdbApiKey, equals('new_tmdb_key'));
+        expect(prefs.getString('tmdb_api_key'), equals('new_tmdb_key'));
+        verify(() => mockTmdbApi.setApiKey('new_tmdb_key')).called(1);
+      });
+
+      test('должен удалить ключ из prefs при пустой строке', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'tmdb_api_key': 'existing_key',
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setTmdbApiKey('');
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.tmdbApiKey, equals(''));
+        expect(prefs.getString('tmdb_api_key'), isNull);
+        verify(() => mockTmdbApi.clearApiKey()).called(1);
+      });
+
+      test('должен вызывать setApiKey а не clearApiKey при непустом ключе',
+          () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setTmdbApiKey('abc123');
+
+        verify(() => mockTmdbApi.setApiKey('abc123')).called(1);
+        verifyNever(() => mockTmdbApi.clearApiKey());
+      });
+    });
+
+    group('setSteamGridDbApiKey', () {
+      test('должен сохранить ключ в prefs и обновить состояние', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setSteamGridDbApiKey('new_sgdb_key');
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.steamGridDbApiKey, equals('new_sgdb_key'));
+        expect(
+          prefs.getString('steamgriddb_api_key'),
+          equals('new_sgdb_key'),
+        );
+        verify(() => mockSteamGridDbApi.setApiKey('new_sgdb_key')).called(1);
+      });
+
+      test('должен удалить ключ из prefs при пустой строке', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'steamgriddb_api_key': 'existing_key',
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setSteamGridDbApiKey('');
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.steamGridDbApiKey, equals(''));
+        expect(prefs.getString('steamgriddb_api_key'), isNull);
+        verify(() => mockSteamGridDbApi.clearApiKey()).called(1);
+      });
+    });
+
+    group('clearSettings', () {
+      test('должен очистить все настройки включая TMDB ключ', () async {
+        when(() => mockDbService.clearPlatforms()).thenAnswer((_) async {});
+
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'igdb_client_id': 'cid',
+            'igdb_client_secret': 'csecret',
+            'igdb_access_token': 'token',
+            'igdb_token_expires': 9999999999,
+            'igdb_last_sync': 1700000000,
+            'steamgriddb_api_key': 'sgdb_key',
+            'tmdb_api_key': 'tmdb_key',
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        // Проверяем, что данные загружены
+        SettingsState state = container.read(settingsNotifierProvider);
+        expect(state.tmdbApiKey, equals('tmdb_key'));
+        expect(state.steamGridDbApiKey, equals('sgdb_key'));
+        expect(state.clientId, equals('cid'));
+
+        await notifier.clearSettings();
+
+        state = container.read(settingsNotifierProvider);
+
+        expect(state.clientId, isNull);
+        expect(state.clientSecret, isNull);
+        expect(state.accessToken, isNull);
+        expect(state.tokenExpires, isNull);
+        expect(state.lastSync, isNull);
+        expect(state.steamGridDbApiKey, isNull);
+        expect(state.tmdbApiKey, isNull);
+        expect(state.platformCount, equals(0));
+        expect(state.connectionStatus, equals(ConnectionStatus.unknown));
+
+        // Проверяем, что prefs очищены
+        expect(prefs.getString('igdb_client_id'), isNull);
+        expect(prefs.getString('igdb_client_secret'), isNull);
+        expect(prefs.getString('igdb_access_token'), isNull);
+        expect(prefs.getInt('igdb_token_expires'), isNull);
+        expect(prefs.getInt('igdb_last_sync'), isNull);
+        expect(prefs.getString('steamgriddb_api_key'), isNull);
+        expect(prefs.getString('tmdb_api_key'), isNull);
+
+        // Проверяем, что API клиенты очищены
+        verify(() => mockIgdbApi.clearCredentials()).called(1);
+        verify(() => mockSteamGridDbApi.clearApiKey()).called(1);
+        verify(() => mockTmdbApi.clearApiKey()).called(1);
+        verify(() => mockDbService.clearPlatforms()).called(1);
+      });
+
+      test('должен сбросить состояние к дефолтному', () async {
+        when(() => mockDbService.clearPlatforms()).thenAnswer((_) async {});
+
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'tmdb_api_key': 'tmdb_key',
+            'steamgriddb_api_key': 'sgdb_key',
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.clearSettings();
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        // Должен быть эквивалентен SettingsState() по умолчанию
+        expect(state.isLoading, isFalse);
+        expect(state.errorMessage, isNull);
+        expect(state.hasTmdbKey, isFalse);
+        expect(state.hasSteamGridDbKey, isFalse);
+        expect(state.hasCredentials, isFalse);
+      });
+    });
+
+    group('setCredentials', () {
+      test('должен сохранить credentials в prefs и обновить состояние',
+          () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setCredentials(
+          clientId: 'new_cid',
+          clientSecret: 'new_csecret',
+        );
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.clientId, equals('new_cid'));
+        expect(state.clientSecret, equals('new_csecret'));
+        expect(prefs.getString('igdb_client_id'), equals('new_cid'));
+        expect(prefs.getString('igdb_client_secret'), equals('new_csecret'));
+        expect(state.errorMessage, isNull);
+      });
+    });
+  });
+}

--- a/test/features/settings/providers/settings_state_test.dart
+++ b/test/features/settings/providers/settings_state_test.dart
@@ -13,6 +13,10 @@ void main() {
         SettingsKeys.steamGridDbApiKey,
         equals('steamgriddb_api_key'),
       );
+      expect(
+        SettingsKeys.tmdbApiKey,
+        equals('tmdb_api_key'),
+      );
     });
   });
 
@@ -45,6 +49,7 @@ void main() {
         expect(state.errorMessage, isNull);
         expect(state.isLoading, isFalse);
         expect(state.steamGridDbApiKey, isNull);
+        expect(state.tmdbApiKey, isNull);
       });
 
       test('должен создать со всеми полями', () {
@@ -59,6 +64,7 @@ void main() {
           errorMessage: 'Test error',
           isLoading: true,
           steamGridDbApiKey: 'sgdb_key_123',
+          tmdbApiKey: 'tmdb_key_456',
         );
 
         expect(state.clientId, equals(testClientId));
@@ -71,6 +77,7 @@ void main() {
         expect(state.errorMessage, equals('Test error'));
         expect(state.isLoading, isTrue);
         expect(state.steamGridDbApiKey, equals('sgdb_key_123'));
+        expect(state.tmdbApiKey, equals('tmdb_key_456'));
       });
     });
 
@@ -188,6 +195,30 @@ void main() {
       });
     });
 
+    group('hasTmdbKey', () {
+      test('должен вернуть true когда ключ не пустой', () {
+        const SettingsState state = SettingsState(
+          tmdbApiKey: 'tmdb_key_123',
+        );
+
+        expect(state.hasTmdbKey, isTrue);
+      });
+
+      test('должен вернуть false когда ключ null', () {
+        const SettingsState state = SettingsState();
+
+        expect(state.hasTmdbKey, isFalse);
+      });
+
+      test('должен вернуть false когда ключ пустой', () {
+        const SettingsState state = SettingsState(
+          tmdbApiKey: '',
+        );
+
+        expect(state.hasTmdbKey, isFalse);
+      });
+    });
+
     group('isApiReady', () {
       test('должен вернуть true когда есть credentials и валидный токен', () {
         final int futureExpiry =
@@ -301,6 +332,14 @@ void main() {
         expect(copy.steamGridDbApiKey, equals('new_key'));
       });
 
+      test('должен копировать с изменением tmdbApiKey', () {
+        const SettingsState original = SettingsState();
+        final SettingsState copy =
+            original.copyWith(tmdbApiKey: 'new_tmdb_key');
+
+        expect(copy.tmdbApiKey, equals('new_tmdb_key'));
+      });
+
       test('должен очистить errorMessage при clearError: true', () {
         const SettingsState original = SettingsState(errorMessage: 'Error');
         final SettingsState copy = original.copyWith(clearError: true);
@@ -327,6 +366,7 @@ void main() {
           errorMessage: 'Error',
           isLoading: true,
           steamGridDbApiKey: 'sgdb_key',
+          tmdbApiKey: 'tmdb_key',
         );
 
         final SettingsState copy = original.copyWith();
@@ -341,6 +381,7 @@ void main() {
         expect(copy.errorMessage, equals(original.errorMessage));
         expect(copy.isLoading, equals(original.isLoading));
         expect(copy.steamGridDbApiKey, equals(original.steamGridDbApiKey));
+        expect(copy.tmdbApiKey, equals(original.tmdbApiKey));
       });
     });
   });

--- a/test/shared/models/movie_test.dart
+++ b/test/shared/models/movie_test.dart
@@ -1,0 +1,597 @@
+// Тесты для модели Movie.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/movie.dart';
+
+void main() {
+  group('Movie', () {
+    group('fromJson', () {
+      test('должен создать из полного JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 27205,
+          'title': 'Inception',
+          'original_title': 'Inception',
+          'poster_path': '/qmDpIHrmpJINaRKAfWQfftjCdyi.jpg',
+          'backdrop_path': '/s3TBrRGB1iav7gFOCNx3H31MoES.jpg',
+          'overview': 'A thief who steals corporate secrets...',
+          'genres': <Map<String, dynamic>>[
+            <String, dynamic>{'id': 28, 'name': 'Action'},
+            <String, dynamic>{'id': 878, 'name': 'Science Fiction'},
+            <String, dynamic>{'id': 12, 'name': 'Adventure'},
+          ],
+          'release_date': '2010-07-16',
+          'vote_average': 8.364,
+          'runtime': 148,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.tmdbId, 27205);
+        expect(movie.title, 'Inception');
+        expect(movie.originalTitle, 'Inception');
+        expect(movie.posterUrl,
+            'https://image.tmdb.org/t/p/w500/qmDpIHrmpJINaRKAfWQfftjCdyi.jpg');
+        expect(movie.backdropUrl,
+            'https://image.tmdb.org/t/p/w780/s3TBrRGB1iav7gFOCNx3H31MoES.jpg');
+        expect(movie.overview, 'A thief who steals corporate secrets...');
+        expect(
+            movie.genres, <String>['Action', 'Science Fiction', 'Adventure']);
+        expect(movie.releaseYear, 2010);
+        expect(movie.rating, 8.364);
+        expect(movie.runtime, 148);
+        expect(movie.cachedAt, isNotNull);
+      });
+
+      test('должен создать из минимального JSON (только id и title)', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.tmdbId, 550);
+        expect(movie.title, 'Fight Club');
+        expect(movie.originalTitle, isNull);
+        expect(movie.posterUrl, isNull);
+        expect(movie.backdropUrl, isNull);
+        expect(movie.overview, isNull);
+        expect(movie.genres, isNull);
+        expect(movie.releaseYear, isNull);
+        expect(movie.rating, isNull);
+        expect(movie.runtime, isNull);
+        expect(movie.cachedAt, isNotNull);
+      });
+
+      test('должен обработать genre_ids вместо genres', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'genre_ids': <int>[18, 53, 35],
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.genres, <String>['18', '53', '35']);
+      });
+
+      test('должен предпочитать genres перед genre_ids', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'genres': <Map<String, dynamic>>[
+            <String, dynamic>{'id': 18, 'name': 'Drama'},
+          ],
+          'genre_ids': <int>[18, 53],
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.genres, <String>['Drama']);
+      });
+
+      test('должен обработать null poster_path и backdrop_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 999,
+          'title': 'No Poster Movie',
+          'poster_path': null,
+          'backdrop_path': null,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.posterUrl, isNull);
+        expect(movie.backdropUrl, isNull);
+      });
+
+      test('должен обработать отсутствующие poster_path и backdrop_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 999,
+          'title': 'No Poster Movie',
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.posterUrl, isNull);
+        expect(movie.backdropUrl, isNull);
+      });
+
+      test('должен обработать пустую строку release_date', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 999,
+          'title': 'Unknown Date Movie',
+          'release_date': '',
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.releaseYear, isNull);
+      });
+
+      test('должен обработать null release_date', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 999,
+          'title': 'Null Date Movie',
+          'release_date': null,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.releaseYear, isNull);
+      });
+
+      test('должен обработать короткую строку release_date (менее 4 символов)',
+          () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 999,
+          'title': 'Short Date Movie',
+          'release_date': '20',
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.releaseYear, isNull);
+      });
+
+      test('должен обработать vote_average как int', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'vote_average': 8,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.rating, 8.0);
+      });
+
+      test('должен обработать null vote_average', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'vote_average': null,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.rating, isNull);
+      });
+
+      test('должен обработать null overview и original_title', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'overview': null,
+          'original_title': null,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.overview, isNull);
+        expect(movie.originalTitle, isNull);
+      });
+
+      test('должен обработать null runtime', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'runtime': null,
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.runtime, isNull);
+      });
+
+      test('должен обработать пустой массив genres', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 550,
+          'title': 'Fight Club',
+          'genres': <Map<String, dynamic>>[],
+        };
+
+        final Movie movie = Movie.fromJson(json);
+
+        expect(movie.genres, <String>[]);
+      });
+    });
+
+    group('fromDb', () {
+      test('должен создать из полной записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_id': 27205,
+          'title': 'Inception',
+          'original_title': 'Inception',
+          'poster_url': 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          'backdrop_url': 'https://image.tmdb.org/t/p/w780/backdrop.jpg',
+          'overview': 'A thief who steals corporate secrets...',
+          'genres': jsonEncode(<String>['Action', 'Science Fiction']),
+          'release_year': 2010,
+          'rating': 8.4,
+          'runtime': 148,
+          'cached_at': 1700000000,
+        };
+
+        final Movie movie = Movie.fromDb(row);
+
+        expect(movie.tmdbId, 27205);
+        expect(movie.title, 'Inception');
+        expect(movie.originalTitle, 'Inception');
+        expect(movie.posterUrl, 'https://image.tmdb.org/t/p/w500/poster.jpg');
+        expect(
+            movie.backdropUrl, 'https://image.tmdb.org/t/p/w780/backdrop.jpg');
+        expect(movie.overview, 'A thief who steals corporate secrets...');
+        expect(movie.genres, <String>['Action', 'Science Fiction']);
+        expect(movie.releaseYear, 2010);
+        expect(movie.rating, 8.4);
+        expect(movie.runtime, 148);
+        expect(movie.cachedAt, 1700000000);
+      });
+
+      test('должен обработать null genres', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_id': 550,
+          'title': 'Fight Club',
+          'original_title': null,
+          'poster_url': null,
+          'backdrop_url': null,
+          'overview': null,
+          'genres': null,
+          'release_year': null,
+          'rating': null,
+          'runtime': null,
+          'cached_at': null,
+        };
+
+        final Movie movie = Movie.fromDb(row);
+
+        expect(movie.tmdbId, 550);
+        expect(movie.title, 'Fight Club');
+        expect(movie.genres, isNull);
+        expect(movie.originalTitle, isNull);
+        expect(movie.posterUrl, isNull);
+        expect(movie.backdropUrl, isNull);
+        expect(movie.overview, isNull);
+        expect(movie.releaseYear, isNull);
+        expect(movie.rating, isNull);
+        expect(movie.runtime, isNull);
+        expect(movie.cachedAt, isNull);
+      });
+
+      test('должен обработать пустую строку genres', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_id': 550,
+          'title': 'Fight Club',
+          'original_title': null,
+          'poster_url': null,
+          'backdrop_url': null,
+          'overview': null,
+          'genres': '',
+          'release_year': null,
+          'rating': null,
+          'runtime': null,
+          'cached_at': null,
+        };
+
+        final Movie movie = Movie.fromDb(row);
+
+        expect(movie.genres, isNull);
+      });
+    });
+
+    group('toDb', () {
+      test('должен преобразовать в Map для БД', () {
+        const Movie movie = Movie(
+          tmdbId: 27205,
+          title: 'Inception',
+          originalTitle: 'Inception',
+          posterUrl: 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          backdropUrl: 'https://image.tmdb.org/t/p/w780/backdrop.jpg',
+          overview: 'A thief who steals corporate secrets...',
+          genres: <String>['Action', 'Science Fiction'],
+          releaseYear: 2010,
+          rating: 8.4,
+          runtime: 148,
+          cachedAt: 1700000000,
+        );
+
+        final Map<String, dynamic> db = movie.toDb();
+
+        expect(db['tmdb_id'], 27205);
+        expect(db['title'], 'Inception');
+        expect(db['original_title'], 'Inception');
+        expect(db['poster_url'], 'https://image.tmdb.org/t/p/w500/poster.jpg');
+        expect(
+            db['backdrop_url'], 'https://image.tmdb.org/t/p/w780/backdrop.jpg');
+        expect(db['overview'], 'A thief who steals corporate secrets...');
+        expect(db['genres'], jsonEncode(<String>['Action', 'Science Fiction']));
+        expect(db['release_year'], 2010);
+        expect(db['rating'], 8.4);
+        expect(db['runtime'], 148);
+        expect(db['cached_at'], 1700000000);
+      });
+
+      test('должен обработать null значения', () {
+        const Movie movie = Movie(
+          tmdbId: 550,
+          title: 'Fight Club',
+        );
+
+        final Map<String, dynamic> db = movie.toDb();
+
+        expect(db['tmdb_id'], 550);
+        expect(db['title'], 'Fight Club');
+        expect(db['original_title'], isNull);
+        expect(db['poster_url'], isNull);
+        expect(db['backdrop_url'], isNull);
+        expect(db['overview'], isNull);
+        expect(db['genres'], isNull);
+        expect(db['release_year'], isNull);
+        expect(db['rating'], isNull);
+        expect(db['runtime'], isNull);
+        expect(db['cached_at'], isNull);
+      });
+    });
+
+    group('toDb/fromDb round-trip', () {
+      test('должен сохранить и восстановить все данные', () {
+        const Movie original = Movie(
+          tmdbId: 27205,
+          title: 'Inception',
+          originalTitle: 'Inception',
+          posterUrl: 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          backdropUrl: 'https://image.tmdb.org/t/p/w780/backdrop.jpg',
+          overview: 'A thief who steals corporate secrets...',
+          genres: <String>['Action', 'Science Fiction', 'Adventure'],
+          releaseYear: 2010,
+          rating: 8.4,
+          runtime: 148,
+          cachedAt: 1700000000,
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final Movie restored = Movie.fromDb(db);
+
+        expect(restored.tmdbId, original.tmdbId);
+        expect(restored.title, original.title);
+        expect(restored.originalTitle, original.originalTitle);
+        expect(restored.posterUrl, original.posterUrl);
+        expect(restored.backdropUrl, original.backdropUrl);
+        expect(restored.overview, original.overview);
+        expect(restored.genres, original.genres);
+        expect(restored.releaseYear, original.releaseYear);
+        expect(restored.rating, original.rating);
+        expect(restored.runtime, original.runtime);
+        expect(restored.cachedAt, original.cachedAt);
+      });
+
+      test('должен сохранить и восстановить минимальные данные', () {
+        const Movie original = Movie(
+          tmdbId: 550,
+          title: 'Fight Club',
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final Movie restored = Movie.fromDb(db);
+
+        expect(restored.tmdbId, original.tmdbId);
+        expect(restored.title, original.title);
+        expect(restored.genres, isNull);
+        expect(restored.rating, isNull);
+        expect(restored.runtime, isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('должен создать копию с изменёнными полями', () {
+        const Movie original = Movie(
+          tmdbId: 27205,
+          title: 'Inception',
+          rating: 8.4,
+          runtime: 148,
+        );
+
+        final Movie copy = original.copyWith(
+          title: 'Inception (Updated)',
+          rating: 9.0,
+        );
+
+        expect(copy.tmdbId, 27205);
+        expect(copy.title, 'Inception (Updated)');
+        expect(copy.rating, 9.0);
+        expect(copy.runtime, 148);
+      });
+
+      test('должен сохранить неизменённые поля', () {
+        const Movie original = Movie(
+          tmdbId: 27205,
+          title: 'Inception',
+          originalTitle: 'Inception',
+          posterUrl: 'https://example.com/poster.jpg',
+          backdropUrl: 'https://example.com/backdrop.jpg',
+          overview: 'Description',
+          genres: <String>['Action'],
+          releaseYear: 2010,
+          rating: 8.4,
+          runtime: 148,
+          cachedAt: 1700000000,
+        );
+
+        final Movie copy = original.copyWith(title: 'Updated');
+
+        expect(copy.tmdbId, 27205);
+        expect(copy.originalTitle, 'Inception');
+        expect(copy.posterUrl, 'https://example.com/poster.jpg');
+        expect(copy.backdropUrl, 'https://example.com/backdrop.jpg');
+        expect(copy.overview, 'Description');
+        expect(copy.genres, <String>['Action']);
+        expect(copy.releaseYear, 2010);
+        expect(copy.rating, 8.4);
+        expect(copy.runtime, 148);
+        expect(copy.cachedAt, 1700000000);
+      });
+
+      test('должен позволить изменить все поля', () {
+        const Movie original = Movie(
+          tmdbId: 1,
+          title: 'Original',
+        );
+
+        final Movie copy = original.copyWith(
+          tmdbId: 2,
+          title: 'New Title',
+          originalTitle: 'New Original',
+          posterUrl: 'new_poster',
+          backdropUrl: 'new_backdrop',
+          overview: 'new overview',
+          genres: <String>['Drama'],
+          releaseYear: 2025,
+          rating: 7.5,
+          runtime: 120,
+          cachedAt: 9999999,
+        );
+
+        expect(copy.tmdbId, 2);
+        expect(copy.title, 'New Title');
+        expect(copy.originalTitle, 'New Original');
+        expect(copy.posterUrl, 'new_poster');
+        expect(copy.backdropUrl, 'new_backdrop');
+        expect(copy.overview, 'new overview');
+        expect(copy.genres, <String>['Drama']);
+        expect(copy.releaseYear, 2025);
+        expect(copy.rating, 7.5);
+        expect(copy.runtime, 120);
+        expect(copy.cachedAt, 9999999);
+      });
+    });
+
+    group('equality', () {
+      test('фильмы с одинаковым tmdbId должны быть равны', () {
+        const Movie movie1 = Movie(tmdbId: 27205, title: 'Inception');
+        const Movie movie2 = Movie(tmdbId: 27205, title: 'Another Title');
+
+        expect(movie1, equals(movie2));
+        expect(movie1.hashCode, equals(movie2.hashCode));
+      });
+
+      test('фильмы с разными tmdbId не должны быть равны', () {
+        const Movie movie1 = Movie(tmdbId: 27205, title: 'Inception');
+        const Movie movie2 = Movie(tmdbId: 550, title: 'Inception');
+
+        expect(movie1, isNot(equals(movie2)));
+      });
+
+      test('идентичные объекты должны быть равны', () {
+        const Movie movie = Movie(tmdbId: 27205, title: 'Inception');
+
+        expect(movie, equals(movie));
+      });
+
+      test('сравнение с другим типом не должно быть равно', () {
+        const Movie movie = Movie(tmdbId: 27205, title: 'Inception');
+
+        // ignore: unrelated_type_equality_checks
+        expect(movie == 'not a movie', isFalse);
+      });
+    });
+
+    group('computed properties', () {
+      test('formattedRating должен вернуть рейтинг с одним десятичным знаком',
+          () {
+        const Movie movie = Movie(tmdbId: 1, title: 'Test', rating: 8.364);
+
+        expect(movie.formattedRating, '8.4');
+      });
+
+      test('formattedRating должен вернуть null при отсутствии рейтинга', () {
+        const Movie movie = Movie(tmdbId: 1, title: 'Test');
+
+        expect(movie.formattedRating, isNull);
+      });
+
+      test('formattedRating должен отформатировать целый рейтинг', () {
+        const Movie movie = Movie(tmdbId: 1, title: 'Test', rating: 8.0);
+
+        expect(movie.formattedRating, '8.0');
+      });
+
+      test('formattedRating должен отформатировать нулевой рейтинг', () {
+        const Movie movie = Movie(tmdbId: 1, title: 'Test', rating: 0.0);
+
+        expect(movie.formattedRating, '0.0');
+      });
+
+      test('genresString должен объединить жанры через запятую', () {
+        const Movie movie = Movie(
+          tmdbId: 1,
+          title: 'Test',
+          genres: <String>['Action', 'Science Fiction', 'Adventure'],
+        );
+
+        expect(movie.genresString, 'Action, Science Fiction, Adventure');
+      });
+
+      test('genresString должен вернуть null при отсутствии жанров', () {
+        const Movie movie = Movie(tmdbId: 1, title: 'Test');
+
+        expect(movie.genresString, isNull);
+      });
+
+      test('genresString должен обработать один жанр', () {
+        const Movie movie = Movie(
+          tmdbId: 1,
+          title: 'Test',
+          genres: <String>['Drama'],
+        );
+
+        expect(movie.genresString, 'Drama');
+      });
+
+      test('genresString должен обработать пустой список жанров', () {
+        const Movie movie = Movie(
+          tmdbId: 1,
+          title: 'Test',
+          genres: <String>[],
+        );
+
+        expect(movie.genresString, '');
+      });
+    });
+
+    test('toString должен вернуть читаемое представление', () {
+      const Movie movie = Movie(tmdbId: 27205, title: 'Inception');
+
+      expect(movie.toString(), 'Movie(tmdbId: 27205, title: Inception)');
+    });
+
+    test('toString должен работать с Unicode в названии', () {
+      const Movie movie =
+          Movie(tmdbId: 100, title: 'Властелин Колец');
+
+      expect(movie.toString(),
+          'Movie(tmdbId: 100, title: Властелин Колец)');
+    });
+  });
+}

--- a/test/shared/models/tv_season_test.dart
+++ b/test/shared/models/tv_season_test.dart
@@ -1,0 +1,397 @@
+// Тесты для модели TvSeason.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/tv_season.dart';
+
+void main() {
+  group('TvSeason', () {
+    group('fromJson', () {
+      test('должен создать из полного JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 1,
+          'name': 'Season 1',
+          'episode_count': 7,
+          'poster_path': '/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg',
+          'air_date': '2008-01-20',
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 1396);
+
+        expect(season.tmdbShowId, 1396);
+        expect(season.seasonNumber, 1);
+        expect(season.name, 'Season 1');
+        expect(season.episodeCount, 7);
+        expect(season.posterUrl,
+            'https://image.tmdb.org/t/p/w500/1BP4xYv9ZG4ZVHkL7ocOziBbSYH.jpg');
+        expect(season.airDate, '2008-01-20');
+      });
+
+      test('должен создать из минимального JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 0,
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 1396);
+
+        expect(season.tmdbShowId, 1396);
+        expect(season.seasonNumber, 0);
+        expect(season.name, isNull);
+        expect(season.episodeCount, isNull);
+        expect(season.posterUrl, isNull);
+        expect(season.airDate, isNull);
+      });
+
+      test('должен обработать null poster_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 2,
+          'name': 'Season 2',
+          'poster_path': null,
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 1396);
+
+        expect(season.posterUrl, isNull);
+      });
+
+      test('должен обработать отсутствующий poster_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 3,
+          'name': 'Season 3',
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 1396);
+
+        expect(season.posterUrl, isNull);
+      });
+
+      test('должен обработать null name', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 1,
+          'name': null,
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 100);
+
+        expect(season.name, isNull);
+      });
+
+      test('должен обработать null episode_count', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 1,
+          'episode_count': null,
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 100);
+
+        expect(season.episodeCount, isNull);
+      });
+
+      test('должен обработать null air_date', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 1,
+          'air_date': null,
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 100);
+
+        expect(season.airDate, isNull);
+      });
+
+      test('должен обработать сезон 0 (спецвыпуски)', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 0,
+          'name': 'Specials',
+          'episode_count': 3,
+          'poster_path': '/specials.jpg',
+          'air_date': '2009-02-17',
+        };
+
+        final TvSeason season = TvSeason.fromJson(json, showId: 1396);
+
+        expect(season.seasonNumber, 0);
+        expect(season.name, 'Specials');
+        expect(season.episodeCount, 3);
+        expect(season.posterUrl,
+            'https://image.tmdb.org/t/p/w500/specials.jpg');
+        expect(season.airDate, '2009-02-17');
+      });
+
+      test('должен использовать переданный showId', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'season_number': 1,
+        };
+
+        final TvSeason season1 = TvSeason.fromJson(json, showId: 100);
+        final TvSeason season2 = TvSeason.fromJson(json, showId: 200);
+
+        expect(season1.tmdbShowId, 100);
+        expect(season2.tmdbShowId, 200);
+      });
+    });
+
+    group('fromDb', () {
+      test('должен создать из полной записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+          'name': 'Season 1',
+          'episode_count': 7,
+          'poster_url': 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          'air_date': '2008-01-20',
+        };
+
+        final TvSeason season = TvSeason.fromDb(row);
+
+        expect(season.tmdbShowId, 1396);
+        expect(season.seasonNumber, 1);
+        expect(season.name, 'Season 1');
+        expect(season.episodeCount, 7);
+        expect(season.posterUrl, 'https://image.tmdb.org/t/p/w500/poster.jpg');
+        expect(season.airDate, '2008-01-20');
+      });
+
+      test('должен обработать null значения', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+          'name': null,
+          'episode_count': null,
+          'poster_url': null,
+          'air_date': null,
+        };
+
+        final TvSeason season = TvSeason.fromDb(row);
+
+        expect(season.tmdbShowId, 1396);
+        expect(season.seasonNumber, 1);
+        expect(season.name, isNull);
+        expect(season.episodeCount, isNull);
+        expect(season.posterUrl, isNull);
+        expect(season.airDate, isNull);
+      });
+    });
+
+    group('toDb', () {
+      test('должен преобразовать в Map для БД', () {
+        const TvSeason season = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          name: 'Season 1',
+          episodeCount: 7,
+          posterUrl: 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          airDate: '2008-01-20',
+        );
+
+        final Map<String, dynamic> db = season.toDb();
+
+        expect(db['tmdb_show_id'], 1396);
+        expect(db['season_number'], 1);
+        expect(db['name'], 'Season 1');
+        expect(db['episode_count'], 7);
+        expect(db['poster_url'], 'https://image.tmdb.org/t/p/w500/poster.jpg');
+        expect(db['air_date'], '2008-01-20');
+      });
+
+      test('должен обработать null значения', () {
+        const TvSeason season = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+        );
+
+        final Map<String, dynamic> db = season.toDb();
+
+        expect(db['tmdb_show_id'], 1396);
+        expect(db['season_number'], 1);
+        expect(db['name'], isNull);
+        expect(db['episode_count'], isNull);
+        expect(db['poster_url'], isNull);
+        expect(db['air_date'], isNull);
+      });
+    });
+
+    group('toDb/fromDb round-trip', () {
+      test('должен сохранить и восстановить все данные', () {
+        const TvSeason original = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 3,
+          name: 'Season 3',
+          episodeCount: 13,
+          posterUrl: 'https://image.tmdb.org/t/p/w500/season3.jpg',
+          airDate: '2010-03-21',
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvSeason restored = TvSeason.fromDb(db);
+
+        expect(restored.tmdbShowId, original.tmdbShowId);
+        expect(restored.seasonNumber, original.seasonNumber);
+        expect(restored.name, original.name);
+        expect(restored.episodeCount, original.episodeCount);
+        expect(restored.posterUrl, original.posterUrl);
+        expect(restored.airDate, original.airDate);
+      });
+
+      test('должен сохранить и восстановить минимальные данные', () {
+        const TvSeason original = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 0,
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvSeason restored = TvSeason.fromDb(db);
+
+        expect(restored.tmdbShowId, original.tmdbShowId);
+        expect(restored.seasonNumber, original.seasonNumber);
+        expect(restored.name, isNull);
+        expect(restored.episodeCount, isNull);
+        expect(restored.posterUrl, isNull);
+        expect(restored.airDate, isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('должен создать копию с изменёнными полями', () {
+        const TvSeason original = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          name: 'Season 1',
+          episodeCount: 7,
+        );
+
+        final TvSeason copy = original.copyWith(
+          name: 'Season 1 (Updated)',
+          episodeCount: 8,
+        );
+
+        expect(copy.tmdbShowId, 1396);
+        expect(copy.seasonNumber, 1);
+        expect(copy.name, 'Season 1 (Updated)');
+        expect(copy.episodeCount, 8);
+      });
+
+      test('должен сохранить неизменённые поля', () {
+        const TvSeason original = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          name: 'Season 1',
+          episodeCount: 7,
+          posterUrl: 'https://example.com/poster.jpg',
+          airDate: '2008-01-20',
+        );
+
+        final TvSeason copy = original.copyWith(name: 'Updated');
+
+        expect(copy.tmdbShowId, 1396);
+        expect(copy.seasonNumber, 1);
+        expect(copy.episodeCount, 7);
+        expect(copy.posterUrl, 'https://example.com/poster.jpg');
+        expect(copy.airDate, '2008-01-20');
+      });
+
+      test('должен позволить изменить все поля', () {
+        const TvSeason original = TvSeason(
+          tmdbShowId: 1,
+          seasonNumber: 1,
+        );
+
+        final TvSeason copy = original.copyWith(
+          tmdbShowId: 2,
+          seasonNumber: 5,
+          name: 'New Name',
+          episodeCount: 10,
+          posterUrl: 'new_poster',
+          airDate: '2025-01-01',
+        );
+
+        expect(copy.tmdbShowId, 2);
+        expect(copy.seasonNumber, 5);
+        expect(copy.name, 'New Name');
+        expect(copy.episodeCount, 10);
+        expect(copy.posterUrl, 'new_poster');
+        expect(copy.airDate, '2025-01-01');
+      });
+    });
+
+    group('equality', () {
+      test(
+          'сезоны с одинаковым showId и seasonNumber должны быть равны', () {
+        const TvSeason season1 = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          name: 'Season 1',
+        );
+        const TvSeason season2 = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          name: 'Different Name',
+        );
+
+        expect(season1, equals(season2));
+        expect(season1.hashCode, equals(season2.hashCode));
+      });
+
+      test('сезоны с разными showId не должны быть равны', () {
+        const TvSeason season1 = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+        );
+        const TvSeason season2 = TvSeason(
+          tmdbShowId: 1399,
+          seasonNumber: 1,
+        );
+
+        expect(season1, isNot(equals(season2)));
+      });
+
+      test('сезоны с разными seasonNumber не должны быть равны', () {
+        const TvSeason season1 = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+        );
+        const TvSeason season2 = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 2,
+        );
+
+        expect(season1, isNot(equals(season2)));
+      });
+
+      test('идентичные объекты должны быть равны', () {
+        const TvSeason season = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+        );
+
+        expect(season, equals(season));
+      });
+
+      test('сравнение с другим типом не должно быть равно', () {
+        const TvSeason season = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+        );
+
+        // ignore: unrelated_type_equality_checks
+        expect(season == 'not a season', isFalse);
+      });
+    });
+
+    test('toString должен вернуть читаемое представление', () {
+      const TvSeason season = TvSeason(
+        tmdbShowId: 1396,
+        seasonNumber: 3,
+      );
+
+      expect(season.toString(), 'TvSeason(showId: 1396, season: 3)');
+    });
+
+    test('toString должен работать с сезоном 0', () {
+      const TvSeason season = TvSeason(
+        tmdbShowId: 1396,
+        seasonNumber: 0,
+      );
+
+      expect(season.toString(), 'TvSeason(showId: 1396, season: 0)');
+    });
+  });
+}

--- a/test/shared/models/tv_show_test.dart
+++ b/test/shared/models/tv_show_test.dart
@@ -1,0 +1,684 @@
+// Тесты для модели TvShow.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+
+void main() {
+  group('TvShow', () {
+    group('fromJson', () {
+      test('должен создать из полного JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'original_name': 'Breaking Bad',
+          'poster_path': '/ggFHVNu6YYI5L9pCfOacjizRGt.jpg',
+          'backdrop_path': '/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg',
+          'overview': 'A high school chemistry teacher diagnosed with cancer...',
+          'genres': <Map<String, dynamic>>[
+            <String, dynamic>{'id': 18, 'name': 'Drama'},
+            <String, dynamic>{'id': 80, 'name': 'Crime'},
+          ],
+          'first_air_date': '2008-01-20',
+          'number_of_seasons': 5,
+          'number_of_episodes': 62,
+          'vote_average': 8.912,
+          'status': 'Ended',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.tmdbId, 1396);
+        expect(show.title, 'Breaking Bad');
+        expect(show.originalTitle, 'Breaking Bad');
+        expect(show.posterUrl,
+            'https://image.tmdb.org/t/p/w500/ggFHVNu6YYI5L9pCfOacjizRGt.jpg');
+        expect(show.backdropUrl,
+            'https://image.tmdb.org/t/p/w780/tsRy63Mu5cu8etL1X7ZLyf7UP1M.jpg');
+        expect(show.overview,
+            'A high school chemistry teacher diagnosed with cancer...');
+        expect(show.genres, <String>['Drama', 'Crime']);
+        expect(show.firstAirYear, 2008);
+        expect(show.totalSeasons, 5);
+        expect(show.totalEpisodes, 62);
+        expect(show.rating, 8.912);
+        expect(show.status, 'Ended');
+        expect(show.cachedAt, isNotNull);
+      });
+
+      test('должен создать из минимального JSON (только id и name)', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.tmdbId, 1396);
+        expect(show.title, 'Breaking Bad');
+        expect(show.originalTitle, isNull);
+        expect(show.posterUrl, isNull);
+        expect(show.backdropUrl, isNull);
+        expect(show.overview, isNull);
+        expect(show.genres, isNull);
+        expect(show.firstAirYear, isNull);
+        expect(show.totalSeasons, isNull);
+        expect(show.totalEpisodes, isNull);
+        expect(show.rating, isNull);
+        expect(show.status, isNull);
+        expect(show.cachedAt, isNotNull);
+      });
+
+      test('должен использовать title если name отсутствует', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'title': 'Breaking Bad via title',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.title, 'Breaking Bad via title');
+      });
+
+      test('должен предпочитать name перед title', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Name Value',
+          'title': 'Title Value',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.title, 'Name Value');
+      });
+
+      test('должен использовать original_title если original_name отсутствует',
+          () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'original_title': 'Original via title',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.originalTitle, 'Original via title');
+      });
+
+      test('должен предпочитать original_name перед original_title', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'original_name': 'Original Name',
+          'original_title': 'Original Title',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.originalTitle, 'Original Name');
+      });
+
+      test('должен обработать genre_ids вместо genres', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'genre_ids': <int>[18, 80],
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.genres, <String>['18', '80']);
+      });
+
+      test('должен предпочитать genres перед genre_ids', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'genres': <Map<String, dynamic>>[
+            <String, dynamic>{'id': 18, 'name': 'Drama'},
+          ],
+          'genre_ids': <int>[18, 80],
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.genres, <String>['Drama']);
+      });
+
+      test('должен обработать null poster_path и backdrop_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'poster_path': null,
+          'backdrop_path': null,
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.posterUrl, isNull);
+        expect(show.backdropUrl, isNull);
+      });
+
+      test('должен обработать отсутствующие poster_path и backdrop_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.posterUrl, isNull);
+        expect(show.backdropUrl, isNull);
+      });
+
+      test('должен обработать пустую строку first_air_date', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'first_air_date': '',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.firstAirYear, isNull);
+      });
+
+      test('должен обработать null first_air_date', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'first_air_date': null,
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.firstAirYear, isNull);
+      });
+
+      test(
+          'должен обработать короткую строку first_air_date (менее 4 символов)',
+          () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'first_air_date': '20',
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.firstAirYear, isNull);
+      });
+
+      test('должен обработать vote_average как int', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'vote_average': 9,
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.rating, 9.0);
+      });
+
+      test('должен обработать null vote_average', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'vote_average': null,
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.rating, isNull);
+      });
+
+      test('должен обработать null number_of_seasons и number_of_episodes',
+          () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'number_of_seasons': null,
+          'number_of_episodes': null,
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.totalSeasons, isNull);
+        expect(show.totalEpisodes, isNull);
+      });
+
+      test('должен обработать null status', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'status': null,
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.status, isNull);
+      });
+
+      test('должен обработать пустой массив genres', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 1396,
+          'name': 'Breaking Bad',
+          'genres': <Map<String, dynamic>>[],
+        };
+
+        final TvShow show = TvShow.fromJson(json);
+
+        expect(show.genres, <String>[]);
+      });
+    });
+
+    group('fromDb', () {
+      test('должен создать из полной записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_id': 1396,
+          'title': 'Breaking Bad',
+          'original_title': 'Breaking Bad',
+          'poster_url': 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          'backdrop_url': 'https://image.tmdb.org/t/p/w780/backdrop.jpg',
+          'overview': 'A chemistry teacher...',
+          'genres': jsonEncode(<String>['Drama', 'Crime']),
+          'first_air_year': 2008,
+          'total_seasons': 5,
+          'total_episodes': 62,
+          'rating': 8.9,
+          'status': 'Ended',
+          'cached_at': 1700000000,
+        };
+
+        final TvShow show = TvShow.fromDb(row);
+
+        expect(show.tmdbId, 1396);
+        expect(show.title, 'Breaking Bad');
+        expect(show.originalTitle, 'Breaking Bad');
+        expect(show.posterUrl, 'https://image.tmdb.org/t/p/w500/poster.jpg');
+        expect(
+            show.backdropUrl, 'https://image.tmdb.org/t/p/w780/backdrop.jpg');
+        expect(show.overview, 'A chemistry teacher...');
+        expect(show.genres, <String>['Drama', 'Crime']);
+        expect(show.firstAirYear, 2008);
+        expect(show.totalSeasons, 5);
+        expect(show.totalEpisodes, 62);
+        expect(show.rating, 8.9);
+        expect(show.status, 'Ended');
+        expect(show.cachedAt, 1700000000);
+      });
+
+      test('должен обработать null genres', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_id': 1396,
+          'title': 'Breaking Bad',
+          'original_title': null,
+          'poster_url': null,
+          'backdrop_url': null,
+          'overview': null,
+          'genres': null,
+          'first_air_year': null,
+          'total_seasons': null,
+          'total_episodes': null,
+          'rating': null,
+          'status': null,
+          'cached_at': null,
+        };
+
+        final TvShow show = TvShow.fromDb(row);
+
+        expect(show.tmdbId, 1396);
+        expect(show.title, 'Breaking Bad');
+        expect(show.genres, isNull);
+        expect(show.originalTitle, isNull);
+        expect(show.posterUrl, isNull);
+        expect(show.backdropUrl, isNull);
+        expect(show.overview, isNull);
+        expect(show.firstAirYear, isNull);
+        expect(show.totalSeasons, isNull);
+        expect(show.totalEpisodes, isNull);
+        expect(show.rating, isNull);
+        expect(show.status, isNull);
+        expect(show.cachedAt, isNull);
+      });
+
+      test('должен обработать пустую строку genres', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_id': 1396,
+          'title': 'Breaking Bad',
+          'original_title': null,
+          'poster_url': null,
+          'backdrop_url': null,
+          'overview': null,
+          'genres': '',
+          'first_air_year': null,
+          'total_seasons': null,
+          'total_episodes': null,
+          'rating': null,
+          'status': null,
+          'cached_at': null,
+        };
+
+        final TvShow show = TvShow.fromDb(row);
+
+        expect(show.genres, isNull);
+      });
+    });
+
+    group('toDb', () {
+      test('должен преобразовать в Map для БД', () {
+        const TvShow show = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+          originalTitle: 'Breaking Bad',
+          posterUrl: 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          backdropUrl: 'https://image.tmdb.org/t/p/w780/backdrop.jpg',
+          overview: 'A chemistry teacher...',
+          genres: <String>['Drama', 'Crime'],
+          firstAirYear: 2008,
+          totalSeasons: 5,
+          totalEpisodes: 62,
+          rating: 8.9,
+          status: 'Ended',
+          cachedAt: 1700000000,
+        );
+
+        final Map<String, dynamic> db = show.toDb();
+
+        expect(db['tmdb_id'], 1396);
+        expect(db['title'], 'Breaking Bad');
+        expect(db['original_title'], 'Breaking Bad');
+        expect(db['poster_url'], 'https://image.tmdb.org/t/p/w500/poster.jpg');
+        expect(
+            db['backdrop_url'], 'https://image.tmdb.org/t/p/w780/backdrop.jpg');
+        expect(db['overview'], 'A chemistry teacher...');
+        expect(db['genres'], jsonEncode(<String>['Drama', 'Crime']));
+        expect(db['first_air_year'], 2008);
+        expect(db['total_seasons'], 5);
+        expect(db['total_episodes'], 62);
+        expect(db['rating'], 8.9);
+        expect(db['status'], 'Ended');
+        expect(db['cached_at'], 1700000000);
+      });
+
+      test('должен обработать null значения', () {
+        const TvShow show = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+        );
+
+        final Map<String, dynamic> db = show.toDb();
+
+        expect(db['tmdb_id'], 1396);
+        expect(db['title'], 'Breaking Bad');
+        expect(db['original_title'], isNull);
+        expect(db['poster_url'], isNull);
+        expect(db['backdrop_url'], isNull);
+        expect(db['overview'], isNull);
+        expect(db['genres'], isNull);
+        expect(db['first_air_year'], isNull);
+        expect(db['total_seasons'], isNull);
+        expect(db['total_episodes'], isNull);
+        expect(db['rating'], isNull);
+        expect(db['status'], isNull);
+        expect(db['cached_at'], isNull);
+      });
+    });
+
+    group('toDb/fromDb round-trip', () {
+      test('должен сохранить и восстановить все данные', () {
+        const TvShow original = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+          originalTitle: 'Breaking Bad',
+          posterUrl: 'https://image.tmdb.org/t/p/w500/poster.jpg',
+          backdropUrl: 'https://image.tmdb.org/t/p/w780/backdrop.jpg',
+          overview: 'A chemistry teacher...',
+          genres: <String>['Drama', 'Crime', 'Thriller'],
+          firstAirYear: 2008,
+          totalSeasons: 5,
+          totalEpisodes: 62,
+          rating: 8.9,
+          status: 'Ended',
+          cachedAt: 1700000000,
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvShow restored = TvShow.fromDb(db);
+
+        expect(restored.tmdbId, original.tmdbId);
+        expect(restored.title, original.title);
+        expect(restored.originalTitle, original.originalTitle);
+        expect(restored.posterUrl, original.posterUrl);
+        expect(restored.backdropUrl, original.backdropUrl);
+        expect(restored.overview, original.overview);
+        expect(restored.genres, original.genres);
+        expect(restored.firstAirYear, original.firstAirYear);
+        expect(restored.totalSeasons, original.totalSeasons);
+        expect(restored.totalEpisodes, original.totalEpisodes);
+        expect(restored.rating, original.rating);
+        expect(restored.status, original.status);
+        expect(restored.cachedAt, original.cachedAt);
+      });
+
+      test('должен сохранить и восстановить минимальные данные', () {
+        const TvShow original = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvShow restored = TvShow.fromDb(db);
+
+        expect(restored.tmdbId, original.tmdbId);
+        expect(restored.title, original.title);
+        expect(restored.genres, isNull);
+        expect(restored.rating, isNull);
+        expect(restored.status, isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('должен создать копию с изменёнными полями', () {
+        const TvShow original = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+          rating: 8.9,
+          totalSeasons: 5,
+        );
+
+        final TvShow copy = original.copyWith(
+          title: 'Breaking Bad (Updated)',
+          rating: 9.5,
+        );
+
+        expect(copy.tmdbId, 1396);
+        expect(copy.title, 'Breaking Bad (Updated)');
+        expect(copy.rating, 9.5);
+        expect(copy.totalSeasons, 5);
+      });
+
+      test('должен сохранить неизменённые поля', () {
+        const TvShow original = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+          originalTitle: 'Breaking Bad',
+          posterUrl: 'https://example.com/poster.jpg',
+          backdropUrl: 'https://example.com/backdrop.jpg',
+          overview: 'Description',
+          genres: <String>['Drama'],
+          firstAirYear: 2008,
+          totalSeasons: 5,
+          totalEpisodes: 62,
+          rating: 8.9,
+          status: 'Ended',
+          cachedAt: 1700000000,
+        );
+
+        final TvShow copy = original.copyWith(title: 'Updated');
+
+        expect(copy.tmdbId, 1396);
+        expect(copy.originalTitle, 'Breaking Bad');
+        expect(copy.posterUrl, 'https://example.com/poster.jpg');
+        expect(copy.backdropUrl, 'https://example.com/backdrop.jpg');
+        expect(copy.overview, 'Description');
+        expect(copy.genres, <String>['Drama']);
+        expect(copy.firstAirYear, 2008);
+        expect(copy.totalSeasons, 5);
+        expect(copy.totalEpisodes, 62);
+        expect(copy.rating, 8.9);
+        expect(copy.status, 'Ended');
+        expect(copy.cachedAt, 1700000000);
+      });
+
+      test('должен позволить изменить все поля', () {
+        const TvShow original = TvShow(
+          tmdbId: 1,
+          title: 'Original',
+        );
+
+        final TvShow copy = original.copyWith(
+          tmdbId: 2,
+          title: 'New Title',
+          originalTitle: 'New Original',
+          posterUrl: 'new_poster',
+          backdropUrl: 'new_backdrop',
+          overview: 'new overview',
+          genres: <String>['Comedy'],
+          firstAirYear: 2025,
+          totalSeasons: 3,
+          totalEpisodes: 30,
+          rating: 7.5,
+          status: 'Returning Series',
+          cachedAt: 9999999,
+        );
+
+        expect(copy.tmdbId, 2);
+        expect(copy.title, 'New Title');
+        expect(copy.originalTitle, 'New Original');
+        expect(copy.posterUrl, 'new_poster');
+        expect(copy.backdropUrl, 'new_backdrop');
+        expect(copy.overview, 'new overview');
+        expect(copy.genres, <String>['Comedy']);
+        expect(copy.firstAirYear, 2025);
+        expect(copy.totalSeasons, 3);
+        expect(copy.totalEpisodes, 30);
+        expect(copy.rating, 7.5);
+        expect(copy.status, 'Returning Series');
+        expect(copy.cachedAt, 9999999);
+      });
+    });
+
+    group('equality', () {
+      test('сериалы с одинаковым tmdbId должны быть равны', () {
+        const TvShow show1 = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+        const TvShow show2 = TvShow(tmdbId: 1396, title: 'Another Title');
+
+        expect(show1, equals(show2));
+        expect(show1.hashCode, equals(show2.hashCode));
+      });
+
+      test('сериалы с разными tmdbId не должны быть равны', () {
+        const TvShow show1 = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+        const TvShow show2 = TvShow(tmdbId: 1399, title: 'Breaking Bad');
+
+        expect(show1, isNot(equals(show2)));
+      });
+
+      test('идентичные объекты должны быть равны', () {
+        const TvShow show = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+
+        expect(show, equals(show));
+      });
+
+      test('сравнение с другим типом не должно быть равно', () {
+        const TvShow show = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+
+        // ignore: unrelated_type_equality_checks
+        expect(show == 'not a show', isFalse);
+      });
+    });
+
+    group('computed properties', () {
+      test('formattedRating должен вернуть рейтинг с одним десятичным знаком',
+          () {
+        const TvShow show =
+            TvShow(tmdbId: 1, title: 'Test', rating: 8.912);
+
+        expect(show.formattedRating, '8.9');
+      });
+
+      test('formattedRating должен вернуть null при отсутствии рейтинга', () {
+        const TvShow show = TvShow(tmdbId: 1, title: 'Test');
+
+        expect(show.formattedRating, isNull);
+      });
+
+      test('formattedRating должен отформатировать целый рейтинг', () {
+        const TvShow show =
+            TvShow(tmdbId: 1, title: 'Test', rating: 9.0);
+
+        expect(show.formattedRating, '9.0');
+      });
+
+      test('formattedRating должен отформатировать нулевой рейтинг', () {
+        const TvShow show =
+            TvShow(tmdbId: 1, title: 'Test', rating: 0.0);
+
+        expect(show.formattedRating, '0.0');
+      });
+
+      test('genresString должен объединить жанры через запятую', () {
+        const TvShow show = TvShow(
+          tmdbId: 1,
+          title: 'Test',
+          genres: <String>['Drama', 'Crime', 'Thriller'],
+        );
+
+        expect(show.genresString, 'Drama, Crime, Thriller');
+      });
+
+      test('genresString должен вернуть null при отсутствии жанров', () {
+        const TvShow show = TvShow(tmdbId: 1, title: 'Test');
+
+        expect(show.genresString, isNull);
+      });
+
+      test('genresString должен обработать один жанр', () {
+        const TvShow show = TvShow(
+          tmdbId: 1,
+          title: 'Test',
+          genres: <String>['Drama'],
+        );
+
+        expect(show.genresString, 'Drama');
+      });
+
+      test('genresString должен обработать пустой список жанров', () {
+        const TvShow show = TvShow(
+          tmdbId: 1,
+          title: 'Test',
+          genres: <String>[],
+        );
+
+        expect(show.genresString, '');
+      });
+    });
+
+    test('toString должен вернуть читаемое представление', () {
+      const TvShow show = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+
+      expect(show.toString(), 'TvShow(tmdbId: 1396, title: Breaking Bad)');
+    });
+
+    test('toString должен работать с Unicode в названии', () {
+      const TvShow show =
+          TvShow(tmdbId: 100, title: 'Игра Престолов');
+
+      expect(show.toString(),
+          'TvShow(tmdbId: 100, title: Игра Престолов)');
+    });
+  });
+}


### PR DESCRIPTION
- Create Movie, TvShow, TvSeason models with fromJson/fromDb/toDb/copyWith
- Add TmdbApi client with search, details, popular, multi-search, genres
- Add movies_cache, tv_shows_cache, tv_seasons_cache DB tables (migration v7)
- Add TMDB API key to settings UI and provider
- Add 105 model tests, 81 API tests, 49 settings tests (1180 total)