### PR TITLE
Fix PathAccessException on Windows with OneDrive-synced Documents

### DIFF
--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -37,7 +37,9 @@ class DatabaseService {
   }
 
   Future<Database> _initDatabase() async {
-    final Directory appDir = await getApplicationDocumentsDirectory();
+    // AppSupport вместо Documents — Documents может быть под OneDrive,
+    // который блокирует создание файлов (PathAccessException).
+    final Directory appDir = await getApplicationSupportDirectory();
     final String dbDir = p.join(appDir.path, 'tonkatsu_box');
     final String dbPath = p.join(dbDir, 'tonkatsu_box.db');
 

--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -59,8 +59,9 @@ class ImageCacheService {
       return customPath;
     }
 
-    // Путь по умолчанию
-    final Directory appDir = await getApplicationDocumentsDirectory();
+    // AppSupport вместо Documents — Documents может быть под OneDrive,
+    // который блокирует создание файлов (PathAccessException).
+    final Directory appDir = await getApplicationSupportDirectory();
     return p.join(appDir.path, 'tonkatsu_box', 'image_cache');
   }
 

--- a/lib/features/settings/screens/cache_screen.dart
+++ b/lib/features/settings/screens/cache_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/image_cache_service.dart';
+import '../../../shared/constants/platform_features.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -105,30 +106,32 @@ class _CacheScreenState extends ConsumerState<CacheScreen> {
 
                 const Divider(),
 
-                // Путь к кэшу
-                FutureBuilder<String>(
-                  future: _pathFuture,
-                  builder:
-                      (BuildContext context, AsyncSnapshot<String> snapshot) {
-                    final String path = snapshot.data ?? 'Loading...';
-                    return ListTile(
-                      contentPadding: EdgeInsets.zero,
-                      title: const Text('Cache folder'),
-                      subtitle: Text(
-                        path,
-                        style: AppTypography.bodySmall,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.folder_open),
-                        onPressed: () =>
-                            _selectCacheFolder(cacheService),
-                        tooltip: 'Select folder',
-                      ),
-                    );
-                  },
-                ),
+                // Путь к кэшу (только десктоп — на Android Scoped Storage
+                // не позволяет dart:io писать в выбранную SAF-папку)
+                if (!kIsMobile)
+                  FutureBuilder<String>(
+                    future: _pathFuture,
+                    builder:
+                        (BuildContext context, AsyncSnapshot<String> snapshot) {
+                      final String path = snapshot.data ?? 'Loading...';
+                      return ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: const Text('Cache folder'),
+                        subtitle: Text(
+                          path,
+                          style: AppTypography.bodySmall,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.folder_open),
+                          onPressed: () =>
+                              _selectCacheFolder(cacheService),
+                          tooltip: 'Select folder',
+                        ),
+                      );
+                    },
+                  ),
 
                 // Статистика кэша
                 FutureBuilder<(int, int)>(

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,7 +89,7 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "Tonkatsu Box" "\0"
+            VALUE "CompanyName", "Tonkatsu_Box" "\0"
             VALUE "FileDescription", "Tonkatsu Box" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "tonkatsu_box" "\0"


### PR DESCRIPTION
Switch from getApplicationDocumentsDirectory() to
getApplicationSupportDirectory() for DB and image cache paths. OneDrive can block file creation in Documents folder (errno=5). New path: AppData\Roaming\Tonkatsu_Box\tonkatsu_box\

Also hide cache folder picker on Android (Scoped Storage prevents dart:io writes to SAF-selected directories).