### PR TITLE
Add canvas lock (view mode) and persist grid/list toggle per collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ## [Unreleased]
 
 ### Added
+- Добавлен замок канваса (View Mode Lock) — кнопка-замок в AppBar для блокировки канваса в режим просмотра. Доступен только для собственных/fork коллекций. При блокировке боковые панели (SteamGridDB, VGMaps) закрываются автоматически. Реализован на `CollectionScreen`, `GameDetailScreen`, `MovieDetailScreen`, `TvShowDetailScreen`
+- Добавлено сохранение режима отображения коллекции (grid/list) в SharedPreferences — при переключении выбор запоминается per-collection и восстанавливается при следующем открытии. Ключ `SettingsKeys.collectionViewModePrefix` в `settings_provider.dart`
+
+### Added
 - Добавлен виджет `StatusChipRow` — горизонтальный ряд chip-кнопок для выбора статуса на detail-экранах (все статусы видны сразу, тап = выбор, AnimatedContainer для плавных переходов)
 - Добавлен виджет `StatusRibbon` — диагональная ленточка статуса в верхнем левом углу list-карточек (display only, цвет из `ItemStatus.color`, emoji + метка)
 - Добавлен геттер `ItemStatus.color` — единый маппинг статус→цвет, устранено дублирование `_getStatusColor()`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -26,7 +26,7 @@ Create unlimited collections organized however you want:
 - By theme (Couch co-op, Hidden gems...)
 - Personal lists (Backlog, Completed, Favorites...)
 - Mix games, movies and TV shows in a single collection
-- **Grid mode** — toggle between list and poster grid view
+- **Grid mode** — toggle between list and poster grid view; choice is saved per-collection and restored on next open
 - **Type filter** — filter items by type (All/Games/Movies/TV Shows)
 - **Search** — filter items by name within a collection
 
@@ -204,6 +204,7 @@ Visualize your collection on a free-form canvas, or create a personal canvas for
 - **Persistent viewport** — zoom level and position are saved and restored
 - **Center view** and **Reset positions** controls
 - **List/Canvas toggle** — switch between traditional list and visual canvas via SegmentedButton
+- **Canvas lock** — lock button in AppBar to freeze the canvas in view-only mode (only for own/fork collections). When locked, all editing is disabled and side panels (SteamGridDB, VGMaps) are closed. Available on collection canvas and per-item canvas (detail screens, Canvas tab only)
 - **Context menu** (right-click) — Add Text/Image/Link on empty space; Edit/Delete/Bring to Front/Send to Back on elements
 - **Text blocks** — add custom text with configurable font size (Small 12/Medium 16/Large 24/Title 32), transparent background
 - **Images** — add images from URL or local file (base64 encoded)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,6 +38,8 @@
 - [x] Media type watermark — large tilted semi-transparent background icon on each collection item card
 - [x] Android Lite — collections, search, details, episode tracker, export/import (no Canvas). Platform feature flags
 - [x] Activity Dates — started_at, completed_at, last_activity_at for all collection items. Auto-set on status change. DatePicker for manual editing. Watched dates in episode tracker
+- [x] Canvas Lock — view-only mode toggle (lock icon in AppBar) for own/fork collections. Closes side panels when locked. Available on collection and per-item canvas
+- [x] View Mode Persistence — grid/list toggle saved per-collection in SharedPreferences
 
 ## UI Redesign (completed)
 

--- a/lib/features/collections/screens/game_detail_screen.dart
+++ b/lib/features/collections/screens/game_detail_screen.dart
@@ -51,6 +51,7 @@ class GameDetailScreen extends ConsumerStatefulWidget {
 class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  bool _isViewModeLocked = false;
 
   @override
   void initState() {
@@ -59,6 +60,11 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
       length: kCanvasEnabled ? 2 : 1,
       vsync: this,
     );
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) {
+        setState(() {});
+      }
+    });
   }
 
   @override
@@ -129,6 +135,36 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
         surfaceTintColor: Colors.transparent,
         foregroundColor: AppColors.textPrimary,
         title: Text(collectionGame.gameName),
+        actions: <Widget>[
+          if (widget.isEditable &&
+              kCanvasEnabled &&
+              _tabController.index == 1)
+            IconButton(
+              icon: Icon(
+                _isViewModeLocked ? Icons.lock : Icons.lock_open,
+              ),
+              color: _isViewModeLocked
+                  ? AppColors.warning
+                  : AppColors.textSecondary,
+              tooltip:
+                  _isViewModeLocked ? 'Unlock canvas' : 'Lock canvas',
+              onPressed: () {
+                setState(() {
+                  _isViewModeLocked = !_isViewModeLocked;
+                });
+                if (_isViewModeLocked) {
+                  ref
+                      .read(steamGridDbPanelProvider(widget.collectionId)
+                          .notifier)
+                      .closePanel();
+                  ref
+                      .read(vgMapsPanelProvider(widget.collectionId)
+                          .notifier)
+                      .closePanel();
+                }
+              },
+            ),
+        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: <Tab>[
@@ -228,7 +264,7 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
         Expanded(
           child: CanvasView(
             collectionId: widget.collectionId,
-            isEditable: widget.isEditable,
+            isEditable: widget.isEditable && !_isViewModeLocked,
             collectionItemId: widget.gameId,
           ),
         ),

--- a/lib/features/collections/screens/movie_detail_screen.dart
+++ b/lib/features/collections/screens/movie_detail_screen.dart
@@ -53,6 +53,7 @@ class MovieDetailScreen extends ConsumerStatefulWidget {
 class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  bool _isViewModeLocked = false;
 
   @override
   void initState() {
@@ -61,6 +62,11 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
       length: kCanvasEnabled ? 2 : 1,
       vsync: this,
     );
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) {
+        setState(() {});
+      }
+    });
   }
 
   @override
@@ -131,6 +137,36 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
         surfaceTintColor: Colors.transparent,
         foregroundColor: AppColors.textPrimary,
         title: Text(item.itemName),
+        actions: <Widget>[
+          if (widget.isEditable &&
+              kCanvasEnabled &&
+              _tabController.index == 1)
+            IconButton(
+              icon: Icon(
+                _isViewModeLocked ? Icons.lock : Icons.lock_open,
+              ),
+              color: _isViewModeLocked
+                  ? AppColors.warning
+                  : AppColors.textSecondary,
+              tooltip:
+                  _isViewModeLocked ? 'Unlock canvas' : 'Lock canvas',
+              onPressed: () {
+                setState(() {
+                  _isViewModeLocked = !_isViewModeLocked;
+                });
+                if (_isViewModeLocked) {
+                  ref
+                      .read(steamGridDbPanelProvider(widget.collectionId)
+                          .notifier)
+                      .closePanel();
+                  ref
+                      .read(vgMapsPanelProvider(widget.collectionId)
+                          .notifier)
+                      .closePanel();
+                }
+              },
+            ),
+        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: <Tab>[
@@ -248,7 +284,7 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
         Expanded(
           child: CanvasView(
             collectionId: widget.collectionId,
-            isEditable: widget.isEditable,
+            isEditable: widget.isEditable && !_isViewModeLocked,
             collectionItemId: widget.itemId,
           ),
         ),

--- a/lib/features/collections/screens/tv_show_detail_screen.dart
+++ b/lib/features/collections/screens/tv_show_detail_screen.dart
@@ -61,6 +61,7 @@ class TvShowDetailScreen extends ConsumerStatefulWidget {
 class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  bool _isViewModeLocked = false;
 
   @override
   void initState() {
@@ -69,6 +70,11 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
       length: kCanvasEnabled ? 2 : 1,
       vsync: this,
     );
+    _tabController.addListener(() {
+      if (!_tabController.indexIsChanging) {
+        setState(() {});
+      }
+    });
   }
 
   @override
@@ -139,6 +145,36 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
         surfaceTintColor: Colors.transparent,
         foregroundColor: AppColors.textPrimary,
         title: Text(item.itemName),
+        actions: <Widget>[
+          if (widget.isEditable &&
+              kCanvasEnabled &&
+              _tabController.index == 1)
+            IconButton(
+              icon: Icon(
+                _isViewModeLocked ? Icons.lock : Icons.lock_open,
+              ),
+              color: _isViewModeLocked
+                  ? AppColors.warning
+                  : AppColors.textSecondary,
+              tooltip:
+                  _isViewModeLocked ? 'Unlock canvas' : 'Lock canvas',
+              onPressed: () {
+                setState(() {
+                  _isViewModeLocked = !_isViewModeLocked;
+                });
+                if (_isViewModeLocked) {
+                  ref
+                      .read(steamGridDbPanelProvider(widget.collectionId)
+                          .notifier)
+                      .closePanel();
+                  ref
+                      .read(vgMapsPanelProvider(widget.collectionId)
+                          .notifier)
+                      .closePanel();
+                }
+              },
+            ),
+        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: <Tab>[
@@ -320,7 +356,7 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
         Expanded(
           child: CanvasView(
             collectionId: widget.collectionId,
-            isEditable: widget.isEditable,
+            isEditable: widget.isEditable && !_isViewModeLocked,
             collectionItemId: widget.itemId,
           ),
         ),

--- a/lib/features/settings/providers/settings_provider.dart
+++ b/lib/features/settings/providers/settings_provider.dart
@@ -21,6 +21,9 @@ abstract class SettingsKeys {
 
   /// API ключ для TMDB.
   static const String tmdbApiKey = 'tmdb_api_key';
+
+  /// Префикс для сохранения режима отображения коллекции (grid/list).
+  static const String collectionViewModePrefix = 'collection_view_mode_';
 }
 
 /// Состояние настроек IGDB.

--- a/test/features/collections/screens/movie_detail_screen_test.dart
+++ b/test/features/collections/screens/movie_detail_screen_test.dart
@@ -1016,5 +1016,106 @@ void main() {
         expect(find.byType(MediaDetailView), findsOneWidget);
       });
     });
+
+    group('замок канваса', () {
+      // CanvasView содержит бесконечные анимации, поэтому после переключения
+      // на вкладку Canvas используем pump() вместо pumpAndSettle().
+      Future<void> pumpFrames(WidgetTester tester) async {
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        await tester.pump();
+      }
+
+      testWidgets('не должен показывать замок на вкладке Details',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.byTooltip('Lock canvas'), findsNothing);
+        expect(find.byTooltip('Unlock canvas'), findsNothing);
+      });
+
+      testWidgets('должен показывать замок на вкладке Canvas (editable)',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        // Переключаемся на Canvas
+        await tester.tap(find.text('Canvas'));
+        await pumpFrames(tester);
+
+        expect(find.byTooltip('Lock canvas'), findsOneWidget);
+        expect(find.byIcon(Icons.lock_open), findsOneWidget);
+      });
+
+      testWidgets('не должен показывать замок когда isEditable = false',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: false,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        // Переключаемся на Canvas
+        await tester.tap(find.text('Canvas'));
+        await pumpFrames(tester);
+
+        expect(find.byTooltip('Lock canvas'), findsNothing);
+        expect(find.byTooltip('Unlock canvas'), findsNothing);
+      });
+
+      testWidgets('должен переключать состояние замка',
+          (WidgetTester tester) async {
+        final Movie movie = createTestMovie();
+        final CollectionItem item = createTestItem(movie: movie);
+
+        await tester.pumpWidget(createTestWidget(
+          collectionId: 1,
+          itemId: 1,
+          isEditable: true,
+          items: <CollectionItem>[item],
+        ));
+        await tester.pumpAndSettle();
+
+        // Переключаемся на Canvas
+        await tester.tap(find.text('Canvas'));
+        await pumpFrames(tester);
+
+        // Блокируем
+        await tester.tap(find.byTooltip('Lock canvas'));
+        await pumpFrames(tester);
+
+        expect(find.byIcon(Icons.lock), findsOneWidget);
+        expect(find.byTooltip('Unlock canvas'), findsOneWidget);
+
+        // Разблокируем
+        await tester.tap(find.byTooltip('Unlock canvas'));
+        await pumpFrames(tester);
+
+        expect(find.byIcon(Icons.lock_open), findsOneWidget);
+        expect(find.byTooltip('Lock canvas'), findsOneWidget);
+      });
+    });
   });
 }

--- a/test/features/settings/providers/settings_provider_test.dart
+++ b/test/features/settings/providers/settings_provider_test.dart
@@ -55,6 +55,23 @@ void main() {
     return container;
   }
 
+  group('SettingsKeys', () {
+    test('collectionViewModePrefix должен быть корректным', () {
+      expect(
+        SettingsKeys.collectionViewModePrefix,
+        equals('collection_view_mode_'),
+      );
+    });
+
+    test('collectionViewModePrefix должен формировать ключ по collectionId',
+        () {
+      const int collectionId = 42;
+      const String key =
+          '${SettingsKeys.collectionViewModePrefix}$collectionId';
+      expect(key, equals('collection_view_mode_42'));
+    });
+  });
+
   group('SettingsNotifier', () {
     group('build / _loadFromPrefs', () {
       test('должен загрузить TMDB ключ из prefs и установить в TmdbApi',


### PR DESCRIPTION
Canvas lock: lock icon in AppBar freezes canvas to view-only mode for own/fork collections, closing side panels when locked. Available on CollectionScreen and all detail screens (Canvas tab). Grid/list view mode saved in SharedPreferences per collection and restored on next open.