### PR TITLE
Compact collection screen redesign: 2-row layout with unified FilterRow

### DIFF
--- a/lib/shared/models/collection_sort_mode.dart
+++ b/lib/shared/models/collection_sort_mode.dart
@@ -3,24 +3,32 @@
 /// Режим сортировки элементов в коллекции.
 enum CollectionSortMode {
   /// Ручной порядок (drag-and-drop, sort_order ASC).
-  manual('manual', 'Manual', 'Custom order'),
+  manual('manual', 'Manual', 'Manual', 'Custom order'),
 
   /// По дате добавления (added_at DESC, новые первыми).
-  addedDate('added_date', 'Date Added', 'Newest first'),
+  addedDate('added_date', 'Date Added', 'Date', 'Newest first'),
 
   /// По статусу (активные первыми, завершённые последними).
-  status('status', 'Status', 'Active first'),
+  status('status', 'Status', 'Status', 'Active first'),
 
   /// По алфавиту (itemName ASC).
-  name('name', 'Name', 'A to Z');
+  name('name', 'Name', 'A-Z', 'A to Z');
 
-  const CollectionSortMode(this.value, this.displayLabel, this.description);
+  const CollectionSortMode(
+    this.value,
+    this.displayLabel,
+    this.shortLabel,
+    this.description,
+  );
 
   /// Строковое значение для хранения в SharedPreferences.
   final String value;
 
   /// Отображаемое название.
   final String displayLabel;
+
+  /// Короткий лейбл для компактного UI (2-6 символов).
+  final String shortLabel;
 
   /// Краткое описание порядка сортировки.
   final String description;

--- a/test/shared/models/collection_sort_mode_test.dart
+++ b/test/shared/models/collection_sort_mode_test.dart
@@ -57,6 +57,24 @@ void main() {
       });
     });
 
+    group('shortLabel', () {
+      test('manual должен иметь shortLabel "Manual"', () {
+        expect(CollectionSortMode.manual.shortLabel, 'Manual');
+      });
+
+      test('addedDate должен иметь shortLabel "Date"', () {
+        expect(CollectionSortMode.addedDate.shortLabel, 'Date');
+      });
+
+      test('status должен иметь shortLabel "Status"', () {
+        expect(CollectionSortMode.status.shortLabel, 'Status');
+      });
+
+      test('name должен иметь shortLabel "A-Z"', () {
+        expect(CollectionSortMode.name.shortLabel, 'A-Z');
+      });
+    });
+
     group('description', () {
       test('manual должен иметь описание "Custom order"', () {
         expect(CollectionSortMode.manual.description, 'Custom order');
@@ -148,6 +166,16 @@ void main() {
             mode.displayLabel.isNotEmpty,
             isTrue,
             reason: '${mode.name} displayLabel должен быть непустым',
+          );
+        }
+      });
+
+      test('каждый режим должен иметь непустой shortLabel', () {
+        for (final CollectionSortMode mode in CollectionSortMode.values) {
+          expect(
+            mode.shortLabel.isNotEmpty,
+            isTrue,
+            reason: '${mode.name} shortLabel должен быть непустым',
           );
         }
       });


### PR DESCRIPTION
Reduce collection screen from 4+ rows to 2 rows (AppBar + FilterRow):
- Remove Header with stats/progress bar
- Move Edit/Export to PopupMenu, add Board toggle always visible
- Replace FilterChips + SortSelector with unified FilterRow (media type dropdown, search field, sort dropdown, grid/list toggle)
- Add sort direction (ASC/DESC) with SharedPreferences persistence
- Add shortLabel to CollectionSortMode enum