### PR TITLE
Remove personal data from export, add offline media import, fix animation image cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@
 
 ## [Unreleased]
 
+### Added
+- Добавлен экспорт canvas-изображений в полный экспорт `.xcollx` — изображения с канваса (`CanvasItemType.image`) теперь включаются в секцию `images` с ключом `canvas_images/{hash}`
+- Добавлен полный офлайн-экспорт: секция `media` в `.xcollx` содержит данные Game/Movie/TvShow (через `toDb()` без `cached_at`). При импорте данные восстанавливаются из файла через `fromDb()` — API-вызовы не требуются
+- Добавлен этап `ImportStage.restoringMedia` для отслеживания прогресса восстановления медиа-данных
+- Добавлено поле `media` в `XcollFile` с поддержкой сериализации/десериализации
+- Добавлен метод `ExportService._collectMediaData()` — сбор Game/Movie/TvShow из joined полей элементов с дедупликацией по ID
+- Добавлены методы `ImportService._restoreEmbeddedMedia()` и `_fetchMediaFromApi()` — условный импорт: офлайн из файла или онлайн из API
+
+### Fixed
+- Исправлен маппинг `ImageType` для анимации: `_imageTypeFor()` в `CollectionScreen` и `HeroCollectionCard` теперь учитывает `platformId` — анимационные сериалы (`AnimationSource.tvShow`) отображают обложки из `tv_show_posters` вместо `movie_posters`
+
+### Changed
+- Изменён `_AppRouter` — приложение больше не блокируется без API ключей, только поиск недоступен
+- Изменён `SearchScreen` — при отсутствии API ключей показывает заглушку вместо интерфейса поиска
+- Увеличена ширина кнопок Save в настройках: 80px → 100px (текст не обрезается на узких экранах)
+- Уменьшены размеры шрифтов на 2px для лучшего отображения на Android (h1: 26, h2: 18, h3: 14, body: 12, bodySmall: 11, caption: 10)
+
+### Fixed
+- Исправлена валидация API ключей: при пустом поле показывается ошибка вместо ложного успеха
+
 ### Removed
+- Удалены персональные данные прогресса из экспорта коллекции: `status`, `current_season`, `current_episode` больше не включаются в `.xcoll`/`.xcollx` файлы. При импорте старых файлов с этими полями — обратная совместимость сохранена
 - Удалён класс `CollectionGame` и enum `GameStatus` (`lib/shared/models/collection_game.dart`) — полностью заменены на `CollectionItem` и `ItemStatus`
 - Удалён `CollectionGamesNotifier` и провайдеры `collectionGamesProvider`, `collectionGamesNotifierProvider` из `collections_provider.dart` (~180 строк)
 - Удалён legacy-маппинг статуса `'playing'` — статус `inProgress` теперь единообразен для всех типов медиа. Миграция БД v13→v14 обновляет существующие записи

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -195,8 +195,10 @@ Export collections in three formats:
 ### Full Export (`.xcollx`)
 - Everything from light export, plus:
 - Canvas data (viewport, items, connections) including per-item canvases
-- Base64-encoded cover images for offline import
-- Self-contained — recipients don't need internet for covers
+- Base64-encoded cover images (game covers, movie/TV show posters)
+- Base64-encoded canvas images (images added to canvas boards)
+- Embedded media data (Game/Movie/TvShow) for fully offline import — no IGDB/TMDB API calls needed
+- Self-contained — recipients can import without internet (all data, covers, and canvas images included)
 
 ## Forking
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'features/settings/providers/settings_provider.dart';
-import 'features/settings/screens/settings_screen.dart';
 import 'shared/navigation/navigation_shell.dart';
 import 'shared/theme/app_theme.dart';
 
@@ -27,18 +25,12 @@ class XeraboraApp extends ConsumerWidget {
 
 /// Роутер приложения.
 ///
-/// Определяет начальный экран на основе состояния API ключей.
-class _AppRouter extends ConsumerWidget {
+/// Всегда показывает [NavigationShell]. Поиск недоступен без API ключей.
+class _AppRouter extends StatelessWidget {
   const _AppRouter();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final bool hasValidApiKey = ref.watch(hasValidApiKeyProvider);
-
-    if (!hasValidApiKey) {
-      return const SettingsScreen(isInitialSetup: true);
-    }
-
+  Widget build(BuildContext context) {
     return const NavigationShell();
   }
 }

--- a/lib/core/services/xcoll_file.dart
+++ b/lib/core/services/xcoll_file.dart
@@ -92,6 +92,7 @@ class XcollFile {
     this.items = const <Map<String, dynamic>>[],
     this.canvas,
     this.images = const <String, String>{},
+    this.media = const <String, dynamic>{},
   });
 
   /// Создаёт [XcollFile] из JSON строки.
@@ -173,6 +174,10 @@ class XcollFile {
                 MapEntry<String, String>(key, value as String))
         : const <String, String>{};
 
+    // Media data (optional, full export only)
+    final Map<String, dynamic> media =
+        json['media'] as Map<String, dynamic>? ?? const <String, dynamic>{};
+
     return XcollFile(
       version: 2,
       format: format,
@@ -183,6 +188,7 @@ class XcollFile {
       items: items,
       canvas: canvas,
       images: images,
+      media: media,
     );
   }
 
@@ -226,9 +232,15 @@ class XcollFile {
 
   /// Base64-изображения обложек (только full export).
   ///
-  /// Ключ — '{ImageType.folder}/{externalId}' (например, 'game_covers/12345').
+  /// Ключ — '{ImageType.folder}/{imageId}' (например, 'game_covers/12345').
   /// Значение — base64-строка изображения.
   final Map<String, String> images;
+
+  /// Полные данные медиа-объектов (только full export).
+  ///
+  /// Структура: `{games: [...], movies: [...], tv_shows: [...]}`.
+  /// Каждый элемент — Map в формате `toDb()` соответствующей модели.
+  final Map<String, dynamic> media;
 
   /// Является ли полным экспортом.
   bool get isFull => format == ExportFormat.full;
@@ -245,6 +257,7 @@ class XcollFile {
       'items': items,
       if (canvas != null) 'canvas': canvas!.toJson(),
       if (images.isNotEmpty) 'images': images,
+      if (media.isNotEmpty) 'media': media,
     };
   }
 

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -484,18 +484,21 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       child: Column(
         children: <Widget>[
           // Фильтр по типу
-          Row(
-            children: <Widget>[
-              _buildFilterChip(label: 'All', type: null),
-              const SizedBox(width: AppSpacing.sm),
-              _buildFilterChip(label: 'Games', type: MediaType.game),
-              const SizedBox(width: AppSpacing.sm),
-              _buildFilterChip(label: 'Movies', type: MediaType.movie),
-              const SizedBox(width: AppSpacing.sm),
-              _buildFilterChip(label: 'TV Shows', type: MediaType.tvShow),
-              const SizedBox(width: AppSpacing.sm),
-              _buildFilterChip(label: 'Animation', type: MediaType.animation),
-            ],
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: <Widget>[
+                _buildFilterChip(label: 'All', type: null),
+                const SizedBox(width: AppSpacing.sm),
+                _buildFilterChip(label: 'Games', type: MediaType.game),
+                const SizedBox(width: AppSpacing.sm),
+                _buildFilterChip(label: 'Movies', type: MediaType.movie),
+                const SizedBox(width: AppSpacing.sm),
+                _buildFilterChip(label: 'TV Shows', type: MediaType.tvShow),
+                const SizedBox(width: AppSpacing.sm),
+                _buildFilterChip(label: 'Animation', type: MediaType.animation),
+              ],
+            ),
           ),
 
           const SizedBox(height: AppSpacing.sm),
@@ -744,7 +747,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             key: ValueKey<int>(item.id),
             title: item.itemName,
             imageUrl: item.thumbnailUrl ?? '',
-            cacheImageType: _imageTypeFor(item.mediaType),
+            cacheImageType: _imageTypeFor(item.mediaType, item.platformId),
             cacheImageId: item.externalId.toString(),
             rating: _normalizedRating(item),
             year: _yearFor(item),
@@ -811,7 +814,10 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
   }
 
   /// ImageType для кэширования по типу медиа.
-  static ImageType _imageTypeFor(MediaType mediaType) {
+  ///
+  /// Для [MediaType.animation] использует [platformId] для определения
+  /// источника: [AnimationSource.tvShow] → tvShowPoster, иначе moviePoster.
+  static ImageType _imageTypeFor(MediaType mediaType, int? platformId) {
     switch (mediaType) {
       case MediaType.game:
         return ImageType.gameCover;
@@ -820,6 +826,9 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       case MediaType.tvShow:
         return ImageType.tvShowPoster;
       case MediaType.animation:
+        if (platformId == AnimationSource.tvShow) {
+          return ImageType.tvShowPoster;
+        }
         return ImageType.moviePoster;
     }
   }

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -9,7 +9,6 @@ import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/hero_collection_card.dart';
 import '../../../shared/widgets/section_header.dart';
 import '../../../shared/widgets/shimmer_loading.dart';
-import '../../settings/providers/settings_provider.dart';
 import '../providers/collections_provider.dart';
 import '../widgets/collection_tile.dart';
 import '../widgets/create_collection_dialog.dart';
@@ -24,7 +23,6 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final SettingsState settings = ref.watch(settingsNotifierProvider);
     final AsyncValue<List<Collection>> collectionsAsync =
         ref.watch(collectionsProvider);
 
@@ -45,9 +43,7 @@ class HomeScreen extends ConsumerWidget {
             icon: const Icon(Icons.file_download_outlined),
             color: AppColors.textSecondary,
             tooltip: 'Import Collection',
-            onPressed: settings.isApiReady
-                ? () => _importCollection(context, ref)
-                : null,
+            onPressed: () => _importCollection(context, ref),
           ),
         ],
       ),

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -21,6 +21,7 @@ import '../../../shared/widgets/cached_image.dart' as app_cached;
 import '../../../shared/widgets/poster_card.dart';
 import '../../../shared/widgets/shimmer_loading.dart';
 import '../../collections/providers/collections_provider.dart';
+import '../../settings/providers/settings_provider.dart';
 import '../providers/game_search_provider.dart';
 import '../providers/genre_provider.dart';
 import '../providers/media_search_provider.dart';
@@ -707,6 +708,50 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
   @override
   Widget build(BuildContext context) {
+    final bool isApiReady = ref.watch(hasValidApiKeyProvider);
+
+    if (!isApiReady) {
+      return Scaffold(
+        backgroundColor: AppColors.background,
+        appBar: AppBar(
+          backgroundColor: AppColors.background,
+          surfaceTintColor: Colors.transparent,
+          foregroundColor: AppColors.textPrimary,
+          title: const Text('Search'),
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(
+                  Icons.search_off,
+                  size: 64,
+                  color: AppColors.textTertiary.withAlpha(100),
+                ),
+                const SizedBox(height: AppSpacing.md),
+                Text(
+                  'Search unavailable',
+                  style: AppTypography.h2.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'Configure IGDB API keys in Settings to enable search.',
+                  style: AppTypography.body.copyWith(
+                    color: AppColors.textTertiary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -675,7 +675,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
                 const Spacer(),
                 SizedBox(
-                  width: 80,
+                  width: 100,
                   height: 40,
                   child: FilledButton(
                     onPressed: _saveSteamGridDbKey,
@@ -692,15 +692,17 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   Future<void> _saveSteamGridDbKey() async {
     final String apiKey = _steamGridDbKeyController.text.trim();
+    if (apiKey.isEmpty) {
+      _showSnackBar('Please enter a SteamGridDB API key');
+      return;
+    }
+
     final SettingsNotifier notifier =
         ref.read(settingsNotifierProvider.notifier);
     await notifier.setSteamGridDbApiKey(apiKey);
 
     if (mounted) {
-      _showSnackBar(
-        apiKey.isEmpty ? 'API key cleared' : 'API key saved',
-        isError: false,
-      );
+      _showSnackBar('API key saved', isError: false);
     }
   }
 
@@ -775,7 +777,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
                 const Spacer(),
                 SizedBox(
-                  width: 80,
+                  width: 100,
                   height: 40,
                   child: FilledButton(
                     onPressed: _saveTmdbKey,
@@ -792,15 +794,17 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   Future<void> _saveTmdbKey() async {
     final String apiKey = _tmdbKeyController.text.trim();
+    if (apiKey.isEmpty) {
+      _showSnackBar('Please enter a TMDB API key');
+      return;
+    }
+
     final SettingsNotifier notifier =
         ref.read(settingsNotifierProvider.notifier);
     await notifier.setTmdbApiKey(apiKey);
 
     if (mounted) {
-      _showSnackBar(
-        apiKey.isEmpty ? 'TMDB API key cleared' : 'TMDB API key saved',
-        isError: false,
-      );
+      _showSnackBar('TMDB API key saved', isError: false);
     }
   }
 

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -130,7 +130,9 @@ class CollectionItem with Exportable {
       platformId: json['platform_id'] as int?,
       currentSeason: (json['current_season'] as int?) ?? 0,
       currentEpisode: (json['current_episode'] as int?) ?? 0,
-      status: ItemStatus.fromString(json['status'] as String),
+      status: json['status'] != null
+          ? ItemStatus.fromString(json['status'] as String)
+          : ItemStatus.notStarted,
       authorComment: json['comment'] as String?,
       addedAt: addedAt ?? DateTime.now(),
     );
@@ -269,6 +271,7 @@ class CollectionItem with Exportable {
       const <String>{
         'id', 'collection_id', 'user_comment', 'added_at', 'sort_order',
         'started_at', 'completed_at', 'last_activity_at',
+        'status', 'current_season', 'current_episode',
       };
 
   @override
@@ -310,9 +313,6 @@ class CollectionItem with Exportable {
       'media_type': mediaType.value,
       'external_id': externalId,
       'platform_id': platformId,
-      'current_season': currentSeason,
-      'current_episode': currentEpisode,
-      'status': status.value,
       'comment': authorComment,
     };
   }

--- a/lib/shared/theme/app_typography.dart
+++ b/lib/shared/theme/app_typography.dart
@@ -15,7 +15,7 @@ abstract final class AppTypography {
   /// Крупный заголовок (название приложения, заголовок экрана).
   static const TextStyle h1 = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 28,
+    fontSize: 26,
     fontWeight: FontWeight.bold,
     color: AppColors.textPrimary,
     height: 1.2,
@@ -25,7 +25,7 @@ abstract final class AppTypography {
   /// Заголовок секции.
   static const TextStyle h2 = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: FontWeight.w600,
     color: AppColors.textPrimary,
     height: 1.3,
@@ -35,7 +35,7 @@ abstract final class AppTypography {
   /// Подзаголовок (название карточки, элемент списка).
   static const TextStyle h3 = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 16,
+    fontSize: 14,
     fontWeight: FontWeight.w600,
     color: AppColors.textPrimary,
     height: 1.3,
@@ -44,7 +44,7 @@ abstract final class AppTypography {
   /// Основной текст.
   static const TextStyle body = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 14,
+    fontSize: 12,
     fontWeight: FontWeight.normal,
     color: AppColors.textPrimary,
     height: 1.4,
@@ -53,7 +53,7 @@ abstract final class AppTypography {
   /// Мелкий текст (даты, мета-информация).
   static const TextStyle bodySmall = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: FontWeight.normal,
     color: AppColors.textSecondary,
     height: 1.4,
@@ -62,7 +62,7 @@ abstract final class AppTypography {
   /// Подпись (badge, chip, label).
   static const TextStyle caption = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: FontWeight.w500,
     color: AppColors.textTertiary,
     height: 1.2,
@@ -71,7 +71,7 @@ abstract final class AppTypography {
   /// Название на постерной карточке.
   static const TextStyle posterTitle = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 14,
+    fontSize: 12,
     fontWeight: FontWeight.w600,
     color: AppColors.textPrimary,
     height: 1.3,
@@ -80,7 +80,7 @@ abstract final class AppTypography {
   /// Подпись на постерной карточке (год, жанр).
   static const TextStyle posterSubtitle = TextStyle(
     fontFamily: fontFamily,
-    fontSize: 11,
+    fontSize: 10,
     fontWeight: FontWeight.w400,
     color: AppColors.textSecondary,
     height: 1.3,

--- a/lib/shared/widgets/hero_collection_card.dart
+++ b/lib/shared/widgets/hero_collection_card.dart
@@ -88,7 +88,10 @@ class HeroCollectionCard extends ConsumerWidget {
   }
 
   /// Возвращает [ImageType] для кэширования по типу медиа.
-  static ImageType _imageTypeFor(MediaType mediaType) {
+  ///
+  /// Для [MediaType.animation] использует [platformId] для определения
+  /// источника: [AnimationSource.tvShow] → tvShowPoster, иначе moviePoster.
+  static ImageType _imageTypeFor(MediaType mediaType, int? platformId) {
     switch (mediaType) {
       case MediaType.game:
         return ImageType.gameCover;
@@ -97,6 +100,9 @@ class HeroCollectionCard extends ConsumerWidget {
       case MediaType.tvShow:
         return ImageType.tvShowPoster;
       case MediaType.animation:
+        if (platformId == AnimationSource.tvShow) {
+          return ImageType.tvShowPoster;
+        }
         return ImageType.moviePoster;
     }
   }
@@ -247,7 +253,7 @@ class HeroCollectionCard extends ConsumerWidget {
         for (final CollectionItem item in withCovers)
           Expanded(
             child: CachedImage(
-              imageType: _imageTypeFor(item.mediaType),
+              imageType: _imageTypeFor(item.mediaType, item.platformId),
               imageId: item.externalId.toString(),
               remoteUrl: item.thumbnailUrl!,
               fit: BoxFit.cover,
@@ -375,7 +381,7 @@ class HeroCollectionCard extends ConsumerWidget {
               width: cellSize - gap / 2,
               height: cellSize - gap / 2,
               child: CachedImage(
-                imageType: _imageTypeFor(withCovers[i].mediaType),
+                imageType: _imageTypeFor(withCovers[i].mediaType, withCovers[i].platformId),
                 imageId: withCovers[i].externalId.toString(),
                 remoteUrl: withCovers[i].thumbnailUrl!,
                 fit: BoxFit.cover,
@@ -404,7 +410,7 @@ class HeroCollectionCard extends ConsumerWidget {
               width: cellSize - gap / 2,
               height: cellSize - gap / 2,
               child: CachedImage(
-                imageType: _imageTypeFor(withCovers[_mosaicCount].mediaType),
+                imageType: _imageTypeFor(withCovers[_mosaicCount].mediaType, withCovers[_mosaicCount].platformId),
                 imageId: withCovers[_mosaicCount].externalId.toString(),
                 remoteUrl: withCovers[_mosaicCount].thumbnailUrl!,
                 fit: BoxFit.cover,

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -7,6 +7,7 @@ import 'package:xerabora/app.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/shared/models/collection.dart';
+import 'package:xerabora/shared/navigation/navigation_shell.dart';
 
 class MockCollectionRepository extends Mock implements CollectionRepository {}
 
@@ -39,7 +40,7 @@ void main() {
       expect(find.byType(MaterialApp), findsOneWidget);
     });
 
-    testWidgets('должен показывать SettingsScreen когда нет API ключа',
+    testWidgets('должен показывать NavigationShell',
         (WidgetTester tester) async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
       final SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -54,43 +55,9 @@ void main() {
         ),
       );
 
-      await tester.pumpAndSettle();
-
-      // SettingsScreen показывается для initial setup
-      expect(find.text('IGDB API Setup'), findsOneWidget);
-    });
-
-    testWidgets('должен показывать HomeScreen когда есть валидный API ключ',
-        (WidgetTester tester) async {
-      final int futureExpiry =
-          DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
-
-      SharedPreferences.setMockInitialValues(<String, Object>{
-        'igdb_client_id': 'test_client_id',
-        'igdb_client_secret': 'test_client_secret',
-        'igdb_access_token': 'test_access_token',
-        'igdb_token_expires': futureExpiry,
-      });
-      final SharedPreferences prefs = await SharedPreferences.getInstance();
-
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: <Override>[
-            sharedPreferencesProvider.overrideWithValue(prefs),
-            collectionRepositoryProvider.overrideWithValue(mockRepo),
-          ],
-          child: const XeraboraApp(),
-        ),
-      );
-
-      // Use multiple pump() instead of pumpAndSettle() to avoid timeout
-      // due to async providers
-      await tester.pump();
-      await tester.pump();
       await tester.pump();
 
-      // HomeScreen показывает заголовок Collections
-      expect(find.text('Collections'), findsOneWidget);
+      expect(find.byType(NavigationShell), findsOneWidget);
     });
 
     testWidgets('должен использовать Material 3', (WidgetTester tester) async {

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -12,8 +12,11 @@ import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/game.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
 
 class MockCanvasRepository extends Mock implements CanvasRepository {}
 
@@ -52,6 +55,9 @@ void main() {
     String? authorComment,
     int currentSeason = 0,
     int currentEpisode = 0,
+    Game? game,
+    Movie? movie,
+    TvShow? tvShow,
   }) {
     return CollectionItem(
       id: id,
@@ -64,6 +70,9 @@ void main() {
       currentSeason: currentSeason,
       currentEpisode: currentEpisode,
       addedAt: testDate,
+      game: game,
+      movie: movie,
+      tvShow: tvShow,
     );
   }
 
@@ -165,20 +174,15 @@ void main() {
         expect(xcoll.items[0]['media_type'], equals('game'));
         expect(xcoll.items[0]['external_id'], equals(100));
         expect(xcoll.items[0]['platform_id'], equals(18));
-        expect(xcoll.items[0]['status'], equals('completed'));
         expect(xcoll.items[0]['comment'], equals('Great game'));
 
         // Фильм
         expect(xcoll.items[1]['media_type'], equals('movie'));
         expect(xcoll.items[1]['external_id'], equals(550));
-        expect(xcoll.items[1]['status'], equals('not_started'));
 
         // Сериал
         expect(xcoll.items[2]['media_type'], equals('tv_show'));
         expect(xcoll.items[2]['external_id'], equals(1399));
-        expect(xcoll.items[2]['status'], equals('in_progress'));
-        expect(xcoll.items[2]['current_season'], equals(3));
-        expect(xcoll.items[2]['current_episode'], equals(5));
       });
 
       test('должен использовать toExport() для каждого элемента', () {
@@ -194,8 +198,6 @@ void main() {
         final XcollFile xcoll =
             sut.createLightExport(collection, <CollectionItem>[item]);
 
-        // toExport() использует status.value, а не dbValue
-        expect(xcoll.items[0]['status'], equals('completed'));
         // toExport() переименовывает author_comment → comment
         expect(xcoll.items[0]['comment'], equals('Classic'));
         // Internal поля НЕ включены
@@ -428,7 +430,6 @@ void main() {
         expect(restored.items[0]['external_id'], equals(111));
         expect(restored.items[0]['platform_id'], equals(22));
         expect(restored.items[0]['comment'], equals('Fantastic game'));
-        expect(restored.items[0]['status'], equals('completed'));
       });
     });
 
@@ -642,6 +643,396 @@ void main() {
 
         expect(xcoll.images, isEmpty);
       });
+
+      test('должен использовать tvShowPoster для animation с tvShow platformId',
+          () async {
+        final Uint8List tvBytes = Uint8List.fromList(<int>[7, 8, 9]);
+        when(() => mockImageCache.readImageBytes(
+              ImageType.tvShowPoster,
+              '500',
+            )).thenAnswer((_) async => tvBytes);
+
+        when(() => mockCanvasRepo.getGameCanvasItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.animation,
+            externalId: 500,
+            platformId: 1, // AnimationSource.tvShow
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutImages.createFullExport(collection, items, 1);
+
+        expect(xcoll.images.containsKey('tv_show_posters/500'), isTrue);
+        expect(
+          xcoll.images['tv_show_posters/500'],
+          equals(base64Encode(tvBytes)),
+        );
+      });
+
+      test('должен использовать moviePoster для animation с movie platformId',
+          () async {
+        final Uint8List movieBytes = Uint8List.fromList(<int>[1, 2, 3]);
+        when(() => mockImageCache.readImageBytes(
+              ImageType.moviePoster,
+              '600',
+            )).thenAnswer((_) async => movieBytes);
+
+        when(() => mockCanvasRepo.getGameCanvasItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.animation,
+            externalId: 600,
+            platformId: 0, // AnimationSource.movie
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutImages.createFullExport(collection, items, 1);
+
+        expect(xcoll.images.containsKey('movie_posters/600'), isTrue);
+      });
+    });
+
+    group('canvas images в full export', () {
+      late MockCanvasRepository mockCanvasRepo;
+      late MockImageCacheService mockImageCache;
+
+      setUp(() {
+        mockCanvasRepo = MockCanvasRepository();
+        mockImageCache = MockImageCacheService();
+
+        when(() => mockCanvasRepo.getViewport(any()))
+            .thenAnswer((_) async => null);
+        when(() => mockCanvasRepo.getConnections(any()))
+            .thenAnswer((_) async => <CanvasConnection>[]);
+        when(() => mockCanvasRepo.getGameCanvasItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+      });
+
+      test('должен собрать canvas images из collection canvas', () async {
+        final Uint8List canvasBytes = Uint8List.fromList(<int>[10, 20, 30]);
+        const String testUrl = 'https://example.com/image.png';
+
+        // FNV-1a hash of testUrl
+        int hash = 0x811c9dc5;
+        for (int i = 0; i < testUrl.length; i++) {
+          hash ^= testUrl.codeUnitAt(i);
+          hash = (hash * 0x01000193) & 0xFFFFFFFF;
+        }
+        final String expectedImageId =
+            hash.toRadixString(16).padLeft(8, '0');
+
+        final CanvasItem imageCanvasItem = CanvasItem(
+          id: 1,
+          collectionId: 1,
+          itemType: CanvasItemType.image,
+          x: 100.0,
+          y: 200.0,
+          data: const <String, dynamic>{'url': testUrl},
+          createdAt: testDate,
+        );
+
+        when(() => mockCanvasRepo.getItems(1))
+            .thenAnswer((_) async => <CanvasItem>[imageCanvasItem]);
+        when(() => mockImageCache.readImageBytes(
+              ImageType.canvasImage,
+              expectedImageId,
+            )).thenAnswer((_) async => canvasBytes);
+        // Cover images — нет элементов
+        when(() => mockImageCache.readImageBytes(
+              ImageType.gameCover,
+              any(),
+            )).thenAnswer((_) async => null);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+
+        final XcollFile xcoll = await sutImages.createFullExport(
+          collection,
+          <CollectionItem>[],
+          1,
+        );
+
+        final String expectedKey = 'canvas_images/$expectedImageId';
+        expect(xcoll.images.containsKey(expectedKey), isTrue);
+        expect(
+          xcoll.images[expectedKey],
+          equals(base64Encode(canvasBytes)),
+        );
+      });
+
+      test('должен собрать canvas images из per-item canvas', () async {
+        final Uint8List canvasBytes = Uint8List.fromList(<int>[40, 50, 60]);
+        const String testUrl = 'https://example.com/per-item.png';
+
+        int hash = 0x811c9dc5;
+        for (int i = 0; i < testUrl.length; i++) {
+          hash ^= testUrl.codeUnitAt(i);
+          hash = (hash * 0x01000193) & 0xFFFFFFFF;
+        }
+        final String expectedImageId =
+            hash.toRadixString(16).padLeft(8, '0');
+
+        final CanvasItem perItemImageCanvasItem = CanvasItem(
+          id: 2,
+          collectionId: 1,
+          collectionItemId: 10,
+          itemType: CanvasItemType.image,
+          x: 50.0,
+          y: 75.0,
+          data: const <String, dynamic>{'url': testUrl},
+          createdAt: testDate,
+        );
+
+        // Collection canvas — пустой
+        when(() => mockCanvasRepo.getItems(1))
+            .thenAnswer((_) async => <CanvasItem>[]);
+
+        // Per-item canvas с image
+        when(() => mockCanvasRepo.getGameCanvasItems(10))
+            .thenAnswer((_) async => <CanvasItem>[perItemImageCanvasItem]);
+        when(() => mockCanvasRepo.getGameCanvasConnections(10))
+            .thenAnswer((_) async => <CanvasConnection>[]);
+        when(() => mockCanvasRepo.getGameCanvasViewport(10))
+            .thenAnswer((_) async => null);
+
+        when(() => mockImageCache.readImageBytes(
+              ImageType.canvasImage,
+              expectedImageId,
+            )).thenAnswer((_) async => canvasBytes);
+        when(() => mockImageCache.readImageBytes(
+              ImageType.gameCover,
+              '100',
+            )).thenAnswer((_) async => null);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(id: 10, externalId: 100),
+        ];
+
+        final XcollFile xcoll =
+            await sutImages.createFullExport(collection, items, 1);
+
+        final String expectedKey = 'canvas_images/$expectedImageId';
+        expect(xcoll.images.containsKey(expectedKey), isTrue);
+      });
+
+      test('должен пропустить не-image canvas items', () async {
+        final CanvasItem textCanvasItem = CanvasItem(
+          id: 1,
+          collectionId: 1,
+          itemType: CanvasItemType.text,
+          x: 100.0,
+          y: 200.0,
+          data: const <String, dynamic>{'text': 'Hello'},
+          createdAt: testDate,
+        );
+
+        when(() => mockCanvasRepo.getItems(1))
+            .thenAnswer((_) async => <CanvasItem>[textCanvasItem]);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+
+        final XcollFile xcoll = await sutImages.createFullExport(
+          collection,
+          <CollectionItem>[],
+          1,
+        );
+
+        // Никаких canvas_images ключей
+        final bool hasCanvasImages = xcoll.images.keys
+            .any((String k) => k.startsWith('canvas_images/'));
+        expect(hasCanvasImages, isFalse);
+      });
+
+      test('должен пропустить image canvas item без URL', () async {
+        final CanvasItem imageNoUrl = CanvasItem(
+          id: 1,
+          collectionId: 1,
+          itemType: CanvasItemType.image,
+          x: 100.0,
+          y: 200.0,
+          data: const <String, dynamic>{'base64': 'abc123'},
+          createdAt: testDate,
+        );
+
+        when(() => mockCanvasRepo.getItems(1))
+            .thenAnswer((_) async => <CanvasItem>[imageNoUrl]);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+
+        final XcollFile xcoll = await sutImages.createFullExport(
+          collection,
+          <CollectionItem>[],
+          1,
+        );
+
+        final bool hasCanvasImages = xcoll.images.keys
+            .any((String k) => k.startsWith('canvas_images/'));
+        expect(hasCanvasImages, isFalse);
+      });
+
+      test('должен дедуплицировать одинаковые URL', () async {
+        final Uint8List bytes = Uint8List.fromList(<int>[1, 2, 3]);
+        const String url = 'https://example.com/same.png';
+
+        int hash = 0x811c9dc5;
+        for (int i = 0; i < url.length; i++) {
+          hash ^= url.codeUnitAt(i);
+          hash = (hash * 0x01000193) & 0xFFFFFFFF;
+        }
+        final String imageId = hash.toRadixString(16).padLeft(8, '0');
+
+        final CanvasItem img1 = CanvasItem(
+          id: 1,
+          collectionId: 1,
+          itemType: CanvasItemType.image,
+          x: 0,
+          y: 0,
+          data: const <String, dynamic>{'url': url},
+          createdAt: testDate,
+        );
+        final CanvasItem img2 = CanvasItem(
+          id: 2,
+          collectionId: 1,
+          itemType: CanvasItemType.image,
+          x: 100,
+          y: 0,
+          data: const <String, dynamic>{'url': url},
+          createdAt: testDate,
+        );
+
+        when(() => mockCanvasRepo.getItems(1))
+            .thenAnswer((_) async => <CanvasItem>[img1, img2]);
+        when(() => mockImageCache.readImageBytes(
+              ImageType.canvasImage,
+              imageId,
+            )).thenAnswer((_) async => bytes);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+
+        final XcollFile xcoll = await sutImages.createFullExport(
+          collection,
+          <CollectionItem>[],
+          1,
+        );
+
+        // Только один ключ canvas_images
+        final int canvasImageCount = xcoll.images.keys
+            .where((String k) => k.startsWith('canvas_images/'))
+            .length;
+        expect(canvasImageCount, equals(1));
+
+        // readImageBytes вызван только 1 раз
+        verify(() => mockImageCache.readImageBytes(
+              ImageType.canvasImage,
+              imageId,
+            )).called(1);
+      });
+
+      test('должен объединить cover images и canvas images', () async {
+        final Uint8List coverBytes = Uint8List.fromList(<int>[1, 2, 3]);
+        final Uint8List canvasBytes = Uint8List.fromList(<int>[4, 5, 6]);
+        const String canvasUrl = 'https://example.com/canvas.png';
+
+        int hash = 0x811c9dc5;
+        for (int i = 0; i < canvasUrl.length; i++) {
+          hash ^= canvasUrl.codeUnitAt(i);
+          hash = (hash * 0x01000193) & 0xFFFFFFFF;
+        }
+        final String canvasImageId =
+            hash.toRadixString(16).padLeft(8, '0');
+
+        final CanvasItem imageCanvasItem = CanvasItem(
+          id: 1,
+          collectionId: 1,
+          itemType: CanvasItemType.image,
+          x: 0,
+          y: 0,
+          data: const <String, dynamic>{'url': canvasUrl},
+          createdAt: testDate,
+        );
+
+        when(() => mockCanvasRepo.getItems(1))
+            .thenAnswer((_) async => <CanvasItem>[imageCanvasItem]);
+        when(() => mockCanvasRepo.getGameCanvasItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+
+        when(() => mockImageCache.readImageBytes(
+              ImageType.gameCover,
+              '100',
+            )).thenAnswer((_) async => coverBytes);
+        when(() => mockImageCache.readImageBytes(
+              ImageType.canvasImage,
+              canvasImageId,
+            )).thenAnswer((_) async => canvasBytes);
+
+        final ExportService sutImages = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(id: 10, externalId: 100),
+        ];
+
+        final XcollFile xcoll =
+            await sutImages.createFullExport(collection, items, 1);
+
+        // Обложка
+        expect(xcoll.images.containsKey('game_covers/100'), isTrue);
+        // Canvas image
+        expect(
+          xcoll.images.containsKey('canvas_images/$canvasImageId'),
+          isTrue,
+        );
+        expect(xcoll.images.length, equals(2));
+      });
     });
 
     group('v2 → XcollFile round-trip', () {
@@ -681,14 +1072,338 @@ void main() {
         expect(restoredGame.mediaType, equals(MediaType.game));
         expect(restoredGame.externalId, equals(42));
         expect(restoredGame.platformId, equals(6));
-        expect(restoredGame.status, equals(ItemStatus.completed));
+        expect(restoredGame.status, equals(ItemStatus.notStarted));
         expect(restoredGame.authorComment, equals('Best game'));
 
         final CollectionItem restoredTvShow =
             CollectionItem.fromExport(restored.items[1]);
         expect(restoredTvShow.mediaType, equals(MediaType.tvShow));
-        expect(restoredTvShow.currentSeason, equals(2));
-        expect(restoredTvShow.currentEpisode, equals(8));
+        expect(restoredTvShow.currentSeason, equals(0));
+        expect(restoredTvShow.currentEpisode, equals(0));
+      });
+    });
+
+    // ==================== media в full export ====================
+
+    group('media в full export', () {
+      late MockCanvasRepository mockCanvasRepo;
+      late MockImageCacheService mockImageCache;
+
+      setUp(() {
+        mockCanvasRepo = MockCanvasRepository();
+        mockImageCache = MockImageCacheService();
+
+        // Стандартные моки для canvas
+        when(() => mockCanvasRepo.getViewport(any()))
+            .thenAnswer((_) async => null);
+        when(() => mockCanvasRepo.getItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+        when(() => mockCanvasRepo.getConnections(any()))
+            .thenAnswer((_) async => <CanvasConnection>[]);
+        when(() => mockCanvasRepo.getGameCanvasItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+
+        // Стандартные моки для images
+        when(() => mockImageCache.readImageBytes(any(), any()))
+            .thenAnswer((_) async => null);
+      });
+
+      test('должен включить game данные через toDb()', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const Game testGame = Game(
+          id: 42,
+          name: 'Test Game',
+          summary: 'A test game',
+          genres: <String>['Action', 'RPG'],
+          rating: 85.5,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.game,
+            externalId: 42,
+            game: testGame,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media, isNotEmpty);
+        final List<dynamic> games =
+            xcoll.media['games'] as List<dynamic>;
+        expect(games.length, equals(1));
+        final Map<String, dynamic> gameData =
+            games[0] as Map<String, dynamic>;
+        expect(gameData['id'], equals(42));
+        expect(gameData['name'], equals('Test Game'));
+        expect(gameData['genres'], equals('Action|RPG'));
+        expect(gameData.containsKey('cached_at'), isFalse);
+      });
+
+      test('должен включить movie данные через toDb()', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const Movie testMovie = Movie(
+          tmdbId: 550,
+          title: 'Fight Club',
+          overview: 'An insomniac office worker...',
+          rating: 8.4,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.movie,
+            externalId: 550,
+            platformId: null,
+            movie: testMovie,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media, isNotEmpty);
+        final List<dynamic> movies =
+            xcoll.media['movies'] as List<dynamic>;
+        expect(movies.length, equals(1));
+        final Map<String, dynamic> movieData =
+            movies[0] as Map<String, dynamic>;
+        expect(movieData['tmdb_id'], equals(550));
+        expect(movieData['title'], equals('Fight Club'));
+        expect(movieData.containsKey('cached_at'), isFalse);
+      });
+
+      test('должен включить tv_show данные через toDb()', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const TvShow testTvShow = TvShow(
+          tmdbId: 1399,
+          title: 'Game of Thrones',
+          totalSeasons: 8,
+          totalEpisodes: 73,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.tvShow,
+            externalId: 1399,
+            platformId: null,
+            tvShow: testTvShow,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media, isNotEmpty);
+        final List<dynamic> tvShows =
+            xcoll.media['tv_shows'] as List<dynamic>;
+        expect(tvShows.length, equals(1));
+        final Map<String, dynamic> tvData =
+            tvShows[0] as Map<String, dynamic>;
+        expect(tvData['tmdb_id'], equals(1399));
+        expect(tvData['title'], equals('Game of Thrones'));
+        expect(tvData.containsKey('cached_at'), isFalse);
+      });
+
+      test('должен дедуплицировать по externalId', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const Game testGame = Game(id: 42, name: 'Same Game');
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.game,
+            externalId: 42,
+            game: testGame,
+          ),
+          createTestItem(
+            id: 2,
+            mediaType: MediaType.game,
+            externalId: 42,
+            game: testGame,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        final List<dynamic> games =
+            xcoll.media['games'] as List<dynamic>;
+        expect(games.length, equals(1));
+      });
+
+      test('должен поместить animation tvShow в tv_shows', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const TvShow animTvShow = TvShow(
+          tmdbId: 999,
+          title: 'Animated Series',
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.animation,
+            externalId: 999,
+            platformId: AnimationSource.tvShow,
+            tvShow: animTvShow,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media.containsKey('games'), isFalse);
+        expect(xcoll.media.containsKey('movies'), isFalse);
+        final List<dynamic> tvShows =
+            xcoll.media['tv_shows'] as List<dynamic>;
+        expect(tvShows.length, equals(1));
+        final Map<String, dynamic> data =
+            tvShows[0] as Map<String, dynamic>;
+        expect(data['tmdb_id'], equals(999));
+      });
+
+      test('должен поместить animation movie в movies', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const Movie animMovie = Movie(
+          tmdbId: 888,
+          title: 'Animated Movie',
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.animation,
+            externalId: 888,
+            platformId: AnimationSource.movie,
+            movie: animMovie,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media.containsKey('games'), isFalse);
+        expect(xcoll.media.containsKey('tv_shows'), isFalse);
+        final List<dynamic> movies =
+            xcoll.media['movies'] as List<dynamic>;
+        expect(movies.length, equals(1));
+        final Map<String, dynamic> data =
+            movies[0] as Map<String, dynamic>;
+        expect(data['tmdb_id'], equals(888));
+      });
+
+      test('должен пропустить элементы без joined данных', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.game,
+            externalId: 42,
+            // game: null — нет joined данных
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media, isEmpty);
+      });
+
+      test('должен вернуть пустой media при пустых items', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media, isEmpty);
+      });
+
+      test('должен собрать смешанные типы медиа', () async {
+        final ExportService sutMedia = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+        );
+
+        const Game testGame = Game(id: 42, name: 'Game');
+        const Movie testMovie = Movie(tmdbId: 550, title: 'Movie');
+        const TvShow testTvShow = TvShow(tmdbId: 1399, title: 'TV');
+
+        final Collection collection = createTestCollection();
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestItem(
+            id: 1,
+            mediaType: MediaType.game,
+            externalId: 42,
+            game: testGame,
+          ),
+          createTestItem(
+            id: 2,
+            mediaType: MediaType.movie,
+            externalId: 550,
+            platformId: null,
+            movie: testMovie,
+          ),
+          createTestItem(
+            id: 3,
+            mediaType: MediaType.tvShow,
+            externalId: 1399,
+            platformId: null,
+            tvShow: testTvShow,
+          ),
+        ];
+
+        final XcollFile xcoll =
+            await sutMedia.createFullExport(collection, items, 1);
+
+        expect(xcoll.media, isNotEmpty);
+        expect((xcoll.media['games'] as List<dynamic>).length, equals(1));
+        expect((xcoll.media['movies'] as List<dynamic>).length, equals(1));
+        expect(
+            (xcoll.media['tv_shows'] as List<dynamic>).length, equals(1));
       });
     });
   });

--- a/test/core/services/import_service_test.dart
+++ b/test/core/services/import_service_test.dart
@@ -17,7 +17,6 @@ import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/game.dart';
-import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
@@ -41,9 +40,11 @@ void main() {
     registerFallbackValue(const Game(id: 0, name: 'fallback'));
     registerFallbackValue(const Movie(tmdbId: 0, title: 'fallback'));
     registerFallbackValue(const TvShow(tmdbId: 0, title: 'fallback'));
+    registerFallbackValue(const <Game>[]);
+    registerFallbackValue(const <Movie>[]);
+    registerFallbackValue(const <TvShow>[]);
     registerFallbackValue(CollectionType.own);
     registerFallbackValue(MediaType.game);
-    registerFallbackValue(ItemStatus.notStarted);
     registerFallbackValue(const CanvasViewport(collectionId: 0));
     registerFallbackValue(CanvasItem(
       id: 0,
@@ -215,7 +216,7 @@ void main() {
   "author": "Author",
   "created": "2024-01-15T12:00:00.000Z",
   "items": [
-    {"media_type": "game", "external_id": 100, "status": "completed"}
+    {"media_type": "game", "external_id": 100}
   ]
 }
 ''');
@@ -289,14 +290,12 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
               'platform_id': 48,
               'comment': 'Great game',
             },
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 200,
-              'status': 'in_progress',
             },
           ],
         );
@@ -328,7 +327,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutV2.importFromXcoll(xcoll);
@@ -345,7 +343,6 @@ void main() {
               externalId: 100,
               platformId: 48,
               authorComment: 'Great game',
-              status: ItemStatus.completed,
             )).called(1);
         verify(() => mockRepo.addItem(
               collectionId: 10,
@@ -353,7 +350,6 @@ void main() {
               externalId: 200,
               platformId: null,
               authorComment: null,
-              status: ItemStatus.inProgress,
             )).called(1);
       });
 
@@ -368,7 +364,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'movie',
               'external_id': 550,
-              'status': 'completed',
             },
           ],
         );
@@ -397,7 +392,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutV2.importFromXcoll(xcoll);
@@ -420,7 +414,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'tv_show',
               'external_id': 1399,
-              'status': 'in_progress',
               'current_season': 3,
               'current_episode': 5,
             },
@@ -452,7 +445,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutV2.importFromXcoll(xcoll);
@@ -475,17 +467,14 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
             },
             <String, dynamic>{
               'media_type': 'movie',
               'external_id': 550,
-              'status': 'completed',
             },
             <String, dynamic>{
               'media_type': 'tv_show',
               'external_id': 1399,
-              'status': 'in_progress',
             },
           ],
         );
@@ -518,7 +507,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutV2.importFromXcoll(xcoll);
@@ -542,12 +530,10 @@ void main() {
             <String, dynamic>{
               'media_type': 'movie',
               'external_id': 550,
-              'status': 'completed',
             },
             <String, dynamic>{
               'media_type': 'movie',
               'external_id': 999,
-              'status': 'not_started',
             },
           ],
         );
@@ -576,7 +562,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutV2.importFromXcoll(xcoll);
@@ -597,7 +582,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'tv_show',
               'external_id': 1399,
-              'status': 'in_progress',
             },
           ],
         );
@@ -623,7 +607,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutV2.importFromXcoll(xcoll);
@@ -643,7 +626,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
             },
           ],
         );
@@ -675,7 +657,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'movie',
               'external_id': 550,
-              'status': 'completed',
             },
           ],
         );
@@ -699,7 +680,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutNoTmdb.importFromXcoll(xcoll);
@@ -751,12 +731,10 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
             },
             <String, dynamic>{
               'media_type': 'movie',
               'external_id': 550,
-              'status': 'completed',
             },
           ],
         );
@@ -786,7 +764,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final List<ImportStage> stages = <ImportStage>[];
@@ -816,12 +793,10 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
             },
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 200,
-              'status': 'completed',
             },
           ],
         );
@@ -849,7 +824,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async {
           callCount++;
           return callCount == 1 ? 1 : null;
@@ -1272,7 +1246,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
               '_canvas': <String, dynamic>{
                 'viewport': <String, dynamic>{
                   'scale': 0.5,
@@ -1312,7 +1285,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 50); // collectionItemId = 50
         when(() => mockCanvas.saveGameCanvasViewport(any(), any()))
             .thenAnswer((_) async {});
@@ -1348,7 +1320,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
               '_canvas': <String, dynamic>{
                 'items': <Map<String, dynamic>>[
                   <String, dynamic>{
@@ -1403,7 +1374,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 51);
 
         int nextCanvasId = 200;
@@ -1453,7 +1423,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
               '_canvas': <String, dynamic>{
                 'items': <Map<String, dynamic>>[
                   <String, dynamic>{
@@ -1510,7 +1479,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 52);
 
         // createItem: export ID 10 → new ID 301, export ID 20 → new ID 302
@@ -1566,7 +1534,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
               '_canvas': <String, dynamic>{
                 'viewport': <String, dynamic>{
                   'scale': 0.5,
@@ -1606,7 +1573,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 1);
 
         final ImportResult result = await sutNoCanvas.importFromXcoll(xcoll);
@@ -1633,7 +1599,6 @@ void main() {
             <String, dynamic>{
               'media_type': 'game',
               'external_id': 100,
-              'status': 'completed',
               '_canvas': <String, dynamic>{
                 'items': <Map<String, dynamic>>[
                   <String, dynamic>{
@@ -1682,7 +1647,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 53);
 
         when(() => mockCanvas.createItem(any())).thenAnswer((Invocation inv) async {
@@ -1744,7 +1708,6 @@ void main() {
               'media_type': 'game',
               'external_id': 100,
               'platform_id': 18,
-              'status': 'not_started',
             },
           ],
           images: images,
@@ -1777,7 +1740,6 @@ void main() {
               externalId: any(named: 'externalId'),
               platformId: any(named: 'platformId'),
               authorComment: any(named: 'authorComment'),
-              status: any(named: 'status'),
             )).thenAnswer((_) async => 10);
         when(() => mockCanvas.getGameCanvasItems(any()))
             .thenAnswer((_) async => <CanvasItem>[]);
@@ -1834,7 +1796,6 @@ void main() {
               'media_type': 'game',
               'external_id': 100,
               'platform_id': 18,
-              'status': 'not_started',
             },
           ],
           images: <String, String>{'movie_posters/550': base64Data},
@@ -1938,7 +1899,6 @@ void main() {
               'media_type': 'game',
               'external_id': 100,
               'platform_id': 18,
-              'status': 'not_started',
             },
           ],
           images: <String, String>{'game_covers/100': base64Data},
@@ -1974,6 +1934,282 @@ void main() {
         );
 
         expect(stages, contains(ImportStage.importingImages));
+      });
+    });
+
+    // ==================== v2 full с embedded media ====================
+
+    group('importFromXcoll (v2 full с embedded media)', () {
+      late ImportService sutMedia;
+      late MockCanvasRepository mockCanvas;
+      late MockImageCacheService mockImageCache;
+
+      setUp(() {
+        mockCanvas = MockCanvasRepository();
+        mockImageCache = MockImageCacheService();
+        sutMedia = ImportService(
+          repository: mockRepo,
+          igdbApi: mockApi,
+          tmdbApi: mockTmdb,
+          database: mockDb,
+          canvasRepository: mockCanvas,
+          imageCacheService: mockImageCache,
+        );
+      });
+
+      void setupDefaultMocksForMedia() {
+        final Collection createdCollection = Collection(
+          id: 10,
+          name: 'Test',
+          author: 'Author',
+          type: CollectionType.imported,
+          createdAt: testDate,
+        );
+        when(() => mockRepo.create(
+              name: any(named: 'name'),
+              author: any(named: 'author'),
+              type: any(named: 'type'),
+            )).thenAnswer((_) async => createdCollection);
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              authorComment: any(named: 'authorComment'),
+            )).thenAnswer((_) async => 1);
+        when(() => mockDb.upsertGames(any())).thenAnswer((_) async {});
+        when(() => mockDb.upsertMovies(any())).thenAnswer((_) async {});
+        when(() => mockDb.upsertTvShows(any())).thenAnswer((_) async {});
+        when(() => mockImageCache.saveImageBytes(any(), any(), any()))
+            .thenAnswer((_) async => true);
+      }
+
+      test('должен восстановить games из embedded media', () async {
+        setupDefaultMocksForMedia();
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'With Media',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'game',
+              'external_id': 42,
+            },
+          ],
+          media: const <String, dynamic>{
+            'games': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'id': 42,
+                'name': 'Offline Game',
+                'summary': 'Test',
+                'genres': 'Action|RPG',
+              },
+            ],
+          },
+        );
+
+        final ImportResult result = await sutMedia.importFromXcoll(xcoll);
+
+        expect(result.success, isTrue);
+        // Должен вызвать upsertGames, а НЕ igdb API
+        verify(() => mockDb.upsertGames(any())).called(1);
+        verifyNever(() => mockApi.getGamesByIds(any()));
+      });
+
+      test('должен восстановить movies из embedded media', () async {
+        setupDefaultMocksForMedia();
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'With Movies',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'movie',
+              'external_id': 550,
+            },
+          ],
+          media: const <String, dynamic>{
+            'movies': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'tmdb_id': 550,
+                'title': 'Fight Club',
+              },
+            ],
+          },
+        );
+
+        final ImportResult result = await sutMedia.importFromXcoll(xcoll);
+
+        expect(result.success, isTrue);
+        verify(() => mockDb.upsertMovies(any())).called(1);
+        verifyNever(() => mockTmdb.getMovie(any()));
+      });
+
+      test('должен восстановить tv_shows из embedded media', () async {
+        setupDefaultMocksForMedia();
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'With TV Shows',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'tv_show',
+              'external_id': 1399,
+            },
+          ],
+          media: const <String, dynamic>{
+            'tv_shows': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'tmdb_id': 1399,
+                'title': 'Game of Thrones',
+                'total_seasons': 8,
+              },
+            ],
+          },
+        );
+
+        final ImportResult result = await sutMedia.importFromXcoll(xcoll);
+
+        expect(result.success, isTrue);
+        verify(() => mockDb.upsertTvShows(any())).called(1);
+        verifyNever(() => mockTmdb.getTvShow(any()));
+      });
+
+      test('должен восстановить все типы медиа из embedded', () async {
+        setupDefaultMocksForMedia();
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'All Types',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{'media_type': 'game', 'external_id': 1},
+            <String, dynamic>{'media_type': 'movie', 'external_id': 2},
+            <String, dynamic>{'media_type': 'tv_show', 'external_id': 3},
+          ],
+          media: const <String, dynamic>{
+            'games': <Map<String, dynamic>>[
+              <String, dynamic>{'id': 1, 'name': 'G'},
+            ],
+            'movies': <Map<String, dynamic>>[
+              <String, dynamic>{'tmdb_id': 2, 'title': 'M'},
+            ],
+            'tv_shows': <Map<String, dynamic>>[
+              <String, dynamic>{'tmdb_id': 3, 'title': 'T'},
+            ],
+          },
+        );
+
+        final ImportResult result = await sutMedia.importFromXcoll(xcoll);
+
+        expect(result.success, isTrue);
+        expect(result.itemsImported, equals(3));
+        verify(() => mockDb.upsertGames(any())).called(1);
+        verify(() => mockDb.upsertMovies(any())).called(1);
+        verify(() => mockDb.upsertTvShows(any())).called(1);
+        verifyNever(() => mockApi.getGamesByIds(any()));
+        verifyNever(() => mockTmdb.getMovie(any()));
+        verifyNever(() => mockTmdb.getTvShow(any()));
+      });
+
+      test('должен использовать API при пустом media', () async {
+        setupDefaultMocksForMedia();
+        when(() => mockApi.getGamesByIds(any()))
+            .thenAnswer((_) async => const <Game>[Game(id: 42, name: 'G')]);
+        when(() => mockDb.upsertGame(any())).thenAnswer((_) async {});
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.light,
+          name: 'No Media',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{'media_type': 'game', 'external_id': 42},
+          ],
+          // media пуст — должен загрузить из API
+        );
+
+        final ImportResult result = await sutMedia.importFromXcoll(xcoll);
+
+        expect(result.success, isTrue);
+        verify(() => mockApi.getGamesByIds(<int>[42])).called(1);
+        verifyNever(() => mockDb.upsertGames(any()));
+      });
+
+      test('должен отслеживать прогресс restoringMedia', () async {
+        setupDefaultMocksForMedia();
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'Progress',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{'media_type': 'game', 'external_id': 1},
+          ],
+          media: const <String, dynamic>{
+            'games': <Map<String, dynamic>>[
+              <String, dynamic>{'id': 1, 'name': 'G'},
+            ],
+          },
+        );
+
+        final List<ImportStage> stages = <ImportStage>[];
+        await sutMedia.importFromXcoll(
+          xcoll,
+          onProgress: (ImportProgress progress) {
+            if (!stages.contains(progress.stage)) {
+              stages.add(progress.stage);
+            }
+          },
+        );
+
+        expect(stages, contains(ImportStage.restoringMedia));
+        // Не должно быть этапов API-загрузки
+        expect(stages, isNot(contains(ImportStage.fetchingGames)));
+        expect(stages, isNot(contains(ImportStage.fetchingMovies)));
+        expect(stages, isNot(contains(ImportStage.fetchingTvShows)));
+      });
+
+      test('должен пропустить пустые категории в embedded media', () async {
+        setupDefaultMocksForMedia();
+
+        final XcollFile xcoll = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'Only Games',
+          author: 'Author',
+          created: testDate,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{'media_type': 'game', 'external_id': 1},
+          ],
+          media: const <String, dynamic>{
+            'games': <Map<String, dynamic>>[
+              <String, dynamic>{'id': 1, 'name': 'G'},
+            ],
+            // movies и tv_shows отсутствуют
+          },
+        );
+
+        final ImportResult result = await sutMedia.importFromXcoll(xcoll);
+
+        expect(result.success, isTrue);
+        verify(() => mockDb.upsertGames(any())).called(1);
+        verifyNever(() => mockDb.upsertMovies(any()));
+        verifyNever(() => mockDb.upsertTvShows(any()));
       });
     });
   });

--- a/test/shared/models/export_coverage_test.dart
+++ b/test/shared/models/export_coverage_test.dart
@@ -181,7 +181,6 @@ void main() {
       minimalExportJson: const <String, dynamic>{
         'media_type': 'game',
         'external_id': 1,
-        'status': 'not_started',
       },
     );
 

--- a/test/shared/theme/app_typography_test.dart
+++ b/test/shared/theme/app_typography_test.dart
@@ -82,14 +82,14 @@ void main() {
 
     group('Poster стили', () {
       test('posterTitle должен быть определён', () {
-        expect(AppTypography.posterTitle.fontSize, equals(14));
+        expect(AppTypography.posterTitle.fontSize, equals(12));
         expect(AppTypography.posterTitle.fontWeight, equals(FontWeight.w600));
         expect(AppTypography.posterTitle.color, equals(AppColors.textPrimary));
         expect(AppTypography.posterTitle.fontFamily, equals('Inter'));
       });
 
       test('posterSubtitle должен быть определён', () {
-        expect(AppTypography.posterSubtitle.fontSize, equals(11));
+        expect(AppTypography.posterSubtitle.fontSize, equals(10));
         expect(AppTypography.posterSubtitle.fontWeight, equals(FontWeight.w400));
         expect(AppTypography.posterSubtitle.color, equals(AppColors.textSecondary));
         expect(AppTypography.posterSubtitle.fontFamily, equals('Inter'));

--- a/test/shared/widgets/hero_collection_card_test.dart
+++ b/test/shared/widgets/hero_collection_card_test.dart
@@ -10,7 +10,10 @@ import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/collections/providers/collections_provider.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
 import 'package:xerabora/shared/theme/app_colors.dart';
 import 'package:xerabora/shared/navigation/navigation_shell.dart';
 import 'package:xerabora/shared/widgets/hero_collection_card.dart';
@@ -584,6 +587,102 @@ void main() {
           (Widget w) => w is ColoredBox && w.color == AppColors.gameAccent,
         );
         expect(accentLine, findsNothing);
+      });
+    });
+
+    group('animation ImageType', () {
+      testWidgets(
+          'animation movie должен запрашивать moviePoster из кэша',
+          (WidgetTester tester) async {
+        final Collection collection = createTestCollection();
+        const CollectionStats stats = CollectionStats(
+          total: 1,
+          completed: 1,
+          inProgress: 0,
+          notStarted: 0,
+          dropped: 0,
+          planned: 0,
+        );
+        final List<CollectionItem> items = <CollectionItem>[
+          CollectionItem(
+            id: 10,
+            collectionId: 1,
+            mediaType: MediaType.animation,
+            externalId: 401,
+            platformId: AnimationSource.movie,
+            status: ItemStatus.completed,
+            addedAt: testDate,
+            movie: const Movie(
+              tmdbId: 401,
+              title: 'Spirited Away',
+              posterUrl: 'https://example.com/spirited.jpg',
+              rating: 8.6,
+              releaseYear: 2001,
+            ),
+          ),
+        ];
+
+        await tester.pumpWidget(buildTestWidget(
+          collection: collection,
+          stats: stats,
+          items: items,
+        ));
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        verify(() => mockCacheService.getImageUri(
+              type: ImageType.moviePoster,
+              imageId: '401',
+              remoteUrl: any(named: 'remoteUrl'),
+            )).called(greaterThan(0));
+      });
+
+      testWidgets(
+          'animation tvShow должен запрашивать tvShowPoster из кэша',
+          (WidgetTester tester) async {
+        final Collection collection = createTestCollection();
+        const CollectionStats stats = CollectionStats(
+          total: 1,
+          completed: 0,
+          inProgress: 1,
+          notStarted: 0,
+          dropped: 0,
+          planned: 0,
+        );
+        final List<CollectionItem> items = <CollectionItem>[
+          CollectionItem(
+            id: 11,
+            collectionId: 1,
+            mediaType: MediaType.animation,
+            externalId: 501,
+            platformId: AnimationSource.tvShow,
+            status: ItemStatus.inProgress,
+            addedAt: testDate,
+            tvShow: const TvShow(
+              tmdbId: 501,
+              title: 'Attack on Titan',
+              posterUrl: 'https://example.com/aot.jpg',
+              rating: 8.9,
+              firstAirYear: 2013,
+            ),
+          ),
+        ];
+
+        await tester.pumpWidget(buildTestWidget(
+          collection: collection,
+          stats: stats,
+          items: items,
+        ));
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        verify(() => mockCacheService.getImageUri(
+              type: ImageType.tvShowPoster,
+              imageId: '501',
+              remoteUrl: any(named: 'remoteUrl'),
+            )).called(greaterThan(0));
       });
     });
   });


### PR DESCRIPTION
- Remove status/current_season/current_episode from export (personal data)
- Add embedded media section to full export (.xcollx) for offline import
- Fix animation ImageType: tvShow animations now use tvShowPoster in UI
- Remove API key requirement for app startup (only search needs keys)
- Add search unavailable screen when API keys not configured
- Improve settings: wider save buttons, empty key validation
- Reduce font sizes by 2px for better Android display