### PR TITLE
Add activity dates tracking and fix game status sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@
 ## [Unreleased]
 
 ### Added
+- Добавлена система дат активности элементов коллекции: `started_at`, `completed_at`, `last_activity_at` — для отслеживания прогресса и истории взаимодействия с играми, фильмами и сериалами
+- Добавлена миграция БД v11→v12: три новых колонки в `collection_items`, инициализация `last_activity_at` из `added_at` для существующих записей
+- Добавлен виджет `ActivityDatesSection` (`lib/features/collections/widgets/activity_dates_section.dart`) — секция с 4 строками: Added (readonly), Started (editable), Completed (editable), Last Activity (readonly). DatePicker для ручного редактирования дат
+- Добавлен метод `updateItemActivityDates` в `DatabaseService` и `CollectionRepository` — ручное обновление дат через DatePicker
+- Добавлены методы `updateActivityDates` в `CollectionGamesNotifier` и `CollectionItemsNotifier` — оптимистичное обновление дат в UI
+- Добавлена автоматическая установка дат при смене статуса: `last_activity_at` обновляется всегда, `started_at` устанавливается при переходе в inProgress/Playing (если null), `completed_at` устанавливается при переходе в Completed
+- Добавлено отображение даты просмотра (`watched_at`) в каждом эпизоде трекера сериалов
+
+### Changed
+- Изменён `updateItemStatus` в `DatabaseService` — теперь автоматически устанавливает даты активности при смене статуса (SELECT + UPDATE в одном вызове)
+- Изменены модели `CollectionItem` и `CollectionGame` — добавлены поля `startedAt`, `completedAt`, `lastActivityAt`, обновлены `fromDb`, `toDb`, `copyWith`, `fromCollectionItem`, `toCollectionItem`
+- Изменён `EpisodeTrackerState` — `watchedEpisodes` изменён с `Set<(int, int)>` на `Map<(int, int), DateTime?>` для хранения дат просмотра
+- Изменены `GameDetailScreen`, `MovieDetailScreen`, `TvShowDetailScreen` — добавлена секция `ActivityDatesSection` в `extraSections`
+- Изменён `_EpisodeTile` в `TvShowDetailScreen` — отображает дату просмотра эпизода в subtitle
+
+### Fixed
+- Исправлена рассинхронизация статусов при возврате из `GameDetailScreen` в список коллекции: `CollectionGamesNotifier` теперь инвалидирует `collectionItemsNotifierProvider` при обновлении статуса, дат, комментариев — обеспечивая синхронизацию между двумя провайдерами
+
+---
+
+### Added
 - Добавлена поддержка Android (Lite версия без Canvas)
 - Добавлена Android конфигурация: `build.gradle.kts`, `AndroidManifest.xml`, `MainActivity.kt`, иконки, стили
 - Добавлен файл платформенных флагов `platform_features.dart` (`kCanvasEnabled`, `kVgMapsEnabled`, `kScreenshotEnabled`) — условное отключение Canvas, VGMaps, Screenshot на мобильных платформах

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -79,6 +79,16 @@ Track status for each item in your collection with context-aware labels:
 
 View statistics per collection — see your completion rate at a glance.
 
+### Activity Dates
+
+Track when you started, finished, and last interacted with each item:
+- **Added** — auto-set when item is added to collection (read-only)
+- **Started** — auto-set when status changes to In Progress/Playing/Watching (if not already set); editable via DatePicker
+- **Completed** — auto-set when status changes to Completed; editable via DatePicker
+- **Last Activity** — auto-updated on any status change (read-only)
+
+Displayed in the `ActivityDatesSection` widget on all detail screens (game, movie, TV show). Dates persist in SQLite and survive export/import.
+
 ## Collection Sorting
 
 Sort items within a collection using different modes:
@@ -95,7 +105,7 @@ Track your viewing progress for TV shows at the episode level:
 - **Episode Progress bar** — shows overall watched/total count with a LinearProgressIndicator
 - **Season sections** — ExpansionTile for each season with watched count badge
 - **Lazy loading** — episodes are fetched from TMDB API only when a season is expanded (cached in SQLite for offline access)
-- **Per-episode checkboxes** — mark individual episodes as watched/unwatched with CheckboxListTile
+- **Per-episode checkboxes** — mark individual episodes as watched/unwatched with CheckboxListTile; watched date displayed in subtitle
 - **Bulk actions** — "Mark all" / "Unmark all" button per season to toggle all episodes at once
 - **Auto-complete** — when all episodes are watched, the show's status is automatically set to Completed (compares against total episode count from show metadata)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,6 +34,10 @@
 - [x] Config Export/Import — ConfigService with JSON export/import of 7 SharedPreferences keys, file picker dialogs
 - [x] Task #13: Image Caching — local caching of game covers, movie posters, TV show posters with auto-download, fallback to network, toggle in Settings
 - [x] Export v2 — Exportable mixin, XcollFile model (v1/v2), .xcoll (light) and .xcollx (full with canvas + images). Embedded cover images as base64 for offline import. Canvas URL image caching via ImageType.canvasImage
+- [x] Collection sorting — sort by Date Added, Status, Name, or Manual (drag-and-drop). Per-collection persistence via SharedPreferences
+- [x] Media type watermark — large tilted semi-transparent background icon on each collection item card
+- [x] Android Lite — collections, search, details, episode tracker, export/import (no Canvas). Platform feature flags
+- [x] Activity Dates — started_at, completed_at, last_activity_at for all collection items. Auto-set on status change. DatePicker for manual editing. Watched dates in episode tracker
 
 ## Future Plans
 

--- a/lib/data/repositories/collection_repository.dart
+++ b/lib/data/repositories/collection_repository.dart
@@ -216,6 +216,21 @@ class CollectionRepository {
     await _db.updateItemUserComment(id, comment);
   }
 
+  /// Обновляет даты активности элемента.
+  Future<void> updateItemActivityDates(
+    int id, {
+    DateTime? startedAt,
+    DateTime? completedAt,
+    DateTime? lastActivityAt,
+  }) async {
+    await _db.updateItemActivityDates(
+      id,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      lastActivityAt: lastActivityAt,
+    );
+  }
+
   // ==================== Collection Games (Legacy) ====================
 
   /// Возвращает все игры в коллекции.

--- a/lib/features/collections/screens/game_detail_screen.dart
+++ b/lib/features/collections/screens/game_detail_screen.dart
@@ -15,6 +15,7 @@ import '../providers/vgmaps_panel_provider.dart';
 import '../../../shared/constants/platform_features.dart';
 import '../widgets/canvas_view.dart';
 import '../widgets/steamgriddb_panel.dart';
+import '../widgets/activity_dates_section.dart';
 import '../widgets/status_dropdown.dart';
 import '../widgets/vgmaps_panel.dart';
 
@@ -141,6 +142,17 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
               onChanged: (GameStatus status) =>
                   _updateStatus(collectionGame.id, status),
             ),
+            extraSections: <Widget>[
+              ActivityDatesSection(
+                addedAt: collectionGame.addedAt,
+                startedAt: collectionGame.startedAt,
+                completedAt: collectionGame.completedAt,
+                lastActivityAt: collectionGame.lastActivityAt,
+                isEditable: widget.isEditable,
+                onDateChanged: (String type, DateTime date) =>
+                    _updateActivityDate(collectionGame.id, type, date),
+              ),
+            ],
             authorComment: collectionGame.authorComment,
             userComment: collectionGame.userComment,
             hasAuthorComment: collectionGame.hasAuthorComment,
@@ -358,6 +370,24 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
     await ref
         .read(collectionGamesNotifierProvider(widget.collectionId).notifier)
         .updateStatus(id, status);
+  }
+
+  Future<void> _updateActivityDate(int id, String type, DateTime date) async {
+    final CollectionGamesNotifier notifier =
+        ref.read(collectionGamesNotifierProvider(widget.collectionId).notifier);
+    if (type == 'started') {
+      await notifier.updateActivityDates(
+        id,
+        startedAt: date,
+        lastActivityAt: DateTime.now(),
+      );
+    } else {
+      await notifier.updateActivityDates(
+        id,
+        completedAt: date,
+        lastActivityAt: DateTime.now(),
+      );
+    }
   }
 
   Future<void> _saveAuthorComment(int id, String? text) async {

--- a/lib/features/collections/screens/movie_detail_screen.dart
+++ b/lib/features/collections/screens/movie_detail_screen.dart
@@ -17,6 +17,7 @@ import '../providers/canvas_provider.dart';
 import '../providers/collections_provider.dart';
 import '../providers/steamgriddb_panel_provider.dart';
 import '../providers/vgmaps_panel_provider.dart';
+import '../widgets/activity_dates_section.dart';
 import '../widgets/canvas_view.dart';
 import '../widgets/item_status_dropdown.dart';
 import '../widgets/steamgriddb_panel.dart';
@@ -146,6 +147,17 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
               onChanged: (ItemStatus status) =>
                   _updateStatus(item.id, status),
             ),
+            extraSections: <Widget>[
+              ActivityDatesSection(
+                addedAt: item.addedAt,
+                startedAt: item.startedAt,
+                completedAt: item.completedAt,
+                lastActivityAt: item.lastActivityAt,
+                isEditable: widget.isEditable,
+                onDateChanged: (String type, DateTime date) =>
+                    _updateActivityDate(item.id, type, date),
+              ),
+            ],
             authorComment: item.authorComment,
             userComment: item.userComment,
             hasAuthorComment: item.hasAuthorComment,
@@ -377,6 +389,24 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
     await ref
         .read(collectionItemsNotifierProvider(widget.collectionId).notifier)
         .updateStatus(id, status, MediaType.movie);
+  }
+
+  Future<void> _updateActivityDate(int id, String type, DateTime date) async {
+    final CollectionItemsNotifier notifier =
+        ref.read(collectionItemsNotifierProvider(widget.collectionId).notifier);
+    if (type == 'started') {
+      await notifier.updateActivityDates(
+        id,
+        startedAt: date,
+        lastActivityAt: DateTime.now(),
+      );
+    } else {
+      await notifier.updateActivityDates(
+        id,
+        completedAt: date,
+        lastActivityAt: DateTime.now(),
+      );
+    }
   }
 
   Future<void> _saveAuthorComment(int id, String? text) async {

--- a/lib/features/collections/widgets/activity_dates_section.dart
+++ b/lib/features/collections/widgets/activity_dates_section.dart
@@ -1,0 +1,204 @@
+// Секция отображения и редактирования дат активности элемента коллекции.
+
+import 'package:flutter/material.dart';
+
+/// Форматирует [DateTime] в читаемую строку (например, "Jan 15, 2025").
+String _formatDate(DateTime date) {
+  const List<String> months = <String>[
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  return '${months[date.month - 1]} ${date.day}, ${date.year}';
+}
+
+/// Колбэк для изменения даты.
+///
+/// [type] — тип даты ('started' или 'completed'),
+/// [date] — выбранная дата.
+typedef OnDateChanged = Future<void> Function(String type, DateTime date);
+
+/// Секция для отображения и редактирования дат активности.
+///
+/// Показывает Added, Started, Completed и Last Activity.
+/// Позволяет редактировать Started и Completed через DatePicker.
+class ActivityDatesSection extends StatelessWidget {
+  /// Создаёт [ActivityDatesSection].
+  const ActivityDatesSection({
+    required this.addedAt,
+    required this.isEditable,
+    required this.onDateChanged,
+    this.startedAt,
+    this.completedAt,
+    this.lastActivityAt,
+    super.key,
+  });
+
+  /// Дата добавления (readonly).
+  final DateTime addedAt;
+
+  /// Дата начала.
+  final DateTime? startedAt;
+
+  /// Дата завершения.
+  final DateTime? completedAt;
+
+  /// Дата последней активности (readonly).
+  final DateTime? lastActivityAt;
+
+  /// Можно ли редактировать даты.
+  final bool isEditable;
+
+  /// Колбэк при изменении даты.
+  final OnDateChanged onDateChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Icon(
+              Icons.calendar_month_outlined,
+              size: 20,
+              color: colorScheme.primary,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              'Activity Dates',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _DateRow(
+          icon: Icons.add_circle_outline,
+          label: 'Added',
+          date: addedAt,
+          editable: false,
+        ),
+        const SizedBox(height: 6),
+        _DateRow(
+          icon: Icons.play_circle_outline,
+          label: 'Started',
+          date: startedAt,
+          editable: isEditable,
+          onTap: () => _pickDate(context, 'started', startedAt),
+        ),
+        const SizedBox(height: 6),
+        _DateRow(
+          icon: Icons.check_circle_outline,
+          label: 'Completed',
+          date: completedAt,
+          editable: isEditable,
+          onTap: () => _pickDate(context, 'completed', completedAt),
+        ),
+        if (lastActivityAt != null) ...<Widget>[
+          const SizedBox(height: 6),
+          _DateRow(
+            icon: Icons.update,
+            label: 'Last Activity',
+            date: lastActivityAt,
+            editable: false,
+          ),
+        ],
+      ],
+    );
+  }
+
+  Future<void> _pickDate(
+    BuildContext context,
+    String type,
+    DateTime? current,
+  ) async {
+    final DateTime initialDate = current ?? DateTime.now();
+    final DateTime firstDate = DateTime(1980);
+    final DateTime lastDate = DateTime.now().add(const Duration(days: 365));
+
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: firstDate,
+      lastDate: lastDate,
+      helpText: type == 'started' ? 'Select start date' : 'Select completion date',
+    );
+
+    if (picked != null && context.mounted) {
+      await onDateChanged(type, picked);
+    }
+  }
+}
+
+class _DateRow extends StatelessWidget {
+  const _DateRow({
+    required this.icon,
+    required this.label,
+    required this.date,
+    required this.editable,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final DateTime? date;
+  final bool editable;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    final Widget content = Row(
+      children: <Widget>[
+        Icon(icon, size: 16, color: colorScheme.onSurfaceVariant),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const Spacer(),
+        Text(
+          date != null ? _formatDate(date!) : '\u2014',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: date != null ? FontWeight.w500 : FontWeight.w400,
+            color: date != null
+                ? colorScheme.onSurface
+                : colorScheme.onSurfaceVariant,
+          ),
+        ),
+        if (editable) ...<Widget>[
+          const SizedBox(width: 4),
+          Icon(
+            Icons.edit_outlined,
+            size: 14,
+            color: colorScheme.primary,
+          ),
+        ],
+      ],
+    );
+
+    if (editable && onTap != null) {
+      return InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+          child: content,
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: content,
+    );
+  }
+}

--- a/lib/shared/models/collection_game.dart
+++ b/lib/shared/models/collection_game.dart
@@ -92,6 +92,9 @@ class CollectionGame {
     required this.platformId,
     required this.status,
     required this.addedAt,
+    this.startedAt,
+    this.completedAt,
+    this.lastActivityAt,
     this.authorComment,
     this.userComment,
     this.game,
@@ -128,6 +131,9 @@ class CollectionGame {
       userComment: item.userComment,
       status: GameStatus.fromItemStatus(item.status),
       addedAt: item.addedAt,
+      startedAt: item.startedAt,
+      completedAt: item.completedAt,
+      lastActivityAt: item.lastActivityAt,
       game: item.game,
       platform: item.platform,
     );
@@ -179,6 +185,15 @@ class CollectionGame {
   /// Дата добавления в коллекцию.
   final DateTime addedAt;
 
+  /// Дата начала (начал играть).
+  final DateTime? startedAt;
+
+  /// Дата завершения.
+  final DateTime? completedAt;
+
+  /// Дата последней активности.
+  final DateTime? lastActivityAt;
+
   /// Данные игры (joined).
   final Game? game;
 
@@ -213,6 +228,9 @@ class CollectionGame {
       authorComment: authorComment,
       userComment: userComment,
       addedAt: addedAt,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      lastActivityAt: lastActivityAt,
       game: game,
       platform: platform,
     );
@@ -251,6 +269,9 @@ class CollectionGame {
     String? userComment,
     GameStatus? status,
     DateTime? addedAt,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    DateTime? lastActivityAt,
     Game? game,
     Platform? platform,
   }) {
@@ -263,6 +284,9 @@ class CollectionGame {
       userComment: userComment ?? this.userComment,
       status: status ?? this.status,
       addedAt: addedAt ?? this.addedAt,
+      startedAt: startedAt ?? this.startedAt,
+      completedAt: completedAt ?? this.completedAt,
+      lastActivityAt: lastActivityAt ?? this.lastActivityAt,
       game: game ?? this.game,
       platform: platform ?? this.platform,
     );

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -22,6 +22,9 @@ class CollectionItem with Exportable {
     required this.externalId,
     required this.status,
     required this.addedAt,
+    this.startedAt,
+    this.completedAt,
+    this.lastActivityAt,
     this.platformId,
     this.currentSeason = 0,
     this.currentEpisode = 0,
@@ -51,6 +54,21 @@ class CollectionItem with Exportable {
       addedAt: DateTime.fromMillisecondsSinceEpoch(
         (row['added_at'] as int) * 1000,
       ),
+      startedAt: row['started_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['started_at'] as int) * 1000,
+            )
+          : null,
+      completedAt: row['completed_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['completed_at'] as int) * 1000,
+            )
+          : null,
+      lastActivityAt: row['last_activity_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['last_activity_at'] as int) * 1000,
+            )
+          : null,
     );
   }
 
@@ -77,6 +95,21 @@ class CollectionItem with Exportable {
       addedAt: DateTime.fromMillisecondsSinceEpoch(
         (row['added_at'] as int) * 1000,
       ),
+      startedAt: row['started_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['started_at'] as int) * 1000,
+            )
+          : null,
+      completedAt: row['completed_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['completed_at'] as int) * 1000,
+            )
+          : null,
+      lastActivityAt: row['last_activity_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['last_activity_at'] as int) * 1000,
+            )
+          : null,
       game: game,
       movie: movie,
       tvShow: tvShow,
@@ -140,6 +173,15 @@ class CollectionItem with Exportable {
 
   /// Дата добавления в коллекцию.
   final DateTime addedAt;
+
+  /// Дата начала (начал играть/смотреть).
+  final DateTime? startedAt;
+
+  /// Дата завершения.
+  final DateTime? completedAt;
+
+  /// Дата последней активности.
+  final DateTime? lastActivityAt;
 
   /// Данные игры (joined).
   final Game? game;
@@ -211,7 +253,10 @@ class CollectionItem with Exportable {
 
   @override
   Set<String> get internalDbFields =>
-      const <String>{'id', 'collection_id', 'user_comment', 'added_at', 'sort_order'};
+      const <String>{
+        'id', 'collection_id', 'user_comment', 'added_at', 'sort_order',
+        'started_at', 'completed_at', 'last_activity_at',
+      };
 
   @override
   Map<String, String> get dbToExportKeyMapping =>
@@ -233,6 +278,15 @@ class CollectionItem with Exportable {
       'user_comment': userComment,
       'added_at': addedAt.millisecondsSinceEpoch ~/ 1000,
       'sort_order': sortOrder,
+      'started_at': startedAt != null
+          ? startedAt!.millisecondsSinceEpoch ~/ 1000
+          : null,
+      'completed_at': completedAt != null
+          ? completedAt!.millisecondsSinceEpoch ~/ 1000
+          : null,
+      'last_activity_at': lastActivityAt != null
+          ? lastActivityAt!.millisecondsSinceEpoch ~/ 1000
+          : null,
     };
   }
 
@@ -264,6 +318,9 @@ class CollectionItem with Exportable {
     String? authorComment,
     String? userComment,
     DateTime? addedAt,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    DateTime? lastActivityAt,
     Game? game,
     Movie? movie,
     TvShow? tvShow,
@@ -282,6 +339,9 @@ class CollectionItem with Exportable {
       authorComment: authorComment ?? this.authorComment,
       userComment: userComment ?? this.userComment,
       addedAt: addedAt ?? this.addedAt,
+      startedAt: startedAt ?? this.startedAt,
+      completedAt: completedAt ?? this.completedAt,
+      lastActivityAt: lastActivityAt ?? this.lastActivityAt,
       game: game ?? this.game,
       movie: movie ?? this.movie,
       tvShow: tvShow ?? this.tvShow,

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -123,7 +123,7 @@ void main() {
       final Map<int, List<TvEpisode>> episodes = <int, List<TvEpisode>>{
         1: <TvEpisode>[testEpisode1, testEpisode2],
       };
-      final Set<(int, int)> watched = <(int, int)>{(1, 1)};
+      final Map<(int, int), DateTime?> watched = <(int, int), DateTime?>{(1, 1): null};
       final Map<int, bool> loading = <int, bool>{1: false};
 
       final EpisodeTrackerState state = EpisodeTrackerState(
@@ -136,7 +136,7 @@ void main() {
       expect(state.episodesBySeason.length, 1);
       expect(state.episodesBySeason[1]?.length, 2);
       expect(state.watchedEpisodes.length, 1);
-      expect(state.watchedEpisodes.contains((1, 1)), true);
+      expect(state.watchedEpisodes.containsKey((1, 1)), true);
       expect(state.loadingSeasons[1], false);
       expect(state.error, 'Test error');
     });
@@ -158,7 +158,7 @@ void main() {
 
       test('должен копировать с изменёнными watchedEpisodes', () {
         const EpisodeTrackerState original = EpisodeTrackerState();
-        final Set<(int, int)> newWatched = <(int, int)>{(1, 1)};
+        final Map<(int, int), DateTime?> newWatched = <(int, int), DateTime?>{(1, 1): null};
 
         final EpisodeTrackerState copy =
             original.copyWith(watchedEpisodes: newWatched);
@@ -191,7 +191,7 @@ void main() {
     group('isEpisodeWatched', () {
       test('должен возвращать true для просмотренного эпизода', () {
         const EpisodeTrackerState state = EpisodeTrackerState(
-          watchedEpisodes: <(int, int)>{(1, 1), (1, 2)},
+          watchedEpisodes: <(int, int), DateTime?>{(1, 1): null, (1, 2): null},
         );
 
         expect(state.isEpisodeWatched(1, 1), true);
@@ -200,7 +200,7 @@ void main() {
 
       test('должен возвращать false для непросмотренного эпизода', () {
         const EpisodeTrackerState state = EpisodeTrackerState(
-          watchedEpisodes: <(int, int)>{(1, 1)},
+          watchedEpisodes: <(int, int), DateTime?>{(1, 1): null},
         );
 
         expect(state.isEpisodeWatched(1, 2), false);
@@ -211,7 +211,7 @@ void main() {
     group('watchedCountForSeason', () {
       test('должен возвращать количество просмотренных эпизодов в сезоне', () {
         const EpisodeTrackerState state = EpisodeTrackerState(
-          watchedEpisodes: <(int, int)>{(1, 1), (1, 2), (2, 1)},
+          watchedEpisodes: <(int, int), DateTime?>{(1, 1): null, (1, 2): null, (2, 1): null},
         );
 
         expect(state.watchedCountForSeason(1), 2);
@@ -223,7 +223,7 @@ void main() {
     group('totalWatchedCount', () {
       test('должен возвращать общее количество просмотренных эпизодов', () {
         const EpisodeTrackerState state = EpisodeTrackerState(
-          watchedEpisodes: <(int, int)>{(1, 1), (1, 2), (2, 1)},
+          watchedEpisodes: <(int, int), DateTime?>{(1, 1): null, (1, 2): null, (2, 1): null},
         );
 
         expect(state.totalWatchedCount, 3);
@@ -260,7 +260,7 @@ void main() {
     group('build', () {
       test('должен инициализироваться с пустым состоянием', () {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
 
         final ProviderContainer container = createContainer();
         final EpisodeTrackerState state =
@@ -273,10 +273,10 @@ void main() {
       });
 
       test('должен загружать просмотренные эпизоды из БД', () async {
-        final Set<(int, int)> watchedEpisodes = <(int, int)>{
-          (1, 1),
-          (1, 2),
-          (2, 1),
+        final Map<(int, int), DateTime?> watchedEpisodes = <(int, int), DateTime?>{
+          (1, 1): null,
+          (1, 2): null,
+          (2, 1): null,
         };
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
@@ -317,7 +317,7 @@ void main() {
     group('loadSeason', () {
       test('должен загружать эпизоды из кеша БД', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> cachedEpisodes = <TvEpisode>[
           testEpisode1,
           testEpisode2,
@@ -348,7 +348,7 @@ void main() {
 
       test('должен загружать эпизоды из API если кеш пуст', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         final List<TvEpisode> apiEpisodes = <TvEpisode>[
@@ -384,7 +384,7 @@ void main() {
 
       test('должен кешировать результаты API в БД', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         final List<TvEpisode> apiEpisodes = <TvEpisode>[
@@ -410,7 +410,7 @@ void main() {
 
       test('не должен кешировать пустой список из API', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
@@ -434,7 +434,7 @@ void main() {
 
       test('должен обрабатывать ошибку загрузки из API', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
@@ -460,7 +460,7 @@ void main() {
 
       test('не должен загружать уже загруженный сезон', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> cachedEpisodes = <TvEpisode>[testEpisode1];
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => cachedEpisodes);
@@ -482,7 +482,7 @@ void main() {
 
       test('не должен загружать сезон, который уже загружается', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async {
           // Имитируем долгую загрузку
@@ -510,7 +510,7 @@ void main() {
 
       test('должен устанавливать loading flag во время загрузки', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async {
           await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -543,7 +543,7 @@ void main() {
     group('toggleEpisode', () {
       test('должен отмечать эпизод как просмотренный', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
                 mockDb.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
             .thenAnswer((_) async {});
@@ -567,7 +567,7 @@ void main() {
       });
 
       test('должен снимать отметку просмотра с эпизода', () async {
-        final Set<(int, int)> watchedEpisodes = <(int, int)>{(1, 1)};
+        final Map<(int, int), DateTime?> watchedEpisodes = <(int, int), DateTime?>{(1, 1): null};
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
         when(
@@ -594,7 +594,7 @@ void main() {
 
       test('должен обновлять состояние после отметки просмотра', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
                 mockDb.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
             .thenAnswer((_) async {});
@@ -624,7 +624,7 @@ void main() {
     group('refreshSeason', () {
       test('должен принудительно загружать эпизоды из API', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> cachedEpisodes = <TvEpisode>[testEpisode1];
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => cachedEpisodes);
@@ -661,7 +661,7 @@ void main() {
       test('должен обновлять эпизоды даже если сезон ещё не загружен',
           () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> apiEpisodes = <TvEpisode>[testEpisode1];
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenAnswer((_) async => apiEpisodes);
@@ -684,7 +684,7 @@ void main() {
 
       test('должен обрабатывать ошибку API при обновлении', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenThrow(Exception('API unavailable'));
 
@@ -704,7 +704,7 @@ void main() {
 
       test('не должен кешировать пустой результат API', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
 
@@ -723,7 +723,7 @@ void main() {
     group('toggleSeason', () {
       test('должен отмечать все эпизоды сезона как просмотренные', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer(
           (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
@@ -766,10 +766,10 @@ void main() {
 
       test('должен снимать отметку просмотра со всех эпизодов сезона',
           () async {
-        final Set<(int, int)> watchedEpisodes = <(int, int)>{
-          (1, 1),
-          (1, 2),
-          (1, 3),
+        final Map<(int, int), DateTime?> watchedEpisodes = <(int, int), DateTime?>{
+          (1, 1): null,
+          (1, 2): null,
+          (1, 3): null,
         };
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
@@ -803,7 +803,7 @@ void main() {
 
       test('должен отмечать частично просмотренный сезон как полностью просмотренный',
           () async {
-        final Set<(int, int)> watchedEpisodes = <(int, int)>{(1, 1)};
+        final Map<(int, int), DateTime?> watchedEpisodes = <(int, int), DateTime?>{(1, 1): null};
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
@@ -845,7 +845,7 @@ void main() {
 
       test('не должен делать ничего если сезон не загружен', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
 
         final ProviderContainer container = createContainer();
         final EpisodeTrackerNotifier notifier =
@@ -864,7 +864,7 @@ void main() {
 
       test('не должен делать ничего если сезон пустой', () async {
         when(() => mockDb.getWatchedEpisodes(testCollectionId, testShowId))
-            .thenAnswer((_) async => <(int, int)>{});
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockDb.getEpisodesByShowAndSeason(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))

--- a/test/features/collections/screens/game_detail_screen_test.dart
+++ b/test/features/collections/screens/game_detail_screen_test.dart
@@ -215,6 +215,10 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
+      // Скролл вниз мимо ActivityDatesSection
+      await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+      await tester.pumpAndSettle();
+
       expect(find.text('My Notes'), findsOneWidget);
       expect(find.text('Finished on 2024-01-15'), findsOneWidget);
     });
@@ -234,6 +238,10 @@ void main() {
         isEditable: true,
         games: <CollectionGame>[collectionGame],
       ));
+      await tester.pumpAndSettle();
+
+      // Скролл вниз мимо ActivityDatesSection
+      await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
       await tester.pumpAndSettle();
 
       // Должно быть 2 кнопки Edit: для комментария автора и личных заметок

--- a/test/features/collections/screens/movie_detail_screen_test.dart
+++ b/test/features/collections/screens/movie_detail_screen_test.dart
@@ -609,6 +609,10 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
+        // Скролл вниз мимо ActivityDatesSection
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
         // 2 кнопки Edit: для Author's Comment и My Notes
         expect(find.text('Edit'), findsNWidgets(2));
       });
@@ -649,6 +653,10 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
+        // Скролл вниз мимо ActivityDatesSection
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
         expect(find.text('My Notes'), findsOneWidget);
         expect(find.text('Watched on 2024-01-15'), findsOneWidget);
       });
@@ -668,6 +676,10 @@ void main() {
           isEditable: true,
           items: <CollectionItem>[item],
         ));
+        await tester.pumpAndSettle();
+
+        // Скролл вниз мимо ActivityDatesSection
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
         await tester.pumpAndSettle();
 
         expect(
@@ -846,6 +858,10 @@ void main() {
         // Секция Status всё ещё отображается
         expect(find.text('Status'), findsOneWidget);
 
+        // Скролл вниз мимо ActivityDatesSection
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
         // Секции комментариев отображаются
         expect(find.text("Author's Comment"), findsOneWidget);
         expect(find.text('My Notes'), findsOneWidget);
@@ -894,14 +910,18 @@ void main() {
           findsOneWidget,
         );
 
+        // Скролл вниз мимо ActivityDatesSection
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
         // Комментарий автора
         expect(find.text('Great comedy-drama!'), findsOneWidget);
 
         // Личные заметки
         expect(find.text('Enjoyed it a lot.'), findsOneWidget);
 
-        // Статус
-        expect(find.text('Completed'), findsOneWidget);
+        // Статус (может быть 2: один в dropdown, один в ActivityDatesSection)
+        expect(find.text('Completed'), findsWidgets);
       });
 
       testWidgets(

--- a/test/features/collections/screens/tv_show_detail_screen_test.dart
+++ b/test/features/collections/screens/tv_show_detail_screen_test.dart
@@ -94,7 +94,7 @@ void main() {
     when(() => mockDb.getTvSeasonsByShowId(any()))
         .thenAnswer((_) async => <TvSeason>[]);
     when(() => mockDb.getWatchedEpisodes(any(), any()))
-        .thenAnswer((_) async => <(int, int)>{});
+        .thenAnswer((_) async => <(int, int), DateTime?>{});
 
     // Мокаем TmdbApi — возвращаем пустой список сезонов (fallback)
     when(() => mockTmdbApi.getTvSeasons(any()))
@@ -680,7 +680,9 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
-        // 2 кнопки Edit: Author's Comment и My Notes
+        // 2 кнопки Edit: Author's Comment и My Notes (скролл вниз мимо ActivityDates)
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+        await tester.pumpAndSettle();
         expect(find.text('Edit'), findsNWidgets(2));
       });
 
@@ -698,7 +700,9 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
-        // Только 1 кнопка Edit: для My Notes
+        // Только 1 кнопка Edit: для My Notes (скролл вниз мимо ActivityDates)
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
+        await tester.pumpAndSettle();
         expect(find.text('Edit'), findsOneWidget);
       });
     });
@@ -718,6 +722,14 @@ void main() {
           isEditable: true,
           items: <CollectionItem>[item],
         ));
+        await tester.pumpAndSettle();
+
+        // Скролл к секции My Notes
+        await tester.scrollUntilVisible(
+          find.text('My Notes'),
+          200,
+          scrollable: find.byType(Scrollable).at(1),
+        );
         await tester.pumpAndSettle();
 
         expect(find.text('My Notes'), findsOneWidget);
@@ -742,6 +754,14 @@ void main() {
           isEditable: true,
           items: <CollectionItem>[item],
         ));
+        await tester.pumpAndSettle();
+
+        // Скролл к секции заметок
+        await tester.scrollUntilVisible(
+          find.text('No notes yet. Tap Edit to add your personal notes.'),
+          200,
+          scrollable: find.byType(Scrollable).at(1),
+        );
         await tester.pumpAndSettle();
 
         expect(
@@ -829,8 +849,8 @@ void main() {
           findsOneWidget,
         );
 
-        // Status
-        expect(find.text('Completed'), findsOneWidget);
+        // Status (может быть 2: один в dropdown, один в ActivityDatesSection)
+        expect(find.text('Completed'), findsWidgets);
 
         // Author's comment & user notes — скролл к нижней части
         // Указываем scrollable MediaDetailView (второй после TabBarView)
@@ -978,8 +998,8 @@ void main() {
         ));
         await tester.pumpAndSettle();
 
-        // Прокручиваем до секции My Notes
-        await tester.ensureVisible(find.text('My Notes'));
+        // Прокручиваем до секции My Notes (мимо ActivityDatesSection)
+        await tester.drag(find.byType(Scrollable).at(1), const Offset(0, -300));
         await tester.pumpAndSettle();
 
         // isEditable=false значит есть только 1 кнопка Edit (для My Notes)


### PR DESCRIPTION
Add started_at, completed_at, last_activity_at fields to collection items with auto-set on status change and manual editing via DatePicker. Display watched_at dates in episode tracker. Fix status desync between GameDetailScreen and CollectionScreen by invalidating collectionItemsNotifierProvider from CollectionGamesNotifier mutations.