### PR TITLE
Add search sorting/filters, per-item canvas, and fix canvas data isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@
 ## [Unreleased]
 
 ### Added
+- Добавлен персональный Canvas для каждого элемента коллекции (per-item canvas): каждая игра, фильм или сериал имеет собственный холст, доступный через вкладку Canvas на экране деталей
+- Добавлен `GameCanvasNotifier` (`lib/features/collections/providers/canvas_provider.dart`) — NotifierProvider.family по ключу `({collectionId, collectionItemId})`. Автоинициализация одним медиа-элементом, поддержка всех типов canvas-элементов (game/movie/tvShow/text/image/link)
+- Добавлена миграция БД v8→v9: колонка `collection_item_id` в таблицах `canvas_items` и `canvas_connections`, индексы, таблица `game_canvas_viewport`
+- Добавлены методы в `DatabaseService`: `getGameCanvasItems`, `getGameCanvasItemCount`, `getGameCanvasConnections`, `getGameCanvasViewport`, `upsertGameCanvasViewport`, `deleteGameCanvasItems`, `deleteGameCanvasConnections`, `deleteGameCanvasViewport`
+- Добавлены методы в `CanvasRepository`: `getGameCanvasItems`, `getGameCanvasItemsWithData`, `hasGameCanvasItems`, `getGameCanvasViewport`, `saveGameCanvasViewport`, `getGameCanvasConnections`
+- Добавлено поле `collectionItemId: int?` в модели `CanvasItem` и `CanvasConnection` (null для коллекционного canvas, значение для per-item)
+- Добавлена сортировка результатов поиска: `SearchSort` с полями relevance/date/rating и направлением asc/desc. Виджет `SortSelector` с визуальным индикатором направления
+- Добавлена фильтрация поиска TMDB: фильтр по году выпуска и жанрам. Виджет `MediaFilterSheet` (BottomSheet с DraggableScrollableSheet, FilterChip для жанров)
+- Добавлены провайдеры жанров: `movieGenresProvider`, `tvGenresProvider` — кэширование списков жанров из TMDB API
+- Добавлены параметры `year` и `firstAirDateYear` в методы `TmdbApi.searchMovies()` и `TmdbApi.searchTvShows()`
+- Добавлены боковые панели SteamGridDB и VGMaps в экраны деталей (`GameDetailScreen`, `MovieDetailScreen`, `TvShowDetailScreen`) — теперь панели доступны на per-item canvas, а не только на основном canvas коллекции
+- Добавлены тесты: `search_sort_test.dart`, `sort_selector_test.dart`, `media_filter_sheet_test.dart`, `genre_provider_test.dart`, обновлены `game_search_provider_test.dart`, `media_search_provider_test.dart`, `tmdb_api_test.dart`, `canvas_item_test.dart`, `canvas_connection_test.dart`, `canvas_repository_test.dart`, `game_detail_screen_test.dart`, `movie_detail_screen_test.dart`, `tv_show_detail_screen_test.dart`
+
+### Changed
+- Изменены `GameDetailScreen`, `MovieDetailScreen`, `TvShowDetailScreen` — добавлен `TabBar` с вкладками Details и Canvas. Вкладка Details использует `MediaDetailView(embedded: true)`, вкладка Canvas содержит `CanvasView` с боковыми панелями SteamGridDB (320px) и VGMaps (500px)
+- Изменён `MediaDetailView` — добавлен параметр `embedded: bool` (true = только контент без Scaffold, false = полный экран)
+- Изменён `CanvasView` — принимает необязательный `collectionItemId` для работы с per-item canvas
+- Изменён `SearchScreen` — добавлены `SortSelector` и `MediaFilterSheet` для сортировки и фильтрации результатов поиска
+- Изменён `GameSearchNotifier` — добавлены методы `setSort()`, `_applySort()` с сортировкой по релевантности (exact match/startsWith/contains), дате и рейтингу
+- Изменён `MediaSearchNotifier` — добавлены методы `setSort()`, `setYearFilter()`, `setGenreFilter()` с локальной фильтрацией по жанрам и серверной фильтрацией по году
+- Изменён `CanvasRepository` — выделен приватный метод `_enrichItemsWithMediaData()` для переиспользования при обогащении данными Game/Movie/TvShow
+
+### Fixed
+- Исправлена утечка данных между per-item canvas и основным canvas коллекции: добавлен фильтр `AND collection_item_id IS NULL` в 6 SQL-методов `DatabaseService` (`getCanvasItems`, `deleteCanvasItemByRef`, `deleteCanvasItemsByCollection`, `getCanvasItemCount`, `getCanvasConnections`, `deleteCanvasConnectionsByCollection`)
+- Исправлена проблема: боковые панели SteamGridDB и VGMaps не открывались на per-item canvas (виджеты панелей отсутствовали в widget tree detail-экранов)
+
+---
+
+### Added
 - Добавлен виджет `SourceBadge` (`lib/shared/widgets/source_badge.dart`) — бейдж источника данных (IGDB, TMDB, SteamGridDB, VGMaps) с цветовой маркировкой и текстовой меткой. Размеры: small, medium, large
 - Добавлен виджет `MediaCard` (`lib/shared/widgets/media_card.dart`) — базовый виджет карточки результата поиска: постер 60x80, название, subtitle, metadata, trailing-виджет. GameCard, MovieCard, TvShowCard переписаны как тонкие обёртки
 - Добавлен виджет `MediaDetailView` (`lib/shared/widgets/media_detail_view.dart`) — базовый виджет экрана деталей медиа: постер 80x120, SourceBadge, info chips, описание, секция статуса, комментарии, заметки, диалог редактирования. GameDetailScreen, MovieDetailScreen, TvShowDetailScreen переписаны как тонкие обёртки

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -22,13 +22,26 @@ Search across multiple media types via tabbed interface:
 ### Movies (TMDB)
 - Posters, genres, runtime
 - Release dates and ratings
+- Filter by release year and genres
 - Add to any collection with one tap
 
 ### TV Shows (TMDB)
 - Posters, genres, seasons/episodes
 - Show status (Returning, Ended, Cancelled)
 - Release dates and ratings
+- Filter by first air year and genres
 - Add to any collection with one tap
+
+### Sorting
+- Sort results by relevance, date, or rating
+- Toggle ascending/descending order
+- Relevance scoring: exact match > starts with > contains
+
+### Filtering (Movies & TV Shows)
+- Filter by release year (1900–2100)
+- Filter by genres (multi-select from TMDB genre list)
+- Active filter chips displayed below the search bar
+- "Clear All" to reset filters
 
 ## Visual Identity
 
@@ -70,12 +83,16 @@ Track your viewing progress for TV shows:
 
 ## Detail Screens
 
-Tap any item in a collection to see its full details. All detail screens share a unified layout via `MediaDetailView`:
+Tap any item in a collection to see its full details. All detail screens have two tabs:
+
+**Details tab** — unified layout via `MediaDetailView`:
 - Compact poster (80x120) with source badge (IGDB/TMDB)
 - Type icon and label
 - Info chips (year, rating, genres, etc.)
 - Inline description (max 4 lines)
 - Status dropdown, author comment, personal notes
+
+**Canvas tab** — personal canvas for the item with full canvas functionality (see Per-Item Canvas above)
 
 ### Game Details
 - Source: IGDB
@@ -115,7 +132,7 @@ Found a collection you like? Fork it:
 
 ## Canvas View
 
-Visualize your collection on a free-form canvas:
+Visualize your collection on a free-form canvas, or create a personal canvas for each item:
 - **Infinite canvas** with zoom (0.3x – 3.0x) and pan
 - **Drag-and-drop** all elements with real-time visual feedback
 - **Dot grid background** for visual alignment
@@ -154,6 +171,14 @@ Visualize your collection on a free-form canvas:
   - Click "Add to Canvas" to place the map image on the canvas (scaled to max 400px width)
   - Toggle via FAB button or right-click "Browse maps..."
   - Mutually exclusive with SteamGridDB panel (opening one closes the other)
+
+### Per-Item Canvas
+Each game, movie, or TV show in a collection has its own personal canvas:
+- Access via the **Canvas** tab on any detail screen (game/movie/TV show)
+- Auto-initialized with the item's media card (game cover, movie poster, etc.)
+- Full canvas functionality: text, images, links, connections, SteamGridDB and VGMaps panels
+- Completely isolated from the collection canvas — items don't leak between canvases
+- Separate viewport (zoom/position) saved per item
 
 ## TMDB Integration
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,9 @@
 - [x] Stage 17: Universal Search — tabbed search (Games/Movies/TV Shows), MediaSearchProvider, MovieCard, TvShowCard, add movies/TV shows to collections
 - [x] Stage 18: Media Display — movie/TV show detail screens, ItemStatusDropdown, CanvasMediaCard, CollectionScreen switched to CollectionItem, canvas support for all media types
 - [x] UI Cards: Source badges (IGDB/TMDB), unified MediaCard for search, unified MediaDetailView for detail screens, media type color coding, canvas card type borders
+- [x] Search Sorting: Sort results by relevance, date, or rating with toggleable direction
+- [x] TMDB Filters: Filter movies/TV shows by release year and genres
+- [x] Per-Item Canvas: Personal canvas for each game/movie/TV show with TabBar detail screens, SteamGridDB and VGMaps panels, data isolation
 - [ ] Stage 13: Export Full — extended .rcoll-full format with canvas layout and images
 
 ## Future Plans

--- a/lib/core/api/tmdb_api.dart
+++ b/lib/core/api/tmdb_api.dart
@@ -125,10 +125,15 @@ class TmdbApi {
   ///
   /// [query] — строка поиска.
   /// [page] — номер страницы (по умолчанию 1).
+  /// [year] — фильтр по году релиза (опционально).
   ///
   /// Возвращает список найденных фильмов.
   /// Throws [TmdbApiException] при ошибке запроса.
-  Future<List<Movie>> searchMovies(String query, {int page = 1}) async {
+  Future<List<Movie>> searchMovies(
+    String query, {
+    int page = 1,
+    int? year,
+  }) async {
     _ensureApiKey();
 
     if (query.trim().isEmpty) {
@@ -136,14 +141,18 @@ class TmdbApi {
     }
 
     try {
+      final Map<String, dynamic> params = <String, dynamic>{
+        'api_key': _apiKey,
+        'language': language,
+        'query': query.trim(),
+        'page': page,
+      };
+      if (year != null) {
+        params['year'] = year;
+      }
       final Response<dynamic> response = await _dio.get<dynamic>(
         '$_baseUrl/search/movie',
-        queryParameters: <String, dynamic>{
-          'api_key': _apiKey,
-          'language': language,
-          'query': query.trim(),
-          'page': page,
-        },
+        queryParameters: params,
       );
 
       if (response.statusCode != 200 || response.data == null) {
@@ -243,10 +252,15 @@ class TmdbApi {
   ///
   /// [query] — строка поиска.
   /// [page] — номер страницы (по умолчанию 1).
+  /// [firstAirDateYear] — фильтр по году первого показа (опционально).
   ///
   /// Возвращает список найденных сериалов.
   /// Throws [TmdbApiException] при ошибке запроса.
-  Future<List<TvShow>> searchTvShows(String query, {int page = 1}) async {
+  Future<List<TvShow>> searchTvShows(
+    String query, {
+    int page = 1,
+    int? firstAirDateYear,
+  }) async {
     _ensureApiKey();
 
     if (query.trim().isEmpty) {
@@ -254,14 +268,18 @@ class TmdbApi {
     }
 
     try {
+      final Map<String, dynamic> params = <String, dynamic>{
+        'api_key': _apiKey,
+        'language': language,
+        'query': query.trim(),
+        'page': page,
+      };
+      if (firstAirDateYear != null) {
+        params['first_air_date_year'] = firstAirDateYear;
+      }
       final Response<dynamic> response = await _dio.get<dynamic>(
         '$_baseUrl/search/tv',
-        queryParameters: <String, dynamic>{
-          'api_key': _apiKey,
-          'language': language,
-          'query': query.trim(),
-          'page': page,
-        },
+        queryParameters: params,
       );
 
       if (response.statusCode != 200 || response.data == null) {

--- a/lib/features/collections/providers/canvas_provider.dart
+++ b/lib/features/collections/providers/canvas_provider.dart
@@ -69,6 +69,94 @@ class CanvasState {
   }
 }
 
+/// Общий интерфейс для управления канвасом.
+///
+/// Реализуется [CanvasNotifier] (коллекционный canvas)
+/// и [GameCanvasNotifier] (per-game canvas).
+abstract class BaseCanvasController {
+  /// Перемещает элемент.
+  void moveItem(int itemId, double x, double y);
+
+  /// Обновляет viewport.
+  void updateViewport(double scale, double offsetX, double offsetY);
+
+  /// Сбрасывает viewport.
+  void resetViewport();
+
+  /// Сбрасывает позиции в сетку.
+  Future<void> resetPositions(double viewportWidth);
+
+  /// Добавляет элемент.
+  Future<CanvasItem> addItem(CanvasItem item);
+
+  /// Удаляет элемент.
+  Future<void> deleteItem(int itemId);
+
+  /// Добавляет текстовый блок.
+  Future<CanvasItem> addTextItem(
+    double x,
+    double y,
+    String content,
+    double fontSize,
+  );
+
+  /// Добавляет изображение.
+  Future<CanvasItem> addImageItem(
+    double x,
+    double y,
+    Map<String, dynamic> imageData, {
+    double width,
+    double height,
+  });
+
+  /// Добавляет ссылку.
+  Future<CanvasItem> addLinkItem(
+    double x,
+    double y,
+    String url,
+    String label,
+  );
+
+  /// Обновляет данные элемента.
+  Future<void> updateItemData(int itemId, Map<String, dynamic> data);
+
+  /// Обновляет размеры элемента.
+  Future<void> updateItemSize(
+    int itemId, {
+    required double width,
+    required double height,
+  });
+
+  /// Перемещает на передний план.
+  Future<void> bringToFront(int itemId);
+
+  /// Перемещает на задний план.
+  Future<void> sendToBack(int itemId);
+
+  /// Начинает создание связи.
+  void startConnection(int fromItemId);
+
+  /// Завершает создание связи.
+  Future<void> completeConnection(int toItemId);
+
+  /// Отменяет режим создания связи.
+  void cancelConnection();
+
+  /// Удаляет связь.
+  Future<void> deleteConnection(int connectionId);
+
+  /// Обновляет связь.
+  Future<void> updateConnection(
+    int connectionId, {
+    String? label,
+    String? color,
+    ConnectionStyle? style,
+  });
+
+  /// Перезагрузка canvas.
+  Future<void> refresh();
+}
+
 /// Провайдер для управления канвасом конкретной коллекции.
 final NotifierProviderFamily<CanvasNotifier, CanvasState, int>
     canvasNotifierProvider =
@@ -77,7 +165,8 @@ final NotifierProviderFamily<CanvasNotifier, CanvasState, int>
 );
 
 /// Notifier для управления состоянием канваса.
-class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
+class CanvasNotifier extends FamilyNotifier<CanvasState, int>
+    implements BaseCanvasController {
   late CanvasRepository _repository;
   late int _collectionId;
   Timer? _viewportSaveTimer;
@@ -320,6 +409,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Обновляет канвас (перезагрузка из БД).
+  @override
   Future<void> refresh() async {
     state = state.copyWith(isLoading: true, error: null);
     await _loadCanvas();
@@ -328,6 +418,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   /// Перемещает элемент на канвасе.
   ///
   /// Обновляет state мгновенно, сохраняет в БД с debounce.
+  @override
   void moveItem(int itemId, double x, double y) {
     // Локальное обновление
     state = state.copyWith(
@@ -349,6 +440,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   /// Обновляет viewport (зум и позицию камеры).
   ///
   /// Сохраняет в БД с debounce.
+  @override
   void updateViewport(double scale, double offsetX, double offsetY) {
     final CanvasViewport newViewport = CanvasViewport(
       collectionId: _collectionId,
@@ -367,6 +459,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Сбрасывает viewport в значение по умолчанию (scale=1, offset=0,0).
+  @override
   void resetViewport() {
     final CanvasViewport defaultViewport = CanvasViewport(
       collectionId: _collectionId,
@@ -383,6 +476,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   /// [viewportWidth] — ширина видимой области для расчёта колонок.
   /// Элементы центрируются вокруг [CanvasRepository.initialCenterX],
   /// [CanvasRepository.initialCenterY].
+  @override
   Future<void> resetPositions(double viewportWidth) async {
     final List<CanvasItem> items = state.items;
     if (items.isEmpty) return;
@@ -420,6 +514,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Добавляет элемент на канвас.
+  @override
   Future<CanvasItem> addItem(CanvasItem item) async {
     final CanvasItem created = await _repository.createItem(item);
     state = state.copyWith(
@@ -432,6 +527,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   ///
   /// Связи удаляются каскадно в БД (FK CASCADE).
   /// В state фильтруем connections с участием удалённого элемента.
+  @override
   Future<void> deleteItem(int itemId) async {
     await _repository.deleteItem(itemId);
     state = state.copyWith(
@@ -446,6 +542,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Добавляет текстовый блок на канвас.
+  @override
   Future<CanvasItem> addTextItem(
     double x,
     double y,
@@ -483,6 +580,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   ///
   /// [width] и [height] задают размер элемента на канвасе.
   /// Если не указаны, используется 200x200.
+  @override
   Future<CanvasItem> addImageItem(
     double x,
     double y,
@@ -515,6 +613,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Добавляет ссылку на канвас.
+  @override
   Future<CanvasItem> addLinkItem(
     double x,
     double y,
@@ -549,6 +648,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Обновляет дополнительные данные элемента.
+  @override
   Future<void> updateItemData(
     int itemId,
     Map<String, dynamic> data,
@@ -567,6 +667,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   /// Обновляет размеры элемента.
   ///
   /// Обновляет state мгновенно, сохраняет в БД.
+  @override
   Future<void> updateItemSize(
     int itemId, {
     required double width,
@@ -584,6 +685,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Перемещает элемент на передний план (максимальный z-index).
+  @override
   Future<void> bringToFront(int itemId) async {
     if (state.items.isEmpty) return;
 
@@ -604,6 +706,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Перемещает элемент на задний план (минимальный z-index).
+  @override
   Future<void> sendToBack(int itemId) async {
     if (state.items.isEmpty) return;
 
@@ -629,6 +732,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   ///
   /// Устанавливает режим создания связи. При следующем клике
   /// на элемент вызывается [completeConnection].
+  @override
   void startConnection(int fromItemId) {
     state = state.copyWith(connectingFromId: fromItemId);
   }
@@ -637,6 +741,7 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   ///
   /// Создаёт новую связь между [connectingFromId] и [toItemId],
   /// сохраняет в БД и обновляет state.
+  @override
   Future<void> completeConnection(int toItemId) async {
     final int? fromItemId = state.connectingFromId;
     if (fromItemId == null || fromItemId == toItemId) {
@@ -661,11 +766,13 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Отменяет режим создания связи.
+  @override
   void cancelConnection() {
     state = state.copyWith(clearConnectingFromId: true);
   }
 
   /// Удаляет связь.
+  @override
   Future<void> deleteConnection(int connectionId) async {
     await _repository.deleteConnection(connectionId);
     state = state.copyWith(
@@ -676,6 +783,537 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int> {
   }
 
   /// Обновляет свойства связи (label, color, style).
+  @override
+  Future<void> updateConnection(
+    int connectionId, {
+    String? label,
+    String? color,
+    ConnectionStyle? style,
+  }) async {
+    final int index = state.connections.indexWhere(
+      (CanvasConnection conn) => conn.id == connectionId,
+    );
+    if (index == -1) return;
+
+    final CanvasConnection updated = state.connections[index].copyWith(
+      label: label,
+      clearLabel: label == null,
+      color: color,
+      style: style,
+    );
+
+    await _repository.updateConnection(updated);
+
+    final List<CanvasConnection> newConnections =
+        List<CanvasConnection>.from(state.connections);
+    newConnections[index] = updated;
+    state = state.copyWith(connections: newConnections);
+  }
+}
+
+// ==================== Game Canvas ====================
+
+/// Провайдер для управления per-item canvas.
+///
+/// Ключ — `({collectionId, collectionItemId})`.
+/// В отличие от [canvasNotifierProvider], per-item canvas:
+/// - Не синхронизируется реактивно с элементами коллекции
+/// - Автоинициализируется одним медиа-элементом (игра/фильм/сериал)
+/// - Поддерживает game/movie/tvShow/text/image/link элементы
+final NotifierProviderFamily<GameCanvasNotifier, CanvasState,
+        ({int collectionId, int collectionItemId})>
+    gameCanvasNotifierProvider = NotifierProvider.family<GameCanvasNotifier,
+        CanvasState, ({int collectionId, int collectionItemId})>(
+  GameCanvasNotifier.new,
+);
+
+/// Notifier для управления per-item canvas.
+///
+/// Упрощённая версия [CanvasNotifier] без реактивной синхронизации
+/// с элементами коллекции. Каждый элемент коллекции имеет свой canvas.
+class GameCanvasNotifier
+    extends FamilyNotifier<CanvasState, ({int collectionId, int collectionItemId})>
+    implements BaseCanvasController {
+  late CanvasRepository _repository;
+  late int _collectionId;
+  late int _collectionItemId;
+  Timer? _viewportSaveTimer;
+  Timer? _positionSaveTimer;
+
+  @override
+  CanvasState build(({int collectionId, int collectionItemId}) arg) {
+    _collectionId = arg.collectionId;
+    _collectionItemId = arg.collectionItemId;
+    _repository = ref.watch(canvasRepositoryProvider);
+
+    ref.onDispose(() {
+      _viewportSaveTimer?.cancel();
+      _positionSaveTimer?.cancel();
+    });
+
+    // Загружаем canvas после инициализации state
+    Future<void>.microtask(_loadCanvas);
+
+    return const CanvasState();
+  }
+
+  Future<void> _loadCanvas() async {
+    try {
+      final bool hasItems =
+          await _repository.hasGameCanvasItems(_collectionItemId);
+
+      if (!hasItems) {
+        await _initializeWithCollectionItem();
+        return;
+      }
+
+      final (
+        List<CanvasItem> items,
+        CanvasViewport? viewport,
+        List<CanvasConnection> connections,
+      ) = await (
+        _repository.getGameCanvasItemsWithData(_collectionItemId),
+        _repository.getGameCanvasViewport(_collectionItemId),
+        _repository.getGameCanvasConnections(_collectionItemId),
+      ).wait;
+
+      state = state.copyWith(
+        items: items,
+        connections: connections,
+        viewport: viewport ??
+            CanvasViewport(collectionId: _collectionItemId),
+        isLoading: false,
+        isInitialized: true,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Инициализирует per-item canvas с одним медиа-элементом.
+  Future<void> _initializeWithCollectionItem() async {
+    final AsyncValue<List<CollectionItem>> itemsAsync =
+        ref.read(collectionItemsNotifierProvider(_collectionId));
+    final List<CollectionItem> allItems =
+        itemsAsync.valueOrNull ?? <CollectionItem>[];
+
+    CollectionItem? collectionItem;
+    for (final CollectionItem item in allItems) {
+      if (item.id == _collectionItemId) {
+        collectionItem = item;
+        break;
+      }
+    }
+
+    if (collectionItem == null) {
+      state = state.copyWith(
+        viewport: CanvasViewport(collectionId: _collectionItemId),
+        isLoading: false,
+        isInitialized: true,
+      );
+      return;
+    }
+
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final CanvasItemType canvasType =
+        CanvasItemType.fromMediaType(collectionItem.mediaType);
+
+    // Размещаем единственный элемент по центру canvas
+    const double x = CanvasRepository.initialCenterX -
+        CanvasRepository.defaultCardWidth / 2;
+    const double y = CanvasRepository.initialCenterY -
+        CanvasRepository.defaultCardHeight / 2;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      collectionItemId: _collectionItemId,
+      itemType: canvasType,
+      itemRefId: collectionItem.externalId,
+      x: x,
+      y: y,
+      width: CanvasRepository.defaultCardWidth,
+      height: CanvasRepository.defaultCardHeight,
+      zIndex: 0,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    final CanvasItem created = await _repository.createItem(item);
+    final CanvasItem enriched = created.copyWith(
+      game: collectionItem.game,
+      movie: collectionItem.movie,
+      tvShow: collectionItem.tvShow,
+    );
+
+    await _repository.saveGameCanvasViewport(
+      _collectionItemId,
+      CanvasViewport(collectionId: _collectionItemId),
+    );
+
+    state = state.copyWith(
+      items: <CanvasItem>[enriched],
+      viewport: CanvasViewport(collectionId: _collectionItemId),
+      isLoading: false,
+      isInitialized: true,
+    );
+  }
+
+  /// Перезагрузка canvas из БД.
+  @override
+  Future<void> refresh() async {
+    state = state.copyWith(isLoading: true, error: null);
+    await _loadCanvas();
+  }
+
+  /// Перемещает элемент на канвасе.
+  @override
+  void moveItem(int itemId, double x, double y) {
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(x: x, y: y);
+        }
+        return item;
+      }).toList(),
+    );
+
+    _positionSaveTimer?.cancel();
+    _positionSaveTimer = Timer(const Duration(milliseconds: 300), () {
+      _repository.updateItemPosition(itemId, x: x, y: y);
+    });
+  }
+
+  /// Обновляет viewport (зум и позицию камеры).
+  @override
+  void updateViewport(double scale, double offsetX, double offsetY) {
+    final CanvasViewport newViewport = CanvasViewport(
+      collectionId: _collectionItemId,
+      scale: scale,
+      offsetX: offsetX,
+      offsetY: offsetY,
+    );
+
+    state = state.copyWith(viewport: newViewport);
+
+    _viewportSaveTimer?.cancel();
+    _viewportSaveTimer = Timer(const Duration(milliseconds: 500), () {
+      _repository.saveGameCanvasViewport(_collectionItemId, newViewport);
+    });
+  }
+
+  /// Сбрасывает viewport в значение по умолчанию.
+  @override
+  void resetViewport() {
+    final CanvasViewport defaultViewport = CanvasViewport(
+      collectionId: _collectionItemId,
+    );
+
+    state = state.copyWith(viewport: defaultViewport);
+
+    _viewportSaveTimer?.cancel();
+    _repository.saveGameCanvasViewport(_collectionItemId, defaultViewport);
+  }
+
+  /// Сбрасывает позиции элементов в сетку.
+  @override
+  Future<void> resetPositions(double viewportWidth) async {
+    final List<CanvasItem> items = state.items;
+    if (items.isEmpty) return;
+
+    const double cardW = CanvasRepository.defaultCardWidth;
+    const double cardH = CanvasRepository.defaultCardHeight;
+    const double gap = CanvasRepository.gridGap;
+
+    final int columns =
+        ((viewportWidth + gap) / (cardW + gap)).floor().clamp(1, items.length);
+    final int rowCount = (items.length + columns - 1) ~/ columns;
+
+    final double gridWidth = columns * (cardW + gap) - gap;
+    final double gridHeight = rowCount * (cardH + gap) - gap;
+    final double startX =
+        CanvasRepository.initialCenterX - gridWidth / 2;
+    final double startY =
+        CanvasRepository.initialCenterY - gridHeight / 2;
+
+    final List<CanvasItem> updated = <CanvasItem>[];
+    for (int i = 0; i < items.length; i++) {
+      final int col = i % columns;
+      final int row = i ~/ columns;
+      final double x = startX + col * (cardW + gap);
+      final double y = startY + row * (cardH + gap);
+
+      final CanvasItem item = items[i].copyWith(x: x, y: y, zIndex: 0);
+      updated.add(item);
+      _repository.updateItemPosition(item.id, x: x, y: y);
+    }
+
+    state = state.copyWith(items: updated);
+  }
+
+  /// Добавляет элемент на game canvas.
+  @override
+  Future<CanvasItem> addItem(CanvasItem item) async {
+    final CanvasItem created = await _repository.createItem(item);
+    state = state.copyWith(
+      items: <CanvasItem>[...state.items, created],
+    );
+    return created;
+  }
+
+  /// Удаляет элемент с game canvas.
+  @override
+  Future<void> deleteItem(int itemId) async {
+    await _repository.deleteItem(itemId);
+    state = state.copyWith(
+      items: state.items
+          .where((CanvasItem item) => item.id != itemId)
+          .toList(),
+      connections: state.connections
+          .where((CanvasConnection conn) =>
+              conn.fromItemId != itemId && conn.toItemId != itemId)
+          .toList(),
+    );
+  }
+
+  /// Добавляет текстовый блок.
+  @override
+  Future<CanvasItem> addTextItem(
+    double x,
+    double y,
+    String content,
+    double fontSize,
+  ) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int maxZ = state.items.isEmpty
+        ? 0
+        : state.items
+              .map((CanvasItem item) => item.zIndex)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      collectionItemId: _collectionItemId,
+      itemType: CanvasItemType.text,
+      x: x,
+      y: y,
+      width: 200,
+      height: null,
+      zIndex: maxZ,
+      data: <String, dynamic>{
+        'content': content,
+        'fontSize': fontSize,
+      },
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    return addItem(item);
+  }
+
+  /// Добавляет изображение.
+  @override
+  Future<CanvasItem> addImageItem(
+    double x,
+    double y,
+    Map<String, dynamic> imageData, {
+    double width = 200,
+    double height = 200,
+  }) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int maxZ = state.items.isEmpty
+        ? 0
+        : state.items
+              .map((CanvasItem item) => item.zIndex)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      collectionItemId: _collectionItemId,
+      itemType: CanvasItemType.image,
+      x: x,
+      y: y,
+      width: width,
+      height: height,
+      zIndex: maxZ,
+      data: imageData,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    return addItem(item);
+  }
+
+  /// Добавляет ссылку.
+  @override
+  Future<CanvasItem> addLinkItem(
+    double x,
+    double y,
+    String url,
+    String label,
+  ) async {
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final int maxZ = state.items.isEmpty
+        ? 0
+        : state.items
+              .map((CanvasItem item) => item.zIndex)
+              .reduce((int a, int b) => a > b ? a : b) +
+          1;
+
+    final CanvasItem item = CanvasItem(
+      id: 0,
+      collectionId: _collectionId,
+      collectionItemId: _collectionItemId,
+      itemType: CanvasItemType.link,
+      x: x,
+      y: y,
+      width: 200,
+      height: 48,
+      zIndex: maxZ,
+      data: <String, dynamic>{
+        'url': url,
+        'label': label,
+      },
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    return addItem(item);
+  }
+
+  /// Обновляет данные элемента.
+  @override
+  Future<void> updateItemData(
+    int itemId,
+    Map<String, dynamic> data,
+  ) async {
+    await _repository.updateItemData(itemId, data);
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(data: data);
+        }
+        return item;
+      }).toList(),
+    );
+  }
+
+  /// Обновляет размеры элемента.
+  @override
+  Future<void> updateItemSize(
+    int itemId, {
+    required double width,
+    required double height,
+  }) async {
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(width: width, height: height);
+        }
+        return item;
+      }).toList(),
+    );
+    await _repository.updateItemSize(itemId, width: width, height: height);
+  }
+
+  /// Перемещает элемент на передний план.
+  @override
+  Future<void> bringToFront(int itemId) async {
+    if (state.items.isEmpty) return;
+
+    final int maxZ = state.items
+        .map((CanvasItem item) => item.zIndex)
+        .reduce((int a, int b) => a > b ? a : b);
+    final int newZ = maxZ + 1;
+
+    await _repository.updateItemZIndex(itemId, newZ);
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(zIndex: newZ);
+        }
+        return item;
+      }).toList(),
+    );
+  }
+
+  /// Перемещает элемент на задний план.
+  @override
+  Future<void> sendToBack(int itemId) async {
+    if (state.items.isEmpty) return;
+
+    final int minZ = state.items
+        .map((CanvasItem item) => item.zIndex)
+        .reduce((int a, int b) => a < b ? a : b);
+    final int newZ = minZ - 1;
+
+    await _repository.updateItemZIndex(itemId, newZ);
+    state = state.copyWith(
+      items: state.items.map((CanvasItem item) {
+        if (item.id == itemId) {
+          return item.copyWith(zIndex: newZ);
+        }
+        return item;
+      }).toList(),
+    );
+  }
+
+  // ==================== Connections ====================
+
+  /// Начинает создание связи.
+  @override
+  void startConnection(int fromItemId) {
+    state = state.copyWith(connectingFromId: fromItemId);
+  }
+
+  /// Завершает создание связи.
+  @override
+  Future<void> completeConnection(int toItemId) async {
+    final int? fromItemId = state.connectingFromId;
+    if (fromItemId == null || fromItemId == toItemId) {
+      cancelConnection();
+      return;
+    }
+
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final CanvasConnection conn = CanvasConnection(
+      id: 0,
+      collectionId: _collectionId,
+      collectionItemId: _collectionItemId,
+      fromItemId: fromItemId,
+      toItemId: toItemId,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+
+    final CanvasConnection created = await _repository.createConnection(conn);
+    state = state.copyWith(
+      connections: <CanvasConnection>[...state.connections, created],
+      clearConnectingFromId: true,
+    );
+  }
+
+  /// Отменяет режим создания связи.
+  @override
+  void cancelConnection() {
+    state = state.copyWith(clearConnectingFromId: true);
+  }
+
+  /// Удаляет связь.
+  @override
+  Future<void> deleteConnection(int connectionId) async {
+    await _repository.deleteConnection(connectionId);
+    state = state.copyWith(
+      connections: state.connections
+          .where((CanvasConnection conn) => conn.id != connectionId)
+          .toList(),
+    );
+  }
+
+  /// Обновляет свойства связи.
+  @override
   Future<void> updateConnection(
     int connectionId, {
     String? label,

--- a/lib/features/collections/screens/game_detail_screen.dart
+++ b/lib/features/collections/screens/game_detail_screen.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection_game.dart';
 import '../../../shared/models/game.dart';
+import '../../../shared/models/steamgriddb_image.dart';
 import '../../../shared/widgets/media_detail_view.dart';
 import '../../../shared/widgets/source_badge.dart';
+import '../providers/canvas_provider.dart';
 import '../providers/collections_provider.dart';
+import '../providers/steamgriddb_panel_provider.dart';
+import '../providers/vgmaps_panel_provider.dart';
+import '../widgets/canvas_view.dart';
+import '../widgets/steamgriddb_panel.dart';
 import '../widgets/status_dropdown.dart';
+import '../widgets/vgmaps_panel.dart';
 
 /// Экран детального просмотра игры в коллекции.
 ///
-/// Позволяет просматривать полную информацию об игре,
-/// изменять статус и редактировать комментарии.
+/// Содержит две вкладки: Details (информация об игре) и Canvas (персональный
+/// холст для заметок, скриншотов и ссылок).
 class GameDetailScreen extends ConsumerStatefulWidget {
   /// Создаёт [GameDetailScreen].
   const GameDetailScreen({
@@ -34,7 +42,22 @@ class GameDetailScreen extends ConsumerStatefulWidget {
   ConsumerState<GameDetailScreen> createState() => _GameDetailScreenState();
 }
 
-class _GameDetailScreenState extends ConsumerState<GameDetailScreen> {
+class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final AsyncValue<List<CollectionGame>> gamesAsync =
@@ -73,30 +96,58 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen> {
 
   Widget _buildContent(CollectionGame collectionGame) {
     final Game? game = collectionGame.game;
+    _currentItemName = collectionGame.gameName;
 
-    return MediaDetailView(
-      title: collectionGame.gameName,
-      coverUrl: game?.coverUrl,
-      placeholderIcon: Icons.videogame_asset,
-      source: DataSource.igdb,
-      typeIcon: Icons.sports_esports,
-      typeLabel: collectionGame.platformName,
-      infoChips: _buildInfoChips(game),
-      description: game?.summary,
-      statusWidget: StatusDropdown(
-        status: collectionGame.status,
-        onChanged: (GameStatus status) =>
-            _updateStatus(collectionGame.id, status),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(collectionGame.gameName),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const <Tab>[
+            Tab(
+              icon: Icon(Icons.info_outline),
+              text: 'Details',
+            ),
+            Tab(
+              icon: Icon(Icons.dashboard_outlined),
+              text: 'Canvas',
+            ),
+          ],
+        ),
       ),
-      authorComment: collectionGame.authorComment,
-      userComment: collectionGame.userComment,
-      hasAuthorComment: collectionGame.hasAuthorComment,
-      hasUserComment: collectionGame.hasUserComment,
-      isEditable: widget.isEditable,
-      onAuthorCommentSave: (String? text) =>
-          _saveAuthorComment(collectionGame.id, text),
-      onUserCommentSave: (String? text) =>
-          _saveUserComment(collectionGame.id, text),
+      body: TabBarView(
+        controller: _tabController,
+        children: <Widget>[
+          // Вкладка Details
+          MediaDetailView(
+            title: collectionGame.gameName,
+            coverUrl: game?.coverUrl,
+            placeholderIcon: Icons.videogame_asset,
+            source: DataSource.igdb,
+            typeIcon: Icons.sports_esports,
+            typeLabel: collectionGame.platformName,
+            infoChips: _buildInfoChips(game),
+            description: game?.summary,
+            statusWidget: StatusDropdown(
+              status: collectionGame.status,
+              onChanged: (GameStatus status) =>
+                  _updateStatus(collectionGame.id, status),
+            ),
+            authorComment: collectionGame.authorComment,
+            userComment: collectionGame.userComment,
+            hasAuthorComment: collectionGame.hasAuthorComment,
+            hasUserComment: collectionGame.hasUserComment,
+            isEditable: widget.isEditable,
+            onAuthorCommentSave: (String? text) =>
+                _saveAuthorComment(collectionGame.id, text),
+            onUserCommentSave: (String? text) =>
+                _saveUserComment(collectionGame.id, text),
+            embedded: true,
+          ),
+          // Вкладка Canvas с боковыми панелями
+          _buildCanvasTab(),
+        ],
+      ),
     );
   }
 
@@ -121,6 +172,178 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen> {
       ));
     }
     return chips;
+  }
+
+  ({int collectionId, int collectionItemId}) get _canvasArg => (
+        collectionId: widget.collectionId,
+        collectionItemId: widget.gameId,
+      );
+
+  Widget _buildCanvasTab() {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: CanvasView(
+            collectionId: widget.collectionId,
+            isEditable: widget.isEditable,
+            collectionItemId: widget.gameId,
+          ),
+        ),
+        // Боковая панель SteamGridDB
+        Consumer(
+          builder:
+              (BuildContext context, WidgetRef ref, Widget? child) {
+            final bool isPanelOpen = ref.watch(
+              steamGridDbPanelProvider(widget.collectionId)
+                  .select((SteamGridDbPanelState s) => s.isOpen),
+            );
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: isPanelOpen ? 320 : 0,
+              curve: Curves.easeInOut,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                border: isPanelOpen
+                    ? Border(
+                        left: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant,
+                        ),
+                      )
+                    : null,
+              ),
+              child: isPanelOpen
+                  ? OverflowBox(
+                      maxWidth: 320,
+                      alignment: Alignment.centerLeft,
+                      child: SteamGridDbPanel(
+                        collectionId: widget.collectionId,
+                        collectionName: _currentItemName ?? '',
+                        onAddImage: _addSteamGridDbImage,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          },
+        ),
+        // Боковая панель VGMaps Browser
+        Consumer(
+          builder:
+              (BuildContext context, WidgetRef ref, Widget? child) {
+            final bool isPanelOpen = ref.watch(
+              vgMapsPanelProvider(widget.collectionId)
+                  .select((VgMapsPanelState s) => s.isOpen),
+            );
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: isPanelOpen ? 500 : 0,
+              curve: Curves.easeInOut,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                border: isPanelOpen
+                    ? Border(
+                        left: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant,
+                        ),
+                      )
+                    : null,
+              ),
+              child: isPanelOpen
+                  ? OverflowBox(
+                      maxWidth: 500,
+                      alignment: Alignment.centerLeft,
+                      child: VgMapsPanel(
+                        collectionId: widget.collectionId,
+                        onAddImage: _addVgMapsImage,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  /// Имя текущего элемента (для поиска в SteamGridDB).
+  String? _currentItemName;
+
+  void _addSteamGridDbImage(SteamGridDbImage image) {
+    const double maxWidth = 300;
+    const double defaultSize = 200;
+    double targetWidth = defaultSize;
+    double targetHeight = defaultSize;
+
+    if (image.width > 0 && image.height > 0) {
+      final double aspectRatio = image.width / image.height;
+      targetWidth =
+          image.width.toDouble() > maxWidth ? maxWidth : image.width.toDouble();
+      targetHeight = targetWidth / aspectRatio;
+    }
+
+    final double centerX =
+        CanvasRepository.initialCenterX - targetWidth / 2;
+    final double centerY =
+        CanvasRepository.initialCenterY - targetHeight / 2;
+
+    ref
+        .read(gameCanvasNotifierProvider(_canvasArg).notifier)
+        .addImageItem(
+          centerX,
+          centerY,
+          <String, dynamic>{'url': image.url},
+          width: targetWidth,
+          height: targetHeight,
+        );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Image added to canvas'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  void _addVgMapsImage(String url, int? width, int? height) {
+    const double maxWidth = 400;
+    double targetWidth = maxWidth;
+    double targetHeight = maxWidth;
+
+    if (width != null && height != null && width > 0 && height > 0) {
+      final double aspectRatio = width / height;
+      targetWidth =
+          width.toDouble() > maxWidth ? maxWidth : width.toDouble();
+      targetHeight = targetWidth / aspectRatio;
+    }
+
+    final double centerX =
+        CanvasRepository.initialCenterX - targetWidth / 2;
+    final double centerY =
+        CanvasRepository.initialCenterY - targetHeight / 2;
+
+    ref
+        .read(gameCanvasNotifierProvider(_canvasArg).notifier)
+        .addImageItem(
+          centerX,
+          centerY,
+          <String, dynamic>{'url': url},
+          width: targetWidth,
+          height: targetHeight,
+        );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Map added to canvas'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
   }
 
   Future<void> _updateStatus(int id, GameStatus status) async {

--- a/lib/features/collections/screens/movie_detail_screen.dart
+++ b/lib/features/collections/screens/movie_detail_screen.dart
@@ -3,19 +3,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/movie.dart';
+import '../../../shared/models/steamgriddb_image.dart';
 import '../../../shared/widgets/media_detail_view.dart';
 import '../../../shared/widgets/source_badge.dart';
+import '../providers/canvas_provider.dart';
 import '../providers/collections_provider.dart';
+import '../providers/steamgriddb_panel_provider.dart';
+import '../providers/vgmaps_panel_provider.dart';
+import '../widgets/canvas_view.dart';
 import '../widgets/item_status_dropdown.dart';
+import '../widgets/steamgriddb_panel.dart';
+import '../widgets/vgmaps_panel.dart';
 
 /// Экран детального просмотра фильма в коллекции.
 ///
-/// Позволяет просматривать полную информацию о фильме,
-/// изменять статус и редактировать комментарии.
+/// Содержит две вкладки: Details (информация о фильме) и Canvas (персональный
+/// холст для заметок, скриншотов и ссылок).
 class MovieDetailScreen extends ConsumerStatefulWidget {
   /// Создаёт [MovieDetailScreen].
   const MovieDetailScreen({
@@ -38,7 +46,22 @@ class MovieDetailScreen extends ConsumerStatefulWidget {
   ConsumerState<MovieDetailScreen> createState() => _MovieDetailScreenState();
 }
 
-class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen> {
+class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final AsyncValue<List<CollectionItem>> itemsAsync =
@@ -77,30 +100,59 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen> {
 
   Widget _buildContent(CollectionItem item) {
     final Movie? movie = item.movie;
+    _currentItemName = item.itemName;
 
-    return MediaDetailView(
-      title: item.itemName,
-      coverUrl: movie?.posterThumbUrl,
-      placeholderIcon: Icons.movie_outlined,
-      source: DataSource.tmdb,
-      typeIcon: Icons.movie_outlined,
-      typeLabel: 'Movie',
-      infoChips: _buildInfoChips(movie),
-      description: movie?.overview,
-      statusWidget: ItemStatusDropdown(
-        status: item.status,
-        mediaType: MediaType.movie,
-        onChanged: (ItemStatus status) => _updateStatus(item.id, status),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(item.itemName),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const <Tab>[
+            Tab(
+              icon: Icon(Icons.info_outline),
+              text: 'Details',
+            ),
+            Tab(
+              icon: Icon(Icons.dashboard_outlined),
+              text: 'Canvas',
+            ),
+          ],
+        ),
       ),
-      authorComment: item.authorComment,
-      userComment: item.userComment,
-      hasAuthorComment: item.hasAuthorComment,
-      hasUserComment: item.hasUserComment,
-      isEditable: widget.isEditable,
-      onAuthorCommentSave: (String? text) =>
-          _saveAuthorComment(item.id, text),
-      onUserCommentSave: (String? text) =>
-          _saveUserComment(item.id, text),
+      body: TabBarView(
+        controller: _tabController,
+        children: <Widget>[
+          // Вкладка Details
+          MediaDetailView(
+            title: item.itemName,
+            coverUrl: movie?.posterThumbUrl,
+            placeholderIcon: Icons.movie_outlined,
+            source: DataSource.tmdb,
+            typeIcon: Icons.movie_outlined,
+            typeLabel: 'Movie',
+            infoChips: _buildInfoChips(movie),
+            description: movie?.overview,
+            statusWidget: ItemStatusDropdown(
+              status: item.status,
+              mediaType: MediaType.movie,
+              onChanged: (ItemStatus status) =>
+                  _updateStatus(item.id, status),
+            ),
+            authorComment: item.authorComment,
+            userComment: item.userComment,
+            hasAuthorComment: item.hasAuthorComment,
+            hasUserComment: item.hasUserComment,
+            isEditable: widget.isEditable,
+            onAuthorCommentSave: (String? text) =>
+                _saveAuthorComment(item.id, text),
+            onUserCommentSave: (String? text) =>
+                _saveUserComment(item.id, text),
+            embedded: true,
+          ),
+          // Вкладка Canvas с боковыми панелями
+          _buildCanvasTab(),
+        ],
+      ),
     );
   }
 
@@ -142,6 +194,175 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen> {
       return '${hours}h';
     }
     return '${mins}m';
+  }
+
+  ({int collectionId, int collectionItemId}) get _canvasArg => (
+        collectionId: widget.collectionId,
+        collectionItemId: widget.itemId,
+      );
+
+  Widget _buildCanvasTab() {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: CanvasView(
+            collectionId: widget.collectionId,
+            isEditable: widget.isEditable,
+            collectionItemId: widget.itemId,
+          ),
+        ),
+        Consumer(
+          builder:
+              (BuildContext context, WidgetRef ref, Widget? child) {
+            final bool isPanelOpen = ref.watch(
+              steamGridDbPanelProvider(widget.collectionId)
+                  .select((SteamGridDbPanelState s) => s.isOpen),
+            );
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: isPanelOpen ? 320 : 0,
+              curve: Curves.easeInOut,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                border: isPanelOpen
+                    ? Border(
+                        left: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant,
+                        ),
+                      )
+                    : null,
+              ),
+              child: isPanelOpen
+                  ? OverflowBox(
+                      maxWidth: 320,
+                      alignment: Alignment.centerLeft,
+                      child: SteamGridDbPanel(
+                        collectionId: widget.collectionId,
+                        collectionName: _currentItemName ?? '',
+                        onAddImage: _addSteamGridDbImage,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          },
+        ),
+        Consumer(
+          builder:
+              (BuildContext context, WidgetRef ref, Widget? child) {
+            final bool isPanelOpen = ref.watch(
+              vgMapsPanelProvider(widget.collectionId)
+                  .select((VgMapsPanelState s) => s.isOpen),
+            );
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: isPanelOpen ? 500 : 0,
+              curve: Curves.easeInOut,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                border: isPanelOpen
+                    ? Border(
+                        left: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant,
+                        ),
+                      )
+                    : null,
+              ),
+              child: isPanelOpen
+                  ? OverflowBox(
+                      maxWidth: 500,
+                      alignment: Alignment.centerLeft,
+                      child: VgMapsPanel(
+                        collectionId: widget.collectionId,
+                        onAddImage: _addVgMapsImage,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  String? _currentItemName;
+
+  void _addSteamGridDbImage(SteamGridDbImage image) {
+    const double maxWidth = 300;
+    const double defaultSize = 200;
+    double targetWidth = defaultSize;
+    double targetHeight = defaultSize;
+
+    if (image.width > 0 && image.height > 0) {
+      final double aspectRatio = image.width / image.height;
+      targetWidth =
+          image.width.toDouble() > maxWidth ? maxWidth : image.width.toDouble();
+      targetHeight = targetWidth / aspectRatio;
+    }
+
+    final double centerX =
+        CanvasRepository.initialCenterX - targetWidth / 2;
+    final double centerY =
+        CanvasRepository.initialCenterY - targetHeight / 2;
+
+    ref
+        .read(gameCanvasNotifierProvider(_canvasArg).notifier)
+        .addImageItem(
+          centerX,
+          centerY,
+          <String, dynamic>{'url': image.url},
+          width: targetWidth,
+          height: targetHeight,
+        );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Image added to canvas'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  void _addVgMapsImage(String url, int? width, int? height) {
+    const double maxWidth = 400;
+    double targetWidth = maxWidth;
+    double targetHeight = maxWidth;
+
+    if (width != null && height != null && width > 0 && height > 0) {
+      final double aspectRatio = width / height;
+      targetWidth =
+          width.toDouble() > maxWidth ? maxWidth : width.toDouble();
+      targetHeight = targetWidth / aspectRatio;
+    }
+
+    final double centerX =
+        CanvasRepository.initialCenterX - targetWidth / 2;
+    final double centerY =
+        CanvasRepository.initialCenterY - targetHeight / 2;
+
+    ref
+        .read(gameCanvasNotifierProvider(_canvasArg).notifier)
+        .addImageItem(
+          centerX,
+          centerY,
+          <String, dynamic>{'url': url},
+          width: targetWidth,
+          height: targetHeight,
+        );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Map added to canvas'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
   }
 
   Future<void> _updateStatus(int id, ItemStatus status) async {

--- a/lib/features/collections/screens/tv_show_detail_screen.dart
+++ b/lib/features/collections/screens/tv_show_detail_screen.dart
@@ -3,20 +3,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/media_type.dart';
+import '../../../shared/models/steamgriddb_image.dart';
 import '../../../shared/models/tv_show.dart';
 import '../../../shared/widgets/media_detail_view.dart';
 import '../../../shared/widgets/source_badge.dart';
+import '../providers/canvas_provider.dart';
 import '../providers/collections_provider.dart';
+import '../providers/steamgriddb_panel_provider.dart';
+import '../providers/vgmaps_panel_provider.dart';
+import '../widgets/canvas_view.dart';
 import '../widgets/item_status_dropdown.dart';
+import '../widgets/steamgriddb_panel.dart';
+import '../widgets/vgmaps_panel.dart';
 
 /// Экран детального просмотра сериала в коллекции.
 ///
-/// Позволяет просматривать полную информацию о сериале,
-/// отслеживать прогресс (сезон/эпизод), изменять статус
-/// и редактировать комментарии.
+/// Содержит две вкладки: Details (информация о сериале с прогрессом) и Canvas
+/// (персональный холст для заметок, скриншотов и ссылок).
 class TvShowDetailScreen extends ConsumerStatefulWidget {
   /// Создаёт [TvShowDetailScreen].
   const TvShowDetailScreen({
@@ -40,7 +47,22 @@ class TvShowDetailScreen extends ConsumerStatefulWidget {
       _TvShowDetailScreenState();
 }
 
-class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen> {
+class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final AsyncValue<List<CollectionItem>> itemsAsync =
@@ -79,33 +101,62 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen> {
 
   Widget _buildContent(CollectionItem item) {
     final TvShow? tvShow = item.tvShow;
+    _currentItemName = item.itemName;
 
-    return MediaDetailView(
-      title: item.itemName,
-      coverUrl: tvShow?.posterThumbUrl,
-      placeholderIcon: Icons.tv_outlined,
-      source: DataSource.tmdb,
-      typeIcon: Icons.tv_outlined,
-      typeLabel: 'TV Show',
-      infoChips: _buildInfoChips(tvShow),
-      description: tvShow?.overview,
-      statusWidget: ItemStatusDropdown(
-        status: item.status,
-        mediaType: MediaType.tvShow,
-        onChanged: (ItemStatus status) => _updateStatus(item.id, status),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(item.itemName),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const <Tab>[
+            Tab(
+              icon: Icon(Icons.info_outline),
+              text: 'Details',
+            ),
+            Tab(
+              icon: Icon(Icons.dashboard_outlined),
+              text: 'Canvas',
+            ),
+          ],
+        ),
       ),
-      extraSections: <Widget>[
-        _buildProgressSection(context, item, tvShow),
-      ],
-      authorComment: item.authorComment,
-      userComment: item.userComment,
-      hasAuthorComment: item.hasAuthorComment,
-      hasUserComment: item.hasUserComment,
-      isEditable: widget.isEditable,
-      onAuthorCommentSave: (String? text) =>
-          _saveAuthorComment(item.id, text),
-      onUserCommentSave: (String? text) =>
-          _saveUserComment(item.id, text),
+      body: TabBarView(
+        controller: _tabController,
+        children: <Widget>[
+          // Вкладка Details
+          MediaDetailView(
+            title: item.itemName,
+            coverUrl: tvShow?.posterThumbUrl,
+            placeholderIcon: Icons.tv_outlined,
+            source: DataSource.tmdb,
+            typeIcon: Icons.tv_outlined,
+            typeLabel: 'TV Show',
+            infoChips: _buildInfoChips(tvShow),
+            description: tvShow?.overview,
+            statusWidget: ItemStatusDropdown(
+              status: item.status,
+              mediaType: MediaType.tvShow,
+              onChanged: (ItemStatus status) =>
+                  _updateStatus(item.id, status),
+            ),
+            extraSections: <Widget>[
+              _buildProgressSection(context, item, tvShow),
+            ],
+            authorComment: item.authorComment,
+            userComment: item.userComment,
+            hasAuthorComment: item.hasAuthorComment,
+            hasUserComment: item.hasUserComment,
+            isEditable: widget.isEditable,
+            onAuthorCommentSave: (String? text) =>
+                _saveAuthorComment(item.id, text),
+            onUserCommentSave: (String? text) =>
+                _saveUserComment(item.id, text),
+            embedded: true,
+          ),
+          // Вкладка Canvas с боковыми панелями
+          _buildCanvasTab(),
+        ],
+      ),
     );
   }
 
@@ -296,6 +347,175 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen> {
         ],
       ),
     );
+  }
+
+  ({int collectionId, int collectionItemId}) get _canvasArg => (
+        collectionId: widget.collectionId,
+        collectionItemId: widget.itemId,
+      );
+
+  Widget _buildCanvasTab() {
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: CanvasView(
+            collectionId: widget.collectionId,
+            isEditable: widget.isEditable,
+            collectionItemId: widget.itemId,
+          ),
+        ),
+        Consumer(
+          builder:
+              (BuildContext context, WidgetRef ref, Widget? child) {
+            final bool isPanelOpen = ref.watch(
+              steamGridDbPanelProvider(widget.collectionId)
+                  .select((SteamGridDbPanelState s) => s.isOpen),
+            );
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: isPanelOpen ? 320 : 0,
+              curve: Curves.easeInOut,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                border: isPanelOpen
+                    ? Border(
+                        left: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant,
+                        ),
+                      )
+                    : null,
+              ),
+              child: isPanelOpen
+                  ? OverflowBox(
+                      maxWidth: 320,
+                      alignment: Alignment.centerLeft,
+                      child: SteamGridDbPanel(
+                        collectionId: widget.collectionId,
+                        collectionName: _currentItemName ?? '',
+                        onAddImage: _addSteamGridDbImage,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          },
+        ),
+        Consumer(
+          builder:
+              (BuildContext context, WidgetRef ref, Widget? child) {
+            final bool isPanelOpen = ref.watch(
+              vgMapsPanelProvider(widget.collectionId)
+                  .select((VgMapsPanelState s) => s.isOpen),
+            );
+            return AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: isPanelOpen ? 500 : 0,
+              curve: Curves.easeInOut,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                border: isPanelOpen
+                    ? Border(
+                        left: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .outlineVariant,
+                        ),
+                      )
+                    : null,
+              ),
+              child: isPanelOpen
+                  ? OverflowBox(
+                      maxWidth: 500,
+                      alignment: Alignment.centerLeft,
+                      child: VgMapsPanel(
+                        collectionId: widget.collectionId,
+                        onAddImage: _addVgMapsImage,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  String? _currentItemName;
+
+  void _addSteamGridDbImage(SteamGridDbImage image) {
+    const double maxWidth = 300;
+    const double defaultSize = 200;
+    double targetWidth = defaultSize;
+    double targetHeight = defaultSize;
+
+    if (image.width > 0 && image.height > 0) {
+      final double aspectRatio = image.width / image.height;
+      targetWidth =
+          image.width.toDouble() > maxWidth ? maxWidth : image.width.toDouble();
+      targetHeight = targetWidth / aspectRatio;
+    }
+
+    final double centerX =
+        CanvasRepository.initialCenterX - targetWidth / 2;
+    final double centerY =
+        CanvasRepository.initialCenterY - targetHeight / 2;
+
+    ref
+        .read(gameCanvasNotifierProvider(_canvasArg).notifier)
+        .addImageItem(
+          centerX,
+          centerY,
+          <String, dynamic>{'url': image.url},
+          width: targetWidth,
+          height: targetHeight,
+        );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Image added to canvas'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  void _addVgMapsImage(String url, int? width, int? height) {
+    const double maxWidth = 400;
+    double targetWidth = maxWidth;
+    double targetHeight = maxWidth;
+
+    if (width != null && height != null && width > 0 && height > 0) {
+      final double aspectRatio = width / height;
+      targetWidth =
+          width.toDouble() > maxWidth ? maxWidth : width.toDouble();
+      targetHeight = targetWidth / aspectRatio;
+    }
+
+    final double centerX =
+        CanvasRepository.initialCenterX - targetWidth / 2;
+    final double centerY =
+        CanvasRepository.initialCenterY - targetHeight / 2;
+
+    ref
+        .read(gameCanvasNotifierProvider(_canvasArg).notifier)
+        .addImageItem(
+          centerX,
+          centerY,
+          <String, dynamic>{'url': url},
+          width: targetWidth,
+          height: targetHeight,
+        );
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Map added to canvas'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
   }
 
   Future<void> _updateStatus(int id, ItemStatus status) async {

--- a/lib/features/search/providers/game_search_provider.dart
+++ b/lib/features/search/providers/game_search_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../data/repositories/game_repository.dart';
 import '../../../shared/models/game.dart';
+import '../../../shared/models/search_sort.dart';
 
 /// Состояние поиска игр.
 class GameSearchState {
@@ -13,6 +14,7 @@ class GameSearchState {
     this.isLoading = false,
     this.error,
     this.selectedPlatformIds = const <int>[],
+    this.currentSort = const SearchSort(),
   });
 
   /// Текущий поисковый запрос.
@@ -30,6 +32,9 @@ class GameSearchState {
   /// Выбранные платформы для фильтрации.
   final List<int> selectedPlatformIds;
 
+  /// Текущая сортировка.
+  final SearchSort currentSort;
+
   /// Проверяет, есть ли результаты.
   bool get hasResults => results.isNotEmpty;
 
@@ -46,6 +51,7 @@ class GameSearchState {
     bool? isLoading,
     String? error,
     List<int>? selectedPlatformIds,
+    SearchSort? currentSort,
     bool clearError = false,
   }) {
     return GameSearchState(
@@ -54,6 +60,7 @@ class GameSearchState {
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
       selectedPlatformIds: selectedPlatformIds ?? this.selectedPlatformIds,
+      currentSort: currentSort ?? this.currentSort,
     );
   }
 
@@ -65,7 +72,8 @@ class GameSearchState {
         listEquals(other.results, results) &&
         other.isLoading == isLoading &&
         other.error == error &&
-        listEquals(other.selectedPlatformIds, selectedPlatformIds);
+        listEquals(other.selectedPlatformIds, selectedPlatformIds) &&
+        other.currentSort == currentSort;
   }
 
   @override
@@ -75,6 +83,7 @@ class GameSearchState {
         isLoading,
         error,
         Object.hashAll(selectedPlatformIds),
+        currentSort,
       );
 }
 
@@ -125,7 +134,8 @@ class GameSearchNotifier extends Notifier<GameSearchState> {
 
       // Проверяем, что запрос всё ещё актуален
       if (state.query == query) {
-        state = state.copyWith(results: results, isLoading: false);
+        final List<Game> sorted = _applySort(results, state.currentSort, query);
+        state = state.copyWith(results: sorted, isLoading: false);
       }
     } on Exception catch (e) {
       if (state.query == query) {
@@ -135,6 +145,89 @@ class GameSearchNotifier extends Notifier<GameSearchState> {
         );
       }
     }
+  }
+
+  /// Устанавливает сортировку и пересортирует текущие результаты.
+  void setSort(SearchSort sort) {
+    if (state.currentSort == sort) return;
+
+    final List<Game> sorted = _applySort(
+      state.results,
+      sort,
+      state.query,
+    );
+    state = state.copyWith(currentSort: sort, results: sorted);
+  }
+
+  /// Применяет сортировку к списку игр.
+  List<Game> _applySort(
+    List<Game> games,
+    SearchSort sort,
+    String query,
+  ) {
+    if (games.isEmpty) return games;
+
+    final List<Game> sorted = List<Game>.of(games);
+    final bool ascending = sort.order == SearchSortOrder.ascending;
+
+    switch (sort.field) {
+      case SearchSortField.relevance:
+        _sortByRelevance(sorted, query, ascending);
+      case SearchSortField.date:
+        _sortByDate(sorted, ascending);
+      case SearchSortField.rating:
+        _sortByRating(sorted, ascending);
+    }
+
+    return sorted;
+  }
+
+  void _sortByRelevance(List<Game> games, String query, bool ascending) {
+    final String lowerQuery = query.toLowerCase();
+
+    games.sort((Game a, Game b) {
+      final int scoreA = _relevanceScore(a.name.toLowerCase(), lowerQuery);
+      final int scoreB = _relevanceScore(b.name.toLowerCase(), lowerQuery);
+      return ascending ? scoreA.compareTo(scoreB) : scoreB.compareTo(scoreA);
+    });
+  }
+
+  /// Возвращает оценку релевантности (больше = лучше).
+  int _relevanceScore(String name, String query) {
+    if (name == query) return 3;
+    if (name.startsWith(query)) return 2;
+    if (name.contains(query)) return 1;
+    return 0;
+  }
+
+  void _sortByDate(List<Game> games, bool ascending) {
+    games.sort((Game a, Game b) {
+      final DateTime? dateA = a.releaseDate;
+      final DateTime? dateB = b.releaseDate;
+
+      if (dateA == null && dateB == null) return 0;
+      if (dateA == null) return 1;
+      if (dateB == null) return -1;
+
+      return ascending
+          ? dateA.compareTo(dateB)
+          : dateB.compareTo(dateA);
+    });
+  }
+
+  void _sortByRating(List<Game> games, bool ascending) {
+    games.sort((Game a, Game b) {
+      final double? ratingA = a.rating;
+      final double? ratingB = b.rating;
+
+      if (ratingA == null && ratingB == null) return 0;
+      if (ratingA == null) return 1;
+      if (ratingB == null) return -1;
+
+      return ascending
+          ? ratingA.compareTo(ratingB)
+          : ratingB.compareTo(ratingA);
+    });
   }
 
   /// Устанавливает фильтр по платформам и повторяет поиск.

--- a/lib/features/search/providers/genre_provider.dart
+++ b/lib/features/search/providers/genre_provider.dart
@@ -1,0 +1,23 @@
+// Провайдеры для кэширования жанров из TMDB.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/tmdb_api.dart';
+
+/// Провайдер жанров фильмов из TMDB.
+///
+/// Загружает список жанров один раз и кэширует в памяти.
+final FutureProvider<List<TmdbGenre>> movieGenresProvider =
+    FutureProvider<List<TmdbGenre>>((Ref ref) async {
+  final TmdbApi api = ref.watch(tmdbApiProvider);
+  return api.getMovieGenres();
+});
+
+/// Провайдер жанров сериалов из TMDB.
+///
+/// Загружает список жанров один раз и кэширует в памяти.
+final FutureProvider<List<TmdbGenre>> tvGenresProvider =
+    FutureProvider<List<TmdbGenre>>((Ref ref) async {
+  final TmdbApi api = ref.watch(tmdbApiProvider);
+  return api.getTvGenres();
+});

--- a/lib/features/search/providers/media_search_provider.dart
+++ b/lib/features/search/providers/media_search_provider.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../../shared/models/movie.dart';
+import '../../../shared/models/search_sort.dart';
 import '../../../shared/models/tv_show.dart';
 
 /// Активный таб поиска медиа.
@@ -27,6 +28,9 @@ class MediaSearchState {
     this.isLoading = false,
     this.error,
     this.activeTab = MediaSearchTab.movies,
+    this.currentSort = const SearchSort(),
+    this.selectedYear,
+    this.selectedGenreIds = const <int>[],
   });
 
   /// Текущий поисковый запрос.
@@ -46,6 +50,18 @@ class MediaSearchState {
 
   /// Активный таб.
   final MediaSearchTab activeTab;
+
+  /// Текущая сортировка.
+  final SearchSort currentSort;
+
+  /// Фильтр по году (опционально).
+  final int? selectedYear;
+
+  /// Фильтр по жанрам (ID жанров TMDB).
+  final List<int> selectedGenreIds;
+
+  /// Проверяет, есть ли активные фильтры.
+  bool get hasFilters => selectedYear != null || selectedGenreIds.isNotEmpty;
 
   /// Проверяет, есть ли результаты для активного таба.
   bool get hasResults {
@@ -68,7 +84,11 @@ class MediaSearchState {
     bool? isLoading,
     String? error,
     MediaSearchTab? activeTab,
+    SearchSort? currentSort,
+    int? selectedYear,
+    List<int>? selectedGenreIds,
     bool clearError = false,
+    bool clearYear = false,
   }) {
     return MediaSearchState(
       query: query ?? this.query,
@@ -77,6 +97,9 @@ class MediaSearchState {
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
       activeTab: activeTab ?? this.activeTab,
+      currentSort: currentSort ?? this.currentSort,
+      selectedYear: clearYear ? null : (selectedYear ?? this.selectedYear),
+      selectedGenreIds: selectedGenreIds ?? this.selectedGenreIds,
     );
   }
 
@@ -89,7 +112,10 @@ class MediaSearchState {
         listEquals(other.tvShowResults, tvShowResults) &&
         other.isLoading == isLoading &&
         other.error == error &&
-        other.activeTab == activeTab;
+        other.activeTab == activeTab &&
+        other.currentSort == currentSort &&
+        other.selectedYear == selectedYear &&
+        listEquals(other.selectedGenreIds, selectedGenreIds);
   }
 
   @override
@@ -100,6 +126,9 @@ class MediaSearchState {
         isLoading,
         error,
         activeTab,
+        currentSort,
+        selectedYear,
+        Object.hashAll(selectedGenreIds),
       );
 }
 
@@ -149,22 +178,46 @@ class MediaSearchNotifier extends Notifier<MediaSearchState> {
     try {
       switch (state.activeTab) {
         case MediaSearchTab.movies:
-          final List<Movie> results = await _tmdbApi.searchMovies(query);
+          final List<Movie> results = await _tmdbApi.searchMovies(
+            query,
+            year: state.selectedYear,
+          );
           if (state.query == query) {
             // Кэшируем результаты
             if (results.isNotEmpty) {
               await _db.upsertMovies(results);
             }
-            state = state.copyWith(movieResults: results, isLoading: false);
+            final List<Movie> filtered = _filterMoviesByGenre(
+              results,
+              state.selectedGenreIds,
+            );
+            final List<Movie> sorted = _applySortToMovies(
+              filtered,
+              state.currentSort,
+              query,
+            );
+            state = state.copyWith(movieResults: sorted, isLoading: false);
           }
         case MediaSearchTab.tvShows:
-          final List<TvShow> results = await _tmdbApi.searchTvShows(query);
+          final List<TvShow> results = await _tmdbApi.searchTvShows(
+            query,
+            firstAirDateYear: state.selectedYear,
+          );
           if (state.query == query) {
             // Кэшируем результаты
             if (results.isNotEmpty) {
               await _db.upsertTvShows(results);
             }
-            state = state.copyWith(tvShowResults: results, isLoading: false);
+            final List<TvShow> filtered = _filterTvShowsByGenre(
+              results,
+              state.selectedGenreIds,
+            );
+            final List<TvShow> sorted = _applySortToTvShows(
+              filtered,
+              state.currentSort,
+              query,
+            );
+            state = state.copyWith(tvShowResults: sorted, isLoading: false);
           }
       }
     } on TmdbApiException catch (e) {
@@ -182,6 +235,241 @@ class MediaSearchNotifier extends Notifier<MediaSearchState> {
         );
       }
     }
+  }
+
+  /// Устанавливает сортировку и пересортирует текущие результаты.
+  void setSort(SearchSort sort) {
+    if (state.currentSort == sort) return;
+
+    final List<Movie> sortedMovies = _applySortToMovies(
+      state.movieResults,
+      sort,
+      state.query,
+    );
+    final List<TvShow> sortedTvShows = _applySortToTvShows(
+      state.tvShowResults,
+      sort,
+      state.query,
+    );
+    state = state.copyWith(
+      currentSort: sort,
+      movieResults: sortedMovies,
+      tvShowResults: sortedTvShows,
+    );
+  }
+
+  /// Применяет сортировку к списку фильмов.
+  List<Movie> _applySortToMovies(
+    List<Movie> movies,
+    SearchSort sort,
+    String query,
+  ) {
+    if (movies.isEmpty) return movies;
+
+    final List<Movie> sorted = List<Movie>.of(movies);
+    final bool ascending = sort.order == SearchSortOrder.ascending;
+
+    switch (sort.field) {
+      case SearchSortField.relevance:
+        _sortMoviesByRelevance(sorted, query, ascending);
+      case SearchSortField.date:
+        sorted.sort((Movie a, Movie b) {
+          final int? yearA = a.releaseYear;
+          final int? yearB = b.releaseYear;
+          if (yearA == null && yearB == null) return 0;
+          if (yearA == null) return 1;
+          if (yearB == null) return -1;
+          return ascending ? yearA.compareTo(yearB) : yearB.compareTo(yearA);
+        });
+      case SearchSortField.rating:
+        sorted.sort((Movie a, Movie b) {
+          final double? ratingA = a.rating;
+          final double? ratingB = b.rating;
+          if (ratingA == null && ratingB == null) return 0;
+          if (ratingA == null) return 1;
+          if (ratingB == null) return -1;
+          return ascending
+              ? ratingA.compareTo(ratingB)
+              : ratingB.compareTo(ratingA);
+        });
+    }
+
+    return sorted;
+  }
+
+  /// Применяет сортировку к списку сериалов.
+  List<TvShow> _applySortToTvShows(
+    List<TvShow> tvShows,
+    SearchSort sort,
+    String query,
+  ) {
+    if (tvShows.isEmpty) return tvShows;
+
+    final List<TvShow> sorted = List<TvShow>.of(tvShows);
+    final bool ascending = sort.order == SearchSortOrder.ascending;
+
+    switch (sort.field) {
+      case SearchSortField.relevance:
+        _sortTvShowsByRelevance(sorted, query, ascending);
+      case SearchSortField.date:
+        sorted.sort((TvShow a, TvShow b) {
+          final int? yearA = a.firstAirYear;
+          final int? yearB = b.firstAirYear;
+          if (yearA == null && yearB == null) return 0;
+          if (yearA == null) return 1;
+          if (yearB == null) return -1;
+          return ascending ? yearA.compareTo(yearB) : yearB.compareTo(yearA);
+        });
+      case SearchSortField.rating:
+        sorted.sort((TvShow a, TvShow b) {
+          final double? ratingA = a.rating;
+          final double? ratingB = b.rating;
+          if (ratingA == null && ratingB == null) return 0;
+          if (ratingA == null) return 1;
+          if (ratingB == null) return -1;
+          return ascending
+              ? ratingA.compareTo(ratingB)
+              : ratingB.compareTo(ratingA);
+        });
+    }
+
+    return sorted;
+  }
+
+  void _sortMoviesByRelevance(
+    List<Movie> movies,
+    String query,
+    bool ascending,
+  ) {
+    final String lowerQuery = query.toLowerCase();
+    movies.sort((Movie a, Movie b) {
+      final int scoreA = _relevanceScore(a.title.toLowerCase(), lowerQuery);
+      final int scoreB = _relevanceScore(b.title.toLowerCase(), lowerQuery);
+      return ascending ? scoreA.compareTo(scoreB) : scoreB.compareTo(scoreA);
+    });
+  }
+
+  void _sortTvShowsByRelevance(
+    List<TvShow> tvShows,
+    String query,
+    bool ascending,
+  ) {
+    final String lowerQuery = query.toLowerCase();
+    tvShows.sort((TvShow a, TvShow b) {
+      final int scoreA = _relevanceScore(a.title.toLowerCase(), lowerQuery);
+      final int scoreB = _relevanceScore(b.title.toLowerCase(), lowerQuery);
+      return ascending ? scoreA.compareTo(scoreB) : scoreB.compareTo(scoreA);
+    });
+  }
+
+  /// Возвращает оценку релевантности (больше = лучше).
+  int _relevanceScore(String name, String query) {
+    if (name == query) return 3;
+    if (name.startsWith(query)) return 2;
+    if (name.contains(query)) return 1;
+    return 0;
+  }
+
+  /// Устанавливает фильтр по году и повторяет поиск.
+  Future<void> setYearFilter(int? year) async {
+    if (state.selectedYear == year) return;
+
+    if (year != null) {
+      state = state.copyWith(selectedYear: year);
+    } else {
+      state = state.copyWith(clearYear: true);
+    }
+
+    if (state.query.length >= minQueryLength) {
+      await _performSearch(state.query);
+    }
+  }
+
+  /// Устанавливает фильтр по жанрам и пересортирует результаты.
+  ///
+  /// Жанры фильтруются локально (TMDB Search API не поддерживает with_genres).
+  Future<void> setGenreFilter(List<int> genreIds) async {
+    if (listEquals(state.selectedGenreIds, genreIds)) return;
+
+    state = state.copyWith(selectedGenreIds: genreIds);
+
+    // Перезапускаем поиск для обновления локального фильтра
+    if (state.query.length >= minQueryLength) {
+      await _performSearch(state.query);
+    }
+  }
+
+  /// Применяет фильтры года и жанров за один вызов.
+  ///
+  /// Выполняет только один поиск вместо двух отдельных вызовов
+  /// [setYearFilter] и [setGenreFilter].
+  Future<void> applyFilters({
+    int? year,
+    required List<int> genreIds,
+  }) async {
+    final bool yearChanged = state.selectedYear != year;
+    final bool genresChanged =
+        !listEquals(state.selectedGenreIds, genreIds);
+
+    if (!yearChanged && !genresChanged) return;
+
+    state = state.copyWith(
+      selectedYear: year,
+      clearYear: year == null,
+      selectedGenreIds: genreIds,
+    );
+
+    if (state.query.length >= minQueryLength) {
+      await _performSearch(state.query);
+    }
+  }
+
+  /// Очищает все фильтры и повторяет поиск.
+  Future<void> clearFilters() async {
+    if (!state.hasFilters) return;
+
+    state = state.copyWith(
+      clearYear: true,
+      selectedGenreIds: <int>[],
+    );
+
+    if (state.query.length >= minQueryLength) {
+      await _performSearch(state.query);
+    }
+  }
+
+  /// Фильтрует фильмы по жанрам локально.
+  List<Movie> _filterMoviesByGenre(
+    List<Movie> movies,
+    List<int> genreIds,
+  ) {
+    if (genreIds.isEmpty) return movies;
+
+    final Set<String> genreIdStrings =
+        genreIds.map((int id) => id.toString()).toSet();
+
+    return movies.where((Movie movie) {
+      final List<String>? movieGenres = movie.genres;
+      if (movieGenres == null || movieGenres.isEmpty) return false;
+      return genreIdStrings.any(movieGenres.contains);
+    }).toList();
+  }
+
+  /// Фильтрует сериалы по жанрам локально.
+  List<TvShow> _filterTvShowsByGenre(
+    List<TvShow> tvShows,
+    List<int> genreIds,
+  ) {
+    if (genreIds.isEmpty) return tvShows;
+
+    final Set<String> genreIdStrings =
+        genreIds.map((int id) => id.toString()).toSet();
+
+    return tvShows.where((TvShow tvShow) {
+      final List<String>? showGenres = tvShow.genres;
+      if (showGenres == null || showGenres.isEmpty) return false;
+      return genreIdStrings.any(showGenres.contains);
+    }).toList();
   }
 
   /// Переключает активный таб и повторяет поиск при необходимости.

--- a/lib/features/search/widgets/media_filter_sheet.dart
+++ b/lib/features/search/widgets/media_filter_sheet.dart
@@ -1,0 +1,251 @@
+// BottomSheet для фильтров поиска фильмов и сериалов.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../core/api/tmdb_api.dart';
+
+/// BottomSheet для фильтров поиска медиа (год + жанры).
+///
+/// Позволяет задать год релиза и выбрать жанры для фильтрации.
+class MediaFilterSheet extends StatefulWidget {
+  /// Создаёт [MediaFilterSheet].
+  const MediaFilterSheet({
+    required this.genres,
+    required this.selectedGenreIds,
+    required this.onApply,
+    this.selectedYear,
+    super.key,
+  });
+
+  /// Список доступных жанров.
+  final List<TmdbGenre> genres;
+
+  /// Текущий выбранный год (может быть null).
+  final int? selectedYear;
+
+  /// Текущие выбранные ID жанров.
+  final List<int> selectedGenreIds;
+
+  /// Callback при применении фильтров.
+  final void Function({int? year, required List<int> genreIds}) onApply;
+
+  @override
+  State<MediaFilterSheet> createState() => _MediaFilterSheetState();
+}
+
+class _MediaFilterSheetState extends State<MediaFilterSheet> {
+  late TextEditingController _yearController;
+  late List<int> _selectedGenreIds;
+
+  @override
+  void initState() {
+    super.initState();
+    _yearController = TextEditingController(
+      text: widget.selectedYear?.toString() ?? '',
+    );
+    _selectedGenreIds = List<int>.from(widget.selectedGenreIds);
+  }
+
+  @override
+  void dispose() {
+    _yearController.dispose();
+    super.dispose();
+  }
+
+  int? get _parsedYear {
+    final String text = _yearController.text.trim();
+    if (text.isEmpty) return null;
+    final int? year = int.tryParse(text);
+    if (year == null || year < 1900 || year > 2100) return null;
+    return year;
+  }
+
+  void _toggleGenre(int genreId) {
+    setState(() {
+      if (_selectedGenreIds.contains(genreId)) {
+        _selectedGenreIds.remove(genreId);
+      } else {
+        _selectedGenreIds.add(genreId);
+      }
+    });
+  }
+
+  void _clearAll() {
+    setState(() {
+      _yearController.clear();
+      _selectedGenreIds.clear();
+    });
+  }
+
+  void _apply() {
+    widget.onApply(
+      year: _parsedYear,
+      genreIds: _selectedGenreIds,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (BuildContext context, ScrollController scrollController) {
+        return Column(
+          children: <Widget>[
+            // Handle
+            Padding(
+              padding: const EdgeInsets.only(top: 12, bottom: 8),
+              child: Container(
+                width: 32,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+
+            // Header
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: <Widget>[
+                  Text(
+                    'Filters',
+                    style: theme.textTheme.titleLarge,
+                  ),
+                  const Spacer(),
+                  if (_selectedGenreIds.isNotEmpty ||
+                      _yearController.text.isNotEmpty)
+                    TextButton(
+                      onPressed: _clearAll,
+                      child: const Text('Clear All'),
+                    ),
+                ],
+              ),
+            ),
+
+            const Divider(height: 16),
+
+            // Content
+            Expanded(
+              child: ListView(
+                controller: scrollController,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                children: <Widget>[
+                  // Year section
+                  Text(
+                    'Release Year',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: 120,
+                    child: TextField(
+                      controller: _yearController,
+                      keyboardType: TextInputType.number,
+                      inputFormatters: <TextInputFormatter>[
+                        FilteringTextInputFormatter.digitsOnly,
+                        LengthLimitingTextInputFormatter(4),
+                      ],
+                      decoration: const InputDecoration(
+                        hintText: 'e.g. 2024',
+                        border: OutlineInputBorder(),
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                      ),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // Genres section
+                  Text(
+                    'Genres',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+
+                  if (widget.genres.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(
+                        'No genres available',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    )
+                  else
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 4,
+                      children: widget.genres.map((TmdbGenre genre) {
+                        final bool isSelected =
+                            _selectedGenreIds.contains(genre.id);
+                        return FilterChip(
+                          label: Text(genre.name),
+                          selected: isSelected,
+                          onSelected: (_) => _toggleGenre(genre.id),
+                          visualDensity: VisualDensity.compact,
+                        );
+                      }).toList(),
+                    ),
+
+                  const SizedBox(height: 16),
+                ],
+              ),
+            ),
+
+            // Bottom actions
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                boxShadow: <BoxShadow>[
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.1),
+                    blurRadius: 4,
+                    offset: const Offset(0, -2),
+                  ),
+                ],
+              ),
+              child: SafeArea(
+                child: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('Cancel'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: _apply,
+                        child: const Text('Apply'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/search/widgets/sort_selector.dart
+++ b/lib/features/search/widgets/sort_selector.dart
@@ -1,0 +1,106 @@
+// Виджет выбора сортировки результатов поиска.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/search_sort.dart';
+
+/// Виджет выбора сортировки для результатов поиска.
+///
+/// Показывает сегментированную кнопку с тремя опциями:
+/// Relevance, Date, Rating. При повторном нажатии на активный
+/// сегмент переключается направление сортировки.
+class SortSelector extends StatelessWidget {
+  /// Создаёт [SortSelector].
+  const SortSelector({
+    required this.currentSort,
+    required this.onChanged,
+    super.key,
+  });
+
+  /// Текущая сортировка.
+  final SearchSort currentSort;
+
+  /// Callback при изменении сортировки.
+  final ValueChanged<SearchSort> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: <Widget>[
+          Icon(
+            Icons.sort,
+            size: 16,
+            color: colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'Sort:',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: SegmentedButton<SearchSortField>(
+              segments: <ButtonSegment<SearchSortField>>[
+                ButtonSegment<SearchSortField>(
+                  value: SearchSortField.relevance,
+                  label: Text(
+                    'Relevance${_orderIndicator(SearchSortField.relevance)}',
+                  ),
+                  icon: const Icon(Icons.auto_awesome, size: 16),
+                ),
+                ButtonSegment<SearchSortField>(
+                  value: SearchSortField.date,
+                  label: Text(
+                    'Date${_orderIndicator(SearchSortField.date)}',
+                  ),
+                  icon: const Icon(Icons.calendar_today, size: 16),
+                ),
+                ButtonSegment<SearchSortField>(
+                  value: SearchSortField.rating,
+                  label: Text(
+                    'Rating${_orderIndicator(SearchSortField.rating)}',
+                  ),
+                  icon: const Icon(Icons.star, size: 16),
+                ),
+              ],
+              selected: <SearchSortField>{currentSort.field},
+              onSelectionChanged: (Set<SearchSortField> selected) {
+                final SearchSortField field = selected.first;
+                if (field == currentSort.field) {
+                  // Повторное нажатие — переключаем направление
+                  onChanged(currentSort.toggleOrder());
+                } else {
+                  // Новое поле — сброс на descending
+                  onChanged(SearchSort(
+                    field: field,
+                    order: SearchSortOrder.descending,
+                  ));
+                }
+              },
+              style: ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                textStyle: WidgetStatePropertyAll<TextStyle?>(
+                  theme.textTheme.labelSmall,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Возвращает индикатор направления для активного поля.
+  String _orderIndicator(SearchSortField field) {
+    if (currentSort.field != field) return '';
+    return currentSort.order == SearchSortOrder.ascending ? ' \u2191' : ' \u2193';
+  }
+}

--- a/lib/shared/models/canvas_connection.dart
+++ b/lib/shared/models/canvas_connection.dart
@@ -37,6 +37,7 @@ class CanvasConnection {
     required this.fromItemId,
     required this.toItemId,
     required this.createdAt,
+    this.collectionItemId,
     this.label,
     this.color = '#666666',
     this.style = ConnectionStyle.solid,
@@ -47,6 +48,7 @@ class CanvasConnection {
     return CanvasConnection(
       id: row['id'] as int,
       collectionId: row['collection_id'] as int,
+      collectionItemId: row['collection_item_id'] as int?,
       fromItemId: row['from_item_id'] as int,
       toItemId: row['to_item_id'] as int,
       label: row['label'] as String?,
@@ -63,6 +65,7 @@ class CanvasConnection {
     return CanvasConnection(
       id: json['id'] as int? ?? 0,
       collectionId: json['collection_id'] as int? ?? 0,
+      collectionItemId: json['collection_item_id'] as int?,
       fromItemId: json['from_item_id'] as int,
       toItemId: json['to_item_id'] as int,
       label: json['label'] as String?,
@@ -81,6 +84,9 @@ class CanvasConnection {
 
   /// ID коллекции.
   final int collectionId;
+
+  /// ID элемента коллекции (для per-game canvas, null для коллекционного).
+  final int? collectionItemId;
 
   /// ID элемента-источника.
   final int fromItemId;
@@ -105,6 +111,7 @@ class CanvasConnection {
     return <String, dynamic>{
       if (id != 0) 'id': id,
       'collection_id': collectionId,
+      'collection_item_id': collectionItemId,
       'from_item_id': fromItemId,
       'to_item_id': toItemId,
       'label': label,
@@ -118,6 +125,7 @@ class CanvasConnection {
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'id': id,
+      'collection_item_id': collectionItemId,
       'from_item_id': fromItemId,
       'to_item_id': toItemId,
       'label': label,
@@ -134,6 +142,7 @@ class CanvasConnection {
   CanvasConnection copyWith({
     int? id,
     int? collectionId,
+    int? collectionItemId,
     int? fromItemId,
     int? toItemId,
     String? label,
@@ -145,6 +154,7 @@ class CanvasConnection {
     return CanvasConnection(
       id: id ?? this.id,
       collectionId: collectionId ?? this.collectionId,
+      collectionItemId: collectionItemId ?? this.collectionItemId,
       fromItemId: fromItemId ?? this.fromItemId,
       toItemId: toItemId ?? this.toItemId,
       label: clearLabel ? null : (label ?? this.label),

--- a/lib/shared/models/canvas_item.dart
+++ b/lib/shared/models/canvas_item.dart
@@ -68,6 +68,7 @@ class CanvasItem {
     required this.x,
     required this.y,
     required this.createdAt,
+    this.collectionItemId,
     this.itemRefId,
     this.width,
     this.height,
@@ -90,6 +91,7 @@ class CanvasItem {
     return CanvasItem(
       id: row['id'] as int,
       collectionId: row['collection_id'] as int,
+      collectionItemId: row['collection_item_id'] as int?,
       itemType: CanvasItemType.fromString(row['item_type'] as String),
       itemRefId: row['item_ref_id'] as int?,
       x: (row['x'] as num).toDouble(),
@@ -109,6 +111,7 @@ class CanvasItem {
     return CanvasItem(
       id: json['id'] as int? ?? 0,
       collectionId: json['collection_id'] as int? ?? 0,
+      collectionItemId: json['collection_item_id'] as int?,
       itemType: CanvasItemType.fromString(json['type'] as String? ?? 'game'),
       itemRefId: json['refId'] as int?,
       x: (json['x'] as num).toDouble(),
@@ -130,6 +133,9 @@ class CanvasItem {
 
   /// ID коллекции.
   final int collectionId;
+
+  /// ID элемента коллекции (для per-game canvas, null для коллекционного).
+  final int? collectionItemId;
 
   /// Тип элемента.
   final CanvasItemType itemType;
@@ -172,6 +178,7 @@ class CanvasItem {
     return <String, dynamic>{
       if (id != 0) 'id': id,
       'collection_id': collectionId,
+      'collection_item_id': collectionItemId,
       'item_type': itemType.value,
       'item_ref_id': itemRefId,
       'x': x,
@@ -188,6 +195,7 @@ class CanvasItem {
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'id': id,
+      'collection_item_id': collectionItemId,
       'type': itemType.value,
       'refId': itemRefId,
       'x': x,
@@ -204,6 +212,7 @@ class CanvasItem {
   CanvasItem copyWith({
     int? id,
     int? collectionId,
+    int? collectionItemId,
     CanvasItemType? itemType,
     int? itemRefId,
     double? x,
@@ -220,6 +229,7 @@ class CanvasItem {
     return CanvasItem(
       id: id ?? this.id,
       collectionId: collectionId ?? this.collectionId,
+      collectionItemId: collectionItemId ?? this.collectionItemId,
       itemType: itemType ?? this.itemType,
       itemRefId: itemRefId ?? this.itemRefId,
       x: x ?? this.x,

--- a/lib/shared/models/search_sort.dart
+++ b/lib/shared/models/search_sort.dart
@@ -1,0 +1,77 @@
+// Модель сортировки результатов поиска.
+
+/// Поле сортировки.
+enum SearchSortField {
+  /// По релевантности (совпадение с запросом).
+  relevance,
+
+  /// По дате выпуска.
+  date,
+
+  /// По рейтингу.
+  rating,
+}
+
+/// Направление сортировки.
+enum SearchSortOrder {
+  /// По возрастанию.
+  ascending,
+
+  /// По убыванию.
+  descending,
+}
+
+/// Настройки сортировки результатов поиска.
+class SearchSort {
+  /// Создаёт [SearchSort].
+  const SearchSort({
+    this.field = SearchSortField.relevance,
+    this.order = SearchSortOrder.descending,
+  });
+
+  /// Поле сортировки.
+  final SearchSortField field;
+
+  /// Направление сортировки.
+  final SearchSortOrder order;
+
+  /// Значение по умолчанию (релевантность, по убыванию).
+  static const SearchSort defaultSort = SearchSort();
+
+  /// Проверяет, является ли сортировка значением по умолчанию.
+  bool get isDefault => field == SearchSortField.relevance;
+
+  /// Создаёт копию с изменённым полем.
+  SearchSort copyWith({
+    SearchSortField? field,
+    SearchSortOrder? order,
+  }) {
+    return SearchSort(
+      field: field ?? this.field,
+      order: order ?? this.order,
+    );
+  }
+
+  /// Переключает направление сортировки.
+  SearchSort toggleOrder() {
+    return copyWith(
+      order: order == SearchSortOrder.ascending
+          ? SearchSortOrder.descending
+          : SearchSortOrder.ascending,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SearchSort &&
+        other.field == field &&
+        other.order == order;
+  }
+
+  @override
+  int get hashCode => Object.hash(field, order);
+
+  @override
+  String toString() => 'SearchSort($field, $order)';
+}

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -42,6 +42,7 @@ class MediaDetailView extends StatelessWidget {
     this.userComment,
     this.hasAuthorComment = false,
     this.hasUserComment = false,
+    this.embedded = false,
     super.key,
   });
 
@@ -90,6 +91,13 @@ class MediaDetailView extends StatelessWidget {
   /// Можно ли редактировать комментарий автора.
   final bool isEditable;
 
+  /// Встраиваемый режим (без Scaffold и AppBar).
+  ///
+  /// Если true, виджет возвращает только контент без обёртки в Scaffold.
+  /// Используется когда MediaDetailView встроен в другой экран (например,
+  /// в TabBarView на GameDetailScreen).
+  final bool embedded;
+
   /// Колбэк сохранения комментария автора.
   final ValueChanged<String?> onAuthorCommentSave;
 
@@ -98,30 +106,34 @@ class MediaDetailView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Widget content = ListView(
+      padding: const EdgeInsets.all(16),
+      children: <Widget>[
+        _buildHeader(context),
+        if (statusWidget != null) ...<Widget>[
+          const SizedBox(height: 16),
+          _buildStatusSection(context),
+        ],
+        if (extraSections != null)
+          for (final Widget section in extraSections!) ...<Widget>[
+            const SizedBox(height: 16),
+            section,
+          ],
+        const SizedBox(height: 16),
+        _buildAuthorCommentSection(context),
+        const SizedBox(height: 16),
+        _buildUserNotesSection(context),
+        const SizedBox(height: 24),
+      ],
+    );
+
+    if (embedded) return content;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: <Widget>[
-          _buildHeader(context),
-          if (statusWidget != null) ...<Widget>[
-            const SizedBox(height: 16),
-            _buildStatusSection(context),
-          ],
-          if (extraSections != null)
-            for (final Widget section in extraSections!) ...<Widget>[
-              const SizedBox(height: 16),
-              section,
-            ],
-          const SizedBox(height: 16),
-          _buildAuthorCommentSection(context),
-          const SizedBox(height: 16),
-          _buildUserNotesSection(context),
-          const SizedBox(height: 24),
-        ],
-      ),
+      body: content,
     );
   }
 

--- a/test/core/api/tmdb_api_test.dart
+++ b/test/core/api/tmdb_api_test.dart
@@ -543,6 +543,56 @@ void main() {
           throwsA(isA<TmdbApiException>()),
         );
       });
+
+      test('должен передать year в queryParameters когда указан', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.searchMovies('test', year: 2024);
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params['year'], equals(2024));
+      });
+
+      test('не должен передавать year когда не указан', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.searchMovies('test');
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params.containsKey('year'), isFalse);
+      });
     });
 
     // ----- getMovie -----
@@ -830,6 +880,56 @@ void main() {
           () => sut.searchTvShows('test'),
           throwsA(isA<TmdbApiException>()),
         );
+      });
+
+      test('должен передать first_air_date_year в queryParameters', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.searchTvShows('test', firstAirDateYear: 2023);
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params['first_air_date_year'], equals(2023));
+      });
+
+      test('не должен передавать first_air_date_year когда не указан', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.searchTvShows('test');
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params.containsKey('first_air_date_year'), isFalse);
       });
     });
 

--- a/test/features/collections/screens/game_detail_screen_test.dart
+++ b/test/features/collections/screens/game_detail_screen_test.dart
@@ -451,5 +451,72 @@ void main() {
       expect(find.byType(SourceBadge), findsOneWidget);
       expect(find.text('IGDB'), findsOneWidget);
     });
+
+    testWidgets('должен отображать TabBar с двумя вкладками',
+        (WidgetTester tester) async {
+      const Game game = Game(id: 100, name: 'Test Game');
+      const Platform platform = Platform(id: 18, name: 'SNES');
+      final CollectionGame collectionGame = createTestCollectionGame(
+        game: game,
+        platform: platform,
+      );
+
+      await tester.pumpWidget(createTestWidget(
+        collectionId: 1,
+        gameId: 1,
+        isEditable: true,
+        games: <CollectionGame>[collectionGame],
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.byType(Tab), findsNWidgets(2));
+      expect(find.text('Details'), findsOneWidget);
+      expect(find.text('Canvas'), findsOneWidget);
+    });
+
+    testWidgets('должен отображать иконки вкладок',
+        (WidgetTester tester) async {
+      const Game game = Game(id: 100, name: 'Test Game');
+      const Platform platform = Platform(id: 18, name: 'SNES');
+      final CollectionGame collectionGame = createTestCollectionGame(
+        game: game,
+        platform: platform,
+      );
+
+      await tester.pumpWidget(createTestWidget(
+        collectionId: 1,
+        gameId: 1,
+        isEditable: true,
+        games: <CollectionGame>[collectionGame],
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+      expect(find.byIcon(Icons.dashboard_outlined), findsOneWidget);
+    });
+
+    testWidgets('должен начинать с вкладки Details',
+        (WidgetTester tester) async {
+      const Game game = Game(id: 100, name: 'Test Game');
+      const Platform platform = Platform(id: 18, name: 'SNES');
+      final CollectionGame collectionGame = createTestCollectionGame(
+        game: game,
+        platform: platform,
+        authorComment: 'Test author comment',
+      );
+
+      await tester.pumpWidget(createTestWidget(
+        collectionId: 1,
+        gameId: 1,
+        isEditable: true,
+        games: <CollectionGame>[collectionGame],
+      ));
+      await tester.pumpAndSettle();
+
+      // Содержимое вкладки Details должно быть видимым по умолчанию
+      expect(find.text("Author's Comment"), findsOneWidget);
+      expect(find.text('Test author comment'), findsOneWidget);
+    });
   });
 }

--- a/test/features/collections/screens/movie_detail_screen_test.dart
+++ b/test/features/collections/screens/movie_detail_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/widgets/media_detail_view.dart';
 import 'package:xerabora/shared/widgets/source_badge.dart';
 
 // Mock-нотифайер для подмены collectionItemsNotifierProvider в тестах.
@@ -739,7 +740,11 @@ void main() {
 
         // Прокручиваем до секции My Notes, чтобы кнопка Edit была видна
         final Finder myNotesEdit = find.text('Edit').last;
-        await tester.scrollUntilVisible(myNotesEdit, 200);
+        await tester.scrollUntilVisible(
+          myNotesEdit,
+          200,
+          scrollable: find.byType(Scrollable).at(1),
+        );
         await tester.pumpAndSettle();
 
         // Нажимаем последнюю кнопку Edit (My Notes)
@@ -933,6 +938,58 @@ void main() {
 
         expect(find.byType(SourceBadge), findsOneWidget);
         expect(find.text('TMDB'), findsOneWidget);
+      });
+    });
+
+    group('TabBar', () {
+      testWidgets('должен отображать TabBar с двумя вкладками',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TabBar), findsOneWidget);
+        expect(find.byType(Tab), findsNWidgets(2));
+      });
+
+      testWidgets('должен отображать иконки вкладок',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.info_outline), findsOneWidget);
+        expect(find.byIcon(Icons.dashboard_outlined), findsOneWidget);
+      });
+
+      testWidgets('должен начинать с вкладки Details',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(MediaDetailView), findsOneWidget);
       });
     });
   });

--- a/test/features/collections/screens/tv_show_detail_screen_test.dart
+++ b/test/features/collections/screens/tv_show_detail_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
+import 'package:xerabora/shared/widgets/media_detail_view.dart';
 import 'package:xerabora/shared/widgets/source_badge.dart';
 
 class MockCollectionRepository extends Mock implements CollectionRepository {}
@@ -354,7 +355,9 @@ void main() {
         expect(find.byIcon(Icons.playlist_play), findsNothing);
         expect(find.byIcon(Icons.category_outlined), findsNothing);
         expect(find.byIcon(Icons.star_outline), findsNothing);
-        expect(find.byIcon(Icons.info_outline), findsNothing);
+        // Icons.info_outline appears in TabBar, so check chip absence by count
+        // TabBar has 1 info_outline icon (Details tab), chips should add 0 more
+        expect(find.byIcon(Icons.info_outline), findsOneWidget);
       });
     });
 
@@ -819,9 +822,11 @@ void main() {
         expect(find.text('Completed'), findsOneWidget);
 
         // Author's comment & user notes — скролл к нижней части
+        // Указываем scrollable MediaDetailView (второй после TabBarView)
         await tester.scrollUntilVisible(
           find.text('Rewatched twice'),
           200,
+          scrollable: find.byType(Scrollable).at(1),
         );
         await tester.pumpAndSettle();
         expect(find.text('Best series ever'), findsOneWidget);
@@ -990,6 +995,60 @@ void main() {
 
         expect(find.byType(SourceBadge), findsOneWidget);
         expect(find.text('TMDB'), findsOneWidget);
+      });
+    });
+
+    group('TabBar', () {
+      testWidgets('должен отображать TabBar с двумя вкладками',
+          (WidgetTester tester) async {
+        final TvShow tvShow = createTestTvShow();
+        final CollectionItem item = createTestCollectionItem(tvShow: tvShow);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TabBar), findsOneWidget);
+        expect(find.byType(Tab), findsNWidgets(2));
+      });
+
+      testWidgets('должен отображать иконки вкладок',
+          (WidgetTester tester) async {
+        final TvShow tvShow = createTestTvShow();
+        final CollectionItem item = createTestCollectionItem(tvShow: tvShow);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        // info_outline appears both in TabBar and as status chip icon,
+        // so we check at least one exists for tab icon
+        expect(find.byIcon(Icons.info_outline), findsWidgets);
+        expect(find.byIcon(Icons.dashboard_outlined), findsOneWidget);
+      });
+
+      testWidgets('должен начинать с вкладки Details',
+          (WidgetTester tester) async {
+        final TvShow tvShow = createTestTvShow();
+        final CollectionItem item = createTestCollectionItem(tvShow: tvShow);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(MediaDetailView), findsOneWidget);
       });
     });
   });

--- a/test/features/search/providers/game_search_provider_test.dart
+++ b/test/features/search/providers/game_search_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/features/search/providers/game_search_provider.dart';
 import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/search_sort.dart';
 
 void main() {
   group('GameSearchState', () {
@@ -13,6 +14,7 @@ void main() {
       expect(state.isLoading, isFalse);
       expect(state.error, isNull);
       expect(state.selectedPlatformIds, isEmpty);
+      expect(state.currentSort, const SearchSort());
     });
 
     test('hasResults returns true when results is not empty', () {
@@ -162,6 +164,29 @@ void main() {
 
         expect(updated.selectedPlatformIds, isEmpty);
       });
+
+      test('updates currentSort', () {
+        const GameSearchState original = GameSearchState();
+        const SearchSort newSort = SearchSort(
+          field: SearchSortField.rating,
+          order: SearchSortOrder.ascending,
+        );
+
+        final GameSearchState updated =
+            original.copyWith(currentSort: newSort);
+
+        expect(updated.currentSort.field, SearchSortField.rating);
+        expect(updated.currentSort.order, SearchSortOrder.ascending);
+      });
+
+      test('preserves currentSort when not specified', () {
+        const SearchSort sort = SearchSort(field: SearchSortField.date);
+        const GameSearchState original = GameSearchState(currentSort: sort);
+
+        final GameSearchState updated = original.copyWith(query: 'test');
+
+        expect(updated.currentSort, sort);
+      });
     });
 
     group('equality', () {
@@ -203,6 +228,29 @@ void main() {
         // listEquals compares order too
         expect(listEquals(state1.selectedPlatformIds, state2.selectedPlatformIds), isFalse);
         expect(state1, isNot(equals(state2)));
+      });
+
+      test('states with different currentSort are not equal', () {
+        const GameSearchState state1 = GameSearchState(
+          currentSort: SearchSort(field: SearchSortField.date),
+        );
+        const GameSearchState state2 = GameSearchState(
+          currentSort: SearchSort(field: SearchSortField.rating),
+        );
+
+        expect(state1, isNot(equals(state2)));
+      });
+
+      test('states with same currentSort are equal', () {
+        const GameSearchState state1 = GameSearchState(
+          currentSort: SearchSort(field: SearchSortField.date),
+        );
+        const GameSearchState state2 = GameSearchState(
+          currentSort: SearchSort(field: SearchSortField.date),
+        );
+
+        expect(state1, equals(state2));
+        expect(state1.hashCode, equals(state2.hashCode));
       });
     });
   });

--- a/test/features/search/providers/media_search_provider_test.dart
+++ b/test/features/search/providers/media_search_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/features/search/providers/media_search_provider.dart';
 import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/search_sort.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 
 void main() {
@@ -23,6 +24,36 @@ void main() {
       expect(state.isLoading, isFalse);
       expect(state.error, isNull);
       expect(state.activeTab, MediaSearchTab.movies);
+      expect(state.currentSort, const SearchSort());
+      expect(state.selectedYear, isNull);
+      expect(state.selectedGenreIds, isEmpty);
+    });
+
+    group('hasFilters', () {
+      test('returns false for default state', () {
+        const MediaSearchState state = MediaSearchState();
+        expect(state.hasFilters, isFalse);
+      });
+
+      test('returns true when year is set', () {
+        const MediaSearchState state = MediaSearchState(selectedYear: 2024);
+        expect(state.hasFilters, isTrue);
+      });
+
+      test('returns true when genres are set', () {
+        const MediaSearchState state = MediaSearchState(
+          selectedGenreIds: <int>[28, 12],
+        );
+        expect(state.hasFilters, isTrue);
+      });
+
+      test('returns true when both year and genres are set', () {
+        const MediaSearchState state = MediaSearchState(
+          selectedYear: 2024,
+          selectedGenreIds: <int>[28],
+        );
+        expect(state.hasFilters, isTrue);
+      });
     });
 
     group('hasResults', () {
@@ -218,6 +249,88 @@ void main() {
 
         expect(updated.activeTab, MediaSearchTab.tvShows);
       });
+
+      test('updates currentSort', () {
+        const MediaSearchState original = MediaSearchState();
+        const SearchSort newSort = SearchSort(
+          field: SearchSortField.rating,
+          order: SearchSortOrder.ascending,
+        );
+
+        final MediaSearchState updated =
+            original.copyWith(currentSort: newSort);
+
+        expect(updated.currentSort.field, SearchSortField.rating);
+        expect(updated.currentSort.order, SearchSortOrder.ascending);
+      });
+
+      test('preserves currentSort when not specified', () {
+        const SearchSort sort = SearchSort(field: SearchSortField.date);
+        const MediaSearchState original = MediaSearchState(currentSort: sort);
+
+        final MediaSearchState updated = original.copyWith(query: 'test');
+
+        expect(updated.currentSort, sort);
+      });
+
+      test('updates selectedYear', () {
+        const MediaSearchState original = MediaSearchState();
+
+        final MediaSearchState updated =
+            original.copyWith(selectedYear: 2024);
+
+        expect(updated.selectedYear, 2024);
+      });
+
+      test('clears selectedYear with clearYear', () {
+        const MediaSearchState original = MediaSearchState(
+          selectedYear: 2024,
+        );
+
+        final MediaSearchState updated = original.copyWith(clearYear: true);
+
+        expect(updated.selectedYear, isNull);
+      });
+
+      test('preserves selectedYear when not specified', () {
+        const MediaSearchState original = MediaSearchState(
+          selectedYear: 2023,
+        );
+
+        final MediaSearchState updated = original.copyWith(query: 'test');
+
+        expect(updated.selectedYear, 2023);
+      });
+
+      test('updates selectedGenreIds', () {
+        const MediaSearchState original = MediaSearchState();
+
+        final MediaSearchState updated =
+            original.copyWith(selectedGenreIds: <int>[28, 12]);
+
+        expect(updated.selectedGenreIds, <int>[28, 12]);
+      });
+
+      test('clears selectedGenreIds with empty list', () {
+        const MediaSearchState original = MediaSearchState(
+          selectedGenreIds: <int>[28, 12],
+        );
+
+        final MediaSearchState updated =
+            original.copyWith(selectedGenreIds: <int>[]);
+
+        expect(updated.selectedGenreIds, isEmpty);
+      });
+
+      test('preserves selectedGenreIds when not specified', () {
+        const MediaSearchState original = MediaSearchState(
+          selectedGenreIds: <int>[28],
+        );
+
+        final MediaSearchState updated = original.copyWith(query: 'test');
+
+        expect(updated.selectedGenreIds, <int>[28]);
+      });
     });
 
     group('equality', () {
@@ -332,6 +445,75 @@ void main() {
           isFalse,
         );
         expect(state1, isNot(equals(state2)));
+      });
+
+      test('states with different currentSort are not equal', () {
+        const MediaSearchState state1 = MediaSearchState(
+          currentSort: SearchSort(field: SearchSortField.date),
+        );
+        const MediaSearchState state2 = MediaSearchState(
+          currentSort: SearchSort(field: SearchSortField.rating),
+        );
+
+        expect(state1, isNot(equals(state2)));
+      });
+
+      test('states with same currentSort are equal', () {
+        const MediaSearchState state1 = MediaSearchState(
+          currentSort: SearchSort(field: SearchSortField.date),
+        );
+        const MediaSearchState state2 = MediaSearchState(
+          currentSort: SearchSort(field: SearchSortField.date),
+        );
+
+        expect(state1, equals(state2));
+        expect(state1.hashCode, equals(state2.hashCode));
+      });
+
+      test('states with different selectedYear are not equal', () {
+        const MediaSearchState state1 = MediaSearchState(
+          selectedYear: 2024,
+        );
+        const MediaSearchState state2 = MediaSearchState(
+          selectedYear: 2023,
+        );
+
+        expect(state1, isNot(equals(state2)));
+      });
+
+      test('states with same selectedYear are equal', () {
+        const MediaSearchState state1 = MediaSearchState(
+          selectedYear: 2024,
+        );
+        const MediaSearchState state2 = MediaSearchState(
+          selectedYear: 2024,
+        );
+
+        expect(state1, equals(state2));
+        expect(state1.hashCode, equals(state2.hashCode));
+      });
+
+      test('states with different selectedGenreIds are not equal', () {
+        const MediaSearchState state1 = MediaSearchState(
+          selectedGenreIds: <int>[28],
+        );
+        const MediaSearchState state2 = MediaSearchState(
+          selectedGenreIds: <int>[12],
+        );
+
+        expect(state1, isNot(equals(state2)));
+      });
+
+      test('states with same selectedGenreIds are equal', () {
+        const MediaSearchState state1 = MediaSearchState(
+          selectedGenreIds: <int>[28, 12],
+        );
+        const MediaSearchState state2 = MediaSearchState(
+          selectedGenreIds: <int>[28, 12],
+        );
+
+        expect(state1, equals(state2));
+        expect(state1.hashCode, equals(state2.hashCode));
       });
     });
   });

--- a/test/features/search/widgets/media_filter_sheet_test.dart
+++ b/test/features/search/widgets/media_filter_sheet_test.dart
@@ -1,0 +1,283 @@
+// Тесты для MediaFilterSheet.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/features/search/widgets/media_filter_sheet.dart';
+
+void main() {
+  const List<TmdbGenre> testGenres = <TmdbGenre>[
+    TmdbGenre(id: 28, name: 'Action'),
+    TmdbGenre(id: 12, name: 'Adventure'),
+    TmdbGenre(id: 18, name: 'Drama'),
+    TmdbGenre(id: 35, name: 'Comedy'),
+  ];
+
+  Widget buildTestWidget({
+    List<TmdbGenre> genres = testGenres,
+    int? selectedYear,
+    List<int> selectedGenreIds = const <int>[],
+    void Function({int? year, required List<int> genreIds})? onApply,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: MediaFilterSheet(
+          genres: genres,
+          selectedYear: selectedYear,
+          selectedGenreIds: selectedGenreIds,
+          onApply: onApply ??
+              ({int? year, required List<int> genreIds}) {},
+        ),
+      ),
+    );
+  }
+
+  group('MediaFilterSheet', () {
+    group('Render', () {
+      testWidgets('should show title', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Filters'), findsOneWidget);
+      });
+
+      testWidgets('should show Release Year section', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Release Year'), findsOneWidget);
+      });
+
+      testWidgets('should show Genres section', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Genres'), findsOneWidget);
+      });
+
+      testWidgets('should show genre chips', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Action'), findsOneWidget);
+        expect(find.text('Adventure'), findsOneWidget);
+        expect(find.text('Drama'), findsOneWidget);
+        expect(find.text('Comedy'), findsOneWidget);
+      });
+
+      testWidgets('should show Cancel and Apply buttons',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Cancel'), findsOneWidget);
+        expect(find.text('Apply'), findsOneWidget);
+      });
+
+      testWidgets('should show year hint', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('e.g. 2024'), findsOneWidget);
+      });
+
+      testWidgets('should show empty genres message when no genres',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(genres: const <TmdbGenre>[]),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('No genres available'), findsOneWidget);
+      });
+    });
+
+    group('Initial State', () {
+      testWidgets('should show selected year', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(selectedYear: 2024));
+        await tester.pumpAndSettle();
+
+        expect(find.text('2024'), findsOneWidget);
+      });
+
+      testWidgets('should show Clear All when year is set',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(selectedYear: 2024));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Clear All'), findsOneWidget);
+      });
+
+      testWidgets('should not show Clear All when empty',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Clear All'), findsNothing);
+      });
+    });
+
+    group('Genre Selection', () {
+      testWidgets('should toggle genre on tap', (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        // Тапаем на Action
+        await tester.tap(find.text('Action'));
+        await tester.pumpAndSettle();
+
+        // FilterChip должен стать selected — Clear All появляется
+        expect(find.text('Clear All'), findsOneWidget);
+      });
+
+      testWidgets('should show selected genres from initial state',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(selectedGenreIds: const <int>[28, 18]),
+        );
+        await tester.pumpAndSettle();
+
+        // Clear All должен быть виден
+        expect(find.text('Clear All'), findsOneWidget);
+      });
+    });
+
+    group('Clear All', () {
+      testWidgets('should clear genres and year', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            selectedYear: 2024,
+            selectedGenreIds: const <int>[28],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Clear All'));
+        await tester.pumpAndSettle();
+
+        // Clear All скрывается после очистки
+        expect(find.text('Clear All'), findsNothing);
+      });
+    });
+
+    group('Apply', () {
+      testWidgets('should call onApply with selected values',
+          (WidgetTester tester) async {
+        int? appliedYear;
+        List<int>? appliedGenres;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            selectedYear: 2024,
+            selectedGenreIds: const <int>[28, 18],
+            onApply: ({int? year, required List<int> genreIds}) {
+              appliedYear = year;
+              appliedGenres = genreIds;
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        expect(appliedYear, 2024);
+        expect(appliedGenres, <int>[28, 18]);
+      });
+
+      testWidgets('should call onApply with null year when empty',
+          (WidgetTester tester) async {
+        int? appliedYear;
+        bool yearWasNull = false;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            onApply: ({int? year, required List<int> genreIds}) {
+              appliedYear = year;
+              yearWasNull = year == null;
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        expect(appliedYear, isNull);
+        expect(yearWasNull, isTrue);
+      });
+
+      testWidgets('should call onApply with empty genres when none selected',
+          (WidgetTester tester) async {
+        List<int>? appliedGenres;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            onApply: ({int? year, required List<int> genreIds}) {
+              appliedGenres = genreIds;
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        expect(appliedGenres, isEmpty);
+      });
+    });
+
+    group('Year Validation', () {
+      testWidgets('should return null for invalid year',
+          (WidgetTester tester) async {
+        int? appliedYear;
+        bool yearWasNull = false;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            onApply: ({int? year, required List<int> genreIds}) {
+              appliedYear = year;
+              yearWasNull = year == null;
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Вводим невалидный год
+        final Finder yearField = find.byType(TextField);
+        await tester.enterText(yearField, '123');
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        // 123 < 1900, поэтому null
+        expect(appliedYear, isNull);
+        expect(yearWasNull, isTrue);
+      });
+
+      testWidgets('should accept valid year',
+          (WidgetTester tester) async {
+        int? appliedYear;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            onApply: ({int? year, required List<int> genreIds}) {
+              appliedYear = year;
+            },
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final Finder yearField = find.byType(TextField);
+        await tester.enterText(yearField, '2020');
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Apply'));
+        await tester.pumpAndSettle();
+
+        expect(appliedYear, 2020);
+      });
+    });
+  });
+}

--- a/test/shared/models/canvas_connection_test.dart
+++ b/test/shared/models/canvas_connection_test.dart
@@ -28,6 +28,7 @@ void main() {
     CanvasConnection createTestConnection({
       int id = 1,
       int collectionId = 10,
+      int? collectionItemId,
       int fromItemId = 100,
       int toItemId = 200,
       String? label,
@@ -37,6 +38,7 @@ void main() {
       return CanvasConnection(
         id: id,
         collectionId: collectionId,
+        collectionItemId: collectionItemId,
         fromItemId: fromItemId,
         toItemId: toItemId,
         label: label,
@@ -69,6 +71,13 @@ void main() {
       expect(conn.color, '#666666');
       expect(conn.style, ConnectionStyle.solid);
       expect(conn.label, isNull);
+    });
+
+    test('should create with collectionItemId', () {
+      final CanvasConnection conn = createTestConnection(
+        collectionItemId: 42,
+      );
+      expect(conn.collectionItemId, 42);
     });
 
     group('fromDb', () {
@@ -128,6 +137,40 @@ void main() {
         final CanvasConnection conn = CanvasConnection.fromDb(row);
         expect(conn.style, ConnectionStyle.dashed);
       });
+
+      test('should parse collectionItemId from database row', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 3,
+          'collection_id': 10,
+          'collection_item_id': 55,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': null,
+          'color': '#FF0000',
+          'style': 'solid',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromDb(row);
+        expect(conn.collectionItemId, 55);
+      });
+
+      test('should handle null collectionItemId', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 4,
+          'collection_id': 10,
+          'collection_item_id': null,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': null,
+          'color': '#FF0000',
+          'style': 'solid',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromDb(row);
+        expect(conn.collectionItemId, isNull);
+      });
     });
 
     group('fromJson', () {
@@ -180,6 +223,23 @@ void main() {
           lessThan(2),
         );
       });
+
+      test('should parse collectionItemId from JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'id': 5,
+          'collection_id': 10,
+          'collection_item_id': 33,
+          'from_item_id': 100,
+          'to_item_id': 200,
+          'label': null,
+          'color': '#FF0000',
+          'style': 'solid',
+          'created_at': testTimestamp,
+        };
+
+        final CanvasConnection conn = CanvasConnection.fromJson(json);
+        expect(conn.collectionItemId, 33);
+      });
     });
 
     group('toDb', () {
@@ -210,6 +270,14 @@ void main() {
         final Map<String, dynamic> db = conn.toDb();
         expect(db['label'], isNull);
       });
+
+      test('should serialize collectionItemId to database map', () {
+        final CanvasConnection conn = createTestConnection(
+          collectionItemId: 77,
+        );
+        final Map<String, dynamic> db = conn.toDb();
+        expect(db['collection_item_id'], 77);
+      });
     });
 
     group('toJson', () {
@@ -233,6 +301,14 @@ void main() {
         final CanvasConnection conn = createTestConnection();
         final Map<String, dynamic> json = conn.toJson();
         expect(json.containsKey('collection_id'), isFalse);
+      });
+
+      test('should include collectionItemId in export when set', () {
+        final CanvasConnection conn = createTestConnection(
+          collectionItemId: 88,
+        );
+        final Map<String, dynamic> json = conn.toJson();
+        expect(json['collection_item_id'], 88);
       });
     });
 
@@ -315,6 +391,18 @@ void main() {
         expect(copy.color, '#000000');
         expect(copy.style, ConnectionStyle.arrow);
         expect(copy.createdAt, newDate);
+      });
+
+      test('should copy with changed collectionItemId', () {
+        final CanvasConnection original = createTestConnection(
+          collectionItemId: 10,
+        );
+        final CanvasConnection copy = original.copyWith(
+          collectionItemId: 99,
+        );
+        expect(copy.collectionItemId, 99);
+        expect(copy.id, original.id);
+        expect(copy.collectionId, original.collectionId);
       });
     });
 

--- a/test/shared/models/canvas_item_test.dart
+++ b/test/shared/models/canvas_item_test.dart
@@ -32,6 +32,7 @@ void main() {
     CanvasItem createTestItem({
       int id = 1,
       int collectionId = 10,
+      int? collectionItemId,
       CanvasItemType itemType = CanvasItemType.game,
       int? itemRefId = 100,
       double x = 50.0,
@@ -44,6 +45,7 @@ void main() {
       return CanvasItem(
         id: id,
         collectionId: collectionId,
+        collectionItemId: collectionItemId,
         itemType: itemType,
         itemRefId: itemRefId,
         x: x,
@@ -83,6 +85,14 @@ void main() {
       expect(item.data, isNotNull);
       expect(item.data!['content'], 'Hello');
       expect(item.data!['fontSize'], 16);
+    });
+
+    test('should create with collectionItemId', () {
+      final CanvasItem item = createTestItem(collectionItemId: 42);
+
+      expect(item.collectionItemId, 42);
+      expect(item.id, 1);
+      expect(item.collectionId, 10);
     });
 
     group('fromDb', () {
@@ -184,6 +194,48 @@ void main() {
         expect(item.x, 50.0);
         expect(item.y, 100.0);
       });
+
+      test('should parse collectionItemId from database row', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'collection_item_id': 42,
+          'item_type': 'game',
+          'item_ref_id': 100,
+          'x': 50.0,
+          'y': 100.0,
+          'width': 160.0,
+          'height': 220.0,
+          'z_index': 0,
+          'data': null,
+          'created_at': testTimestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromDb(row);
+
+        expect(item.collectionItemId, 42);
+      });
+
+      test('should handle null collectionItemId', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'collection_id': 10,
+          'collection_item_id': null,
+          'item_type': 'game',
+          'item_ref_id': 100,
+          'x': 50.0,
+          'y': 100.0,
+          'width': null,
+          'height': null,
+          'z_index': 0,
+          'data': null,
+          'created_at': testTimestamp,
+        };
+
+        final CanvasItem item = CanvasItem.fromDb(row);
+
+        expect(item.collectionItemId, isNull);
+      });
     });
 
     group('toDb', () {
@@ -223,6 +275,21 @@ void main() {
 
         expect(db.containsKey('id'), false);
       });
+
+      test('should serialize collectionItemId to database map', () {
+        final CanvasItem item = createTestItem(collectionItemId: 42);
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db['collection_item_id'], 42);
+      });
+
+      test('should serialize null collectionItemId', () {
+        final CanvasItem item = createTestItem();
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db.containsKey('collection_item_id'), true);
+        expect(db['collection_item_id'], isNull);
+      });
     });
 
     group('toJson', () {
@@ -250,6 +317,13 @@ void main() {
 
         expect(jsonMap['data'], isA<Map<String, dynamic>>());
         expect((jsonMap['data'] as Map<String, dynamic>)['content'], 'Test');
+      });
+
+      test('should include collectionItemId in export', () {
+        final CanvasItem item = createTestItem(collectionItemId: 42);
+        final Map<String, dynamic> jsonMap = item.toJson();
+
+        expect(jsonMap['collection_item_id'], 42);
       });
     });
 
@@ -307,6 +381,21 @@ void main() {
           DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
         );
       });
+
+      test('should parse collectionItemId from JSON', () {
+        final Map<String, dynamic> jsonMap = <String, dynamic>{
+          'id': 5,
+          'collection_id': 10,
+          'collection_item_id': 42,
+          'type': 'game',
+          'x': 50,
+          'y': 100,
+        };
+
+        final CanvasItem item = CanvasItem.fromJson(jsonMap);
+
+        expect(item.collectionItemId, 42);
+      });
     });
 
     group('copyWith', () {
@@ -334,6 +423,14 @@ void main() {
         expect(copy.x, original.x);
         expect(copy.y, original.y);
         expect(copy.zIndex, original.zIndex);
+      });
+
+      test('should copy with changed collectionItemId', () {
+        final CanvasItem original = createTestItem(collectionItemId: 10);
+        final CanvasItem copy = original.copyWith(collectionItemId: 99);
+
+        expect(copy.collectionItemId, 99);
+        expect(original.collectionItemId, 10);
       });
     });
 

--- a/test/shared/models/search_sort_test.dart
+++ b/test/shared/models/search_sort_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/search_sort.dart';
+
+void main() {
+  group('SearchSortField', () {
+    test('has 3 values', () {
+      expect(SearchSortField.values.length, 3);
+      expect(SearchSortField.values, contains(SearchSortField.relevance));
+      expect(SearchSortField.values, contains(SearchSortField.date));
+      expect(SearchSortField.values, contains(SearchSortField.rating));
+    });
+  });
+
+  group('SearchSortOrder', () {
+    test('has 2 values', () {
+      expect(SearchSortOrder.values.length, 2);
+      expect(SearchSortOrder.values, contains(SearchSortOrder.ascending));
+      expect(SearchSortOrder.values, contains(SearchSortOrder.descending));
+    });
+  });
+
+  group('SearchSort', () {
+    test('creates default sort (relevance, descending)', () {
+      const SearchSort sort = SearchSort();
+
+      expect(sort.field, SearchSortField.relevance);
+      expect(sort.order, SearchSortOrder.descending);
+    });
+
+    test('creates with custom values', () {
+      const SearchSort sort = SearchSort(
+        field: SearchSortField.date,
+        order: SearchSortOrder.ascending,
+      );
+
+      expect(sort.field, SearchSortField.date);
+      expect(sort.order, SearchSortOrder.ascending);
+    });
+
+    test('defaultSort matches default constructor', () {
+      expect(SearchSort.defaultSort, const SearchSort());
+    });
+
+    test('isDefault returns true for relevance sort', () {
+      const SearchSort sort = SearchSort();
+      expect(sort.isDefault, isTrue);
+    });
+
+    test('isDefault returns true for relevance ascending', () {
+      const SearchSort sort = SearchSort(
+        field: SearchSortField.relevance,
+        order: SearchSortOrder.ascending,
+      );
+      expect(sort.isDefault, isTrue);
+    });
+
+    test('isDefault returns false for date sort', () {
+      const SearchSort sort = SearchSort(field: SearchSortField.date);
+      expect(sort.isDefault, isFalse);
+    });
+
+    test('isDefault returns false for rating sort', () {
+      const SearchSort sort = SearchSort(field: SearchSortField.rating);
+      expect(sort.isDefault, isFalse);
+    });
+
+    group('copyWith', () {
+      test('copies with new field', () {
+        const SearchSort original = SearchSort();
+        final SearchSort copy = original.copyWith(field: SearchSortField.date);
+
+        expect(copy.field, SearchSortField.date);
+        expect(copy.order, SearchSortOrder.descending);
+      });
+
+      test('copies with new order', () {
+        const SearchSort original = SearchSort();
+        final SearchSort copy =
+            original.copyWith(order: SearchSortOrder.ascending);
+
+        expect(copy.field, SearchSortField.relevance);
+        expect(copy.order, SearchSortOrder.ascending);
+      });
+
+      test('copies with both fields changed', () {
+        const SearchSort original = SearchSort();
+        final SearchSort copy = original.copyWith(
+          field: SearchSortField.rating,
+          order: SearchSortOrder.ascending,
+        );
+
+        expect(copy.field, SearchSortField.rating);
+        expect(copy.order, SearchSortOrder.ascending);
+      });
+
+      test('returns identical values when no params', () {
+        const SearchSort original = SearchSort(
+          field: SearchSortField.date,
+          order: SearchSortOrder.ascending,
+        );
+        final SearchSort copy = original.copyWith();
+
+        expect(copy, original);
+      });
+    });
+
+    group('toggleOrder', () {
+      test('toggles from descending to ascending', () {
+        const SearchSort sort = SearchSort(
+          field: SearchSortField.date,
+          order: SearchSortOrder.descending,
+        );
+        final SearchSort toggled = sort.toggleOrder();
+
+        expect(toggled.field, SearchSortField.date);
+        expect(toggled.order, SearchSortOrder.ascending);
+      });
+
+      test('toggles from ascending to descending', () {
+        const SearchSort sort = SearchSort(
+          field: SearchSortField.rating,
+          order: SearchSortOrder.ascending,
+        );
+        final SearchSort toggled = sort.toggleOrder();
+
+        expect(toggled.field, SearchSortField.rating);
+        expect(toggled.order, SearchSortOrder.descending);
+      });
+
+      test('preserves field when toggling', () {
+        const SearchSort sort = SearchSort(field: SearchSortField.relevance);
+        final SearchSort toggled = sort.toggleOrder();
+
+        expect(toggled.field, SearchSortField.relevance);
+      });
+    });
+
+    group('equality', () {
+      test('same values are equal', () {
+        const SearchSort a = SearchSort(
+          field: SearchSortField.date,
+          order: SearchSortOrder.ascending,
+        );
+        const SearchSort b = SearchSort(
+          field: SearchSortField.date,
+          order: SearchSortOrder.ascending,
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('different field not equal', () {
+        const SearchSort a = SearchSort(field: SearchSortField.date);
+        const SearchSort b = SearchSort(field: SearchSortField.rating);
+
+        expect(a, isNot(b));
+      });
+
+      test('different order not equal', () {
+        const SearchSort a = SearchSort(
+          field: SearchSortField.date,
+          order: SearchSortOrder.ascending,
+        );
+        const SearchSort b = SearchSort(
+          field: SearchSortField.date,
+          order: SearchSortOrder.descending,
+        );
+
+        expect(a, isNot(b));
+      });
+
+      test('identical instance is equal', () {
+        const SearchSort sort = SearchSort();
+        expect(sort == sort, isTrue);
+      });
+    });
+
+    test('toString returns readable format', () {
+      const SearchSort sort = SearchSort(
+        field: SearchSortField.date,
+        order: SearchSortOrder.ascending,
+      );
+
+      expect(
+        sort.toString(),
+        'SearchSort(SearchSortField.date, SearchSortOrder.ascending)',
+      );
+    });
+  });
+}


### PR DESCRIPTION


- Search: sort by relevance/date/rating, filter movies/TV by year and genres
- Per-item canvas: each game/movie/TV show gets its own canvas via TabBar
- Detail screens: added SteamGridDB and VGMaps panels to per-item canvas
- Fixed canvas data leak: added collection_item_id IS NULL to 6 SQL methods
- DB migration v8→v9: collection_item_id column, game_canvas_viewport table
- Updated docs: CHANGELOG, ARCHITECTURE, FEATURES, ROADMAP