### PR TITLE
Improve Android landscape UX and reduce desktop card sizes

### DIFF
--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -85,7 +85,7 @@ class ImageCacheService {
   /// Возвращает включено ли кэширование.
   Future<bool> isCacheEnabled() async {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_CacheKeys.cacheEnabled) ?? false;
+    return prefs.getBool(_CacheKeys.cacheEnabled) ?? true;
   }
 
   /// Устанавливает состояние кэширования.

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/import_service.dart';
+import '../../../shared/constants/platform_features.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_assets.dart';
 import '../../../shared/theme/app_colors.dart';
@@ -26,22 +27,24 @@ class HomeScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<List<Collection>> collectionsAsync =
         ref.watch(collectionsProvider);
+    final bool isLandscape = isLandscapeMobile(context);
 
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
         backgroundColor: AppColors.background,
         surfaceTintColor: Colors.transparent,
-        title: const Text('Collections', style: AppTypography.h1),
+        toolbarHeight: isLandscape ? 40 : kToolbarHeight,
+        title: isLandscape ? null : const Text('Collections', style: AppTypography.h1),
         actions: <Widget>[
           IconButton(
-            icon: const Icon(Icons.add),
+            icon: Icon(Icons.add, size: isLandscape ? 20 : null),
             color: AppColors.textSecondary,
             tooltip: 'New Collection',
             onPressed: () => _createCollection(context, ref),
           ),
           IconButton(
-            icon: const Icon(Icons.file_download_outlined),
+            icon: Icon(Icons.file_download_outlined, size: isLandscape ? 20 : null),
             color: AppColors.textSecondary,
             tooltip: 'Import Collection',
             onPressed: () => _importCollection(context, ref),
@@ -101,13 +104,15 @@ class HomeScreen extends ConsumerWidget {
     final List<Collection> tileCollections =
         ownCollections.skip(_maxHeroCards).toList();
 
+    final bool isLandscape = isLandscapeMobile(context);
+
     return RefreshIndicator(
       onRefresh: () => ref.read(collectionsProvider.notifier).refresh(),
       child: ListView(
-        padding: const EdgeInsets.only(
-          left: AppSpacing.md,
-          right: AppSpacing.md,
-          bottom: 80,
+        padding: EdgeInsets.only(
+          left: isLandscape ? AppSpacing.sm : AppSpacing.md,
+          right: isLandscape ? AppSpacing.sm : AppSpacing.md,
+          bottom: isLandscape ? 40 : 80,
         ),
         children: <Widget>[
           // Hero-карточки (первые 3 own коллекции)
@@ -515,6 +520,7 @@ class _ImportProgressDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      scrollable: true,
       title: const Text('Importing Collection'),
       content: ValueListenableBuilder<ImportProgress?>(
         valueListenable: progressNotifier,

--- a/lib/features/collections/widgets/canvas_context_menu.dart
+++ b/lib/features/collections/widgets/canvas_context_menu.dart
@@ -261,6 +261,7 @@ class CanvasContextMenu {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
+          scrollable: true,
           title: const Text('Delete element'),
           content: const Text(
             'Are you sure you want to delete this element?',

--- a/lib/features/collections/widgets/canvas_view.dart
+++ b/lib/features/collections/widgets/canvas_view.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -90,7 +88,7 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
   }
 
   /// Минимальный зум.
-  static const double _minScale = 0.3;
+  static const double _minScale = 0.1;
 
   /// Максимальный зум.
   static const double _maxScale = 3.0;
@@ -203,7 +201,9 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
 
     // На десктопе не уменьшаем ниже 1.0, на мобильных — ограничиваем
     // минимальным масштабом InteractiveViewer.
-    final bool isMobile = Platform.isAndroid || Platform.isIOS;
+    final bool isMobile = kIsMobile;
+    // На мобильных отдаляем камеру в 5 раз, чтобы видеть все элементы.
+    if (isMobile) scale /= 5;
     final double minFitScale = isMobile ? _minScale : 1.0;
     scale = scale.clamp(minFitScale, _maxScale);
 
@@ -936,7 +936,7 @@ class _DraggableCanvasItemState extends ConsumerState<_DraggableCanvasItem> {
   static const double _maxItemSize = 2000;
 
   /// Мобильная платформа (тач вместо мыши, слабее GPU).
-  static final bool _isMobile = Platform.isAndroid || Platform.isIOS;
+  static final bool _isMobile = kIsMobile;
 
   /// Размер resize handle (больше на мобильных для удобства тач-ввода).
   static final double _handleSize = _isMobile ? 24 : 14;

--- a/lib/features/collections/widgets/create_collection_dialog.dart
+++ b/lib/features/collections/widgets/create_collection_dialog.dart
@@ -88,50 +88,49 @@ class _CreateCollectionDialogState extends State<CreateCollectionDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('New Collection'),
+      scrollable: true,
       content: Form(
         key: _formKey,
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              TextFormField(
-                controller: _nameController,
-                focusNode: _nameFocus,
-                decoration: const InputDecoration(
-                  labelText: 'Collection Name',
-                  hintText: 'e.g., SNES Classics',
-                  border: OutlineInputBorder(),
-                ),
-                textInputAction: TextInputAction.next,
-                validator: (String? value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return 'Please enter a name';
-                  }
-                  if (value.trim().length < 2) {
-                    return 'Name must be at least 2 characters';
-                  }
-                  return null;
-                },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            TextFormField(
+              controller: _nameController,
+              focusNode: _nameFocus,
+              decoration: const InputDecoration(
+                labelText: 'Collection Name',
+                hintText: 'e.g., SNES Classics',
+                border: OutlineInputBorder(),
               ),
-              const SizedBox(height: AppSpacing.md),
-              TextFormField(
-                controller: _authorController,
-                decoration: const InputDecoration(
-                  labelText: 'Author',
-                  hintText: 'Your name or username',
-                  border: OutlineInputBorder(),
-                ),
-                textInputAction: TextInputAction.done,
-                onFieldSubmitted: (_) => _submit(),
-                validator: (String? value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return 'Please enter an author name';
-                  }
-                  return null;
-                },
+              textInputAction: TextInputAction.next,
+              validator: (String? value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Please enter a name';
+                }
+                if (value.trim().length < 2) {
+                  return 'Name must be at least 2 characters';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: AppSpacing.md),
+            TextFormField(
+              controller: _authorController,
+              decoration: const InputDecoration(
+                labelText: 'Author',
+                hintText: 'Your name or username',
+                border: OutlineInputBorder(),
               ),
-            ],
-          ),
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) => _submit(),
+              validator: (String? value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Please enter an author name';
+                }
+                return null;
+              },
+            ),
+          ],
         ),
       ),
       actions: <Widget>[
@@ -208,6 +207,7 @@ class _RenameCollectionDialogState extends State<RenameCollectionDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Rename Collection'),
+      scrollable: true,
       content: Form(
         key: _formKey,
         child: TextFormField(
@@ -270,6 +270,7 @@ class DeleteCollectionDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Delete Collection?'),
+      scrollable: true,
       content: RichText(
         text: TextSpan(
           style: AppTypography.body,

--- a/lib/features/collections/widgets/dialogs/add_image_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/add_image_dialog.dart
@@ -129,6 +129,7 @@ class _AddImageDialogState extends State<AddImageDialog> {
     final ThemeData theme = Theme.of(context);
 
     return AlertDialog(
+      scrollable: true,
       title: Text(_isEditing ? 'Edit Image' : 'Add Image'),
       content: SizedBox(
         width: 400,

--- a/lib/features/collections/widgets/dialogs/add_link_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/add_link_dialog.dart
@@ -80,6 +80,7 @@ class _AddLinkDialogState extends State<AddLinkDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      scrollable: true,
       title: Text(_isEditing ? 'Edit Link' : 'Add Link'),
       content: SizedBox(
         width: 400,

--- a/lib/features/collections/widgets/dialogs/add_text_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/add_text_dialog.dart
@@ -94,6 +94,7 @@ class _AddTextDialogState extends State<AddTextDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      scrollable: true,
       title: Text(_isEditing ? 'Edit Text' : 'Add Text'),
       content: SizedBox(
         width: 400,

--- a/lib/features/collections/widgets/dialogs/edit_connection_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/edit_connection_dialog.dart
@@ -112,6 +112,7 @@ class _EditConnectionDialogState extends State<EditConnectionDialog> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      scrollable: true,
       title: const Text('Edit Connection'),
       content: SizedBox(
         width: 400,

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -2,6 +2,8 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../shared/constants/platform_features.dart';
+
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../../core/services/image_cache_service.dart';
@@ -220,6 +222,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   }
 
   Widget _buildMediaFilterBar(MediaSearchState searchState) {
+    final bool isLandscape = isLandscapeMobile(context);
     final int filterCount = (searchState.selectedYear != null ? 1 : 0) +
         searchState.selectedGenreIds.length;
     final String buttonLabel = filterCount == 0
@@ -231,17 +234,28 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
       children: <Widget>[
         SizedBox(
           width: double.infinity,
+          height: isLandscape ? 30 : null,
           child: OutlinedButton.icon(
             onPressed: _showMediaFilterSheet,
-            icon: const Icon(Icons.filter_list),
-            label: Text(buttonLabel),
+            icon: Icon(Icons.filter_list, size: isLandscape ? 14 : null),
+            label: Text(
+              buttonLabel,
+              style: isLandscape ? AppTypography.caption : null,
+            ),
+            style: isLandscape
+                ? OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                    ),
+                  )
+                : null,
           ),
         ),
         if (searchState.hasFilters) ...<Widget>[
-          const SizedBox(height: AppSpacing.sm),
+          SizedBox(height: isLandscape ? AppSpacing.xs : AppSpacing.sm),
           _buildMediaFilterChips(searchState),
         ],
-        const SizedBox(height: AppSpacing.sm),
+        SizedBox(height: isLandscape ? AppSpacing.xs : AppSpacing.sm),
       ],
     );
   }
@@ -595,6 +609,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     return showDialog<Collection>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
+        scrollable: true,
         title: const Text('Add to Collection'),
         content: SizedBox(
           width: double.maxFinite,
@@ -640,6 +655,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     return showDialog<int>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
+        scrollable: true,
         title: const Text('Select Platform'),
         content: SingleChildScrollView(
           child: Column(
@@ -736,6 +752,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   @override
   Widget build(BuildContext context) {
     final bool isApiReady = ref.watch(hasValidApiKeyProvider);
+    final bool isLandscape = isLandscapeMobile(context);
 
     if (!isApiReady) {
       return Scaffold(
@@ -744,7 +761,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           backgroundColor: AppColors.background,
           surfaceTintColor: Colors.transparent,
           foregroundColor: AppColors.textPrimary,
-          title: const Text('Search'),
+          title: isLandscape ? null : const Text('Search'),
         ),
         body: Center(
           child: Padding(
@@ -754,7 +771,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               children: <Widget>[
                 Icon(
                   Icons.search_off,
-                  size: 64,
+                  size: isLandscape ? 40 : 64,
                   color: AppColors.textTertiary.withAlpha(100),
                 ),
                 const SizedBox(height: AppSpacing.md),
@@ -781,63 +798,119 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
     return Scaffold(
       backgroundColor: AppColors.background,
+      resizeToAvoidBottomInset: !isLandscape,
       appBar: AppBar(
         backgroundColor: AppColors.background,
         surfaceTintColor: Colors.transparent,
         foregroundColor: AppColors.textPrimary,
-        title: const Text('Search'),
+        title: isLandscape ? null : const Text('Search'),
+        toolbarHeight: isLandscape ? 0 : kToolbarHeight,
         bottom: TabBar(
           controller: _tabController,
           isScrollable: true,
           tabAlignment: TabAlignment.start,
-          tabs: const <Widget>[
-            Tab(icon: Icon(Icons.videogame_asset), text: 'Games'),
-            Tab(icon: Icon(Icons.movie), text: 'Movies'),
-            Tab(icon: Icon(Icons.tv), text: 'TV Shows'),
-            Tab(icon: Icon(Icons.animation), text: 'Animation'),
-          ],
+          labelPadding: isLandscape
+              ? const EdgeInsets.symmetric(horizontal: AppSpacing.sm)
+              : null,
+          tabs: isLandscape
+              ? const <Widget>[
+                  Tab(icon: Icon(Icons.videogame_asset, size: 18)),
+                  Tab(icon: Icon(Icons.movie, size: 18)),
+                  Tab(icon: Icon(Icons.tv, size: 18)),
+                  Tab(icon: Icon(Icons.animation, size: 18)),
+                ]
+              : const <Widget>[
+                  Tab(icon: Icon(Icons.videogame_asset), text: 'Games'),
+                  Tab(icon: Icon(Icons.movie), text: 'Movies'),
+                  Tab(icon: Icon(Icons.tv), text: 'TV Shows'),
+                  Tab(icon: Icon(Icons.animation), text: 'Animation'),
+                ],
         ),
       ),
       body: Column(
         children: <Widget>[
           // Поле поиска
           Padding(
-            padding: const EdgeInsets.all(AppSpacing.md),
+            padding: isLandscape
+                ? const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.sm,
+                    vertical: AppSpacing.xs,
+                  )
+                : const EdgeInsets.all(AppSpacing.md),
             child: Row(
-              children: <Widget>[
-                Expanded(
-                  child: TextField(
-                    controller: _searchController,
-                    focusNode: _searchFocus,
-                    decoration: InputDecoration(
-                      hintText: _searchHint,
-                      prefixIcon: const Icon(Icons.search),
-                      suffixIcon: _searchController.text.isNotEmpty
-                          ? IconButton(
-                              icon: const Icon(Icons.clear),
-                              onPressed: _onClearSearch,
-                            )
-                          : null,
-                      border: const OutlineInputBorder(),
+                children: <Widget>[
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      focusNode: _searchFocus,
+                      style: isLandscape ? AppTypography.bodySmall : null,
+                      decoration: InputDecoration(
+                        hintText: _searchHint,
+                        prefixIcon: Icon(
+                          Icons.search,
+                          size: isLandscape ? 18 : null,
+                        ),
+                        prefixIconConstraints: isLandscape
+                            ? const BoxConstraints(
+                                minWidth: 32,
+                                minHeight: 32,
+                              )
+                            : null,
+                        suffixIcon: _searchController.text.isNotEmpty
+                            ? IconButton(
+                                icon: Icon(
+                                  Icons.clear,
+                                  size: isLandscape ? 16 : null,
+                                ),
+                                onPressed: _onClearSearch,
+                              )
+                            : null,
+                        suffixIconConstraints: isLandscape
+                            ? const BoxConstraints(
+                                minWidth: 32,
+                                minHeight: 32,
+                              )
+                            : null,
+                        border: const OutlineInputBorder(),
+                        isDense: isLandscape,
+                        contentPadding: isLandscape
+                            ? const EdgeInsets.symmetric(
+                                horizontal: AppSpacing.sm,
+                                vertical: AppSpacing.xs,
+                              )
+                            : null,
+                      ),
+                      textInputAction: TextInputAction.search,
+                      onSubmitted: (_) => _onSearchSubmit(),
                     ),
-                    textInputAction: TextInputAction.search,
-                    onSubmitted: (_) => _onSearchSubmit(),
                   ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                FilledButton(
-                  onPressed: _searchController.text.length >= 2
-                      ? _onSearchSubmit
-                      : null,
-                  style: FilledButton.styleFrom(
-                    minimumSize: const Size(48, 48),
-                    padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-                  ),
-                  child: const Text('Search'),
-                ),
-              ],
+                  const SizedBox(width: AppSpacing.sm),
+                  isLandscape
+                      ? IconButton.filled(
+                          onPressed: _searchController.text.length >= 2
+                              ? _onSearchSubmit
+                              : null,
+                          icon: const Icon(Icons.search, size: 18),
+                          style: IconButton.styleFrom(
+                            minimumSize: const Size(36, 36),
+                            padding: EdgeInsets.zero,
+                          ),
+                        )
+                      : FilledButton(
+                          onPressed: _searchController.text.length >= 2
+                              ? _onSearchSubmit
+                              : null,
+                          style: FilledButton.styleFrom(
+                            minimumSize: const Size(48, 48),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: AppSpacing.md,
+                            ),
+                          ),
+                          child: const Text('Search'),
+                        ),
+                ],
+              ),
             ),
-          ),
 
           // Контент табов
           Expanded(
@@ -875,7 +948,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
   int get _gridCrossAxisCount {
     final double screenWidth = MediaQuery.sizeOf(context).width;
+    final bool isLandscape = isLandscapeMobile(context);
     if (screenWidth >= navigationBreakpoint) {
+      return AppSpacing.gridColumnsDesktop;
+    } else if (isLandscape) {
+      // Ландшафт мобильный — больше колонок
       return AppSpacing.gridColumnsDesktop;
     } else if (screenWidth >= 500) {
       return AppSpacing.gridColumnsTablet;
@@ -883,13 +960,23 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     return AppSpacing.gridColumnsMobile;
   }
 
+  /// Отступ и расстояния в гриде, уменьшенные в ландшафте.
+  double get _gridPadding =>
+      isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.md;
+
+  double get _gridCrossAxisSpacing =>
+      isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.md;
+
+  double get _gridMainAxisSpacing =>
+      isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.lg;
+
   Widget _buildShimmerGrid() {
     return GridView.builder(
-      padding: const EdgeInsets.all(AppSpacing.md),
+      padding: EdgeInsets.all(_gridPadding),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _gridCrossAxisCount,
-        crossAxisSpacing: AppSpacing.md,
-        mainAxisSpacing: AppSpacing.lg,
+        crossAxisSpacing: _gridCrossAxisSpacing,
+        mainAxisSpacing: _gridMainAxisSpacing,
         childAspectRatio: 0.55,
       ),
       itemCount: _gridCrossAxisCount * 2,
@@ -903,19 +990,21 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
   Widget _buildGamesTab() {
     final GameSearchState searchState = ref.watch(gameSearchProvider);
+    final double hPadding =
+        isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.md;
 
     return Column(
       children: <Widget>[
         // Фильтр по платформе (только для игр)
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          padding: EdgeInsets.symmetric(horizontal: hPadding),
           child: _buildPlatformFilter(searchState),
         ),
 
         // Сортировка (только когда есть результаты)
         if (searchState.hasResults)
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+            padding: EdgeInsets.symmetric(horizontal: hPadding),
             child: SortSelector(
               currentSort: searchState.currentSort,
               onChanged: (SearchSort sort) {
@@ -932,10 +1021,12 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   }
 
   Widget _buildPlatformFilter(GameSearchState searchState) {
+    final bool isLandscape = isLandscapeMobile(context);
+
     if (_platformsLoading) {
-      return const SizedBox(
-        height: 48,
-        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      return SizedBox(
+        height: isLandscape ? 32 : 48,
+        child: const Center(child: CircularProgressIndicator(strokeWidth: 2)),
       );
     }
 
@@ -953,17 +1044,28 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
       children: <Widget>[
         SizedBox(
           width: double.infinity,
+          height: isLandscape ? 30 : null,
           child: OutlinedButton.icon(
             onPressed: _showPlatformFilterSheet,
-            icon: const Icon(Icons.filter_list),
-            label: Text(buttonLabel),
+            icon: Icon(Icons.filter_list, size: isLandscape ? 14 : null),
+            label: Text(
+              buttonLabel,
+              style: isLandscape ? AppTypography.caption : null,
+            ),
+            style: isLandscape
+                ? OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                    ),
+                  )
+                : null,
           ),
         ),
         if (searchState.selectedPlatformIds.isNotEmpty) ...<Widget>[
-          const SizedBox(height: AppSpacing.sm),
+          SizedBox(height: isLandscape ? AppSpacing.xs : AppSpacing.sm),
           _buildSelectedPlatformChips(searchState.selectedPlatformIds),
         ],
-        const SizedBox(height: AppSpacing.sm),
+        SizedBox(height: isLandscape ? AppSpacing.xs : AppSpacing.sm),
       ],
     );
   }
@@ -1010,11 +1112,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             <int, List<CollectedItemInfo>>{};
 
     return GridView.builder(
-      padding: const EdgeInsets.all(AppSpacing.md),
+      padding: EdgeInsets.all(_gridPadding),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _gridCrossAxisCount,
-        crossAxisSpacing: AppSpacing.md,
-        mainAxisSpacing: AppSpacing.lg,
+        crossAxisSpacing: _gridCrossAxisSpacing,
+        mainAxisSpacing: _gridMainAxisSpacing,
         childAspectRatio: 0.55,
       ),
       itemCount: searchState.results.length,
@@ -1031,6 +1133,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           year: game.releaseYear,
           subtitle: game.genres?.take(2).join(', '),
           isInCollection: infos != null && infos.isNotEmpty,
+          compact: isLandscapeMobile(context),
           onTap: () => _onGameTap(game),
         );
       },
@@ -1041,19 +1144,21 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
   Widget _buildMoviesTab() {
     final MediaSearchState searchState = ref.watch(mediaSearchProvider);
+    final double hPadding =
+        isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.md;
 
     return Column(
       children: <Widget>[
         // Фильтры медиа
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          padding: EdgeInsets.symmetric(horizontal: hPadding),
           child: _buildMediaFilterBar(searchState),
         ),
 
         // Сортировка (только когда есть результаты)
         if (searchState.movieResults.isNotEmpty)
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+            padding: EdgeInsets.symmetric(horizontal: hPadding),
             child: SortSelector(
               currentSort: searchState.currentSort,
               onChanged: (SearchSort sort) {
@@ -1097,11 +1202,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             <int, List<CollectedItemInfo>>{};
 
     return GridView.builder(
-      padding: const EdgeInsets.all(AppSpacing.md),
+      padding: EdgeInsets.all(_gridPadding),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _gridCrossAxisCount,
-        crossAxisSpacing: AppSpacing.md,
-        mainAxisSpacing: AppSpacing.lg,
+        crossAxisSpacing: _gridCrossAxisSpacing,
+        mainAxisSpacing: _gridMainAxisSpacing,
         childAspectRatio: 0.55,
       ),
       itemCount: searchState.movieResults.length,
@@ -1119,6 +1224,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           year: movie.releaseYear,
           subtitle: movie.genres?.take(2).join(', '),
           isInCollection: infos != null && infos.isNotEmpty,
+          compact: isLandscapeMobile(context),
           onTap: () => _onMovieTap(movie),
         );
       },
@@ -1129,19 +1235,21 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
   Widget _buildTvShowsTab() {
     final MediaSearchState searchState = ref.watch(mediaSearchProvider);
+    final double hPadding =
+        isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.md;
 
     return Column(
       children: <Widget>[
         // Фильтры медиа
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          padding: EdgeInsets.symmetric(horizontal: hPadding),
           child: _buildMediaFilterBar(searchState),
         ),
 
         // Сортировка (только когда есть результаты)
         if (searchState.tvShowResults.isNotEmpty)
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+            padding: EdgeInsets.symmetric(horizontal: hPadding),
             child: SortSelector(
               currentSort: searchState.currentSort,
               onChanged: (SearchSort sort) {
@@ -1185,11 +1293,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             <int, List<CollectedItemInfo>>{};
 
     return GridView.builder(
-      padding: const EdgeInsets.all(AppSpacing.md),
+      padding: EdgeInsets.all(_gridPadding),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _gridCrossAxisCount,
-        crossAxisSpacing: AppSpacing.md,
-        mainAxisSpacing: AppSpacing.lg,
+        crossAxisSpacing: _gridCrossAxisSpacing,
+        mainAxisSpacing: _gridMainAxisSpacing,
         childAspectRatio: 0.55,
       ),
       itemCount: searchState.tvShowResults.length,
@@ -1207,6 +1315,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           year: tvShow.firstAirYear,
           subtitle: tvShow.genres?.take(2).join(', '),
           isInCollection: infos != null && infos.isNotEmpty,
+          compact: isLandscapeMobile(context),
           onTap: () => _onTvShowTap(tvShow),
         );
       },
@@ -1409,6 +1518,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
 
   Widget _buildAnimationTab() {
     final MediaSearchState searchState = ref.watch(mediaSearchProvider);
+    final double hPadding =
+        isLandscapeMobile(context) ? AppSpacing.sm : AppSpacing.md;
 
     final bool hasAnimationResults =
         searchState.animationMovieResults.isNotEmpty ||
@@ -1418,14 +1529,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
       children: <Widget>[
         // Фильтры медиа
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          padding: EdgeInsets.symmetric(horizontal: hPadding),
           child: _buildMediaFilterBar(searchState),
         ),
 
         // Сортировка
         if (hasAnimationResults)
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+            padding: EdgeInsets.symmetric(horizontal: hPadding),
             child: SortSelector(
               currentSort: searchState.currentSort,
               onChanged: (SearchSort sort) {
@@ -1480,11 +1591,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     ];
 
     return GridView.builder(
-      padding: const EdgeInsets.all(AppSpacing.md),
+      padding: EdgeInsets.all(_gridPadding),
       gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: _gridCrossAxisCount,
-        crossAxisSpacing: AppSpacing.md,
-        mainAxisSpacing: AppSpacing.lg,
+        crossAxisSpacing: _gridCrossAxisSpacing,
+        mainAxisSpacing: _gridMainAxisSpacing,
         childAspectRatio: 0.55,
       ),
       itemCount: items.length,
@@ -1504,6 +1615,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             year: movie.releaseYear,
             subtitle: 'Movie${_genreSuffix(movie.genres)}',
             isInCollection: infos != null && infos.isNotEmpty,
+            compact: isLandscapeMobile(context),
             onTap: () => _onAnimationMovieTap(movie),
           );
         } else {
@@ -1520,6 +1632,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             year: tvShow.firstAirYear,
             subtitle: 'Series${_genreSuffix(tvShow.genres)}',
             isInCollection: infos != null && infos.isNotEmpty,
+            compact: isLandscapeMobile(context),
             onTap: () => _onAnimationTvShowTap(tvShow),
           );
         }
@@ -1540,6 +1653,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   // ==================== Shared UI states ====================
 
   Widget _buildEmptyState(String message, IconData icon) {
+    final bool isLandscape = isLandscapeMobile(context);
     return Center(
       child: SingleChildScrollView(
         child: Column(
@@ -1547,25 +1661,26 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           children: <Widget>[
             Icon(
               icon,
-              size: 64,
+              size: isLandscape ? 32 : 64,
               color: AppColors.textSecondary.withAlpha(128),
             ),
-            const SizedBox(height: AppSpacing.md),
+            SizedBox(height: isLandscape ? AppSpacing.sm : AppSpacing.md),
             Text(
               message,
-              style: AppTypography.h3.copyWith(
-                    color: AppColors.textSecondary,
-                  ),
+              style: (isLandscape ? AppTypography.body : AppTypography.h3)
+                  .copyWith(color: AppColors.textSecondary),
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              'Type at least 2 characters to start searching',
-              style: AppTypography.body.copyWith(
-                    color: AppColors.textSecondary.withAlpha(179),
-                  ),
-              textAlign: TextAlign.center,
-            ),
+            if (!isLandscape) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Type at least 2 characters to start searching',
+                style: AppTypography.body.copyWith(
+                  color: AppColors.textSecondary.withAlpha(179),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
           ],
         ),
       ),
@@ -1573,28 +1688,28 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   }
 
   Widget _buildNoResults(String query) {
+    final bool isLandscape = isLandscapeMobile(context);
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Icon(
             Icons.search_off,
-            size: 64,
+            size: isLandscape ? 32 : 64,
             color: AppColors.textSecondary.withAlpha(128),
           ),
-          const SizedBox(height: AppSpacing.md),
+          SizedBox(height: isLandscape ? AppSpacing.sm : AppSpacing.md),
           Text(
             'No results found',
-            style: AppTypography.h3.copyWith(
-                  color: AppColors.textSecondary,
-                ),
+            style: (isLandscape ? AppTypography.body : AppTypography.h3)
+                .copyWith(color: AppColors.textSecondary),
           ),
           const SizedBox(height: AppSpacing.sm),
           Text(
             'Nothing found for "$query"',
-            style: AppTypography.body.copyWith(
-                  color: AppColors.textSecondary.withAlpha(179),
-                ),
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary.withAlpha(179),
+            ),
             textAlign: TextAlign.center,
           ),
         ],
@@ -1603,18 +1718,19 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   }
 
   Widget _buildErrorState(String error, {required VoidCallback onRetry}) {
+    final bool isLandscape = isLandscapeMobile(context);
     return Center(
       child: SingleChildScrollView(
-        padding: const EdgeInsets.all(AppSpacing.xl),
+        padding: EdgeInsets.all(isLandscape ? AppSpacing.md : AppSpacing.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            const Icon(
+            Icon(
               Icons.error_outline,
-              size: 64,
+              size: isLandscape ? 32 : 64,
               color: AppColors.error,
             ),
-            const SizedBox(height: AppSpacing.md),
+            SizedBox(height: isLandscape ? AppSpacing.sm : AppSpacing.md),
             Text(
               'Search failed',
               style: AppTypography.h3.copyWith(

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../shared/constants/platform_features.dart';
 import '../../../core/database/database_service.dart';
 import '../../../core/services/config_service.dart';
 import '../../../core/services/image_cache_service.dart';
@@ -172,17 +173,20 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   Widget build(BuildContext context) {
     final SettingsState settings = ref.watch(settingsNotifierProvider);
 
+    final bool isLandscape = isLandscapeMobile(context);
+
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
         backgroundColor: AppColors.background,
         surfaceTintColor: Colors.transparent,
         foregroundColor: AppColors.textPrimary,
-        title: const Text('IGDB API Setup'),
+        toolbarHeight: isLandscape ? 40 : kToolbarHeight,
+        title: isLandscape ? null : const Text('IGDB API Setup'),
         automaticallyImplyLeading: !widget.isInitialSetup,
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        padding: EdgeInsets.all(isLandscape ? AppSpacing.md : AppSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
@@ -577,6 +581,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final bool? confirm = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
+        scrollable: true,
         title: const Text('Clear cache?'),
         content: const Text(
           'This will delete all locally saved images. '
@@ -952,6 +957,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final bool? confirm = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) => AlertDialog(
+        scrollable: true,
         title: const Text('Reset Database?'),
         content: const Text(
           'This will permanently delete all your collections, games, '

--- a/lib/shared/constants/platform_features.dart
+++ b/lib/shared/constants/platform_features.dart
@@ -1,6 +1,8 @@
 // Флаги доступности функций на текущей платформе.
 import 'dart:io' show Platform;
 
+import 'package:flutter/widgets.dart' show BuildContext, MediaQuery, Orientation;
+
 /// Доступен ли Board (визуальная доска) на текущей платформе.
 ///
 /// Board доступен на всех платформах.
@@ -11,3 +13,12 @@ bool get kVgMapsEnabled => Platform.isWindows;
 
 /// Доступен ли Screenshot Capture.
 bool get kScreenshotEnabled => Platform.isWindows;
+
+/// Мобильная платформа (Android / iOS).
+bool get kIsMobile => Platform.isAndroid || Platform.isIOS;
+
+/// Ландшафтный режим на мобильном устройстве.
+bool isLandscapeMobile(BuildContext context) {
+  return kIsMobile &&
+      MediaQuery.orientationOf(context) == Orientation.landscape;
+}

--- a/lib/shared/widgets/hero_collection_card.dart
+++ b/lib/shared/widgets/hero_collection_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/image_cache_service.dart';
 import '../../data/repositories/collection_repository.dart';
 import '../../features/collections/providers/collections_provider.dart';
+import '../../shared/constants/platform_features.dart';
 import '../../shared/models/collection.dart';
 import '../../shared/models/collection_item.dart';
 import '../../shared/models/media_type.dart';
@@ -132,9 +133,9 @@ class HeroCollectionCard extends ConsumerWidget {
           borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
           child: switch (effectiveStyle) {
             HeroCardStyle.mosaic =>
-              _buildMosaicLayout(accent, statsAsync, itemsAsync),
+              _buildMosaicLayout(context, accent, statsAsync, itemsAsync),
             HeroCardStyle.backdrop =>
-              _buildBackdropLayout(accent, statsAsync, itemsAsync),
+              _buildBackdropLayout(context, accent, statsAsync, itemsAsync),
           },
         ),
       ),
@@ -146,14 +147,16 @@ class HeroCollectionCard extends ConsumerWidget {
   // ---------------------------------------------------------------------------
 
   Widget _buildBackdropLayout(
+    BuildContext context,
     Color accent,
     AsyncValue<CollectionStats> statsAsync,
     AsyncValue<List<CollectionItem>> itemsAsync,
   ) {
+    final bool isLandscape = isLandscapeMobile(context);
     return ClipRRect(
       borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
       child: SizedBox(
-        height: 120,
+        height: isLandscape ? 80 : 120,
         child: Stack(
           fit: StackFit.expand,
           children: <Widget>[
@@ -193,7 +196,9 @@ class HeroCollectionCard extends ConsumerWidget {
 
             // Контент
             Padding(
-              padding: const EdgeInsets.all(AppSpacing.md),
+              padding: EdgeInsets.all(
+                isLandscape ? AppSpacing.sm : AppSpacing.md,
+              ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
@@ -203,15 +208,16 @@ class HeroCollectionCard extends ConsumerWidget {
                       Icon(
                         iconForType(collection.type),
                         color: accent,
-                        size: 20,
+                        size: isLandscape ? 16 : 20,
                       ),
                       const SizedBox(width: AppSpacing.xs),
                       Expanded(
                         child: Text(
                           collection.name,
-                          style: AppTypography.h2.copyWith(
-                            color: Colors.white,
-                          ),
+                          style: (isLandscape
+                                  ? AppTypography.h3
+                                  : AppTypography.h2)
+                              .copyWith(color: Colors.white),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -287,13 +293,15 @@ class HeroCollectionCard extends ConsumerWidget {
   // ---------------------------------------------------------------------------
 
   Widget _buildMosaicLayout(
+    BuildContext context,
     Color accent,
     AsyncValue<CollectionStats> statsAsync,
     AsyncValue<List<CollectionItem>> itemsAsync,
   ) {
+    final bool isLandscape = isLandscapeMobile(context);
     return Container(
-      height: 120,
-      padding: const EdgeInsets.all(AppSpacing.md),
+      height: isLandscape ? 80 : 120,
+      padding: EdgeInsets.all(isLandscape ? AppSpacing.sm : AppSpacing.md),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
         gradient: LinearGradient(

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -480,6 +480,7 @@ class MediaDetailView extends StatelessWidget {
     final String? result = await showDialog<String>(
       context: context,
       builder: (BuildContext ctx) => AlertDialog(
+        scrollable: true,
         title: Text(title),
         content: TextField(
           controller: controller,

--- a/lib/shared/widgets/poster_card.dart
+++ b/lib/shared/widgets/poster_card.dart
@@ -27,6 +27,7 @@ class PosterCard extends StatefulWidget {
     this.subtitle,
     this.isInCollection = false,
     this.status,
+    this.compact = false,
     this.onTap,
     this.onLongPress,
     super.key,
@@ -58,6 +59,9 @@ class PosterCard extends StatefulWidget {
 
   /// Статус элемента. Если задан и != notStarted — показывается бейдж.
   final ItemStatus? status;
+
+  /// Компактный режим (уменьшенные размеры для ландшафта).
+  final bool compact;
 
   /// Обработчик нажатия.
   final VoidCallback? onTap;
@@ -120,7 +124,11 @@ class _PosterCardState extends State<PosterCard>
               // Постер с overlay-элементами
               Expanded(
                 child: ClipRRect(
-                  borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+                  borderRadius: BorderRadius.circular(
+                    widget.compact
+                        ? AppSpacing.radiusSm
+                        : AppSpacing.radiusMd,
+                  ),
                   child: Stack(
                     fit: StackFit.expand,
                     children: <Widget>[
@@ -132,20 +140,20 @@ class _PosterCardState extends State<PosterCard>
                         fit: BoxFit.cover,
                         placeholder: Container(
                           color: AppColors.surfaceLight,
-                          child: const Center(
+                          child: Center(
                             child: Icon(
                               Icons.image_outlined,
                               color: AppColors.textTertiary,
-                              size: 32,
+                              size: widget.compact ? 16 : 32,
                             ),
                           ),
                         ),
                         errorWidget: Container(
                           color: AppColors.surfaceLight,
-                          child: const Icon(
+                          child: Icon(
                             Icons.image_not_supported_outlined,
                             color: AppColors.textTertiary,
-                            size: 32,
+                            size: widget.compact ? 16 : 32,
                           ),
                         ),
                       ),
@@ -176,7 +184,9 @@ class _PosterCardState extends State<PosterCard>
                                       ),
                                 ),
                                 borderRadius: BorderRadius.circular(
-                                  AppSpacing.radiusMd,
+                                  widget.compact
+                                      ? AppSpacing.radiusSm
+                                      : AppSpacing.radiusMd,
                                 ),
                               ),
                             ),
@@ -187,26 +197,31 @@ class _PosterCardState extends State<PosterCard>
                       // Рейтинг badge (top-left)
                       if (widget.rating != null && widget.rating! > 0)
                         Positioned(
-                          top: AppSpacing.xs,
-                          left: AppSpacing.xs,
-                          child: RatingBadge(rating: widget.rating!),
+                          top: widget.compact ? 2 : AppSpacing.xs,
+                          left: widget.compact ? 2 : AppSpacing.xs,
+                          child: RatingBadge(
+                            rating: widget.rating!,
+                            compact: widget.compact,
+                          ),
                         ),
 
                       // Отметка "в коллекции" (top-right)
                       if (widget.isInCollection)
                         Positioned(
-                          top: AppSpacing.xs,
-                          right: AppSpacing.xs,
+                          top: widget.compact ? 2 : AppSpacing.xs,
+                          right: widget.compact ? 2 : AppSpacing.xs,
                           child: Container(
-                            padding: const EdgeInsets.all(4),
+                            padding: EdgeInsets.all(
+                              widget.compact ? 2 : 4,
+                            ),
                             decoration: const BoxDecoration(
                               color: AppColors.success,
                               shape: BoxShape.circle,
                             ),
-                            child: const Icon(
+                            child: Icon(
                               Icons.check,
                               color: Colors.white,
-                              size: 12,
+                              size: widget.compact ? 8 : 12,
                             ),
                           ),
                         ),
@@ -215,17 +230,21 @@ class _PosterCardState extends State<PosterCard>
                       if (widget.status != null &&
                           widget.status != ItemStatus.notStarted)
                         Positioned(
-                          bottom: AppSpacing.xs,
-                          left: AppSpacing.xs,
+                          bottom: widget.compact ? 2 : AppSpacing.xs,
+                          left: widget.compact ? 2 : AppSpacing.xs,
                           child: Container(
-                            padding: const EdgeInsets.all(4),
+                            padding: EdgeInsets.all(
+                              widget.compact ? 2 : 4,
+                            ),
                             decoration: BoxDecoration(
                               color: widget.status!.color,
                               shape: BoxShape.circle,
                             ),
                             child: Text(
                               widget.status!.icon,
-                              style: const TextStyle(fontSize: 10),
+                              style: TextStyle(
+                                fontSize: widget.compact ? 7 : 10,
+                              ),
                             ),
                           ),
                         ),
@@ -234,12 +253,14 @@ class _PosterCardState extends State<PosterCard>
                 ),
               ),
 
-              const SizedBox(height: AppSpacing.xs),
+              SizedBox(height: widget.compact ? 2 : AppSpacing.xs),
 
               // Название
               Text(
                 widget.title,
-                style: AppTypography.posterTitle,
+                style: widget.compact
+                    ? AppTypography.posterTitle.copyWith(fontSize: 9)
+                    : AppTypography.posterTitle,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -247,10 +268,13 @@ class _PosterCardState extends State<PosterCard>
               // Подзаголовок (год + жанр)
               if (widget.year != null || widget.subtitle != null)
                 Padding(
-                  padding: const EdgeInsets.only(top: 2),
+                  padding: EdgeInsets.only(top: widget.compact ? 1 : 2),
                   child: Text(
                     _buildSubtitleText(),
-                    style: AppTypography.posterSubtitle,
+                    style: widget.compact
+                        ? AppTypography.posterSubtitle
+                            .copyWith(fontSize: 7)
+                        : AppTypography.posterSubtitle,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),

--- a/lib/shared/widgets/rating_badge.dart
+++ b/lib/shared/widgets/rating_badge.dart
@@ -14,11 +14,15 @@ class RatingBadge extends StatelessWidget {
   /// Создаёт бейдж рейтинга.
   const RatingBadge({
     required this.rating,
+    this.compact = false,
     super.key,
   });
 
   /// Числовой рейтинг (0.0–10.0).
   final double rating;
+
+  /// Компактный режим (уменьшенные размеры для ландшафта).
+  final bool compact;
 
   /// Возвращает цвет фона на основе рейтинга.
   static Color colorForRating(double rating) {
@@ -30,16 +34,19 @@ class RatingBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      padding: EdgeInsets.symmetric(
+        horizontal: compact ? 3 : 6,
+        vertical: compact ? 1 : 2,
+      ),
       decoration: BoxDecoration(
         color: colorForRating(rating),
-        borderRadius: BorderRadius.circular(6),
+        borderRadius: BorderRadius.circular(compact ? 4 : 6),
       ),
       child: Text(
         rating.toStringAsFixed(1),
-        style: const TextStyle(
+        style: TextStyle(
           color: Colors.white,
-          fontSize: 12,
+          fontSize: compact ? 8 : 12,
           fontWeight: FontWeight.bold,
           height: 1.2,
         ),

--- a/lib/shared/widgets/shimmer_loading.dart
+++ b/lib/shared/widgets/shimmer_loading.dart
@@ -87,8 +87,7 @@ class ShimmerPosterCard extends StatelessWidget {
     return const Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        AspectRatio(
-          aspectRatio: AppSpacing.posterAspectRatio,
+        Expanded(
           child: ShimmerBox(
             width: double.infinity,
             height: double.infinity,

--- a/test/features/collections/screens/collection_screen_test.dart
+++ b/test/features/collections/screens/collection_screen_test.dart
@@ -789,7 +789,7 @@ void main() {
         animationCount: 0,
       );
 
-      testWidgets('должен показывать label без каунта при 0 элементах',
+      testWidgets('должен скрывать фильтры при 0 элементах',
           (WidgetTester tester) async {
         when(() => mockRepo.getItemsWithData(
               1,
@@ -810,12 +810,12 @@ void main() {
         ));
         await pumpScreen(tester);
 
-        // Без каунта — не "All (0)", а просто "All"
-        expect(find.text('All'), findsOneWidget);
-        expect(find.text('Games'), findsOneWidget);
-        expect(find.text('Movies'), findsOneWidget);
-        expect(find.text('TV Shows'), findsOneWidget);
-        expect(find.text('Animation'), findsOneWidget);
+        // Фильтры скрыты при пустой коллекции
+        expect(find.text('All'), findsNothing);
+        expect(find.text('Games'), findsNothing);
+        expect(find.text('Movies'), findsNothing);
+        expect(find.text('TV Shows'), findsNothing);
+        expect(find.text('Animation'), findsNothing);
       });
     });
 

--- a/test/shared/widgets/shimmer_loading_test.dart
+++ b/test/shared/widgets/shimmer_loading_test.dart
@@ -64,7 +64,7 @@ void main() {
       );
 
       expect(find.byType(ShimmerPosterCard), findsOneWidget);
-      expect(find.byType(AspectRatio), findsOneWidget);
+      expect(find.byType(Expanded), findsOneWidget);
     });
 
     testWidgets('должен содержать ShimmerBox элементы',


### PR DESCRIPTION
- Add compact mode to PosterCard and RatingBadge for landscape mobile
- Optimize all screens (Home, Collection, Search, Settings) for landscape
- Hide AppBar titles and reduce toolbar height in landscape on mobile
- Use 6-column grid with smaller spacing in landscape mode
- Add scrollable: true to all AlertDialogs to prevent overflow
- Reduce desktop collection grid max card width to 150px
- Increase canvas zoom-out range (0.3→0.1) and default 5x further on mobile
- Extract isLandscapeMobile() and kIsMobile to platform_features.dart
- Enable image cache by default
- Fix ShimmerPosterCard to use Expanded instead of AspectRatio