### PR TITLE
Switch VGMaps panel to vgmaps.de with multi-strategy image capture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ lib/
 | `lib/features/collections/widgets/canvas_image_item.dart` | **Изображение на канвасе**. ConsumerWidget. URL (CachedImage с ImageType.canvasImage, FNV-1a хэш URL как imageId) или base64 (Image.memory). Card с Clip.antiAlias, размер по умолчанию 200x200. Функция `urlToImageId()` для стабильных cache-ключей |
 | `lib/features/collections/widgets/canvas_link_item.dart` | **Ссылка на канвасе**. Card с иконкой и подчёркнутым текстом. Double-tap → url_launcher. Размер по умолчанию 200x48 |
 | `lib/features/collections/widgets/steamgriddb_panel.dart` | **Боковая панель SteamGridDB**. Поиск игр, выбор типа изображений (SegmentedButton), сетка thumbnail-ов (GridView.builder + CachedNetworkImage). Автозаполнение поиска из названия коллекции. Клик на изображение → добавление на канвас |
-| `lib/features/collections/widgets/vgmaps_panel.dart` | **Боковая панель VGMaps Browser**. WebView2 (webview_windows) для просмотра vgmaps.com. Навигация (back/forward/home/reload), поиск по имени игры, JS injection для перехвата ПКМ на `<img>`, bottom bar с превью и "Add to Canvas". Ширина 500px. Взаимоисключение с SteamGridDB панелью |
+| `lib/features/collections/widgets/vgmaps_panel.dart` | **Боковая панель VGMaps Browser**. WebView2 (webview_windows) для просмотра vgmaps.de. Навигация (back/forward/home/reload), поиск по имени игры, JS injection для перехвата ПКМ на `<img>`, bottom bar с превью и "Add to Canvas". Ширина 500px. Взаимоисключение с SteamGridDB панелью |
 
 #### Диалоги
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -212,10 +212,10 @@ Visualize your collection on a free-form canvas, or create a personal canvas for
   - In-memory cache for API results (no re-fetching on tab switch)
   - Toggle via FAB button or right-click "Find images..."
   - Warning when SteamGridDB API key is not configured
-- **VGMaps Browser Panel** — side panel with embedded WebView2 browser for vgmaps.com
-  - Navigate vgmaps.com directly inside the app (back/forward/home/reload)
+- **VGMaps Browser Panel** — side panel with embedded WebView2 browser for vgmaps.de
+  - Navigate vgmaps.de directly inside the app (back/forward/home/reload)
   - Search games by name via built-in search field
-  - Right-click any image on vgmaps.com to capture it
+  - Right-click any image on vgmaps.de to capture it
   - Preview captured image with dimensions in the bottom bar
   - Click "Add to Canvas" to place the map image on the canvas (scaled to max 400px width)
   - Toggle via FAB button or right-click "Browse maps..."

--- a/lib/features/collections/providers/vgmaps_panel_provider.dart
+++ b/lib/features/collections/providers/vgmaps_panel_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// Домашний URL VGMaps.
-const String vgMapsHomeUrl = 'https://www.vgmaps.com/';
+// Домашний URL VGMaps (Better VGMaps).
+const String vgMapsHomeUrl = 'https://vgmaps.de/';
 
 /// Состояние боковой панели VGMaps Browser.
 class VgMapsPanelState {

--- a/test/features/collections/providers/vgmaps_panel_provider_test.dart
+++ b/test/features/collections/providers/vgmaps_panel_provider_test.dart
@@ -396,8 +396,8 @@ void main() {
   });
 
   group('vgMapsHomeUrl', () {
-    test('should be vgmaps.com', () {
-      expect(vgMapsHomeUrl, 'https://www.vgmaps.com/');
+    test('should be vgmaps.de', () {
+      expect(vgMapsHomeUrl, 'https://vgmaps.de/');
     });
   });
 }


### PR DESCRIPTION
Replace vgmaps.com with vgmaps.de (Better VGMaps). Add Capture button to toolbar with 3 fallback strategies: JS executeScript return value, HTTP fetch with HTML parsing from Dart, and postMessage JS injection. Fix FilledButton layout crash caused by global theme minimumSize override.