### PR TITLE
Add filter chip counters, tv_episodes export, always-show export dialog, fix animation ImageType

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -27,7 +27,7 @@ Create unlimited collections organized however you want:
 - Personal lists (Backlog, Completed, Favorites...)
 - Mix games, movies and TV shows in a single collection
 - **Grid mode** — toggle between list and poster grid view; choice is saved per-collection and restored on next open
-- **Type filter** — filter items by type (All/Games/Movies/TV Shows/Animation)
+- **Type filter** — filter items by type (All/Games/Movies/TV Shows/Animation) with item count badges on each chip
 - **Search** — filter items by name within a collection
 
 ## Universal Search
@@ -135,7 +135,8 @@ Sort mode is saved per collection and persists between sessions. A compact sort 
 Track your viewing progress for TV shows and animated series at the episode level:
 - **Episode Progress bar** — shows overall watched/total count with a LinearProgressIndicator
 - **Season sections** — ExpansionTile for each season with watched count badge
-- **Lazy loading** — episodes are fetched from TMDB API only when a season is expanded (cached in SQLite for offline access)
+- **Season preloading** — when adding a TV show or animated series to a collection, all seasons are automatically fetched and cached in SQLite (fire-and-forget, non-blocking)
+- **Lazy episode loading** — episodes are fetched from TMDB API only when a season is expanded (cached in SQLite for offline access)
 - **Per-episode checkboxes** — mark individual episodes as watched/unwatched with CheckboxListTile; watched date displayed in subtitle
 - **Bulk actions** — "Mark all" / "Unmark all" button per season to toggle all episodes at once
 - **Auto-complete** — when all episodes are watched, the show's status is automatically set to Completed (compares against total episode count from show metadata)
@@ -197,8 +198,10 @@ Export collections in three formats:
 - Canvas data (viewport, items, connections) including per-item canvases
 - Base64-encoded cover images (game covers, movie/TV show posters)
 - Base64-encoded canvas images (images added to canvas boards)
-- Embedded media data (Game/Movie/TvShow) for fully offline import — no IGDB/TMDB API calls needed
-- Self-contained — recipients can import without internet (all data, covers, and canvas images included)
+- Embedded media data (Game/Movie/TvShow/TvSeason/TvEpisode) for fully offline import — no IGDB/TMDB API calls needed
+- TV show seasons are preloaded into cache when adding a TV show or animated series to a collection, ensuring they're available for export
+- All episodes for each season are included in the export for complete offline access
+- Self-contained — recipients can import without internet (all data, covers, canvas images, seasons, and episodes included)
 
 ## Forking
 

--- a/docs/RCOLL_FORMAT.md
+++ b/docs/RCOLL_FORMAT.md
@@ -105,6 +105,12 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
     ],
     "tv_shows": [
       { "tmdb_id": 1399, "title": "TV Show", "total_seasons": 8, "total_episodes": 73, "genres": "[\"Drama\"]", ... }
+    ],
+    "tv_seasons": [
+      { "tmdb_show_id": 1399, "season_number": 1, "name": "Season 1", "episode_count": 10, "poster_url": "https://image.tmdb.org/t/p/w500/...", "air_date": "2011-04-17" }
+    ],
+    "tv_episodes": [
+      { "tmdb_show_id": 1399, "season_number": 1, "episode_number": 1, "name": "Winter Is Coming", "overview": "...", "air_date": "2011-04-17", "still_url": "https://image.tmdb.org/t/p/w300/...", "runtime": 62 }
     ]
   }
 }
@@ -123,7 +129,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 | items | array | yes | List of collection items |
 | canvas | object | no | Collection-level canvas (full only) |
 | images | object | no | Base64 cover images (full only) |
-| media | object | no | Embedded Game/Movie/TvShow data for offline import (full only) |
+| media | object | no | Embedded Game/Movie/TvShow/TvSeason/TvEpisode data for offline import (full only) |
 
 ### Item Object
 
@@ -159,17 +165,19 @@ Values are base64-encoded PNG image data.
 
 ### Media Object
 
-Contains full Game/Movie/TvShow data for offline import. Each entry uses the same format as the corresponding model's `toDb()` output (without `cached_at`).
+Contains full Game/Movie/TvShow/TvSeason/TvEpisode data for offline import. Each entry uses the same format as the corresponding model's `toDb()` output (without `cached_at`).
 
 | Field | Type | Description |
 |-------|------|-------------|
 | games | array | Game objects from IGDB (id, name, summary, cover_url, genres, rating, ...) |
 | movies | array | Movie objects from TMDB (tmdb_id, title, overview, poster_url, genres, runtime, ...) |
 | tv_shows | array | TvShow objects from TMDB (tmdb_id, title, total_seasons, total_episodes, genres, ...) |
+| tv_seasons | array | TvSeason objects from TMDB (tmdb_show_id, season_number, name, episode_count, poster_url, air_date) |
+| tv_episodes | array | TvEpisode objects from TMDB (tmdb_show_id, season_number, episode_number, name, overview, air_date, still_url, runtime) |
 
-All three arrays are optional — only non-empty categories are included. Animation items are stored in `movies` (animated films) or `tv_shows` (animated series) based on their `AnimationSource`.
+All five arrays are optional — only non-empty categories are included. Animation items are stored in `movies` (animated films) or `tv_shows` (animated series) based on their `AnimationSource`. Seasons are preloaded when a TV show or animation series is added to a collection. Episodes are included from the local cache for each TV show in the collection.
 
-When `media` is present during import, data is restored directly from the file via `fromDb()` — no API calls to IGDB/TMDB are needed. When `media` is absent (light export or older full exports), the app fetches data from APIs as before.
+When `media` is present during import, data is restored directly from the file via `fromDb()` — no API calls to IGDB/TMDB are needed. TV seasons and episodes are also restored if present. When `media` is absent (light export or older full exports), the app fetches data from APIs as before.
 
 ---
 
@@ -181,7 +189,7 @@ When `media` is present during import, data is restored directly from the file v
 3. Fetches full game/movie/TV data from IGDB/TMDB using IDs
 
 ### v2 Full (`.xcollx`)
-1. If `media` section is present — restores Game/Movie/TvShow data from embedded data (offline)
+1. If `media` section is present — restores Game/Movie/TvShow/TvSeason/TvEpisode data from embedded data (offline)
 2. If `media` section is absent — fetches data from IGDB/TMDB APIs (online, same as light import)
 3. Creates collection and inserts items with metadata
 4. Restores collection-level canvas (viewport, items, connections)

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -877,6 +877,18 @@ class DatabaseService {
 
   // ==================== TV Episodes Cache ====================
 
+  /// Возвращает все эпизоды сериала из кеша.
+  Future<List<TvEpisode>> getEpisodesByShowId(int showId) async {
+    final Database db = await database;
+    final List<Map<String, dynamic>> rows = await db.query(
+      'tv_episodes_cache',
+      where: 'tmdb_show_id = ?',
+      whereArgs: <Object?>[showId],
+      orderBy: 'season_number ASC, episode_number ASC',
+    );
+    return rows.map(TvEpisode.fromDb).toList();
+  }
+
   /// Возвращает эпизоды сезона сериала из кеша.
   Future<List<TvEpisode>> getEpisodesByShowAndSeason(
     int showId,

--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -141,6 +141,17 @@ class ImageCacheService {
     return File(path).existsSync();
   }
 
+  /// Удаляет изображение из кэша.
+  ///
+  /// Безопасно обрабатывает блокировку файла на Windows.
+  Future<void> deleteImage(ImageType type, String imageId) async {
+    final String path = await getLocalImagePath(type, imageId);
+    final File file = File(path);
+    if (file.existsSync()) {
+      await _tryDelete(file);
+    }
+  }
+
   /// Возвращает результат получения изображения.
   ///
   /// Логика:

--- a/lib/core/services/xcoll_file.dart
+++ b/lib/core/services/xcoll_file.dart
@@ -238,7 +238,7 @@ class XcollFile {
 
   /// Полные данные медиа-объектов (только full export).
   ///
-  /// Структура: `{games: [...], movies: [...], tv_shows: [...]}`.
+  /// Структура: `{games: [...], movies: [...], tv_shows: [...], tv_seasons: [...], tv_episodes: [...]}`.
   /// Каждый элемент — Map в формате `toDb()` соответствующей модели.
   final Map<String, dynamic> media;
 

--- a/lib/features/collections/widgets/canvas_media_card.dart
+++ b/lib/features/collections/widgets/canvas_media_card.dart
@@ -90,6 +90,9 @@ class CanvasMediaCard extends ConsumerWidget {
       case CanvasItemType.tvShow:
         return ImageType.tvShowPoster;
       case CanvasItemType.animation:
+        if (item.tvShow != null) {
+          return ImageType.tvShowPoster;
+        }
         return ImageType.moviePoster;
       case CanvasItemType.game:
       case CanvasItemType.text:

--- a/test/features/collections/widgets/canvas_media_card_test.dart
+++ b/test/features/collections/widgets/canvas_media_card_test.dart
@@ -377,6 +377,130 @@ void main() {
       );
     });
 
+    group('Карточка анимации', () {
+      CanvasItem createAnimationItem({
+        Movie? movie,
+        TvShow? tvShow,
+      }) {
+        return CanvasItem(
+          id: 3,
+          collectionId: 10,
+          itemType: CanvasItemType.animation,
+          itemRefId: 400,
+          x: 0,
+          y: 0,
+          width: 160,
+          height: 220,
+          zIndex: 0,
+          createdAt: testDate,
+          movie: movie,
+          tvShow: tvShow,
+        );
+      }
+
+      testWidgets(
+        'animation movie использует ImageType.moviePoster для кэша',
+        (WidgetTester tester) async {
+          final CanvasItem item = createAnimationItem(
+            movie: const Movie(
+              tmdbId: 400,
+              title: 'Spirited Away',
+              posterUrl: 'https://image.tmdb.org/t/p/w500/spirited.jpg',
+            ),
+          );
+
+          await tester.pumpWidget(buildTestWidget(item));
+          await tester.pump();
+
+          final CachedImage cachedImage = tester.widget<CachedImage>(
+            find.byType(CachedImage),
+          );
+          expect(cachedImage.imageType, ImageType.moviePoster);
+          expect(cachedImage.imageId, '400');
+        },
+      );
+
+      testWidgets(
+        'animation tvShow использует ImageType.tvShowPoster для кэша',
+        (WidgetTester tester) async {
+          final CanvasItem item = createAnimationItem(
+            tvShow: const TvShow(
+              tmdbId: 500,
+              title: 'Avatar: The Last Airbender',
+              posterUrl: 'https://image.tmdb.org/t/p/w500/avatar.jpg',
+            ),
+          );
+
+          await tester.pumpWidget(buildTestWidget(item));
+          await tester.pump();
+
+          final CachedImage cachedImage = tester.widget<CachedImage>(
+            find.byType(CachedImage),
+          );
+          expect(cachedImage.imageType, ImageType.tvShowPoster);
+          expect(cachedImage.imageId, '500');
+        },
+      );
+
+      testWidgets(
+        'отображает название анимации когда movie задан',
+        (WidgetTester tester) async {
+          final CanvasItem item = createAnimationItem(
+            movie: const Movie(
+              tmdbId: 400,
+              title: 'Spirited Away',
+            ),
+          );
+
+          await tester.pumpWidget(buildTestWidget(item));
+
+          expect(find.text('Spirited Away'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'отображает название анимации когда tvShow задан',
+        (WidgetTester tester) async {
+          final CanvasItem item = createAnimationItem(
+            tvShow: const TvShow(
+              tmdbId: 500,
+              title: 'Avatar: The Last Airbender',
+            ),
+          );
+
+          await tester.pumpWidget(buildTestWidget(item));
+
+          expect(find.text('Avatar: The Last Airbender'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'отображает "Unknown Animation" когда нет данных',
+        (WidgetTester tester) async {
+          final CanvasItem item = createAnimationItem();
+
+          await tester.pumpWidget(buildTestWidget(item));
+
+          expect(find.text('Unknown Animation'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'отображает иконку анимации и бордер',
+        (WidgetTester tester) async {
+          final CanvasItem item = createAnimationItem();
+
+          await tester.pumpWidget(buildTestWidget(item));
+
+          expect(find.byIcon(Icons.animation), findsOneWidget);
+          final Card card = tester.widget<Card>(find.byType(Card));
+          final RoundedRectangleBorder shape =
+              card.shape! as RoundedRectangleBorder;
+          expect(shape.side.color, MediaTypeTheme.animationColor);
+        },
+      );
+    });
+
     group('Цветные бордеры', () {
       testWidgets(
         'должен отображать красный бордер для фильмов (movieColor)',


### PR DESCRIPTION


- Add item count badges on filter chips (All/Games/Movies/TV Shows/Animation)
- Add tv_episodes to full .xcollx export and import for complete offline access
- Always show export format dialog (Light/Full) regardless of canvas data
- Fix animation ImageType: tvShow animations use tvShowPoster in list and canvas
- Preload TV seasons on add (fire-and-forget) for export readiness
- Fix corrupt cached image handling with _corruptHandled guard and re-download
- Add DatabaseService.getEpisodesByShowId() and parallel Future.wait in export
- Add ImageCacheService.deleteImage() for corrupt file cleanup