### PR TITLE
Add episode tracker with season details, refresh, and auto-complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@
 ## [Unreleased]
 
 ### Added
+- Добавлена модель `TvEpisode` (`lib/shared/models/tv_episode.dart`) — эпизод сериала из TMDB с полями: tmdbShowId, seasonNumber, episodeNumber, name, overview, airDate, stillUrl, runtime. Методы: `fromJson()`, `fromDb()`, `toDb()`, `copyWith()`. Equality по (tmdbShowId, seasonNumber, episodeNumber)
+- Добавлена миграция БД v9→v10: таблицы `tv_episodes_cache` (кэш эпизодов TMDB) и `watched_episodes` (трекинг просмотренных эпизодов по коллекциям, FK CASCADE на collections)
+- Добавлены методы в `DatabaseService`: `getEpisodesByShowAndSeason`, `upsertEpisodes`, `clearEpisodesByShow`, `getWatchedEpisodes`, `markEpisodeWatched`, `markEpisodeUnwatched`, `getWatchedEpisodeCount`, `markSeasonWatched`, `unmarkSeasonWatched`
+- Добавлен метод `TmdbApi.getSeasonEpisodes(int tmdbShowId, int seasonNumber)` — загрузка списка эпизодов сезона из TMDB API (`GET /tv/{id}/season/{number}`)
+- Добавлен провайдер `EpisodeTrackerNotifier` (`lib/features/collections/providers/episode_tracker_provider.dart`) — NotifierProvider.family по ключу `({collectionId, showId})`. State: episodesBySeason, watchedEpisodes (Set<(int,int)>), loadingSeasons, error. Cache-first стратегия: БД → API → кэш. Автоматический статус Completed при просмотре всех эпизодов (сравнение с tvShow.totalEpisodes из метаданных)
+- Добавлена секция Episode Progress в `TvShowDetailScreen`: LinearProgressIndicator с общим прогрессом, ExpansionTile для каждого сезона с ленивой загрузкой эпизодов, CheckboxListTile для отметки просмотра, кнопка Mark all / Unmark all для сезонов
+- Добавлена кнопка Refresh в секции сезонов — принудительное обновление данных из TMDB API (новые сезоны/эпизоды добавляются, метаданные обновляются, watched-статусы сохраняются)
+- Добавлен метод `EpisodeTrackerNotifier.refreshSeason()` — принудительная загрузка эпизодов сезона из API, минуя кэш
+- Добавлен fallback при загрузке сезонов: если кэш БД пуст — автоматическая загрузка из TMDB API с кэшированием
+- Добавлены тесты: `tv_episode_test.dart` (46), `episode_tracker_provider_test.dart` (36), обновлены `tmdb_api_test.dart` (+6 тестов getSeasonEpisodes), обновлены `tv_show_detail_screen_test.dart` (MockDatabaseService, MockTmdbApi, новые тесты Episode Progress)
+
+### Changed
+- Изменён `TvShowDetailScreen` — секция прогресса заменена с простых +/- кнопок (currentSeason/currentEpisode) на полноценный трекер эпизодов с ExpansionTile по сезонам, чекбоксами и автоматическим статусом Completed. Добавлены виджеты `_SeasonsListWidget`, `_SeasonExpansionTile`, `_EpisodeTile`
+
+---
+
+### Added
 - Добавлен персональный Canvas для каждого элемента коллекции (per-item canvas): каждая игра, фильм или сериал имеет собственный холст, доступный через вкладку Canvas на экране деталей
 - Добавлен `GameCanvasNotifier` (`lib/features/collections/providers/canvas_provider.dart`) — NotifierProvider.family по ключу `({collectionId, collectionItemId})`. Автоинициализация одним медиа-элементом, поддержка всех типов canvas-элементов (game/movie/tvShow/text/image/link)
 - Добавлена миграция БД v8→v9: колонка `collection_item_id` в таблицах `canvas_items` и `canvas_connections`, индексы, таблица `game_canvas_viewport`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -73,13 +73,15 @@ Track status for each item in your collection with context-aware labels:
 
 View statistics per collection — see your completion rate at a glance.
 
-### TV Show Progress
+### Episode Tracker (TV Shows)
 
-Track your viewing progress for TV shows:
-- Current season / total seasons
-- Current episode / total episodes
-- Increment/decrement with +/- buttons
-- Format: "S2/5 • E15/50"
+Track your viewing progress for TV shows at the episode level:
+- **Episode Progress bar** — shows overall watched/total count with a LinearProgressIndicator
+- **Season sections** — ExpansionTile for each season with watched count badge
+- **Lazy loading** — episodes are fetched from TMDB API only when a season is expanded (cached in SQLite for offline access)
+- **Per-episode checkboxes** — mark individual episodes as watched/unwatched with CheckboxListTile
+- **Bulk actions** — "Mark all" / "Unmark all" button per season to toggle all episodes at once
+- **Auto-complete** — when all episodes are watched, the show's status is automatically set to Completed (compares against total episode count from show metadata)
 
 ## Detail Screens
 
@@ -107,7 +109,7 @@ Tap any item in a collection to see its full details. All detail screens have tw
 ### TV Show Details
 - Source: TMDB
 - Info chips: first air date, seasons/episodes count, rating, show status (Returning/Ended/Canceled), genres
-- Viewing progress section (current season and episode with +/- controls)
+- Episode tracker section: progress bar, expandable seasons with per-episode checkboxes, bulk mark/unmark, auto-complete
 - Status dropdown (includes "On Hold")
 
 ## Comments

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,6 +28,8 @@
 - [x] Search Sorting: Sort results by relevance, date, or rating with toggleable direction
 - [x] TMDB Filters: Filter movies/TV shows by release year and genres
 - [x] Per-Item Canvas: Personal canvas for each game/movie/TV show with TabBar detail screens, SteamGridDB and VGMaps panels, data isolation
+- [x] Task #11: Season Details — TMDB API season episodes, TvEpisode model, SQLite cache (tv_episodes_cache), lazy-loading per season
+- [x] Task #12: Episode Tracker — per-episode checkboxes, season bulk toggle, watched_episodes DB table, auto-complete to Completed status
 - [ ] Stage 13: Export Full — extended .rcoll-full format with canvas layout and images
 
 ## Future Plans

--- a/lib/features/collections/providers/episode_tracker_provider.dart
+++ b/lib/features/collections/providers/episode_tracker_provider.dart
@@ -1,0 +1,297 @@
+// Провайдер для трекинга просмотренных эпизодов сериала.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/tmdb_api.dart';
+import '../../../core/database/database_service.dart';
+import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/item_status.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/tv_episode.dart';
+import 'collections_provider.dart';
+
+/// Состояние трекера эпизодов.
+class EpisodeTrackerState {
+  /// Создаёт [EpisodeTrackerState].
+  const EpisodeTrackerState({
+    this.episodesBySeason = const <int, List<TvEpisode>>{},
+    this.watchedEpisodes = const <(int, int)>{},
+    this.loadingSeasons = const <int, bool>{},
+    this.error,
+  });
+
+  /// Эпизоды по сезонам (ключ — номер сезона).
+  final Map<int, List<TvEpisode>> episodesBySeason;
+
+  /// Множество просмотренных эпизодов (seasonNumber, episodeNumber).
+  final Set<(int, int)> watchedEpisodes;
+
+  /// Флаги загрузки по сезонам.
+  final Map<int, bool> loadingSeasons;
+
+  /// Ошибка загрузки (если есть).
+  final String? error;
+
+  /// Создаёт копию с изменёнными полями.
+  EpisodeTrackerState copyWith({
+    Map<int, List<TvEpisode>>? episodesBySeason,
+    Set<(int, int)>? watchedEpisodes,
+    Map<int, bool>? loadingSeasons,
+    String? error,
+  }) {
+    return EpisodeTrackerState(
+      episodesBySeason: episodesBySeason ?? this.episodesBySeason,
+      watchedEpisodes: watchedEpisodes ?? this.watchedEpisodes,
+      loadingSeasons: loadingSeasons ?? this.loadingSeasons,
+      error: error,
+    );
+  }
+
+  /// Проверяет, просмотрен ли эпизод.
+  bool isEpisodeWatched(int season, int episode) {
+    return watchedEpisodes.contains((season, episode));
+  }
+
+  /// Возвращает количество просмотренных эпизодов в сезоне.
+  int watchedCountForSeason(int season) {
+    int count = 0;
+    for (final (int s, int _) in watchedEpisodes) {
+      if (s == season) count++;
+    }
+    return count;
+  }
+
+  /// Возвращает общее количество просмотренных эпизодов.
+  int get totalWatchedCount => watchedEpisodes.length;
+
+  /// Возвращает общее количество загруженных эпизодов.
+  int get totalEpisodeCount {
+    int count = 0;
+    for (final List<TvEpisode> episodes in episodesBySeason.values) {
+      count += episodes.length;
+    }
+    return count;
+  }
+}
+
+/// Провайдер для трекинга эпизодов.
+final NotifierProviderFamily<EpisodeTrackerNotifier, EpisodeTrackerState,
+        ({int collectionId, int showId})>
+    episodeTrackerNotifierProvider = NotifierProvider.family<
+        EpisodeTrackerNotifier,
+        EpisodeTrackerState,
+        ({int collectionId, int showId})>(
+  EpisodeTrackerNotifier.new,
+);
+
+/// Нотификатор для управления просмотренными эпизодами.
+class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
+    ({int collectionId, int showId})> {
+  late DatabaseService _db;
+  late TmdbApi _tmdbApi;
+  late int _collectionId;
+  late int _showId;
+
+  @override
+  EpisodeTrackerState build(({int collectionId, int showId}) arg) {
+    _collectionId = arg.collectionId;
+    _showId = arg.showId;
+    _db = ref.watch(databaseServiceProvider);
+    _tmdbApi = ref.watch(tmdbApiProvider);
+
+    Future<void>.microtask(_loadWatchedEpisodes);
+
+    return const EpisodeTrackerState();
+  }
+
+  Future<void> _loadWatchedEpisodes() async {
+    try {
+      final Set<(int, int)> watched =
+          await _db.getWatchedEpisodes(_collectionId, _showId);
+      state = state.copyWith(watchedEpisodes: watched);
+    } on Exception catch (e) {
+      state = state.copyWith(error: 'Failed to load watched episodes: $e');
+    }
+  }
+
+  /// Загружает эпизоды сезона (из кеша или API).
+  Future<void> loadSeason(int seasonNumber) async {
+    // Уже загружен
+    if (state.episodesBySeason.containsKey(seasonNumber)) return;
+    // Уже загружается
+    if (state.loadingSeasons[seasonNumber] == true) return;
+
+    state = state.copyWith(
+      loadingSeasons: <int, bool>{
+        ...state.loadingSeasons,
+        seasonNumber: true,
+      },
+    );
+
+    try {
+      // Пробуем из кеша
+      List<TvEpisode> episodes =
+          await _db.getEpisodesByShowAndSeason(_showId, seasonNumber);
+
+      if (episodes.isEmpty) {
+        // Загружаем из API
+        episodes =
+            await _tmdbApi.getSeasonEpisodes(_showId, seasonNumber);
+        // Кешируем
+        if (episodes.isNotEmpty) {
+          await _db.upsertEpisodes(episodes);
+        }
+      }
+
+      state = state.copyWith(
+        episodesBySeason: <int, List<TvEpisode>>{
+          ...state.episodesBySeason,
+          seasonNumber: episodes,
+        },
+        loadingSeasons: <int, bool>{
+          ...state.loadingSeasons,
+          seasonNumber: false,
+        },
+        error: null,
+      );
+    } on Exception catch (e) {
+      state = state.copyWith(
+        loadingSeasons: <int, bool>{
+          ...state.loadingSeasons,
+          seasonNumber: false,
+        },
+        error: 'Failed to load season $seasonNumber: $e',
+      );
+    }
+  }
+
+  /// Принудительно обновляет эпизоды сезона из API (добавляет новые,
+  /// обновляет метаданные существующих, не трогает watched-статусы).
+  Future<void> refreshSeason(int seasonNumber) async {
+    if (state.loadingSeasons[seasonNumber] == true) return;
+
+    state = state.copyWith(
+      loadingSeasons: <int, bool>{
+        ...state.loadingSeasons,
+        seasonNumber: true,
+      },
+    );
+
+    try {
+      final List<TvEpisode> episodes =
+          await _tmdbApi.getSeasonEpisodes(_showId, seasonNumber);
+      if (episodes.isNotEmpty) {
+        await _db.upsertEpisodes(episodes);
+      }
+
+      state = state.copyWith(
+        episodesBySeason: <int, List<TvEpisode>>{
+          ...state.episodesBySeason,
+          seasonNumber: episodes,
+        },
+        loadingSeasons: <int, bool>{
+          ...state.loadingSeasons,
+          seasonNumber: false,
+        },
+        error: null,
+      );
+    } on Exception catch (e) {
+      state = state.copyWith(
+        loadingSeasons: <int, bool>{
+          ...state.loadingSeasons,
+          seasonNumber: false,
+        },
+        error: 'Failed to refresh season $seasonNumber: $e',
+      );
+    }
+  }
+
+  /// Переключает отметку просмотра эпизода.
+  Future<void> toggleEpisode(int season, int episode) async {
+    final bool isWatched = state.isEpisodeWatched(season, episode);
+
+    if (isWatched) {
+      await _db.markEpisodeUnwatched(
+          _collectionId, _showId, season, episode);
+      final Set<(int, int)> updated = Set<(int, int)>.of(state.watchedEpisodes)
+        ..remove((season, episode));
+      state = state.copyWith(watchedEpisodes: updated);
+    } else {
+      await _db.markEpisodeWatched(
+          _collectionId, _showId, season, episode);
+      final Set<(int, int)> updated = Set<(int, int)>.of(state.watchedEpisodes)
+        ..add((season, episode));
+      state = state.copyWith(watchedEpisodes: updated);
+    }
+
+    await _checkAutoComplete();
+  }
+
+  /// Переключает отметку просмотра всех эпизодов сезона.
+  Future<void> toggleSeason(int season) async {
+    final List<TvEpisode>? episodes = state.episodesBySeason[season];
+    if (episodes == null || episodes.isEmpty) return;
+
+    final int watchedCount = state.watchedCountForSeason(season);
+    final bool allWatched = watchedCount == episodes.length;
+
+    if (allWatched) {
+      // Снимаем все отметки сезона
+      await _db.unmarkSeasonWatched(_collectionId, _showId, season);
+      final Set<(int, int)> updated =
+          Set<(int, int)>.of(state.watchedEpisodes);
+      for (final TvEpisode ep in episodes) {
+        updated.remove((season, ep.episodeNumber));
+      }
+      state = state.copyWith(watchedEpisodes: updated);
+    } else {
+      // Отмечаем все эпизоды сезона
+      final List<int> episodeNumbers =
+          episodes.map((TvEpisode ep) => ep.episodeNumber).toList();
+      await _db.markSeasonWatched(
+          _collectionId, _showId, season, episodeNumbers);
+      final Set<(int, int)> updated =
+          Set<(int, int)>.of(state.watchedEpisodes);
+      for (final int ep in episodeNumbers) {
+        updated.add((season, ep));
+      }
+      state = state.copyWith(watchedEpisodes: updated);
+    }
+
+    await _checkAutoComplete();
+  }
+
+  Future<void> _checkAutoComplete() async {
+    final int totalWatched = state.totalWatchedCount;
+    if (totalWatched == 0) return;
+
+    final List<CollectionItem>? items = ref
+        .read(collectionItemsNotifierProvider(_collectionId))
+        .valueOrNull;
+    if (items == null) return;
+
+    // Находим элемент сериала, чтобы узнать общее количество эпизодов
+    CollectionItem? targetItem;
+    for (final CollectionItem ci in items) {
+      if (ci.externalId == _showId && ci.mediaType == MediaType.tvShow) {
+        targetItem = ci;
+        break;
+      }
+    }
+    if (targetItem == null) return;
+
+    // Используем totalEpisodes из метаданных, а не количество загруженных
+    final int totalInShow = targetItem.tvShow?.totalEpisodes ?? 0;
+    final int total =
+        totalInShow > 0 ? totalInShow : state.totalEpisodeCount;
+    if (total == 0) return;
+
+    if (totalWatched >= total &&
+        targetItem.status != ItemStatus.completed) {
+      await ref
+          .read(collectionItemsNotifierProvider(_collectionId).notifier)
+          .updateStatus(
+              targetItem.id, ItemStatus.completed, MediaType.tvShow);
+    }
+  }
+}

--- a/lib/shared/models/tv_episode.dart
+++ b/lib/shared/models/tv_episode.dart
@@ -1,0 +1,135 @@
+// Модель эпизода сериала из TMDB.
+
+/// Модель эпизода сериала из TMDB API.
+///
+/// Представляет один эпизод конкретного сезона сериала.
+class TvEpisode {
+  /// Создаёт экземпляр [TvEpisode].
+  const TvEpisode({
+    required this.tmdbShowId,
+    required this.seasonNumber,
+    required this.episodeNumber,
+    required this.name,
+    this.overview,
+    this.airDate,
+    this.stillUrl,
+    this.runtime,
+  });
+
+  /// Создаёт [TvEpisode] из JSON ответа TMDB API.
+  factory TvEpisode.fromJson(
+    Map<String, dynamic> json, {
+    required int showId,
+    required int season,
+  }) {
+    String? stillUrl;
+    final String? stillPath = json['still_path'] as String?;
+    if (stillPath != null) {
+      stillUrl = 'https://image.tmdb.org/t/p/w300$stillPath';
+    }
+
+    return TvEpisode(
+      tmdbShowId: showId,
+      seasonNumber: season,
+      episodeNumber: json['episode_number'] as int,
+      name: json['name'] as String? ?? '',
+      overview: json['overview'] as String?,
+      airDate: json['air_date'] as String?,
+      stillUrl: stillUrl,
+      runtime: json['runtime'] as int?,
+    );
+  }
+
+  /// Создаёт [TvEpisode] из записи базы данных.
+  factory TvEpisode.fromDb(Map<String, dynamic> row) {
+    return TvEpisode(
+      tmdbShowId: row['tmdb_show_id'] as int,
+      seasonNumber: row['season_number'] as int,
+      episodeNumber: row['episode_number'] as int,
+      name: row['name'] as String? ?? '',
+      overview: row['overview'] as String?,
+      airDate: row['air_date'] as String?,
+      stillUrl: row['still_url'] as String?,
+      runtime: row['runtime'] as int?,
+    );
+  }
+
+  /// ID сериала в TMDB.
+  final int tmdbShowId;
+
+  /// Номер сезона.
+  final int seasonNumber;
+
+  /// Номер эпизода.
+  final int episodeNumber;
+
+  /// Название эпизода.
+  final String name;
+
+  /// Описание эпизода.
+  final String? overview;
+
+  /// Дата выхода (формат: "YYYY-MM-DD").
+  final String? airDate;
+
+  /// URL кадра из эпизода (still image).
+  final String? stillUrl;
+
+  /// Длительность эпизода в минутах.
+  final int? runtime;
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'tmdb_show_id': tmdbShowId,
+      'season_number': seasonNumber,
+      'episode_number': episodeNumber,
+      'name': name,
+      'overview': overview,
+      'air_date': airDate,
+      'still_url': stillUrl,
+      'runtime': runtime,
+      'cached_at': DateTime.now().millisecondsSinceEpoch,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  TvEpisode copyWith({
+    int? tmdbShowId,
+    int? seasonNumber,
+    int? episodeNumber,
+    String? name,
+    String? overview,
+    String? airDate,
+    String? stillUrl,
+    int? runtime,
+  }) {
+    return TvEpisode(
+      tmdbShowId: tmdbShowId ?? this.tmdbShowId,
+      seasonNumber: seasonNumber ?? this.seasonNumber,
+      episodeNumber: episodeNumber ?? this.episodeNumber,
+      name: name ?? this.name,
+      overview: overview ?? this.overview,
+      airDate: airDate ?? this.airDate,
+      stillUrl: stillUrl ?? this.stillUrl,
+      runtime: runtime ?? this.runtime,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TvEpisode &&
+        other.tmdbShowId == tmdbShowId &&
+        other.seasonNumber == seasonNumber &&
+        other.episodeNumber == episodeNumber;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(tmdbShowId, seasonNumber, episodeNumber);
+
+  @override
+  String toString() =>
+      'TvEpisode(showId: $tmdbShowId, S${seasonNumber}E$episodeNumber: $name)';
+}

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -1,0 +1,878 @@
+// Тесты провайдера EpisodeTrackerNotifier.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/features/collections/providers/episode_tracker_provider.dart';
+import 'package:xerabora/shared/models/tv_episode.dart';
+
+// Моки
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+class MockTmdbApi extends Mock implements TmdbApi {}
+
+// Тестовые данные
+const int testCollectionId = 1;
+const int testShowId = 100;
+
+const ({int collectionId, int showId}) testArg = (
+  collectionId: testCollectionId,
+  showId: testShowId,
+);
+
+const TvEpisode testEpisode1 = TvEpisode(
+  tmdbShowId: testShowId,
+  seasonNumber: 1,
+  episodeNumber: 1,
+  name: 'Episode 1',
+  overview: 'First episode',
+  airDate: '2023-01-01',
+  stillUrl: 'https://example.com/s1e1.jpg',
+  runtime: 45,
+);
+
+const TvEpisode testEpisode2 = TvEpisode(
+  tmdbShowId: testShowId,
+  seasonNumber: 1,
+  episodeNumber: 2,
+  name: 'Episode 2',
+  overview: 'Second episode',
+  airDate: '2023-01-08',
+  stillUrl: 'https://example.com/s1e2.jpg',
+  runtime: 45,
+);
+
+const TvEpisode testEpisode3 = TvEpisode(
+  tmdbShowId: testShowId,
+  seasonNumber: 1,
+  episodeNumber: 3,
+  name: 'Episode 3',
+  overview: 'Third episode',
+  airDate: '2023-01-15',
+  stillUrl: 'https://example.com/s1e3.jpg',
+  runtime: 45,
+);
+
+const TvEpisode testEpisode2s1 = TvEpisode(
+  tmdbShowId: testShowId,
+  seasonNumber: 2,
+  episodeNumber: 1,
+  name: 'Season 2 Episode 1',
+  overview: 'First episode of season 2',
+  airDate: '2023-02-01',
+  stillUrl: 'https://example.com/s2e1.jpg',
+  runtime: 45,
+);
+
+const TvEpisode testEpisode2s2 = TvEpisode(
+  tmdbShowId: testShowId,
+  seasonNumber: 2,
+  episodeNumber: 2,
+  name: 'Season 2 Episode 2',
+  overview: 'Second episode of season 2',
+  airDate: '2023-02-08',
+  stillUrl: 'https://example.com/s2e2.jpg',
+  runtime: 45,
+);
+
+void main() {
+  late MockDatabaseService mockDb;
+  late MockTmdbApi mockTmdbApi;
+
+  setUp(() {
+    mockDb = MockDatabaseService();
+    mockTmdbApi = MockTmdbApi();
+  });
+
+  ProviderContainer createContainer() {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        databaseServiceProvider.overrideWithValue(mockDb),
+        tmdbApiProvider.overrideWithValue(mockTmdbApi),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('EpisodeTrackerState', () {
+    test('должен создаваться с пустыми значениями по умолчанию', () {
+      const EpisodeTrackerState state = EpisodeTrackerState();
+
+      expect(state.episodesBySeason, isEmpty);
+      expect(state.watchedEpisodes, isEmpty);
+      expect(state.loadingSeasons, isEmpty);
+      expect(state.error, isNull);
+    });
+
+    test('должен создаваться с кастомными значениями', () {
+      final Map<int, List<TvEpisode>> episodes = <int, List<TvEpisode>>{
+        1: <TvEpisode>[testEpisode1, testEpisode2],
+      };
+      final Set<(int, int)> watched = <(int, int)>{(1, 1)};
+      final Map<int, bool> loading = <int, bool>{1: false};
+
+      final EpisodeTrackerState state = EpisodeTrackerState(
+        episodesBySeason: episodes,
+        watchedEpisodes: watched,
+        loadingSeasons: loading,
+        error: 'Test error',
+      );
+
+      expect(state.episodesBySeason.length, 1);
+      expect(state.episodesBySeason[1]?.length, 2);
+      expect(state.watchedEpisodes.length, 1);
+      expect(state.watchedEpisodes.contains((1, 1)), true);
+      expect(state.loadingSeasons[1], false);
+      expect(state.error, 'Test error');
+    });
+
+    group('copyWith', () {
+      test('должен копировать с изменёнными episodesBySeason', () {
+        const EpisodeTrackerState original = EpisodeTrackerState();
+        final Map<int, List<TvEpisode>> newEpisodes = <int, List<TvEpisode>>{
+          1: <TvEpisode>[testEpisode1],
+        };
+
+        final EpisodeTrackerState copy =
+            original.copyWith(episodesBySeason: newEpisodes);
+
+        expect(copy.episodesBySeason.length, 1);
+        expect(copy.watchedEpisodes, original.watchedEpisodes);
+        expect(copy.loadingSeasons, original.loadingSeasons);
+      });
+
+      test('должен копировать с изменёнными watchedEpisodes', () {
+        const EpisodeTrackerState original = EpisodeTrackerState();
+        final Set<(int, int)> newWatched = <(int, int)>{(1, 1)};
+
+        final EpisodeTrackerState copy =
+            original.copyWith(watchedEpisodes: newWatched);
+
+        expect(copy.watchedEpisodes.length, 1);
+        expect(copy.episodesBySeason, original.episodesBySeason);
+      });
+
+      test('должен копировать с изменёнными loadingSeasons', () {
+        const EpisodeTrackerState original = EpisodeTrackerState();
+        final Map<int, bool> newLoading = <int, bool>{1: true};
+
+        final EpisodeTrackerState copy =
+            original.copyWith(loadingSeasons: newLoading);
+
+        expect(copy.loadingSeasons[1], true);
+        expect(copy.episodesBySeason, original.episodesBySeason);
+      });
+
+      test('должен копировать с изменённой ошибкой', () {
+        const EpisodeTrackerState original = EpisodeTrackerState();
+
+        final EpisodeTrackerState copy =
+            original.copyWith(error: 'New error');
+
+        expect(copy.error, 'New error');
+      });
+    });
+
+    group('isEpisodeWatched', () {
+      test('должен возвращать true для просмотренного эпизода', () {
+        const EpisodeTrackerState state = EpisodeTrackerState(
+          watchedEpisodes: <(int, int)>{(1, 1), (1, 2)},
+        );
+
+        expect(state.isEpisodeWatched(1, 1), true);
+        expect(state.isEpisodeWatched(1, 2), true);
+      });
+
+      test('должен возвращать false для непросмотренного эпизода', () {
+        const EpisodeTrackerState state = EpisodeTrackerState(
+          watchedEpisodes: <(int, int)>{(1, 1)},
+        );
+
+        expect(state.isEpisodeWatched(1, 2), false);
+        expect(state.isEpisodeWatched(2, 1), false);
+      });
+    });
+
+    group('watchedCountForSeason', () {
+      test('должен возвращать количество просмотренных эпизодов в сезоне', () {
+        const EpisodeTrackerState state = EpisodeTrackerState(
+          watchedEpisodes: <(int, int)>{(1, 1), (1, 2), (2, 1)},
+        );
+
+        expect(state.watchedCountForSeason(1), 2);
+        expect(state.watchedCountForSeason(2), 1);
+        expect(state.watchedCountForSeason(3), 0);
+      });
+    });
+
+    group('totalWatchedCount', () {
+      test('должен возвращать общее количество просмотренных эпизодов', () {
+        const EpisodeTrackerState state = EpisodeTrackerState(
+          watchedEpisodes: <(int, int)>{(1, 1), (1, 2), (2, 1)},
+        );
+
+        expect(state.totalWatchedCount, 3);
+      });
+
+      test('должен возвращать 0 для пустого множества', () {
+        const EpisodeTrackerState state = EpisodeTrackerState();
+
+        expect(state.totalWatchedCount, 0);
+      });
+    });
+
+    group('totalEpisodeCount', () {
+      test('должен возвращать общее количество загруженных эпизодов', () {
+        const EpisodeTrackerState state = EpisodeTrackerState(
+          episodesBySeason: <int, List<TvEpisode>>{
+            1: <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
+            2: <TvEpisode>[testEpisode2s1, testEpisode2s2],
+          },
+        );
+
+        expect(state.totalEpisodeCount, 5);
+      });
+
+      test('должен возвращать 0 для пустой карты', () {
+        const EpisodeTrackerState state = EpisodeTrackerState();
+
+        expect(state.totalEpisodeCount, 0);
+      });
+    });
+  });
+
+  group('EpisodeTrackerNotifier', () {
+    group('build', () {
+      test('должен инициализироваться с пустым состоянием', () {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.episodesBySeason, isEmpty);
+        expect(state.watchedEpisodes, isEmpty);
+        expect(state.loadingSeasons, isEmpty);
+        expect(state.error, isNull);
+      });
+
+      test('должен загружать просмотренные эпизоды из БД', () async {
+        final Set<(int, int)> watchedEpisodes = <(int, int)>{
+          (1, 1),
+          (1, 2),
+          (2, 1),
+        };
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => watchedEpisodes);
+
+        final ProviderContainer container = createContainer();
+        container.read(episodeTrackerNotifierProvider(testArg));
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.watchedEpisodes, watchedEpisodes);
+        verify(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .called(1);
+      });
+
+      test('должен обрабатывать ошибку загрузки просмотренных эпизодов',
+          () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenThrow(Exception('Database error'));
+
+        final ProviderContainer container = createContainer();
+        container.read(episodeTrackerNotifierProvider(testArg));
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.error, contains('Failed to load watched episodes'));
+        expect(state.error, contains('Database error'));
+      });
+    });
+
+    group('loadSeason', () {
+      test('должен загружать эпизоды из кеша БД', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        final List<TvEpisode> cachedEpisodes = <TvEpisode>[
+          testEpisode1,
+          testEpisode2,
+          testEpisode3,
+        ];
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => cachedEpisodes);
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.episodesBySeason[1], cachedEpisodes);
+        expect(state.loadingSeasons[1], false);
+        expect(state.error, isNull);
+        verify(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .called(1);
+        verifyNever(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1));
+      });
+
+      test('должен загружать эпизоды из API если кеш пуст', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        final List<TvEpisode> apiEpisodes = <TvEpisode>[
+          testEpisode1,
+          testEpisode2,
+          testEpisode3,
+        ];
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => apiEpisodes);
+        when(() => mockDb.upsertEpisodes(any()))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.episodesBySeason[1], apiEpisodes);
+        expect(state.loadingSeasons[1], false);
+        expect(state.error, isNull);
+        verify(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .called(1);
+        verify(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1)).called(1);
+        verify(() => mockDb.upsertEpisodes(apiEpisodes)).called(1);
+      });
+
+      test('должен кешировать результаты API в БД', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        final List<TvEpisode> apiEpisodes = <TvEpisode>[
+          testEpisode1,
+          testEpisode2,
+        ];
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => apiEpisodes);
+        when(() => mockDb.upsertEpisodes(any()))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+
+        verify(() => mockDb.upsertEpisodes(apiEpisodes)).called(1);
+      });
+
+      test('не должен кешировать пустой список из API', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.episodesBySeason[1], isEmpty);
+        verifyNever(() => mockDb.upsertEpisodes(any()));
+      });
+
+      test('должен обрабатывать ошибку загрузки из API', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenThrow(Exception('API error'));
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.episodesBySeason[1], isNull);
+        expect(state.loadingSeasons[1], false);
+        expect(state.error, contains('Failed to load season 1'));
+        expect(state.error, contains('API error'));
+      });
+
+      test('не должен загружать уже загруженный сезон', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        final List<TvEpisode> cachedEpisodes = <TvEpisode>[testEpisode1];
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => cachedEpisodes);
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+        await notifier.loadSeason(1);
+
+        // Должен вызваться только один раз
+        verify(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .called(1);
+      });
+
+      test('не должен загружать сезон, который уже загружается', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async {
+          // Имитируем долгую загрузку
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return <TvEpisode>[testEpisode1];
+        });
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        // Запускаем две загрузки параллельно
+        final Future<void> load1 = notifier.loadSeason(1);
+        final Future<void> load2 = notifier.loadSeason(1);
+
+        await Future.wait(<Future<void>>[load1, load2]);
+
+        // Должен вызваться только один раз
+        verify(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .called(1);
+      });
+
+      test('должен устанавливать loading flag во время загрузки', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          return <TvEpisode>[testEpisode1];
+        });
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        final Future<void> loadFuture = notifier.loadSeason(1);
+
+        // Проверяем состояние во время загрузки
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+        expect(state.loadingSeasons[1], true);
+
+        await loadFuture;
+
+        // Проверяем состояние после загрузки
+        state = container.read(episodeTrackerNotifierProvider(testArg));
+        expect(state.loadingSeasons[1], false);
+      });
+    });
+
+    group('toggleEpisode', () {
+      test('должен отмечать эпизод как просмотренный', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() =>
+                mockDb.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.toggleEpisode(1, 1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.isEpisodeWatched(1, 1), true);
+        verify(() =>
+                mockDb.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+            .called(1);
+      });
+
+      test('должен снимать отметку просмотра с эпизода', () async {
+        final Set<(int, int)> watchedEpisodes = <(int, int)>{(1, 1)};
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => watchedEpisodes);
+        when(
+          () => mockDb.markEpisodeUnwatched(testCollectionId, testShowId, 1, 1),
+        ).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.toggleEpisode(1, 1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.isEpisodeWatched(1, 1), false);
+        verify(
+          () => mockDb.markEpisodeUnwatched(testCollectionId, testShowId, 1, 1),
+        ).called(1);
+      });
+
+      test('должен обновлять состояние после отметки просмотра', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() =>
+                mockDb.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+            .thenAnswer((_) async {});
+        when(() =>
+                mockDb.markEpisodeWatched(testCollectionId, testShowId, 1, 2))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.toggleEpisode(1, 1);
+        await notifier.toggleEpisode(1, 2);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.watchedEpisodes.length, 2);
+        expect(state.isEpisodeWatched(1, 1), true);
+        expect(state.isEpisodeWatched(1, 2), true);
+      });
+    });
+
+    group('refreshSeason', () {
+      test('должен принудительно загружать эпизоды из API', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        final List<TvEpisode> cachedEpisodes = <TvEpisode>[testEpisode1];
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => cachedEpisodes);
+        final List<TvEpisode> apiEpisodes = <TvEpisode>[
+          testEpisode1,
+          testEpisode2,
+          testEpisode3,
+        ];
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => apiEpisodes);
+        when(() => mockDb.upsertEpisodes(any()))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+
+        // Сначала загружаем из кеша
+        await notifier.loadSeason(1);
+        EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+        expect(state.episodesBySeason[1]?.length, 1);
+
+        // Обновляем из API
+        await notifier.refreshSeason(1);
+        state = container.read(episodeTrackerNotifierProvider(testArg));
+        expect(state.episodesBySeason[1]?.length, 3);
+        verify(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1)).called(1);
+        verify(() => mockDb.upsertEpisodes(apiEpisodes)).called(1);
+      });
+
+      test('должен обновлять эпизоды даже если сезон ещё не загружен',
+          () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        final List<TvEpisode> apiEpisodes = <TvEpisode>[testEpisode1];
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => apiEpisodes);
+        when(() => mockDb.upsertEpisodes(any()))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.refreshSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+        expect(state.episodesBySeason[1], apiEpisodes);
+        expect(state.loadingSeasons[1], false);
+      });
+
+      test('должен обрабатывать ошибку API при обновлении', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenThrow(Exception('API unavailable'));
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.refreshSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+        expect(state.error, contains('Failed to refresh season 1'));
+        expect(state.loadingSeasons[1], false);
+      });
+
+      test('не должен кешировать пустой результат API', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.refreshSeason(1);
+
+        verifyNever(() => mockDb.upsertEpisodes(any()));
+      });
+    });
+
+    group('toggleSeason', () {
+      test('должен отмечать все эпизоды сезона как просмотренные', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer(
+          (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
+        );
+        when(
+          () => mockDb.markSeasonWatched(
+            testCollectionId,
+            testShowId,
+            1,
+            <int>[1, 2, 3],
+          ),
+        ).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+        await notifier.toggleSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.isEpisodeWatched(1, 1), true);
+        expect(state.isEpisodeWatched(1, 2), true);
+        expect(state.isEpisodeWatched(1, 3), true);
+        expect(state.watchedCountForSeason(1), 3);
+        verify(
+          () => mockDb.markSeasonWatched(
+            testCollectionId,
+            testShowId,
+            1,
+            <int>[1, 2, 3],
+          ),
+        ).called(1);
+      });
+
+      test('должен снимать отметку просмотра со всех эпизодов сезона',
+          () async {
+        final Set<(int, int)> watchedEpisodes = <(int, int)>{
+          (1, 1),
+          (1, 2),
+          (1, 3),
+        };
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => watchedEpisodes);
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer(
+          (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
+        );
+        when(() => mockDb.unmarkSeasonWatched(testCollectionId, testShowId, 1))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+        await notifier.toggleSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.isEpisodeWatched(1, 1), false);
+        expect(state.isEpisodeWatched(1, 2), false);
+        expect(state.isEpisodeWatched(1, 3), false);
+        expect(state.watchedCountForSeason(1), 0);
+        verify(() => mockDb.unmarkSeasonWatched(testCollectionId, testShowId, 1))
+            .called(1);
+      });
+
+      test('должен отмечать частично просмотренный сезон как полностью просмотренный',
+          () async {
+        final Set<(int, int)> watchedEpisodes = <(int, int)>{(1, 1)};
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => watchedEpisodes);
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer(
+          (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
+        );
+        when(
+          () => mockDb.markSeasonWatched(
+            testCollectionId,
+            testShowId,
+            1,
+            <int>[1, 2, 3],
+          ),
+        ).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+        await notifier.toggleSeason(1);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.watchedCountForSeason(1), 3);
+        verify(
+          () => mockDb.markSeasonWatched(
+            testCollectionId,
+            testShowId,
+            1,
+            <int>[1, 2, 3],
+          ),
+        ).called(1);
+      });
+
+      test('не должен делать ничего если сезон не загружен', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.toggleSeason(1);
+
+        verifyNever(
+          () => mockDb.markSeasonWatched(any(), any(), any(), any()),
+        );
+        verifyNever(() => mockDb.unmarkSeasonWatched(any(), any(), any()));
+      });
+
+      test('не должен делать ничего если сезон пустой', () async {
+        when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int)>{});
+        when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
+            .thenAnswer((_) async => <TvEpisode>[]);
+
+        final ProviderContainer container = createContainer();
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        // Ждём выполнения microtask
+        await Future<void>.delayed(Duration.zero);
+
+        await notifier.loadSeason(1);
+        await notifier.toggleSeason(1);
+
+        verifyNever(
+          () => mockDb.markSeasonWatched(any(), any(), any(), any()),
+        );
+        verifyNever(() => mockDb.unmarkSeasonWatched(any(), any(), any()));
+      });
+    });
+  });
+}

--- a/test/shared/models/tv_episode_test.dart
+++ b/test/shared/models/tv_episode_test.dart
@@ -1,0 +1,780 @@
+// Тесты для модели TvEpisode.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/tv_episode.dart';
+
+void main() {
+  group('TvEpisode', () {
+    group('fromJson', () {
+      test('должен создать из полного JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+          'name': 'Pilot',
+          'overview': 'Walter White, a struggling chemistry teacher...',
+          'air_date': '2008-01-20',
+          'still_path': '/ydlY3iPfeOAvu8gVqrxPoMvzNCn.jpg',
+          'runtime': 58,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1396, season: 1);
+
+        expect(episode.tmdbShowId, 1396);
+        expect(episode.seasonNumber, 1);
+        expect(episode.episodeNumber, 1);
+        expect(episode.name, 'Pilot');
+        expect(episode.overview,
+            'Walter White, a struggling chemistry teacher...');
+        expect(episode.airDate, '2008-01-20');
+        expect(episode.stillUrl,
+            'https://image.tmdb.org/t/p/w300/ydlY3iPfeOAvu8gVqrxPoMvzNCn.jpg');
+        expect(episode.runtime, 58);
+      });
+
+      test('должен создать из минимального JSON', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1396, season: 1);
+
+        expect(episode.tmdbShowId, 1396);
+        expect(episode.seasonNumber, 1);
+        expect(episode.episodeNumber, 1);
+        expect(episode.name, '');
+        expect(episode.overview, isNull);
+        expect(episode.airDate, isNull);
+        expect(episode.stillUrl, isNull);
+        expect(episode.runtime, isNull);
+      });
+
+      test('должен обработать null still_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 2,
+          'name': 'Cat\'s in the Bag...',
+          'still_path': null,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1396, season: 1);
+
+        expect(episode.stillUrl, isNull);
+      });
+
+      test('должен обработать отсутствующий still_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 3,
+          'name': '...And the Bag\'s in the River',
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1396, season: 1);
+
+        expect(episode.stillUrl, isNull);
+      });
+
+      test('должен обработать null name (использовать пустую строку)', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+          'name': null,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 100, season: 1);
+
+        expect(episode.name, '');
+      });
+
+      test('должен обработать отсутствующий name (использовать пустую строку)',
+          () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 100, season: 1);
+
+        expect(episode.name, '');
+      });
+
+      test('должен обработать null overview', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+          'overview': null,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 100, season: 1);
+
+        expect(episode.overview, isNull);
+      });
+
+      test('должен обработать null air_date', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+          'air_date': null,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 100, season: 1);
+
+        expect(episode.airDate, isNull);
+      });
+
+      test('должен обработать null runtime', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+          'runtime': null,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 100, season: 1);
+
+        expect(episode.runtime, isNull);
+      });
+
+      test('должен построить still_url из still_path', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 5,
+          'still_path': '/abc123.jpg',
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1396, season: 2);
+
+        expect(episode.stillUrl, 'https://image.tmdb.org/t/p/w300/abc123.jpg');
+      });
+
+      test('должен обработать эпизод 0', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 0,
+          'name': 'Special Episode',
+          'overview': 'A special behind-the-scenes episode',
+          'air_date': '2009-02-17',
+          'still_path': '/special.jpg',
+          'runtime': 30,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1396, season: 0);
+
+        expect(episode.seasonNumber, 0);
+        expect(episode.episodeNumber, 0);
+        expect(episode.name, 'Special Episode');
+        expect(episode.overview, 'A special behind-the-scenes episode');
+        expect(episode.stillUrl,
+            'https://image.tmdb.org/t/p/w300/special.jpg');
+        expect(episode.runtime, 30);
+      });
+
+      test('должен использовать переданные showId и season', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 7,
+        };
+
+        final TvEpisode episode1 =
+            TvEpisode.fromJson(json, showId: 100, season: 1);
+        final TvEpisode episode2 =
+            TvEpisode.fromJson(json, showId: 200, season: 5);
+
+        expect(episode1.tmdbShowId, 100);
+        expect(episode1.seasonNumber, 1);
+        expect(episode2.tmdbShowId, 200);
+        expect(episode2.seasonNumber, 5);
+      });
+
+      test('должен обработать большой номер эпизода', () {
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 999,
+          'name': 'Episode 999',
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1, season: 10);
+
+        expect(episode.episodeNumber, 999);
+      });
+
+      test('должен обработать длинный overview', () {
+        final String longOverview = 'A' * 1000;
+        final Map<String, dynamic> json = <String, dynamic>{
+          'episode_number': 1,
+          'overview': longOverview,
+        };
+
+        final TvEpisode episode =
+            TvEpisode.fromJson(json, showId: 1, season: 1);
+
+        expect(episode.overview, longOverview);
+      });
+    });
+
+    group('fromDb', () {
+      test('должен создать из полной записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+          'episode_number': 1,
+          'name': 'Pilot',
+          'overview': 'Walter White, a struggling chemistry teacher...',
+          'air_date': '2008-01-20',
+          'still_url': 'https://image.tmdb.org/t/p/w300/still.jpg',
+          'runtime': 58,
+        };
+
+        final TvEpisode episode = TvEpisode.fromDb(row);
+
+        expect(episode.tmdbShowId, 1396);
+        expect(episode.seasonNumber, 1);
+        expect(episode.episodeNumber, 1);
+        expect(episode.name, 'Pilot');
+        expect(episode.overview,
+            'Walter White, a struggling chemistry teacher...');
+        expect(episode.airDate, '2008-01-20');
+        expect(episode.stillUrl, 'https://image.tmdb.org/t/p/w300/still.jpg');
+        expect(episode.runtime, 58);
+      });
+
+      test('должен создать из минимальной записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+          'episode_number': 1,
+        };
+
+        final TvEpisode episode = TvEpisode.fromDb(row);
+
+        expect(episode.tmdbShowId, 1396);
+        expect(episode.seasonNumber, 1);
+        expect(episode.episodeNumber, 1);
+        expect(episode.name, '');
+        expect(episode.overview, isNull);
+        expect(episode.airDate, isNull);
+        expect(episode.stillUrl, isNull);
+        expect(episode.runtime, isNull);
+      });
+
+      test('должен обработать null значения', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 2,
+          'episode_number': 5,
+          'name': null,
+          'overview': null,
+          'air_date': null,
+          'still_url': null,
+          'runtime': null,
+        };
+
+        final TvEpisode episode = TvEpisode.fromDb(row);
+
+        expect(episode.tmdbShowId, 1396);
+        expect(episode.seasonNumber, 2);
+        expect(episode.episodeNumber, 5);
+        expect(episode.name, '');
+        expect(episode.overview, isNull);
+        expect(episode.airDate, isNull);
+        expect(episode.stillUrl, isNull);
+        expect(episode.runtime, isNull);
+      });
+
+      test('должен обработать эпизод 0 из БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 0,
+          'episode_number': 0,
+          'name': 'Special',
+        };
+
+        final TvEpisode episode = TvEpisode.fromDb(row);
+
+        expect(episode.seasonNumber, 0);
+        expect(episode.episodeNumber, 0);
+        expect(episode.name, 'Special');
+      });
+    });
+
+    group('toDb', () {
+      test('должен преобразовать в Map для БД', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+          overview: 'Walter White, a struggling chemistry teacher...',
+          airDate: '2008-01-20',
+          stillUrl: 'https://image.tmdb.org/t/p/w300/still.jpg',
+          runtime: 58,
+        );
+
+        final Map<String, dynamic> db = episode.toDb();
+
+        expect(db['tmdb_show_id'], 1396);
+        expect(db['season_number'], 1);
+        expect(db['episode_number'], 1);
+        expect(db['name'], 'Pilot');
+        expect(db['overview'], 'Walter White, a struggling chemistry teacher...');
+        expect(db['air_date'], '2008-01-20');
+        expect(db['still_url'], 'https://image.tmdb.org/t/p/w300/still.jpg');
+        expect(db['runtime'], 58);
+        expect(db['cached_at'], isA<int>());
+      });
+
+      test('должен обработать null значения', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: '',
+        );
+
+        final Map<String, dynamic> db = episode.toDb();
+
+        expect(db['tmdb_show_id'], 1396);
+        expect(db['season_number'], 1);
+        expect(db['episode_number'], 1);
+        expect(db['name'], '');
+        expect(db['overview'], isNull);
+        expect(db['air_date'], isNull);
+        expect(db['still_url'], isNull);
+        expect(db['runtime'], isNull);
+        expect(db['cached_at'], isA<int>());
+      });
+
+      test('должен включить cached_at с текущим временем', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        final int before = DateTime.now().millisecondsSinceEpoch;
+        final Map<String, dynamic> db = episode.toDb();
+        final int after = DateTime.now().millisecondsSinceEpoch;
+
+        expect(db['cached_at'], isA<int>());
+        final int cachedAt = db['cached_at'] as int;
+        expect(cachedAt, greaterThanOrEqualTo(before));
+        expect(cachedAt, lessThanOrEqualTo(after));
+      });
+
+      test('должен обработать эпизод 0', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 0,
+          episodeNumber: 0,
+          name: 'Special',
+        );
+
+        final Map<String, dynamic> db = episode.toDb();
+
+        expect(db['season_number'], 0);
+        expect(db['episode_number'], 0);
+      });
+    });
+
+    group('toDb/fromDb round-trip', () {
+      test('должен сохранить и восстановить все данные', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 3,
+          episodeNumber: 7,
+          name: 'One Minute',
+          overview: 'Hank\'s increasing volatility forces a confrontation...',
+          airDate: '2010-05-02',
+          stillUrl: 'https://image.tmdb.org/t/p/w300/episode.jpg',
+          runtime: 47,
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvEpisode restored = TvEpisode.fromDb(db);
+
+        expect(restored.tmdbShowId, original.tmdbShowId);
+        expect(restored.seasonNumber, original.seasonNumber);
+        expect(restored.episodeNumber, original.episodeNumber);
+        expect(restored.name, original.name);
+        expect(restored.overview, original.overview);
+        expect(restored.airDate, original.airDate);
+        expect(restored.stillUrl, original.stillUrl);
+        expect(restored.runtime, original.runtime);
+      });
+
+      test('должен сохранить и восстановить минимальные данные', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: '',
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvEpisode restored = TvEpisode.fromDb(db);
+
+        expect(restored.tmdbShowId, original.tmdbShowId);
+        expect(restored.seasonNumber, original.seasonNumber);
+        expect(restored.episodeNumber, original.episodeNumber);
+        expect(restored.name, original.name);
+        expect(restored.overview, isNull);
+        expect(restored.airDate, isNull);
+        expect(restored.stillUrl, isNull);
+        expect(restored.runtime, isNull);
+      });
+
+      test('должен сохранить и восстановить эпизод 0', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 0,
+          episodeNumber: 0,
+          name: 'Special',
+          overview: 'Behind the scenes',
+          runtime: 30,
+        );
+
+        final Map<String, dynamic> db = original.toDb();
+        final TvEpisode restored = TvEpisode.fromDb(db);
+
+        expect(restored.tmdbShowId, original.tmdbShowId);
+        expect(restored.seasonNumber, original.seasonNumber);
+        expect(restored.episodeNumber, original.episodeNumber);
+        expect(restored.name, original.name);
+        expect(restored.overview, original.overview);
+        expect(restored.runtime, original.runtime);
+      });
+    });
+
+    group('copyWith', () {
+      test('должен создать копию с изменёнными полями', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+          runtime: 58,
+        );
+
+        final TvEpisode copy = original.copyWith(
+          name: 'Pilot (Extended)',
+          runtime: 65,
+        );
+
+        expect(copy.tmdbShowId, 1396);
+        expect(copy.seasonNumber, 1);
+        expect(copy.episodeNumber, 1);
+        expect(copy.name, 'Pilot (Extended)');
+        expect(copy.runtime, 65);
+      });
+
+      test('должен сохранить неизменённые поля', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+          overview: 'Original overview',
+          airDate: '2008-01-20',
+          stillUrl: 'https://example.com/still.jpg',
+          runtime: 58,
+        );
+
+        final TvEpisode copy = original.copyWith(name: 'Updated');
+
+        expect(copy.tmdbShowId, 1396);
+        expect(copy.seasonNumber, 1);
+        expect(copy.episodeNumber, 1);
+        expect(copy.overview, 'Original overview');
+        expect(copy.airDate, '2008-01-20');
+        expect(copy.stillUrl, 'https://example.com/still.jpg');
+        expect(copy.runtime, 58);
+      });
+
+      test('должен позволить изменить все поля', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Old',
+        );
+
+        final TvEpisode copy = original.copyWith(
+          tmdbShowId: 2,
+          seasonNumber: 5,
+          episodeNumber: 10,
+          name: 'New Name',
+          overview: 'New overview',
+          airDate: '2025-01-01',
+          stillUrl: 'new_still',
+          runtime: 42,
+        );
+
+        expect(copy.tmdbShowId, 2);
+        expect(copy.seasonNumber, 5);
+        expect(copy.episodeNumber, 10);
+        expect(copy.name, 'New Name');
+        expect(copy.overview, 'New overview');
+        expect(copy.airDate, '2025-01-01');
+        expect(copy.stillUrl, 'new_still');
+        expect(copy.runtime, 42);
+      });
+
+      test('должен позволить изменить tmdbShowId', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        final TvEpisode copy = original.copyWith(tmdbShowId: 9999);
+
+        expect(copy.tmdbShowId, 9999);
+      });
+
+      test('должен позволить изменить seasonNumber', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        final TvEpisode copy = original.copyWith(seasonNumber: 5);
+
+        expect(copy.seasonNumber, 5);
+      });
+
+      test('должен позволить изменить episodeNumber', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        final TvEpisode copy = original.copyWith(episodeNumber: 13);
+
+        expect(copy.episodeNumber, 13);
+      });
+
+      test('должен позволить изменить overview', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+          overview: 'Old',
+        );
+
+        final TvEpisode copy = original.copyWith(overview: 'New overview');
+
+        expect(copy.overview, 'New overview');
+      });
+
+      test('должен позволить изменить airDate', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+          airDate: '2020-01-01',
+        );
+
+        final TvEpisode copy = original.copyWith(airDate: '2025-12-31');
+
+        expect(copy.airDate, '2025-12-31');
+      });
+
+      test('должен позволить изменить stillUrl', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+          stillUrl: 'old_url',
+        );
+
+        final TvEpisode copy = original.copyWith(stillUrl: 'new_url');
+
+        expect(copy.stillUrl, 'new_url');
+      });
+
+      test('должен позволить изменить runtime', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+          runtime: 45,
+        );
+
+        final TvEpisode copy = original.copyWith(runtime: 90);
+
+        expect(copy.runtime, 90);
+      });
+    });
+
+    group('equality', () {
+      test(
+          'эпизоды с одинаковым showId, season и episode должны быть равны',
+          () {
+        const TvEpisode episode1 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+        );
+        const TvEpisode episode2 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Different Name',
+        );
+
+        expect(episode1, equals(episode2));
+        expect(episode1.hashCode, equals(episode2.hashCode));
+      });
+
+      test('эпизоды с разными showId не должны быть равны', () {
+        const TvEpisode episode1 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+        const TvEpisode episode2 = TvEpisode(
+          tmdbShowId: 1399,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        expect(episode1, isNot(equals(episode2)));
+      });
+
+      test('эпизоды с разными seasonNumber не должны быть равны', () {
+        const TvEpisode episode1 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+        const TvEpisode episode2 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 2,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        expect(episode1, isNot(equals(episode2)));
+      });
+
+      test('эпизоды с разными episodeNumber не должны быть равны', () {
+        const TvEpisode episode1 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+        const TvEpisode episode2 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 2,
+          name: 'Test',
+        );
+
+        expect(episode1, isNot(equals(episode2)));
+      });
+
+      test('идентичные объекты должны быть равны', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        expect(episode, equals(episode));
+      });
+
+      test('сравнение с другим типом не должно быть равно', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Test',
+        );
+
+        // ignore: unrelated_type_equality_checks
+        expect(episode == 'not an episode', isFalse);
+      });
+
+      test('эпизоды с разными полями (не ключевыми) должны быть равны', () {
+        const TvEpisode episode1 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Name 1',
+          overview: 'Overview 1',
+          runtime: 45,
+        );
+        const TvEpisode episode2 = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Name 2',
+          overview: 'Overview 2',
+          runtime: 60,
+        );
+
+        expect(episode1, equals(episode2));
+        expect(episode1.hashCode, equals(episode2.hashCode));
+      });
+    });
+
+    test('toString должен вернуть читаемое представление', () {
+      const TvEpisode episode = TvEpisode(
+        tmdbShowId: 1396,
+        seasonNumber: 3,
+        episodeNumber: 7,
+        name: 'One Minute',
+      );
+
+      expect(episode.toString(),
+          'TvEpisode(showId: 1396, S3E7: One Minute)');
+    });
+
+    test('toString должен работать с эпизодом 0', () {
+      const TvEpisode episode = TvEpisode(
+        tmdbShowId: 1396,
+        seasonNumber: 0,
+        episodeNumber: 0,
+        name: 'Special',
+      );
+
+      expect(episode.toString(), 'TvEpisode(showId: 1396, S0E0: Special)');
+    });
+
+    test('toString должен работать с пустым name', () {
+      const TvEpisode episode = TvEpisode(
+        tmdbShowId: 1396,
+        seasonNumber: 1,
+        episodeNumber: 1,
+        name: '',
+      );
+
+      expect(episode.toString(), 'TvEpisode(showId: 1396, S1E1: )');
+    });
+
+    test('toString должен работать с большими номерами', () {
+      const TvEpisode episode = TvEpisode(
+        tmdbShowId: 99999,
+        seasonNumber: 15,
+        episodeNumber: 23,
+        name: 'Finale',
+      );
+
+      expect(episode.toString(), 'TvEpisode(showId: 99999, S15E23: Finale)');
+    });
+  });
+}


### PR DESCRIPTION
Implement Tasks #11 (Season Details) and #12 (Episode Tracker):
- TvEpisode model with TMDB API integration (getSeasonEpisodes)
- DB migration v9→v10: tv_episodes_cache and watched_episodes tables
- EpisodeTrackerNotifier with cache-first strategy and per-episode tracking
- Season ExpansionTile UI with lazy-loading, checkboxes, bulk mark/unmark
- Refresh button to fetch new seasons/episodes from TMDB without losing watched status
- Auto-complete: sets status to Completed when all episodes are watched