### PR TITLE
Wishlist feature: quick notes for deferred content search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 ## [Unreleased]
 
 ### Added
+- Добавлена фича «Wishlist» — заметки для отложенного поиска контента (5-й таб навигации)
+  - Модель `WishlistItem` (`lib/shared/models/wishlist_item.dart`) с `fromDb()`, `toDb()`, `copyWith()`
+  - Таблица `wishlist` в SQLite, миграция v18→v19, 8 CRUD методов в `DatabaseService`
+  - `WishlistRepository` (`lib/data/repositories/wishlist_repository.dart`) — тонкая обёртка над БД
+  - `WishlistNotifier` (`wishlistProvider`) — AsyncNotifier с оптимистичным обновлением state
+  - `activeWishlistCountProvider` — счётчик активных (не resolved) элементов для badge
+  - `WishlistScreen` — ListView с FAB, popup menu (Search/Edit/Resolve/Delete), фильтр resolved, clear resolved
+  - `AddWishlistDialog` — создание/редактирование заметки с опциональным типом медиа (ChoiceChip: Game/Movie/TV/Animation)
+  - 5-й таб «Wishlist» в `NavigationShell` с Badge (количество активных заметок)
+  - Тап на заметку → переход в `SearchScreen` с предзаполненным запросом
+  - Resolved заметки: зачёркнутый текст, opacity 0.5, в конце списка
+  - Добавлены тесты: wishlist_item_test (10), database_service_test (+13 Wishlist CRUD), wishlist_repository_test (8), wishlist_provider_test (11), wishlist_screen_test (12), add_wishlist_dialog_test (10), navigation_shell_test (обновлены для 5 табов)
+- Добавлен параметр `initialQuery` в `SearchScreen` — предзаполнение поля поиска и автоматический запуск поиска при открытии из Wishlist
+
+### Added
 - Добавлен тайловый фон на всех экранах — `background_tile.png` (паттерн геймпада) зациклен через `ImageRepeat.repeat` с `opacity: 0.03` и `scale: 0.667` в `MaterialApp.builder`
   - Путь к ассету в `AppAssets.backgroundTile`
   - `scaffoldBackgroundColor` в теме изменён на `Colors.transparent` для прозрачности Scaffold-ов

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Create as many collections as you want — by platform (SNES, PlayStation, PC), 
 ### 🔍 Search & Discover
 Find games, movies, TV shows, and anime from a database of hundreds of thousands of titles. Filter by year, genre, or platform. Add anything you find to your collections with one tap.
 
+### 📝 Wishlist
+No internet right now? Jot down the name of a game or movie to search for later. Tag it with a media type, add a note, and tap it when you're ready — the app opens search with the name pre-filled. Mark items as resolved when you've found them.
+
 ### 📊 Track Your Progress
 Mark items as Not Started, In Progress, Completed, On Hold, or Dropped. For TV shows and anime, track individual episodes with per-season checkboxes. Rate everything from 1 to 10 stars. See when you started and finished each item.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@ Tonkatsu Box — кроссплатформенное приложение на 
 graph TB
     subgraph core ["🔧 Core"]
         api["API<br/><small>igdb_api, tmdb_api,<br/>steamgriddb_api</small>"]
-        database["Database<br/><small>database_service<br/>SQLite, 15 таблиц</small>"]
+        database["Database<br/><small>database_service<br/>SQLite, 16 таблиц</small>"]
         services["Services<br/><small>export, import,<br/>image_cache, config</small>"]
     end
 
@@ -37,12 +37,13 @@ graph TB
         collections["Collections<br/><small>home, collection,<br/>detail screens,<br/>canvas, panels</small>"]
         search["Search<br/><small>game, movie,<br/>tv show, animation</small>"]
         settings["Settings<br/><small>credentials, cache,<br/>database, debug</small>"]
+        wishlist["Wishlist<br/><small>quick notes for<br/>deferred search</small>"]
         home["Home<br/><small>all items grid</small>"]
         splash["Splash<br/><small>animated logo,<br/>DB pre-warming</small>"]
     end
 
     subgraph shared ["🧩 Shared"]
-        models["Models<br/><small>19 моделей:<br/>Game, Movie, TvShow,<br/>Collection, CanvasItem...</small>"]
+        models["Models<br/><small>20 моделей:<br/>Game, Movie, TvShow,<br/>Collection, CanvasItem,<br/>WishlistItem...</small>"]
         widgets["Widgets<br/><small>CachedImage, MediaPosterCard,<br/>BreadcrumbAppBar,<br/>StarRatingBar...</small>"]
         theme["Theme<br/><small>AppColors, AppTypography,<br/>AppSpacing, AppTheme</small>"]
         navigation["Navigation<br/><small>NavigationShell<br/>Rail / BottomBar</small>"]
@@ -101,7 +102,7 @@ lib/
 | `lib/core/api/steamgriddb_api.dart` | **SteamGridDB API клиент**. Bearer token авторизация. Методы: `searchGames()`, `getGrids()`, `getHeroes()`, `getLogos()`, `getIcons()` |
 | `lib/core/api/tmdb_api.dart` | **TMDB API клиент**. Bearer token авторизация. Методы: `searchMovies(query, {year})`, `searchTvShows(query, {firstAirDateYear})`, `multiSearch()`, `getMovieDetails()`, `getTvShowDetails()`, `getPopularMovies()`, `getPopularTvShows()`, `getMovieGenres()`, `getTvGenres()`, `getSeasonEpisodes(tmdbShowId, seasonNumber)` |
 | `lib/shared/constants/platform_features.dart` | **Флаги платформы**. `kCanvasEnabled` (true на всех платформах), `kVgMapsEnabled` (только Windows), `kScreenshotEnabled` (только Windows). VGMaps скрыт на не-Windows платформах |
-| `lib/core/database/database_service.dart` | **SQLite сервис**. Создание таблиц, миграции (версия 18), CRUD для всех сущностей. Использует `databaseFactory.openDatabase()` — кроссплатформенный вызов (FFI на desktop, нативный плагин на Android). Таблицы: `platforms`, `games`, `collections`, `collection_items`, `canvas_items`, `canvas_viewport`, `canvas_connections`, `game_canvas_viewport`, `movies_cache`, `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache`, `watched_episodes`, `tmdb_genres`. Миграция v14: `UPDATE collection_items SET status='in_progress' WHERE status='playing'`. Методы кэша жанров: `cacheTmdbGenres()`, `getTmdbGenreMap()`. Авторезолвинг числовых genre_ids при загрузке коллекций: `_resolveGenresIfNeeded<T>()`. `updateItemStatus` автоматически устанавливает даты активности при смене статуса. `updateItemActivityDates` для ручного обновления дат. Методы per-item canvas: `getGameCanvasItems`, `getGameCanvasConnections`, `getGameCanvasViewport`, `upsertGameCanvasViewport`. Методы эпизодов: `getEpisodesByShowAndSeason`, `upsertEpisodes`, `clearEpisodesByShow`, `getWatchedEpisodes` (возвращает `Map<(int, int), DateTime?>` с датами просмотра), `markEpisodeWatched`, `markEpisodeUnwatched`, `getWatchedEpisodeCount`, `markSeasonWatched`, `unmarkSeasonWatched`. Изоляция данных: коллекционные методы фильтруют `collection_item_id IS NULL`. Метод `clearAllData()` — очистка всех 15 таблиц в транзакции. Метод `updateItemCollectionId()` — обновление `collection_id` и `sort_order` элемента (для Move to Collection). Миграция v18: UNIQUE индексы расширены на `COALESCE(platform_id, -1)` для мультиплатформенных игр. Метод `getUniquePlatformIds()` — уникальные ID платформ из игровых элементов. Метод `deleteCanvasItemByCollectionItemId()` — удаление канвас-элемента по ID элемента коллекции |
+| `lib/core/database/database_service.dart` | **SQLite сервис**. Создание таблиц, миграции (версия 19), CRUD для всех сущностей. Использует `databaseFactory.openDatabase()` — кроссплатформенный вызов (FFI на desktop, нативный плагин на Android). Таблицы: `platforms`, `games`, `collections`, `collection_items`, `canvas_items`, `canvas_viewport`, `canvas_connections`, `game_canvas_viewport`, `movies_cache`, `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache`, `watched_episodes`, `tmdb_genres`, `wishlist`. Миграция v14: `UPDATE collection_items SET status='in_progress' WHERE status='playing'`. Методы кэша жанров: `cacheTmdbGenres()`, `getTmdbGenreMap()`. Авторезолвинг числовых genre_ids при загрузке коллекций: `_resolveGenresIfNeeded<T>()`. `updateItemStatus` автоматически устанавливает даты активности при смене статуса. `updateItemActivityDates` для ручного обновления дат. Методы per-item canvas: `getGameCanvasItems`, `getGameCanvasConnections`, `getGameCanvasViewport`, `upsertGameCanvasViewport`. Методы эпизодов: `getEpisodesByShowAndSeason`, `upsertEpisodes`, `clearEpisodesByShow`, `getWatchedEpisodes` (возвращает `Map<(int, int), DateTime?>` с датами просмотра), `markEpisodeWatched`, `markEpisodeUnwatched`, `getWatchedEpisodeCount`, `markSeasonWatched`, `unmarkSeasonWatched`. Изоляция данных: коллекционные методы фильтруют `collection_item_id IS NULL`. Метод `clearAllData()` — очистка всех 16 таблиц в транзакции. Метод `updateItemCollectionId()` — обновление `collection_id` и `sort_order` элемента (для Move to Collection). Миграция v18: UNIQUE индексы расширены на `COALESCE(platform_id, -1)` для мультиплатформенных игр. Метод `getUniquePlatformIds()` — уникальные ID платформ из игровых элементов. Метод `deleteCanvasItemByCollectionItemId()` — удаление канвас-элемента по ID элемента коллекции. Миграция v19: таблица `wishlist`. Методы wishlist: `addWishlistItem()`, `getWishlistItems()`, `getWishlistItemCount()`, `updateWishlistItem()`, `resolveWishlistItem()`, `unresolveWishlistItem()`, `deleteWishlistItem()`, `clearResolvedWishlistItems()` |
 | `lib/core/services/config_service.dart` | **Сервис конфигурации**. Экспорт/импорт 7 ключей SharedPreferences в JSON файл. Класс `ConfigResult` (success/failure/cancelled). Методы: `collectSettings()`, `applySettings()`, `exportToFile()`, `importFromFile()` |
 | `lib/core/services/image_cache_service.dart` | **Сервис кэширования изображений**. Enum `ImageType` (platformLogo, gameCover, moviePoster, tvShowPoster, canvasImage). Локальное хранение изображений в папках по типу. SharedPreferences для enable/disable и custom path. Валидация magic bytes (JPEG/PNG/WebP) при скачивании и при чтении из кэша. Безопасное удаление файлов (`_tryDelete`) при Windows file lock. Методы: `getImageUri()` (cache-first с fallback на remoteUrl + magic bytes проверка), `downloadImage()` (+ валидация), `downloadImages()`, `readImageBytes()`, `saveImageBytes()`, `clearCache()`, `getCacheSize()`, `getCachedCount()`. Провайдер `imageCacheServiceProvider` |
 | `lib/core/services/xcoll_file.dart` | **Модель файла экспорта/импорта**. Формат v2 (.xcoll/.xcollx, items + canvas + images). Классы: `XcollFile`, `ExportFormat` (light/full), `ExportCanvas`. Файлы v1 выбрасывают `FormatException` |
@@ -115,7 +116,7 @@ lib/
 ### 📦 Models (Модели данных)
 
 <details>
-<summary><strong>19 моделей</strong> — развернуть таблицу</summary>
+<summary><strong>20 моделей</strong> — развернуть таблицу</summary>
 
 | Файл | Назначение |
 |------|------------|
@@ -136,6 +137,7 @@ lib/
 | `lib/shared/models/canvas_item.dart` | **Модель элемента канваса**. Enum `CanvasItemType` (game/movie/tvShow/animation/text/image/link). Поля: id, collectionId, collectionItemId (null для коллекционного canvas, int для per-item), itemType, itemRefId, x, y, width, height, zIndex, data (JSON). Joined поля: `game: Game?`, `movie: Movie?`, `tvShow: TvShow?`. Статический метод `CanvasItemType.fromMediaType()`, геттер `isMediaItem` |
 | `lib/shared/models/canvas_viewport.dart` | **Модель viewport канваса**. Поля: collectionId, scale, offsetX, offsetY. Хранит зум и позицию камеры |
 | `lib/shared/models/canvas_connection.dart` | **Модель связи канваса**. Enum `ConnectionStyle` (solid/dashed/arrow). Поля: id, collectionId, collectionItemId (null для коллекционного canvas, int для per-item), fromItemId, toItemId, label, color (hex), style, createdAt |
+| `lib/shared/models/wishlist_item.dart` | **Модель элемента вишлиста**. Поля: id, text, mediaTypeHint (MediaType?), note, isResolved, createdAt, resolvedAt. Методы: `fromDb()`, `toDb()`, `copyWith()`. Геттер `hasNote` |
 
 </details>
 
@@ -205,13 +207,23 @@ lib/
 
 ---
 
+### 📝 Features: Wishlist (Вишлист)
+
+| Файл | Назначение |
+|------|------------|
+| `lib/features/wishlist/screens/wishlist_screen.dart` | **Экран вишлиста**. ListView с `_WishlistTile`, FAB для добавления, фильтр resolved (visibility toggle), clear resolved с confirmation. Popup menu: Search/Edit/Resolve/Delete. Тап на элемент → `SearchScreen(initialQuery)`. Resolved: opacity 0.5, strikethrough |
+| `lib/features/wishlist/widgets/add_wishlist_dialog.dart` | **Диалог создания/редактирования**. TextField для названия, ChoiceChip для типа медиа (None/Game/Movie/TV/Animation), TextField для заметки. Режим редактирования при `existing` != null |
+| `lib/features/wishlist/providers/wishlist_provider.dart` | **State management вишлиста**. `wishlistProvider` — AsyncNotifierProvider с оптимистичным обновлением. Методы: add, resolve, unresolve, updateItem, delete, clearResolved. Сортировка: active first → by createdAt DESC. `activeWishlistCountProvider` — Provider\<int\> для badge навигации |
+
+---
+
 ### 🔍 Features: Search (Поиск)
 
 #### Экраны
 
 | Файл | Назначение |
 |------|------------|
-| `lib/features/search/screens/search_screen.dart` | **Экран поиска**. TabBar с 4 табами: Games / Movies / TV Shows / Animation. Общее поле ввода с debounce, фильтр платформ (только Games), сортировка (SortSelector), фильтры медиа (год, жанры через MediaFilterSheet). Animation tab объединяет animated movies + TV shows (genre_id=16), исключая их из Movies/TV Shows табов. При `collectionId` — добавляет игры/фильмы/сериалы/анимацию в коллекцию через `collectionItemsNotifierProvider`. Bottom sheet с деталями |
+| `lib/features/search/screens/search_screen.dart` | **Экран поиска**. TabBar с 4 табами: Games / Movies / TV Shows / Animation. Общее поле ввода с debounce, фильтр платформ (только Games), сортировка (SortSelector), фильтры медиа (год, жанры через MediaFilterSheet). Animation tab объединяет animated movies + TV shows (genre_id=16), исключая их из Movies/TV Shows табов. При `collectionId` — добавляет игры/фильмы/сериалы/анимацию в коллекцию через `collectionItemsNotifierProvider`. Bottom sheet с деталями. Параметр `initialQuery` — предзаполнение поиска из Wishlist |
 
 <details>
 <summary><strong>Виджеты и провайдеры поиска</strong> — развернуть таблицу</summary>
@@ -259,7 +271,7 @@ lib/
 
 | Файл | Назначение |
 |------|------------|
-| `lib/shared/navigation/navigation_shell.dart` | **NavigationShell**. Адаптивная навигация: `NavigationRail` (боковая панель) при ширине >= 800px, `BottomNavigationBar` при < 800px. 4 таба: Home (AllItemsScreen), Collections (HomeScreen), Search, Settings. Lazy IndexedStack — AllItemsScreen загружается eager, Collections/Search/Settings строятся при первом переключении на таб. Desktop: логотип 48x48 вынесен в Column выше Rail (не в Rail.leading) |
+| `lib/shared/navigation/navigation_shell.dart` | **NavigationShell**. Адаптивная навигация: `NavigationRail` (боковая панель) при ширине >= 800px, `BottomNavigationBar` при < 800px. 5 табов: Home (AllItemsScreen), Collections (HomeScreen), Wishlist (WishlistScreen), Search, Settings. Lazy IndexedStack — AllItemsScreen загружается eager, остальные строятся при первом переключении на таб. Badge на иконке Wishlist из `activeWishlistCountProvider`. Desktop: логотип 48x48 вынесен в Column выше Rail (не в Rail.leading) |
 
 <details>
 <summary><strong>Общие виджеты</strong> — развернуть таблицу</summary>
@@ -325,13 +337,14 @@ lib/
 | `lib/data/repositories/collection_repository.dart` | **Репозиторий коллекций**. CRUD коллекций и элементов. Форки с snapshot. Статистика (CollectionStats). `moveItemToCollection()` — перемещение элемента с обработкой UNIQUE constraint |
 | `lib/data/repositories/game_repository.dart` | **Репозиторий игр**. Поиск через API + кеширование в SQLite |
 | `lib/data/repositories/canvas_repository.dart` | **Репозиторий канваса**. CRUD для canvas_items, viewport и connections. Коллекционные методы: getItems, getItemsWithData (с joined Game/Movie/TvShow), createItem, updateItem, updateItemPosition, updateItemSize, updateItemData, updateItemZIndex, deleteItem, deleteMediaItem, deleteByCollectionItemId (удаление по ID элемента коллекции), hasCanvasItems, initializeCanvas, getConnections, createConnection, updateConnection, deleteConnection. Per-item методы: getGameCanvasItems, getGameCanvasItemsWithData, hasGameCanvasItems, getGameCanvasViewport, saveGameCanvasViewport, getGameCanvasConnections |
+| `lib/data/repositories/wishlist_repository.dart` | **Репозиторий вишлиста**. Тонкая обёртка над `DatabaseService`. Методы: `getAll()`, `getActiveCount()`, `add()`, `update()`, `resolve()`, `unresolve()`, `delete()`, `clearResolved()`. Провайдер `wishlistRepositoryProvider` |
 
 ---
 
 ## 🗄️ База данных
 
 > [!IMPORTANT]
-> SQLite через `sqflite_common_ffi` на desktop, нативный `sqflite` на Android. Текущая версия БД: **18**. Миграции инкрементальные (v1 -> v2 -> ... -> v18). Всего **15 таблиц**.
+> SQLite через `sqflite_common_ffi` на desktop, нативный `sqflite` на Android. Текущая версия БД: **19**. Миграции инкрементальные (v1 -> v2 -> ... -> v19). Всего **16 таблиц**.
 
 ### ER-диаграмма
 
@@ -354,6 +367,16 @@ erDiagram
     tv_shows_cache ||--o{ tv_episodes_cache : "содержит эпизоды"
 
     canvas_items ||--o{ canvas_connections : "from/to"
+
+    wishlist {
+        int id PK
+        text text
+        text media_type_hint
+        text note
+        int is_resolved
+        int created_at
+        int resolved_at
+    }
 
     games ||--o{ platforms : "platform_ids"
 
@@ -476,7 +499,7 @@ erDiagram
 ### SQL-схема таблиц
 
 <details>
-<summary><strong>Полная SQL-схема всех 15 таблиц</strong> — развернуть</summary>
+<summary><strong>Полная SQL-схема всех 16 таблиц</strong> — развернуть</summary>
 
 ```sql
 -- Платформы из IGDB (кеш)
@@ -662,6 +685,17 @@ CREATE TABLE game_canvas_viewport (
   offset_x REAL NOT NULL DEFAULT 0.0,
   offset_y REAL NOT NULL DEFAULT 0.0
 );
+
+-- Вишлист — заметки для отложенного поиска (v19)
+CREATE TABLE wishlist (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  text TEXT NOT NULL,
+  media_type_hint TEXT,          -- game/movie/tvShow/animation (nullable)
+  note TEXT,
+  is_resolved INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  resolved_at INTEGER
+);
 ```
 
 </details>
@@ -699,6 +733,9 @@ CREATE TABLE game_canvas_viewport (
 | `tvGenresProvider` | FutureProvider | Список жанров сериалов из TMDB (DB-first cache) |
 | `movieGenreMapProvider` | FutureProvider | Маппинг ID->имя жанров фильмов |
 | `tvGenreMapProvider` | FutureProvider | Маппинг ID->имя жанров сериалов |
+| `wishlistRepositoryProvider` | Provider | Репозиторий вишлиста |
+| `wishlistProvider` | AsyncNotifierProvider | Список элементов вишлиста (add/resolve/delete/clearResolved) |
+| `activeWishlistCountProvider` | Provider | Количество активных (не resolved) элементов вишлиста |
 
 </details>
 
@@ -727,10 +764,14 @@ CREATE TABLE game_canvas_viewport (
                                 |   |   +-> SearchScreen(collectionId)
                                 |   |       [добавление игр/фильмов/сериалов]
                                 |   |
-                                +-- Tab 2: SearchScreen()
+                                +-- Tab 2: WishlistScreen (Wishlist) [badge: active count]
+                                |   +-> SearchScreen(initialQuery)
+                                |       [поиск по заметке]
+                                |
+                                +-- Tab 3: SearchScreen()
                                 |   [просмотр игр/фильмов/сериалов]
                                 |
-                                +-- Tab 3: SettingsScreen()
+                                +-- Tab 4: SettingsScreen()
                                     [настройки]
                                     +-> SteamGridDbDebugScreen()
                                         [debug, только в debug сборке]

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,7 +10,7 @@ The app uses a forced dark theme (ThemeMode.dark) with a cinematic design system
 - **AppTypography** — Inter font with 8 text styles (h1–caption, posterTitle, posterSubtitle), negative letter-spacing on headings
 - **AppSpacing** — standardized spacing (4–32px), border radii (4–20px), poster aspect ratio (2:3), grid column counts
 - **AppTheme** — centralized ThemeData with styled AppBar, Card, Input, Dialog, BottomSheet, Chip, Button, NavigationRail, TabBar
-- **Adaptive navigation** — NavigationRail sidebar on desktop (≥800px), BottomNavigationBar on mobile (<800px), 4 tabs: Home, Collections, Search, Settings. Logo 48×48 above NavigationRail (desktop)
+- **Adaptive navigation** — NavigationRail sidebar on desktop (≥800px), BottomNavigationBar on mobile (<800px), 5 tabs: Home, Collections, Wishlist, Search, Settings. Logo 48×48 above NavigationRail (desktop)
 - **BreadcrumbAppBar** — unified navigation breadcrumbs on all screens: logo 20×20 + `›` separators + clickable crumbs. Last crumb is bold (w600), non-last crumbs are clickable and navigate back. Supports TabBar (bottom) and action buttons
 
 <details>
@@ -166,6 +166,21 @@ Applied to board card borders, collection item backgrounds, and tilted watermark
 
 ### Tiled Background
 A subtle gamepad pattern (`background_tile.png`) is repeated across the entire app via `MaterialApp.builder`. The tile is rendered at 3% opacity and 1.5x scale over the dark background, giving all screens a consistent textured look without per-screen configuration.
+
+## 📝 Wishlist
+
+Quick notes for content to find later when internet is available:
+
+- **Text notes** — save game/movie/TV show names for later search
+- **Optional media type hint** — tag notes as Game, Movie, TV Show, or Animation (ChoiceChip selector)
+- **Optional note** — additional context (platform, year, source of recommendation)
+- **Tap to search** — opens SearchScreen with pre-filled query and correct media tab
+- **Resolve/Unresolve** — mark items as found; resolved items show strikethrough text at 50% opacity, sorted to bottom
+- **Filter toggle** — show/hide resolved items
+- **Clear resolved** — bulk delete all resolved items with confirmation dialog
+- **Badge** — navigation icon shows count of active (unresolved) items
+- **Popup menu** — Search, Edit, Mark resolved/Unresolve, Delete per item
+- **FAB** — quick add via floating action button
 
 ## 📤 Sharing
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,9 +2,9 @@
 
 # 🗺️ Roadmap
 
-![Progress](https://img.shields.io/badge/overall_progress-~85%25-brightgreen?style=for-the-badge)
+![Progress](https://img.shields.io/badge/overall_progress-~87%25-brightgreen?style=for-the-badge)
 
-> Approximate completion: **~85%** — Core features, canvas system, media integrations, Android Lite, and UI redesign are done. A few restoration tasks and future plans remain.
+> Approximate completion: **~87%** — Core features, canvas system, media integrations, Android Lite, UI redesign, and Wishlist are done. A few restoration tasks and future plans remain.
 
 ---
 
@@ -58,6 +58,7 @@
 - [x] Settings Restructuring — monolithic SettingsScreen (~1118 lines) split into hub + 4 sub-screens: CredentialsScreen, CacheScreen, DatabaseScreen, DebugHubScreen. Debug screens use breadcrumb navigation
 - [x] Move to Collection — move items between collections or to/from uncategorized. DB `updateItemCollectionId`, shared `CollectionPickerDialog`, PopupMenuButton on detail screens and collection tiles. Board tab hidden for uncategorized items
 - [x] Multi-platform Games — same game with different platforms (SNES, GBA, etc.) in one collection with independent progress/rating/notes. DB migration v18: UNIQUE index with `COALESCE(platform_id, -1)`. Canvas sync via `collectionItemId`. Platform filter chips on Home and CollectionScreen. Platform badge on poster cards
+- [x] Wishlist — quick notes for deferred content search. WishlistItem model, DB migration v19 (wishlist table), WishlistRepository, WishlistNotifier (AsyncNotifierProvider), WishlistScreen with FAB/popup menu/filter/clear resolved, AddWishlistDialog with optional media type hint, 5th navigation tab with badge (active count), tap-to-search integration with SearchScreen(initialQuery)
 
 ---
 

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -16,6 +16,7 @@ import '../../shared/models/platform.dart';
 import '../../shared/models/tv_episode.dart';
 import '../../shared/models/tv_season.dart';
 import '../../shared/models/tv_show.dart';
+import '../../shared/models/wishlist_item.dart';
 
 /// Провайдер для доступа к сервису базы данных.
 final Provider<DatabaseService> databaseServiceProvider =
@@ -52,7 +53,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 18,
+        version: 19,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {
@@ -78,6 +79,7 @@ class DatabaseService {
     await _createTvEpisodesCacheTable(db);
     await _createWatchedEpisodesTable(db);
     await _createTmdbGenresTable(db);
+    await _createWishlistTable(db);
   }
 
   Future<void> _createPlatformsTable(Database db) async {
@@ -251,6 +253,9 @@ class DatabaseService {
     }
     if (oldVersion < 18) {
       await _migrateUniqueIndexWithPlatform(db);
+    }
+    if (oldVersion < 19) {
+      await _createWishlistTable(db);
     }
   }
 
@@ -583,6 +588,20 @@ class DatabaseService {
         type TEXT NOT NULL,
         name TEXT NOT NULL,
         PRIMARY KEY (id, type)
+      )
+    ''');
+  }
+
+  Future<void> _createWishlistTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS wishlist (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        text TEXT NOT NULL,
+        media_type_hint TEXT,
+        note TEXT,
+        is_resolved INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        resolved_at INTEGER
       )
     ''');
   }
@@ -2222,9 +2241,153 @@ class DatabaseService {
     return result.first['count'] as int;
   }
 
+  // ==================== Wishlist ====================
+
+  /// Добавляет элемент в вишлист.
+  ///
+  /// Возвращает созданный [WishlistItem] с присвоенным ID.
+  Future<WishlistItem> addWishlistItem({
+    required String text,
+    MediaType? mediaTypeHint,
+    String? note,
+  }) async {
+    final Database db = await database;
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    final int id = await db.insert(
+      'wishlist',
+      <String, dynamic>{
+        'text': text,
+        'media_type_hint': mediaTypeHint?.value,
+        'note': note,
+        'is_resolved': 0,
+        'created_at': now,
+      },
+    );
+
+    return WishlistItem(
+      id: id,
+      text: text,
+      mediaTypeHint: mediaTypeHint,
+      note: note,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(now * 1000),
+    );
+  }
+
+  /// Возвращает все элементы вишлиста.
+  ///
+  /// Сортировка: активные первыми (по created_at DESC),
+  /// затем resolved (по resolved_at DESC).
+  /// Если [includeResolved] == false, возвращает только активные.
+  Future<List<WishlistItem>> getWishlistItems({
+    bool includeResolved = true,
+  }) async {
+    final Database db = await database;
+    final String where = includeResolved ? '' : 'WHERE is_resolved = 0';
+    final List<Map<String, dynamic>> rows = await db.rawQuery(
+      'SELECT * FROM wishlist $where '
+      'ORDER BY is_resolved ASC, created_at DESC',
+    );
+    return rows.map(WishlistItem.fromDb).toList();
+  }
+
+  /// Возвращает количество элементов вишлиста.
+  ///
+  /// Если [onlyActive] == true, считает только неразрешённые.
+  Future<int> getWishlistItemCount({bool onlyActive = true}) async {
+    final Database db = await database;
+    final String where = onlyActive ? 'WHERE is_resolved = 0' : '';
+    final List<Map<String, dynamic>> result = await db.rawQuery(
+      'SELECT COUNT(*) as count FROM wishlist $where',
+    );
+    return result.first['count'] as int;
+  }
+
+  /// Обновляет элемент вишлиста.
+  Future<void> updateWishlistItem(
+    int id, {
+    String? text,
+    MediaType? mediaTypeHint,
+    bool clearMediaTypeHint = false,
+    String? note,
+    bool clearNote = false,
+  }) async {
+    final Map<String, dynamic> updates = <String, dynamic>{};
+    if (text != null) updates['text'] = text;
+    if (clearMediaTypeHint) {
+      updates['media_type_hint'] = null;
+    } else if (mediaTypeHint != null) {
+      updates['media_type_hint'] = mediaTypeHint.value;
+    }
+    if (clearNote) {
+      updates['note'] = null;
+    } else if (note != null) {
+      updates['note'] = note;
+    }
+    if (updates.isEmpty) return;
+
+    final Database db = await database;
+    await db.update(
+      'wishlist',
+      updates,
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+    );
+  }
+
+  /// Помечает элемент вишлиста как resolved.
+  Future<void> resolveWishlistItem(int id) async {
+    final Database db = await database;
+    final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await db.update(
+      'wishlist',
+      <String, dynamic>{
+        'is_resolved': 1,
+        'resolved_at': now,
+      },
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+    );
+  }
+
+  /// Снимает отметку resolved с элемента вишлиста.
+  Future<void> unresolveWishlistItem(int id) async {
+    final Database db = await database;
+    await db.update(
+      'wishlist',
+      <String, dynamic>{
+        'is_resolved': 0,
+        'resolved_at': null,
+      },
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+    );
+  }
+
+  /// Удаляет элемент вишлиста.
+  Future<void> deleteWishlistItem(int id) async {
+    final Database db = await database;
+    await db.delete(
+      'wishlist',
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+    );
+  }
+
+  /// Удаляет все resolved элементы вишлиста.
+  ///
+  /// Возвращает количество удалённых записей.
+  Future<int> clearResolvedWishlistItems() async {
+    final Database db = await database;
+    return db.delete(
+      'wishlist',
+      where: 'is_resolved = 1',
+    );
+  }
+
   /// Очищает все данные из базы данных.
   ///
-  /// Удаляет содержимое всех 14 таблиц в одной транзакции.
+  /// Удаляет содержимое всех таблиц в одной транзакции.
   /// Сначала зависимые таблицы (FK), затем основные.
   /// Настройки (SharedPreferences) не затрагиваются.
   Future<void> clearAllData() async {
@@ -2245,6 +2408,8 @@ class DatabaseService {
       await txn.delete('movies_cache');
       await txn.delete('games');
       await txn.delete('platforms');
+      // Wishlist
+      await txn.delete('wishlist');
     });
   }
 

--- a/lib/data/repositories/wishlist_repository.dart
+++ b/lib/data/repositories/wishlist_repository.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/database/database_service.dart';
+import '../../shared/models/media_type.dart';
+import '../../shared/models/wishlist_item.dart';
+
+/// Провайдер для репозитория вишлиста.
+final Provider<WishlistRepository> wishlistRepositoryProvider =
+    Provider<WishlistRepository>((Ref ref) {
+  return WishlistRepository(
+    db: ref.watch(databaseServiceProvider),
+  );
+});
+
+/// Репозиторий для работы с элементами вишлиста.
+class WishlistRepository {
+  /// Создаёт экземпляр [WishlistRepository].
+  WishlistRepository({required DatabaseService db}) : _db = db;
+
+  final DatabaseService _db;
+
+  /// Добавляет элемент в вишлист.
+  Future<WishlistItem> add({
+    required String text,
+    MediaType? mediaTypeHint,
+    String? note,
+  }) async {
+    return _db.addWishlistItem(
+      text: text,
+      mediaTypeHint: mediaTypeHint,
+      note: note,
+    );
+  }
+
+  /// Возвращает все элементы вишлиста.
+  Future<List<WishlistItem>> getAll({
+    bool includeResolved = true,
+  }) async {
+    return _db.getWishlistItems(includeResolved: includeResolved);
+  }
+
+  /// Возвращает количество элементов вишлиста.
+  Future<int> getCount({bool onlyActive = true}) async {
+    return _db.getWishlistItemCount(onlyActive: onlyActive);
+  }
+
+  /// Обновляет элемент вишлиста.
+  Future<void> update(
+    int id, {
+    String? text,
+    MediaType? mediaTypeHint,
+    bool clearMediaTypeHint = false,
+    String? note,
+    bool clearNote = false,
+  }) async {
+    return _db.updateWishlistItem(
+      id,
+      text: text,
+      mediaTypeHint: mediaTypeHint,
+      clearMediaTypeHint: clearMediaTypeHint,
+      note: note,
+      clearNote: clearNote,
+    );
+  }
+
+  /// Помечает элемент как resolved.
+  Future<void> resolve(int id) async {
+    return _db.resolveWishlistItem(id);
+  }
+
+  /// Снимает отметку resolved.
+  Future<void> unresolve(int id) async {
+    return _db.unresolveWishlistItem(id);
+  }
+
+  /// Удаляет элемент.
+  Future<void> delete(int id) async {
+    return _db.deleteWishlistItem(id);
+  }
+
+  /// Удаляет все resolved элементы.
+  Future<int> clearResolved() async {
+    return _db.clearResolvedWishlistItems();
+  }
+}

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -43,6 +43,7 @@ class SearchScreen extends ConsumerStatefulWidget {
     this.onGameSelected,
     this.collectionId,
     this.initialTabIndex,
+    this.initialQuery,
     super.key,
   });
 
@@ -54,6 +55,9 @@ class SearchScreen extends ConsumerStatefulWidget {
 
   /// Начальный индекс таба (0=TV, 1=Games).
   final int? initialTabIndex;
+
+  /// Начальный запрос поиска (предзаполняет поле и запускает поиск).
+  final String? initialQuery;
 
   @override
   ConsumerState<SearchScreen> createState() => _SearchScreenState();
@@ -87,9 +91,16 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     _tabController.addListener(_onTabChanged);
     _loadPlatforms();
     _searchController.addListener(_onControllerChanged);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _searchFocus.requestFocus();
-    });
+    if (widget.initialQuery != null && widget.initialQuery!.isNotEmpty) {
+      _searchController.text = widget.initialQuery!;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _onSearchSubmit();
+      });
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _searchFocus.requestFocus();
+      });
+    }
   }
 
   void _onControllerChanged() {

--- a/lib/features/wishlist/providers/wishlist_provider.dart
+++ b/lib/features/wishlist/providers/wishlist_provider.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../data/repositories/wishlist_repository.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/wishlist_item.dart';
+
+/// Провайдер для списка элементов вишлиста.
+final AsyncNotifierProvider<WishlistNotifier, List<WishlistItem>>
+    wishlistProvider =
+    AsyncNotifierProvider<WishlistNotifier, List<WishlistItem>>(
+  WishlistNotifier.new,
+);
+
+/// Notifier для управления вишлистом.
+class WishlistNotifier extends AsyncNotifier<List<WishlistItem>> {
+  late WishlistRepository _repository;
+
+  @override
+  Future<List<WishlistItem>> build() async {
+    _repository = ref.watch(wishlistRepositoryProvider);
+    return _repository.getAll();
+  }
+
+  /// Обновляет список из БД.
+  Future<void> refresh() async {
+    state = const AsyncLoading<List<WishlistItem>>();
+    state = await AsyncValue.guard(() => _repository.getAll());
+  }
+
+  /// Добавляет элемент в вишлист.
+  Future<WishlistItem> add({
+    required String text,
+    MediaType? mediaTypeHint,
+    String? note,
+  }) async {
+    final WishlistItem item = await _repository.add(
+      text: text,
+      mediaTypeHint: mediaTypeHint,
+      note: note,
+    );
+
+    // Оптимистичное обновление: добавляем в начало
+    final List<WishlistItem> current = state.valueOrNull ?? <WishlistItem>[];
+    state = AsyncData<List<WishlistItem>>(
+      <WishlistItem>[item, ...current],
+    );
+
+    return item;
+  }
+
+  /// Помечает элемент как resolved.
+  Future<void> resolve(int id) async {
+    await _repository.resolve(id);
+
+    final List<WishlistItem> current = state.valueOrNull ?? <WishlistItem>[];
+    state = AsyncData<List<WishlistItem>>(
+      _sortItems(
+        current.map((WishlistItem item) {
+          if (item.id == id) {
+            return item.copyWith(
+              isResolved: true,
+              resolvedAt: DateTime.now(),
+            );
+          }
+          return item;
+        }).toList(),
+      ),
+    );
+  }
+
+  /// Снимает отметку resolved.
+  Future<void> unresolve(int id) async {
+    await _repository.unresolve(id);
+
+    final List<WishlistItem> current = state.valueOrNull ?? <WishlistItem>[];
+    state = AsyncData<List<WishlistItem>>(
+      _sortItems(
+        current.map((WishlistItem item) {
+          if (item.id == id) {
+            return item.copyWith(
+              isResolved: false,
+              clearResolvedAt: true,
+            );
+          }
+          return item;
+        }).toList(),
+      ),
+    );
+  }
+
+  /// Обновляет элемент вишлиста.
+  Future<void> updateItem(
+    int id, {
+    String? text,
+    MediaType? mediaTypeHint,
+    bool clearMediaTypeHint = false,
+    String? note,
+    bool clearNote = false,
+  }) async {
+    await _repository.update(
+      id,
+      text: text,
+      mediaTypeHint: mediaTypeHint,
+      clearMediaTypeHint: clearMediaTypeHint,
+      note: note,
+      clearNote: clearNote,
+    );
+
+    final List<WishlistItem> current = state.valueOrNull ?? <WishlistItem>[];
+    state = AsyncData<List<WishlistItem>>(
+      current.map((WishlistItem item) {
+        if (item.id == id) {
+          return item.copyWith(
+            text: text,
+            mediaTypeHint: mediaTypeHint,
+            clearMediaTypeHint: clearMediaTypeHint,
+            note: note,
+            clearNote: clearNote,
+          );
+        }
+        return item;
+      }).toList(),
+    );
+  }
+
+  /// Удаляет элемент.
+  Future<void> delete(int id) async {
+    await _repository.delete(id);
+
+    final List<WishlistItem> current = state.valueOrNull ?? <WishlistItem>[];
+    state = AsyncData<List<WishlistItem>>(
+      current.where((WishlistItem item) => item.id != id).toList(),
+    );
+  }
+
+  /// Удаляет все resolved элементы.
+  Future<int> clearResolved() async {
+    final int count = await _repository.clearResolved();
+
+    final List<WishlistItem> current = state.valueOrNull ?? <WishlistItem>[];
+    state = AsyncData<List<WishlistItem>>(
+      current.where((WishlistItem item) => !item.isResolved).toList(),
+    );
+
+    return count;
+  }
+
+  /// Сортирует: активные первыми (по createdAt DESC),
+  /// затем resolved (по createdAt DESC).
+  List<WishlistItem> _sortItems(List<WishlistItem> items) {
+    final List<WishlistItem> sorted = List<WishlistItem>.of(items);
+    sorted.sort((WishlistItem a, WishlistItem b) {
+      if (a.isResolved != b.isResolved) {
+        return a.isResolved ? 1 : -1;
+      }
+      return b.createdAt.compareTo(a.createdAt);
+    });
+    return sorted;
+  }
+}
+
+/// Количество активных (не resolved) элементов вишлиста.
+final Provider<int> activeWishlistCountProvider = Provider<int>((Ref ref) {
+  final AsyncValue<List<WishlistItem>> itemsAsync = ref.watch(wishlistProvider);
+  final List<WishlistItem>? items = itemsAsync.valueOrNull;
+  if (items == null) return 0;
+  return items.where((WishlistItem item) => !item.isResolved).length;
+});

--- a/lib/features/wishlist/screens/wishlist_screen.dart
+++ b/lib/features/wishlist/screens/wishlist_screen.dart
@@ -1,0 +1,353 @@
+// Экран вишлиста — заметки для отложенного поиска контента.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../shared/constants/media_type_theme.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/wishlist_item.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/breadcrumb_app_bar.dart';
+import '../../search/screens/search_screen.dart';
+import '../providers/wishlist_provider.dart';
+import '../widgets/add_wishlist_dialog.dart';
+
+/// Экран вишлиста.
+///
+/// Показывает список заметок для отложенного поиска контента.
+/// FAB для быстрого добавления, popup menu для действий.
+class WishlistScreen extends ConsumerStatefulWidget {
+  /// Создаёт [WishlistScreen].
+  const WishlistScreen({super.key});
+
+  @override
+  ConsumerState<WishlistScreen> createState() => _WishlistScreenState();
+}
+
+class _WishlistScreenState extends ConsumerState<WishlistScreen> {
+  bool _showResolved = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<List<WishlistItem>> itemsAsync =
+        ref.watch(wishlistProvider);
+
+    return Scaffold(
+      appBar: BreadcrumbAppBar(
+        crumbs: const <BreadcrumbItem>[
+          BreadcrumbItem(label: 'Wishlist'),
+        ],
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(
+              _showResolved
+                  ? Icons.visibility
+                  : Icons.visibility_off,
+            ),
+            tooltip: _showResolved ? 'Hide resolved' : 'Show resolved',
+            onPressed: () {
+              setState(() {
+                _showResolved = !_showResolved;
+              });
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_sweep),
+            tooltip: 'Clear resolved',
+            onPressed: () => _confirmClearResolved(context),
+          ),
+        ],
+      ),
+      body: itemsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object error, StackTrace stack) => Center(
+          child: Text('Error: $error'),
+        ),
+        data: (List<WishlistItem> items) {
+          final List<WishlistItem> filtered = _showResolved
+              ? items
+              : items
+                  .where((WishlistItem item) => !item.isResolved)
+                  .toList();
+
+          if (filtered.isEmpty) {
+            return _buildEmptyState(context);
+          }
+
+          return ListView.builder(
+            padding: const EdgeInsets.only(bottom: 80),
+            itemCount: filtered.length,
+            itemBuilder: (BuildContext context, int index) {
+              return _WishlistTile(
+                item: filtered[index],
+                onTap: () => _searchForItem(context, filtered[index]),
+                onResolve: () => _toggleResolved(filtered[index]),
+                onEdit: () => _editItem(context, filtered[index]),
+                onDelete: () => _deleteItem(context, filtered[index]),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'wishlist_add',
+        onPressed: () => _addItem(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(
+            Icons.bookmark_border,
+            size: 64,
+            color: AppColors.textTertiary.withValues(alpha: 0.5),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text(
+            'No wishlist items yet',
+            style: AppTypography.body.copyWith(
+              color: AppColors.textTertiary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'Tap + to add something to find later',
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textTertiary.withValues(alpha: 0.7),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _addItem(BuildContext context) async {
+    final WishlistDialogResult? result = await AddWishlistDialog.show(context);
+    if (result == null || !mounted) return;
+
+    await ref.read(wishlistProvider.notifier).add(
+          text: result.text,
+          mediaTypeHint: result.mediaTypeHint,
+          note: result.note,
+        );
+  }
+
+  Future<void> _editItem(BuildContext context, WishlistItem item) async {
+    final WishlistDialogResult? result = await AddWishlistDialog.show(
+      context,
+      existing: item,
+    );
+    if (result == null || !mounted) return;
+
+    await ref.read(wishlistProvider.notifier).updateItem(
+          item.id,
+          text: result.text,
+          mediaTypeHint: result.mediaTypeHint,
+          clearMediaTypeHint: result.mediaTypeHint == null,
+          note: result.note,
+          clearNote: result.note == null,
+        );
+  }
+
+  void _toggleResolved(WishlistItem item) {
+    if (item.isResolved) {
+      ref.read(wishlistProvider.notifier).unresolve(item.id);
+    } else {
+      ref.read(wishlistProvider.notifier).resolve(item.id);
+    }
+  }
+
+  Future<void> _deleteItem(BuildContext context, WishlistItem item) async {
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('Delete item'),
+        content: Text('Delete "${item.text}" from wishlist?'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await ref.read(wishlistProvider.notifier).delete(item.id);
+    }
+  }
+
+  void _searchForItem(BuildContext context, WishlistItem item) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => SearchScreen(
+          initialQuery: item.text,
+          initialTabIndex: item.mediaTypeHint == MediaType.game ? 1 : 0,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmClearResolved(BuildContext context) async {
+    final int resolvedCount = ref
+            .read(wishlistProvider)
+            .valueOrNull
+            ?.where((WishlistItem item) => item.isResolved)
+            .length ??
+        0;
+
+    if (resolvedCount == 0) return;
+
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('Clear resolved'),
+        content: Text(
+          'Delete $resolvedCount resolved item${resolvedCount == 1 ? '' : 's'}?',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await ref.read(wishlistProvider.notifier).clearResolved();
+    }
+  }
+}
+
+class _WishlistTile extends StatelessWidget {
+  const _WishlistTile({
+    required this.item,
+    required this.onTap,
+    required this.onResolve,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final WishlistItem item;
+  final VoidCallback onTap;
+  final VoidCallback onResolve;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: item.isResolved ? 0.5 : 1.0,
+      child: ListTile(
+        leading: _buildLeadingIcon(),
+        title: Text(
+          item.text,
+          style: item.isResolved
+              ? const TextStyle(decoration: TextDecoration.lineThrough)
+              : null,
+        ),
+        subtitle: _buildSubtitle(context),
+        trailing: PopupMenuButton<String>(
+          onSelected: (String value) {
+            switch (value) {
+              case 'search':
+                onTap();
+              case 'edit':
+                onEdit();
+              case 'resolve':
+                onResolve();
+              case 'delete':
+                onDelete();
+            }
+          },
+          itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+            const PopupMenuItem<String>(
+              value: 'search',
+              child: ListTile(
+                leading: Icon(Icons.search),
+                title: Text('Search'),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ),
+            const PopupMenuItem<String>(
+              value: 'edit',
+              child: ListTile(
+                leading: Icon(Icons.edit),
+                title: Text('Edit'),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ),
+            PopupMenuItem<String>(
+              value: 'resolve',
+              child: ListTile(
+                leading: Icon(
+                  item.isResolved ? Icons.undo : Icons.check_circle_outline,
+                ),
+                title: Text(item.isResolved ? 'Unresolve' : 'Mark resolved'),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ),
+            const PopupMenuDivider(),
+            const PopupMenuItem<String>(
+              value: 'delete',
+              child: ListTile(
+                leading: Icon(Icons.delete, color: Colors.red),
+                title: Text('Delete', style: TextStyle(color: Colors.red)),
+                contentPadding: EdgeInsets.zero,
+                dense: true,
+              ),
+            ),
+          ],
+        ),
+        onTap: onTap,
+      ),
+    );
+  }
+
+  Widget _buildLeadingIcon() {
+    if (item.mediaTypeHint != null) {
+      return Icon(
+        MediaTypeTheme.iconFor(item.mediaTypeHint!),
+        color: MediaTypeTheme.colorFor(item.mediaTypeHint!),
+      );
+    }
+    return const Icon(Icons.bookmark_border, color: AppColors.textTertiary);
+  }
+
+  Widget? _buildSubtitle(BuildContext context) {
+    final List<String> parts = <String>[];
+    if (item.hasNote) {
+      parts.add(item.note!);
+    }
+    if (item.mediaTypeHint != null && !item.hasNote) {
+      parts.add(item.mediaTypeHint!.displayLabel);
+    }
+
+    if (parts.isEmpty) return null;
+
+    return Text(
+      parts.join(' · '),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}

--- a/lib/features/wishlist/widgets/add_wishlist_dialog.dart
+++ b/lib/features/wishlist/widgets/add_wishlist_dialog.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/constants/media_type_theme.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/wishlist_item.dart';
+import '../../../shared/theme/app_spacing.dart';
+
+// Диалог добавления/редактирования элемента вишлиста.
+
+/// Результат диалога вишлиста.
+class WishlistDialogResult {
+  /// Создаёт экземпляр [WishlistDialogResult].
+  const WishlistDialogResult({
+    required this.text,
+    this.mediaTypeHint,
+    this.note,
+  });
+
+  /// Текст заметки (название контента).
+  final String text;
+
+  /// Опциональный тип медиа.
+  final MediaType? mediaTypeHint;
+
+  /// Дополнительная заметка.
+  final String? note;
+}
+
+/// Диалог для добавления или редактирования элемента вишлиста.
+///
+/// Возвращает [WishlistDialogResult] или `null` при отмене.
+class AddWishlistDialog extends StatefulWidget {
+  /// Создаёт [AddWishlistDialog].
+  const AddWishlistDialog({
+    this.existing,
+    super.key,
+  });
+
+  /// Существующий элемент (для режима редактирования).
+  final WishlistItem? existing;
+
+  /// Показывает диалог и возвращает результат.
+  static Future<WishlistDialogResult?> show(
+    BuildContext context, {
+    WishlistItem? existing,
+  }) {
+    return showDialog<WishlistDialogResult>(
+      context: context,
+      builder: (BuildContext context) {
+        return AddWishlistDialog(existing: existing);
+      },
+    );
+  }
+
+  @override
+  State<AddWishlistDialog> createState() => _AddWishlistDialogState();
+}
+
+class _AddWishlistDialogState extends State<AddWishlistDialog> {
+  late final TextEditingController _textController;
+  late final TextEditingController _noteController;
+  MediaType? _selectedMediaType;
+  bool get _isEditing => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController = TextEditingController(
+      text: widget.existing?.text ?? '',
+    );
+    _noteController = TextEditingController(
+      text: widget.existing?.note ?? '',
+    );
+    _selectedMediaType = widget.existing?.mediaTypeHint;
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final String text = _textController.text.trim();
+    if (text.isEmpty) return;
+
+    final String noteText = _noteController.text.trim();
+    Navigator.of(context).pop(
+      WishlistDialogResult(
+        text: text,
+        mediaTypeHint: _selectedMediaType,
+        note: noteText.isEmpty ? null : noteText,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      scrollable: true,
+      title: Text(_isEditing ? 'Edit Wishlist Item' : 'Add to Wishlist'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            TextField(
+              controller: _textController,
+              autofocus: true,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                labelText: 'Title',
+                hintText: 'Game, movie, or TV show name...',
+                border: OutlineInputBorder(),
+              ),
+              onSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              'Type (optional)',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Wrap(
+              spacing: AppSpacing.xs,
+              children: <Widget>[
+                _buildMediaTypeChip(null, 'Any', Icons.bookmark_border),
+                ...MediaType.values.map(
+                  (MediaType type) => _buildMediaTypeChip(
+                    type,
+                    type.displayLabel,
+                    MediaTypeTheme.iconFor(type),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.md),
+            TextField(
+              controller: _noteController,
+              maxLines: 2,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                labelText: 'Note (optional)',
+                hintText: 'Platform, year, who recommended...',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: Text(_isEditing ? 'Save' : 'Add'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMediaTypeChip(
+    MediaType? type,
+    String label,
+    IconData icon,
+  ) {
+    final bool isSelected = _selectedMediaType == type;
+    final Color? chipColor =
+        type != null ? MediaTypeTheme.colorFor(type) : null;
+
+    return ChoiceChip(
+      label: Text(label),
+      avatar: Icon(
+        icon,
+        size: 18,
+        color: isSelected ? chipColor : null,
+      ),
+      selected: isSelected,
+      selectedColor: chipColor?.withValues(alpha: 0.2),
+      onSelected: (bool selected) {
+        setState(() {
+          _selectedMediaType = selected ? type : null;
+        });
+      },
+    );
+  }
+}

--- a/lib/shared/models/wishlist_item.dart
+++ b/lib/shared/models/wishlist_item.dart
@@ -1,0 +1,119 @@
+// Элемент вишлиста — заметка для отложенного поиска контента.
+
+import 'media_type.dart';
+
+/// Элемент вишлиста.
+///
+/// Представляет текстовую заметку о контенте, который нужно найти позже.
+class WishlistItem {
+  /// Создаёт экземпляр [WishlistItem].
+  const WishlistItem({
+    required this.id,
+    required this.text,
+    required this.createdAt,
+    this.mediaTypeHint,
+    this.note,
+    this.isResolved = false,
+    this.resolvedAt,
+  });
+
+  /// Создаёт [WishlistItem] из записи базы данных.
+  factory WishlistItem.fromDb(Map<String, dynamic> row) {
+    final String? mediaTypeHintValue = row['media_type_hint'] as String?;
+    return WishlistItem(
+      id: row['id'] as int,
+      text: row['text'] as String,
+      mediaTypeHint: mediaTypeHintValue != null
+          ? MediaType.fromString(mediaTypeHintValue)
+          : null,
+      note: row['note'] as String?,
+      isResolved: (row['is_resolved'] as int) == 1,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        (row['created_at'] as int) * 1000,
+      ),
+      resolvedAt: row['resolved_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(
+              (row['resolved_at'] as int) * 1000,
+            )
+          : null,
+    );
+  }
+
+  /// Уникальный идентификатор записи.
+  final int id;
+
+  /// Текст заметки (название контента).
+  final String text;
+
+  /// Опциональный хинт типа медиа.
+  final MediaType? mediaTypeHint;
+
+  /// Дополнительная заметка (платформа, год, откуда узнал).
+  final String? note;
+
+  /// Найдено и добавлено в коллекцию.
+  final bool isResolved;
+
+  /// Дата создания заметки.
+  final DateTime createdAt;
+
+  /// Дата разрешения (когда элемент найден и добавлен).
+  final DateTime? resolvedAt;
+
+  /// Есть ли дополнительная заметка.
+  bool get hasNote => note != null && note!.isNotEmpty;
+
+  /// Преобразует в Map для сохранения в базу данных.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'id': id,
+      'text': text,
+      'media_type_hint': mediaTypeHint?.value,
+      'note': note,
+      'is_resolved': isResolved ? 1 : 0,
+      'created_at': createdAt.millisecondsSinceEpoch ~/ 1000,
+      'resolved_at': resolvedAt != null
+          ? resolvedAt!.millisecondsSinceEpoch ~/ 1000
+          : null,
+    };
+  }
+
+  /// Создаёт копию с изменёнными полями.
+  WishlistItem copyWith({
+    int? id,
+    String? text,
+    MediaType? mediaTypeHint,
+    bool clearMediaTypeHint = false,
+    String? note,
+    bool clearNote = false,
+    bool? isResolved,
+    DateTime? createdAt,
+    DateTime? resolvedAt,
+    bool clearResolvedAt = false,
+  }) {
+    return WishlistItem(
+      id: id ?? this.id,
+      text: text ?? this.text,
+      mediaTypeHint:
+          clearMediaTypeHint ? null : (mediaTypeHint ?? this.mediaTypeHint),
+      note: clearNote ? null : (note ?? this.note),
+      isResolved: isResolved ?? this.isResolved,
+      createdAt: createdAt ?? this.createdAt,
+      resolvedAt:
+          clearResolvedAt ? null : (resolvedAt ?? this.resolvedAt),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WishlistItem && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() =>
+      'WishlistItem(id: $id, text: $text, resolved: $isResolved)';
+}

--- a/lib/shared/navigation/navigation_shell.dart
+++ b/lib/shared/navigation/navigation_shell.dart
@@ -9,6 +9,8 @@ import '../../features/collections/screens/home_screen.dart';
 import '../../features/home/screens/all_items_screen.dart';
 import '../../features/search/screens/search_screen.dart';
 import '../../features/settings/screens/settings_screen.dart';
+import '../../features/wishlist/providers/wishlist_provider.dart';
+import '../../features/wishlist/screens/wishlist_screen.dart';
 import '../gamepad/gamepad_action.dart';
 import '../gamepad/widgets/gamepad_listener.dart';
 import '../theme/app_assets.dart';
@@ -18,7 +20,7 @@ import '../theme/app_colors.dart';
 const double navigationBreakpoint = 800;
 
 /// Количество основных табов.
-const int _tabCount = 4;
+const int _tabCount = 5;
 
 /// Индексы вкладок навигации.
 enum NavTab {
@@ -27,6 +29,9 @@ enum NavTab {
 
   /// Коллекции.
   collections,
+
+  /// Вишлист (заметки для поиска).
+  wishlist,
 
   /// Поиск.
   search,
@@ -145,23 +150,28 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
                   fontSize: 12,
                 ),
                 labelType: NavigationRailLabelType.all,
-                destinations: const <NavigationRailDestination>[
-                  NavigationRailDestination(
+                destinations: <NavigationRailDestination>[
+                  const NavigationRailDestination(
                     icon: Icon(Icons.home_outlined),
                     selectedIcon: Icon(Icons.home),
                     label: Text('Main'),
                   ),
-                  NavigationRailDestination(
+                  const NavigationRailDestination(
                     icon: Icon(Icons.collections_bookmark_outlined),
                     selectedIcon: Icon(Icons.collections_bookmark),
                     label: Text('Collections'),
                   ),
                   NavigationRailDestination(
+                    icon: _buildWishlistIcon(Icons.bookmark_border),
+                    selectedIcon: _buildWishlistIcon(Icons.bookmark),
+                    label: const Text('Wishlist'),
+                  ),
+                  const NavigationRailDestination(
                     icon: Icon(Icons.search_outlined),
                     selectedIcon: Icon(Icons.search),
                     label: Text('Search'),
                   ),
-                  NavigationRailDestination(
+                  const NavigationRailDestination(
                     icon: Icon(Icons.settings_outlined),
                     selectedIcon: Icon(Icons.settings),
                     label: Text('Settings'),
@@ -190,23 +200,28 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
       selectedItemColor: AppColors.textPrimary,
       unselectedItemColor: AppColors.textTertiary,
       type: BottomNavigationBarType.fixed,
-      items: const <BottomNavigationBarItem>[
-        BottomNavigationBarItem(
+      items: <BottomNavigationBarItem>[
+        const BottomNavigationBarItem(
           icon: Icon(Icons.home_outlined),
           activeIcon: Icon(Icons.home),
           label: 'Main',
         ),
-        BottomNavigationBarItem(
+        const BottomNavigationBarItem(
           icon: Icon(Icons.collections_bookmark_outlined),
           activeIcon: Icon(Icons.collections_bookmark),
           label: 'Collections',
         ),
         BottomNavigationBarItem(
+          icon: _buildWishlistIcon(Icons.bookmark_border),
+          activeIcon: _buildWishlistIcon(Icons.bookmark),
+          label: 'Wishlist',
+        ),
+        const BottomNavigationBarItem(
           icon: Icon(Icons.search_outlined),
           activeIcon: Icon(Icons.search),
           label: 'Search',
         ),
-        BottomNavigationBarItem(
+        const BottomNavigationBarItem(
           icon: Icon(Icons.settings_outlined),
           activeIcon: Icon(Icons.settings),
           label: 'Settings',
@@ -231,6 +246,7 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
     final Widget screen = switch (NavTab.values[tabIndex]) {
       NavTab.home => const AllItemsScreen(),
       NavTab.collections => const HomeScreen(),
+      NavTab.wishlist => const WishlistScreen(),
       NavTab.search => const SearchScreen(),
       NavTab.settings => const SettingsScreen(),
     };
@@ -273,6 +289,17 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
       return true;
     }
     return false;
+  }
+
+  Widget _buildWishlistIcon(IconData icon) {
+    final int count = ref.watch(activeWishlistCountProvider);
+    if (count == 0) {
+      return Icon(icon);
+    }
+    return Badge(
+      label: Text('$count'),
+      child: Icon(icon),
+    );
   }
 
   void _onGamepadTabSwitch(GamepadAction action) {

--- a/test/data/repositories/wishlist_repository_test.dart
+++ b/test/data/repositories/wishlist_repository_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/data/repositories/wishlist_repository.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/wishlist_item.dart';
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+void main() {
+  late MockDatabaseService mockDb;
+  late WishlistRepository repository;
+
+  setUp(() {
+    mockDb = MockDatabaseService();
+    repository = WishlistRepository(db: mockDb);
+  });
+
+  setUpAll(() {
+    registerFallbackValue(MediaType.game);
+  });
+
+  final WishlistItem testItem = WishlistItem(
+    id: 1,
+    text: 'Chrono Trigger',
+    mediaTypeHint: MediaType.game,
+    note: 'SNES',
+    createdAt: DateTime(2024, 6, 15),
+  );
+
+  group('WishlistRepository', () {
+    group('add', () {
+      test('должен делегировать в DatabaseService.addWishlistItem', () async {
+        when(
+          () => mockDb.addWishlistItem(
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            note: any(named: 'note'),
+          ),
+        ).thenAnswer((_) async => testItem);
+
+        final WishlistItem result = await repository.add(
+          text: 'Chrono Trigger',
+          mediaTypeHint: MediaType.game,
+          note: 'SNES',
+        );
+
+        expect(result, testItem);
+        verify(
+          () => mockDb.addWishlistItem(
+            text: 'Chrono Trigger',
+            mediaTypeHint: MediaType.game,
+            note: 'SNES',
+          ),
+        ).called(1);
+      });
+
+      test('должен передавать null для опциональных полей', () async {
+        when(
+          () => mockDb.addWishlistItem(
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            note: any(named: 'note'),
+          ),
+        ).thenAnswer((_) async => testItem);
+
+        await repository.add(text: 'Test');
+
+        verify(
+          () => mockDb.addWishlistItem(
+            text: 'Test',
+            mediaTypeHint: null,
+            note: null,
+          ),
+        ).called(1);
+      });
+    });
+
+    group('getAll', () {
+      test('должен делегировать с includeResolved=true по умолчанию',
+          () async {
+        when(
+          () => mockDb.getWishlistItems(includeResolved: true),
+        ).thenAnswer((_) async => <WishlistItem>[testItem]);
+
+        final List<WishlistItem> result = await repository.getAll();
+
+        expect(result, <WishlistItem>[testItem]);
+        verify(() => mockDb.getWishlistItems(includeResolved: true)).called(1);
+      });
+
+      test('должен передавать includeResolved=false', () async {
+        when(
+          () => mockDb.getWishlistItems(includeResolved: false),
+        ).thenAnswer((_) async => <WishlistItem>[]);
+
+        await repository.getAll(includeResolved: false);
+
+        verify(() => mockDb.getWishlistItems(includeResolved: false)).called(1);
+      });
+    });
+
+    group('getCount', () {
+      test('должен делегировать с onlyActive=true по умолчанию', () async {
+        when(
+          () => mockDb.getWishlistItemCount(onlyActive: true),
+        ).thenAnswer((_) async => 5);
+
+        final int count = await repository.getCount();
+
+        expect(count, 5);
+        verify(() => mockDb.getWishlistItemCount(onlyActive: true)).called(1);
+      });
+
+      test('должен передавать onlyActive=false', () async {
+        when(
+          () => mockDb.getWishlistItemCount(onlyActive: false),
+        ).thenAnswer((_) async => 10);
+
+        final int count = await repository.getCount(onlyActive: false);
+
+        expect(count, 10);
+      });
+    });
+
+    group('update', () {
+      test('должен делегировать обновление текста', () async {
+        when(
+          () => mockDb.updateWishlistItem(
+            any(),
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            clearMediaTypeHint: any(named: 'clearMediaTypeHint'),
+            note: any(named: 'note'),
+            clearNote: any(named: 'clearNote'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await repository.update(1, text: 'New Title');
+
+        verify(
+          () => mockDb.updateWishlistItem(
+            1,
+            text: 'New Title',
+            mediaTypeHint: null,
+            clearMediaTypeHint: false,
+            note: null,
+            clearNote: false,
+          ),
+        ).called(1);
+      });
+
+      test('должен передавать clearMediaTypeHint', () async {
+        when(
+          () => mockDb.updateWishlistItem(
+            any(),
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            clearMediaTypeHint: any(named: 'clearMediaTypeHint'),
+            note: any(named: 'note'),
+            clearNote: any(named: 'clearNote'),
+          ),
+        ).thenAnswer((_) async {});
+
+        await repository.update(1, clearMediaTypeHint: true);
+
+        verify(
+          () => mockDb.updateWishlistItem(
+            1,
+            text: null,
+            mediaTypeHint: null,
+            clearMediaTypeHint: true,
+            note: null,
+            clearNote: false,
+          ),
+        ).called(1);
+      });
+    });
+
+    group('resolve', () {
+      test('должен делегировать в resolveWishlistItem', () async {
+        when(() => mockDb.resolveWishlistItem(any()))
+            .thenAnswer((_) async {});
+
+        await repository.resolve(1);
+
+        verify(() => mockDb.resolveWishlistItem(1)).called(1);
+      });
+    });
+
+    group('unresolve', () {
+      test('должен делегировать в unresolveWishlistItem', () async {
+        when(() => mockDb.unresolveWishlistItem(any()))
+            .thenAnswer((_) async {});
+
+        await repository.unresolve(1);
+
+        verify(() => mockDb.unresolveWishlistItem(1)).called(1);
+      });
+    });
+
+    group('delete', () {
+      test('должен делегировать в deleteWishlistItem', () async {
+        when(() => mockDb.deleteWishlistItem(any()))
+            .thenAnswer((_) async {});
+
+        await repository.delete(1);
+
+        verify(() => mockDb.deleteWishlistItem(1)).called(1);
+      });
+    });
+
+    group('clearResolved', () {
+      test('должен делегировать и вернуть количество удалённых', () async {
+        when(() => mockDb.clearResolvedWishlistItems())
+            .thenAnswer((_) async => 3);
+
+        final int count = await repository.clearResolved();
+
+        expect(count, 3);
+        verify(() => mockDb.clearResolvedWishlistItems()).called(1);
+      });
+    });
+  });
+}

--- a/test/features/wishlist/providers/wishlist_provider_test.dart
+++ b/test/features/wishlist/providers/wishlist_provider_test.dart
@@ -1,0 +1,275 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/data/repositories/wishlist_repository.dart';
+import 'package:xerabora/features/wishlist/providers/wishlist_provider.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/wishlist_item.dart';
+
+class MockWishlistRepository extends Mock implements WishlistRepository {}
+
+void main() {
+  late MockWishlistRepository mockRepo;
+
+  setUp(() {
+    mockRepo = MockWishlistRepository();
+  });
+
+  setUpAll(() {
+    registerFallbackValue(MediaType.game);
+  });
+
+  ProviderContainer createContainer({
+    List<Override> extraOverrides = const <Override>[],
+  }) {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        wishlistRepositoryProvider.overrideWithValue(mockRepo),
+        ...extraOverrides,
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<void> pump([int times = 5]) async {
+    for (int i = 0; i < times; i++) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+
+  final WishlistItem item1 = WishlistItem(
+    id: 1,
+    text: 'Chrono Trigger',
+    mediaTypeHint: MediaType.game,
+    createdAt: DateTime(2024, 6, 15),
+  );
+
+  final WishlistItem item2 = WishlistItem(
+    id: 2,
+    text: 'The Matrix',
+    mediaTypeHint: MediaType.movie,
+    createdAt: DateTime(2024, 6, 16),
+  );
+
+  final WishlistItem resolvedItem = WishlistItem(
+    id: 3,
+    text: 'Resolved Game',
+    isResolved: true,
+    createdAt: DateTime(2024, 6, 10),
+    resolvedAt: DateTime(2024, 6, 20),
+  );
+
+  group('WishlistNotifier', () {
+    group('build', () {
+      test('должен загружать элементы из репозитория', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, item2]);
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        final AsyncValue<List<WishlistItem>> state =
+            container.read(wishlistProvider);
+        expect(state.valueOrNull, <WishlistItem>[item1, item2]);
+      });
+
+      test('должен возвращать пустой список если БД пуста', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[]);
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        expect(items, isEmpty);
+      });
+    });
+
+    group('add', () {
+      test('должен добавлять элемент и обновлять state', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[]);
+        when(
+          () => mockRepo.add(
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            note: any(named: 'note'),
+          ),
+        ).thenAnswer((_) async => item1);
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        final WishlistItem result = await container
+            .read(wishlistProvider.notifier)
+            .add(text: 'Chrono Trigger', mediaTypeHint: MediaType.game);
+
+        expect(result, item1);
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        expect(items, contains(item1));
+      });
+    });
+
+    group('resolve', () {
+      test('должен пометить элемент resolved и пересортировать', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, item2]);
+        when(() => mockRepo.resolve(any())).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        await container.read(wishlistProvider.notifier).resolve(1);
+
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        expect(items, isNotNull);
+        // item1 resolved → в конце списка
+        final WishlistItem resolved =
+            items!.firstWhere((WishlistItem i) => i.id == 1);
+        expect(resolved.isResolved, true);
+        expect(resolved.resolvedAt, isNotNull);
+        // resolved должен быть после unresolvedexpect(items.last.id, 1);
+      });
+    });
+
+    group('unresolve', () {
+      test('должен снять отметку resolved', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, resolvedItem]);
+        when(() => mockRepo.unresolve(any())).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        await container.read(wishlistProvider.notifier).unresolve(3);
+
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        final WishlistItem unresolved =
+            items!.firstWhere((WishlistItem i) => i.id == 3);
+        expect(unresolved.isResolved, false);
+        expect(unresolved.resolvedAt, null);
+      });
+    });
+
+    group('update', () {
+      test('должен обновлять текст элемента', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1]);
+        when(
+          () => mockRepo.update(
+            any(),
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            clearMediaTypeHint: any(named: 'clearMediaTypeHint'),
+            note: any(named: 'note'),
+            clearNote: any(named: 'clearNote'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        await container
+            .read(wishlistProvider.notifier)
+            .updateItem(1, text: 'New Title');
+
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        expect(items!.first.text, 'New Title');
+      });
+    });
+
+    group('delete', () {
+      test('должен удалять элемент из state', () async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, item2]);
+        when(() => mockRepo.delete(any())).thenAnswer((_) async {});
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        await container.read(wishlistProvider.notifier).delete(1);
+
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        expect(items!.length, 1);
+        expect(items.first.id, 2);
+      });
+    });
+
+    group('clearResolved', () {
+      test('должен удалить все resolved и вернуть count', () async {
+        when(() => mockRepo.getAll()).thenAnswer(
+          (_) async => <WishlistItem>[item1, item2, resolvedItem],
+        );
+        when(() => mockRepo.clearResolved()).thenAnswer((_) async => 1);
+
+        final ProviderContainer container = createContainer();
+        container.read(wishlistProvider);
+        await pump();
+
+        final int count =
+            await container.read(wishlistProvider.notifier).clearResolved();
+
+        expect(count, 1);
+        final List<WishlistItem>? items =
+            container.read(wishlistProvider).valueOrNull;
+        expect(items!.length, 2);
+        expect(
+          items.any((WishlistItem i) => i.isResolved),
+          false,
+        );
+      });
+    });
+  });
+
+  group('activeWishlistCountProvider', () {
+    test('должен считать только активные элементы', () async {
+      when(() => mockRepo.getAll()).thenAnswer(
+        (_) async => <WishlistItem>[item1, item2, resolvedItem],
+      );
+
+      final ProviderContainer container = createContainer();
+      container.read(wishlistProvider);
+      await pump();
+
+      final int count = container.read(activeWishlistCountProvider);
+      expect(count, 2);
+    });
+
+    test('должен возвращать 0 при пустом списке', () async {
+      when(() => mockRepo.getAll())
+          .thenAnswer((_) async => <WishlistItem>[]);
+
+      final ProviderContainer container = createContainer();
+      container.read(wishlistProvider);
+      await pump();
+
+      final int count = container.read(activeWishlistCountProvider);
+      expect(count, 0);
+    });
+
+    test('должен возвращать 0 пока данные загружаются', () {
+      when(() => mockRepo.getAll()).thenAnswer(
+        (_) async => <WishlistItem>[item1],
+      );
+
+      final ProviderContainer container = createContainer();
+      // Не ждём pump — данные ещё загружаются
+      final int count = container.read(activeWishlistCountProvider);
+      expect(count, 0);
+    });
+  });
+}

--- a/test/features/wishlist/screens/wishlist_screen_test.dart
+++ b/test/features/wishlist/screens/wishlist_screen_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/data/repositories/wishlist_repository.dart';
+import 'package:xerabora/features/wishlist/screens/wishlist_screen.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/wishlist_item.dart';
+
+class MockWishlistRepository extends Mock implements WishlistRepository {}
+
+void main() {
+  late MockWishlistRepository mockRepo;
+
+  setUp(() {
+    mockRepo = MockWishlistRepository();
+  });
+
+  setUpAll(() {
+    registerFallbackValue(MediaType.game);
+  });
+
+  final WishlistItem item1 = WishlistItem(
+    id: 1,
+    text: 'Chrono Trigger',
+    mediaTypeHint: MediaType.game,
+    note: 'SNES RPG',
+    createdAt: DateTime(2024, 6, 15),
+  );
+
+  final WishlistItem item2 = WishlistItem(
+    id: 2,
+    text: 'The Matrix',
+    mediaTypeHint: MediaType.movie,
+    createdAt: DateTime(2024, 6, 16),
+  );
+
+  final WishlistItem resolvedItem = WishlistItem(
+    id: 3,
+    text: 'Resolved Game',
+    isResolved: true,
+    createdAt: DateTime(2024, 6, 10),
+    resolvedAt: DateTime(2024, 6, 20),
+  );
+
+  Widget buildScreen({List<WishlistItem> items = const <WishlistItem>[]}) {
+    return ProviderScope(
+      overrides: <Override>[
+        wishlistRepositoryProvider.overrideWithValue(mockRepo),
+      ],
+      child: MaterialApp(
+        theme: ThemeData.dark(),
+        home: const WishlistScreen(),
+      ),
+    );
+  }
+
+  group('WishlistScreen', () {
+    group('empty state', () {
+      testWidgets('должен показывать empty state при пустом списке',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.text('No wishlist items yet'), findsOneWidget);
+        expect(
+          find.text('Tap + to add something to find later'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('список элементов', () {
+      testWidgets('должен показывать список элементов',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, item2]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Chrono Trigger'), findsOneWidget);
+        expect(find.text('The Matrix'), findsOneWidget);
+      });
+
+      testWidgets('должен показывать заметку в subtitle',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.text('SNES RPG'), findsOneWidget);
+      });
+
+      testWidgets('должен показывать тип медиа как subtitle если нет заметки',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item2]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Movie'), findsOneWidget);
+      });
+    });
+
+    group('resolved стиль', () {
+      testWidgets('должен показывать resolved элементы с opacity',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, resolvedItem]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        // Находим Opacity виджет для resolved элемента
+        final Finder resolvedTileFinder = find.ancestor(
+          of: find.text('Resolved Game'),
+          matching: find.byType(Opacity),
+        );
+        expect(resolvedTileFinder, findsOneWidget);
+
+        final Opacity opacity =
+            tester.widget<Opacity>(resolvedTileFinder);
+        expect(opacity.opacity, 0.5);
+      });
+    });
+
+    group('FAB', () {
+      testWidgets('должен показывать FAB', (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+      });
+
+      testWidgets('должен открывать диалог при нажатии на FAB',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(FloatingActionButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Add to Wishlist'), findsOneWidget);
+      });
+    });
+
+    group('popup menu', () {
+      testWidgets('должен показывать popup menu при нажатии',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Search'), findsOneWidget);
+        expect(find.text('Edit'), findsOneWidget);
+        expect(find.text('Mark resolved'), findsOneWidget);
+        expect(find.text('Delete'), findsOneWidget);
+      });
+
+      testWidgets('должен показывать Unresolve для resolved элемента',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[resolvedItem]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Unresolve'), findsOneWidget);
+      });
+    });
+
+    group('фильтр resolved', () {
+      testWidgets('должен скрывать resolved при toggle',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[item1, resolvedItem]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        // Оба элемента видны
+        expect(find.text('Chrono Trigger'), findsOneWidget);
+        expect(find.text('Resolved Game'), findsOneWidget);
+
+        // Нажимаем кнопку hide resolved
+        await tester.tap(find.byIcon(Icons.visibility));
+        await tester.pumpAndSettle();
+
+        // Resolved скрыт
+        expect(find.text('Chrono Trigger'), findsOneWidget);
+        expect(find.text('Resolved Game'), findsNothing);
+      });
+    });
+
+    group('BreadcrumbAppBar', () {
+      testWidgets('должен показывать Wishlist в хлебных крошках',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Wishlist'), findsOneWidget);
+      });
+    });
+
+    group('clear resolved', () {
+      testWidgets('должен показывать confirmation dialog',
+          (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => <WishlistItem>[resolvedItem]);
+
+        await tester.pumpWidget(buildScreen());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.delete_sweep));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Clear resolved'), findsOneWidget);
+        expect(find.text('Delete 1 resolved item?'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/features/wishlist/widgets/add_wishlist_dialog_test.dart
+++ b/test/features/wishlist/widgets/add_wishlist_dialog_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/wishlist/widgets/add_wishlist_dialog.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/wishlist_item.dart';
+
+void main() {
+  group('AddWishlistDialog', () {
+    Future<void> pumpDialog(
+      WidgetTester tester, {
+      WishlistItem? existing,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(),
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () {
+                    AddWishlistDialog.show(context, existing: existing);
+                  },
+                  child: const Text('Open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+    }
+
+    group('режим создания', () {
+      testWidgets('должен показывать заголовок Add to Wishlist',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        expect(find.text('Add to Wishlist'), findsOneWidget);
+        expect(find.text('Add'), findsOneWidget);
+      });
+
+      testWidgets('должен показывать пустые поля',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        final TextField titleField = tester.widget<TextField>(
+          find.widgetWithText(TextField, '').first,
+        );
+        expect(titleField.controller?.text, '');
+      });
+
+      testWidgets('должен показывать чипы типов медиа',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        expect(find.text('Any'), findsOneWidget);
+        expect(find.text('Game'), findsOneWidget);
+        expect(find.text('Movie'), findsOneWidget);
+        expect(find.text('TV Show'), findsOneWidget);
+        expect(find.text('Animation'), findsOneWidget);
+      });
+
+      testWidgets('не должен отправлять пустой текст',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        await tester.tap(find.text('Add'));
+        await tester.pumpAndSettle();
+
+        // Диалог не закрылся
+        expect(find.text('Add to Wishlist'), findsOneWidget);
+      });
+
+      testWidgets('должен закрываться при Cancel',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Add to Wishlist'), findsNothing);
+      });
+
+      testWidgets('должен выбирать тип медиа',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        // Нажимаем на Game чип
+        await tester.tap(find.text('Game'));
+        await tester.pumpAndSettle();
+
+        // Game чип должен быть selected
+        final ChoiceChip gameChip = tester.widget<ChoiceChip>(
+          find.ancestor(
+            of: find.text('Game'),
+            matching: find.byType(ChoiceChip),
+          ),
+        );
+        expect(gameChip.selected, true);
+      });
+
+      testWidgets('должен снимать выбор при повторном нажатии на Any',
+          (WidgetTester tester) async {
+        await pumpDialog(tester);
+
+        // Выбираем Game
+        await tester.tap(find.text('Game'));
+        await tester.pumpAndSettle();
+
+        // Нажимаем Any — снимает выбор
+        await tester.tap(find.text('Any'));
+        await tester.pumpAndSettle();
+
+        final ChoiceChip anyChip = tester.widget<ChoiceChip>(
+          find.ancestor(
+            of: find.text('Any'),
+            matching: find.byType(ChoiceChip),
+          ),
+        );
+        expect(anyChip.selected, true);
+      });
+    });
+
+    group('режим редактирования', () {
+      final WishlistItem existing = WishlistItem(
+        id: 1,
+        text: 'Chrono Trigger',
+        mediaTypeHint: MediaType.game,
+        note: 'SNES RPG',
+        createdAt: DateTime(2024, 6, 15),
+      );
+
+      testWidgets('должен показывать заголовок Edit',
+          (WidgetTester tester) async {
+        await pumpDialog(tester, existing: existing);
+
+        expect(find.text('Edit Wishlist Item'), findsOneWidget);
+        expect(find.text('Save'), findsOneWidget);
+      });
+
+      testWidgets('должен предзаполнять текст',
+          (WidgetTester tester) async {
+        await pumpDialog(tester, existing: existing);
+
+        expect(find.text('Chrono Trigger'), findsOneWidget);
+      });
+
+      testWidgets('должен предзаполнять заметку',
+          (WidgetTester tester) async {
+        await pumpDialog(tester, existing: existing);
+
+        expect(find.text('SNES RPG'), findsOneWidget);
+      });
+
+      testWidgets('должен предвыбирать тип медиа',
+          (WidgetTester tester) async {
+        await pumpDialog(tester, existing: existing);
+
+        final ChoiceChip gameChip = tester.widget<ChoiceChip>(
+          find.ancestor(
+            of: find.text('Game'),
+            matching: find.byType(ChoiceChip),
+          ),
+        );
+        expect(gameChip.selected, true);
+      });
+    });
+  });
+}

--- a/test/shared/models/wishlist_item_test.dart
+++ b/test/shared/models/wishlist_item_test.dart
@@ -1,0 +1,340 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/wishlist_item.dart';
+
+void main() {
+  group('WishlistItem', () {
+    final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
+    final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
+    final DateTime resolvedDate = DateTime(2024, 6, 20, 18, 0, 0);
+    final int resolvedTimestamp = resolvedDate.millisecondsSinceEpoch ~/ 1000;
+
+    WishlistItem createTestItem({
+      int id = 1,
+      String text = 'Chrono Trigger',
+      MediaType? mediaTypeHint,
+      String? note,
+      bool isResolved = false,
+      DateTime? createdAt,
+      DateTime? resolvedAt,
+    }) {
+      return WishlistItem(
+        id: id,
+        text: text,
+        mediaTypeHint: mediaTypeHint,
+        note: note,
+        isResolved: isResolved,
+        createdAt: createdAt ?? testDate,
+        resolvedAt: resolvedAt,
+      );
+    }
+
+    group('constructor', () {
+      test('должен создавать экземпляр с обязательными полями', () {
+        final WishlistItem item = createTestItem();
+
+        expect(item.id, 1);
+        expect(item.text, 'Chrono Trigger');
+        expect(item.mediaTypeHint, null);
+        expect(item.note, null);
+        expect(item.isResolved, false);
+        expect(item.createdAt, testDate);
+        expect(item.resolvedAt, null);
+      });
+
+      test('должен создавать экземпляр со всеми полями', () {
+        final WishlistItem item = createTestItem(
+          mediaTypeHint: MediaType.game,
+          note: 'SNES RPG, посоветовал друг',
+          isResolved: true,
+          resolvedAt: resolvedDate,
+        );
+
+        expect(item.mediaTypeHint, MediaType.game);
+        expect(item.note, 'SNES RPG, посоветовал друг');
+        expect(item.isResolved, true);
+        expect(item.resolvedAt, resolvedDate);
+      });
+    });
+
+    group('hasNote', () {
+      test('должен возвращать false для null заметки', () {
+        final WishlistItem item = createTestItem();
+        expect(item.hasNote, false);
+      });
+
+      test('должен возвращать false для пустой заметки', () {
+        final WishlistItem item = createTestItem(note: '');
+        expect(item.hasNote, false);
+      });
+
+      test('должен возвращать true для непустой заметки', () {
+        final WishlistItem item = createTestItem(note: 'Some note');
+        expect(item.hasNote, true);
+      });
+    });
+
+    group('fromDb', () {
+      test('должен создавать WishlistItem из записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'text': 'Chrono Trigger',
+          'media_type_hint': null,
+          'note': null,
+          'is_resolved': 0,
+          'created_at': testTimestamp,
+          'resolved_at': null,
+        };
+
+        final WishlistItem item = WishlistItem.fromDb(row);
+
+        expect(item.id, 1);
+        expect(item.text, 'Chrono Trigger');
+        expect(item.mediaTypeHint, null);
+        expect(item.note, null);
+        expect(item.isResolved, false);
+        expect(
+          item.createdAt.millisecondsSinceEpoch ~/ 1000,
+          testTimestamp,
+        );
+        expect(item.resolvedAt, null);
+      });
+
+      test('должен создавать resolved WishlistItem из записи БД', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 2,
+          'text': 'The Matrix',
+          'media_type_hint': 'movie',
+          'note': 'Классика',
+          'is_resolved': 1,
+          'created_at': testTimestamp,
+          'resolved_at': resolvedTimestamp,
+        };
+
+        final WishlistItem item = WishlistItem.fromDb(row);
+
+        expect(item.id, 2);
+        expect(item.text, 'The Matrix');
+        expect(item.mediaTypeHint, MediaType.movie);
+        expect(item.note, 'Классика');
+        expect(item.isResolved, true);
+        expect(
+          item.resolvedAt!.millisecondsSinceEpoch ~/ 1000,
+          resolvedTimestamp,
+        );
+      });
+
+      test('должен обрабатывать все типы медиа', () {
+        for (final MediaType type in MediaType.values) {
+          final Map<String, dynamic> row = <String, dynamic>{
+            'id': 1,
+            'text': 'Test',
+            'media_type_hint': type.value,
+            'note': null,
+            'is_resolved': 0,
+            'created_at': testTimestamp,
+            'resolved_at': null,
+          };
+
+          final WishlistItem item = WishlistItem.fromDb(row);
+          expect(item.mediaTypeHint, type);
+        }
+      });
+    });
+
+    group('toDb', () {
+      test('должен возвращать корректную Map для БД', () {
+        final WishlistItem item = createTestItem();
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db['id'], 1);
+        expect(db['text'], 'Chrono Trigger');
+        expect(db['media_type_hint'], null);
+        expect(db['note'], null);
+        expect(db['is_resolved'], 0);
+        expect(db['created_at'], testTimestamp);
+        expect(db['resolved_at'], null);
+      });
+
+      test('должен включать все поля', () {
+        final WishlistItem item = createTestItem(
+          mediaTypeHint: MediaType.tvShow,
+          note: 'Заметка',
+          isResolved: true,
+          resolvedAt: resolvedDate,
+        );
+        final Map<String, dynamic> db = item.toDb();
+
+        expect(db['media_type_hint'], 'tv_show');
+        expect(db['note'], 'Заметка');
+        expect(db['is_resolved'], 1);
+        expect(db['resolved_at'], resolvedTimestamp);
+      });
+    });
+
+    group('fromDb → toDb roundtrip', () {
+      test('должен быть обратимым для минимального элемента', () {
+        final WishlistItem original = createTestItem();
+        final Map<String, dynamic> db = original.toDb();
+        final WishlistItem restored = WishlistItem.fromDb(db);
+
+        expect(restored.id, original.id);
+        expect(restored.text, original.text);
+        expect(restored.mediaTypeHint, original.mediaTypeHint);
+        expect(restored.note, original.note);
+        expect(restored.isResolved, original.isResolved);
+        expect(restored.resolvedAt, original.resolvedAt);
+      });
+
+      test('должен быть обратимым для полного элемента', () {
+        final WishlistItem original = createTestItem(
+          mediaTypeHint: MediaType.animation,
+          note: 'Аниме',
+          isResolved: true,
+          resolvedAt: resolvedDate,
+        );
+        final Map<String, dynamic> db = original.toDb();
+        final WishlistItem restored = WishlistItem.fromDb(db);
+
+        expect(restored.id, original.id);
+        expect(restored.text, original.text);
+        expect(restored.mediaTypeHint, original.mediaTypeHint);
+        expect(restored.note, original.note);
+        expect(restored.isResolved, original.isResolved);
+        expect(
+          restored.resolvedAt!.millisecondsSinceEpoch ~/ 1000,
+          original.resolvedAt!.millisecondsSinceEpoch ~/ 1000,
+        );
+      });
+    });
+
+    group('copyWith', () {
+      test('должен создавать копию с изменённым текстом', () {
+        final WishlistItem original = createTestItem();
+        final WishlistItem copy = original.copyWith(text: 'New Title');
+
+        expect(copy.text, 'New Title');
+        expect(copy.id, original.id);
+        expect(copy.createdAt, original.createdAt);
+      });
+
+      test('должен создавать копию с изменённым mediaTypeHint', () {
+        final WishlistItem original = createTestItem();
+        final WishlistItem copy =
+            original.copyWith(mediaTypeHint: MediaType.movie);
+
+        expect(copy.mediaTypeHint, MediaType.movie);
+        expect(copy.text, original.text);
+      });
+
+      test('должен очищать mediaTypeHint через clearMediaTypeHint', () {
+        final WishlistItem original =
+            createTestItem(mediaTypeHint: MediaType.game);
+        final WishlistItem copy =
+            original.copyWith(clearMediaTypeHint: true);
+
+        expect(copy.mediaTypeHint, null);
+      });
+
+      test('должен очищать note через clearNote', () {
+        final WishlistItem original = createTestItem(note: 'Заметка');
+        final WishlistItem copy = original.copyWith(clearNote: true);
+
+        expect(copy.note, null);
+      });
+
+      test('должен очищать resolvedAt через clearResolvedAt', () {
+        final WishlistItem original =
+            createTestItem(resolvedAt: resolvedDate);
+        final WishlistItem copy =
+            original.copyWith(clearResolvedAt: true);
+
+        expect(copy.resolvedAt, null);
+      });
+
+      test('должен создавать копию со всеми изменёнными полями', () {
+        final WishlistItem original = createTestItem();
+        final DateTime newDate = DateTime(2025, 1, 1);
+        final WishlistItem copy = original.copyWith(
+          id: 99,
+          text: 'New Text',
+          mediaTypeHint: MediaType.tvShow,
+          note: 'New note',
+          isResolved: true,
+          createdAt: newDate,
+          resolvedAt: resolvedDate,
+        );
+
+        expect(copy.id, 99);
+        expect(copy.text, 'New Text');
+        expect(copy.mediaTypeHint, MediaType.tvShow);
+        expect(copy.note, 'New note');
+        expect(copy.isResolved, true);
+        expect(copy.createdAt, newDate);
+        expect(copy.resolvedAt, resolvedDate);
+      });
+
+      test('должен сохранять все поля при пустом copyWith', () {
+        final WishlistItem original = createTestItem(
+          mediaTypeHint: MediaType.game,
+          note: 'Заметка',
+          isResolved: true,
+          resolvedAt: resolvedDate,
+        );
+        final WishlistItem copy = original.copyWith();
+
+        expect(copy.id, original.id);
+        expect(copy.text, original.text);
+        expect(copy.mediaTypeHint, original.mediaTypeHint);
+        expect(copy.note, original.note);
+        expect(copy.isResolved, original.isResolved);
+        expect(copy.resolvedAt, original.resolvedAt);
+      });
+    });
+
+    group('equality', () {
+      test('должен быть равен при одинаковом id', () {
+        final WishlistItem a = createTestItem(id: 1, text: 'A');
+        final WishlistItem b = createTestItem(id: 1, text: 'B');
+
+        expect(a == b, true);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('должен быть не равен при разных id', () {
+        final WishlistItem a = createTestItem(id: 1);
+        final WishlistItem b = createTestItem(id: 2);
+
+        expect(a == b, false);
+      });
+
+      test('должен быть равен самому себе', () {
+        final WishlistItem item = createTestItem();
+        expect(item == item, true);
+      });
+
+      test('должен быть не равен объекту другого типа', () {
+        final WishlistItem item = createTestItem();
+        // ignore: unrelated_type_equality_checks
+        expect(item == 'string', false);
+      });
+    });
+
+    group('toString', () {
+      test('должен возвращать корректную строку', () {
+        final WishlistItem item = createTestItem(id: 5, text: 'Test Game');
+
+        expect(
+          item.toString(),
+          'WishlistItem(id: 5, text: Test Game, resolved: false)',
+        );
+      });
+
+      test('должен показывать resolved статус', () {
+        final WishlistItem item = createTestItem(isResolved: true);
+
+        expect(item.toString(), contains('resolved: true'));
+      });
+    });
+  });
+}

--- a/test/shared/navigation/navigation_shell_test.dart
+++ b/test/shared/navigation/navigation_shell_test.dart
@@ -6,14 +6,15 @@
 //
 // Ленивая инициализация табов:
 // NavigationShell использует IndexedStack с ленивой загрузкой — Collections,
-// SearchScreen и SettingsScreen строятся только при первом переключении на таб.
-// AllItemsScreen (Home) загружается сразу.
+// WishlistScreen, SearchScreen и SettingsScreen строятся только при первом
+// переключении на таб. AllItemsScreen (Home) загружается сразу.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/features/wishlist/providers/wishlist_provider.dart';
 import 'package:xerabora/shared/navigation/navigation_shell.dart';
 
 void main() {
@@ -26,16 +27,20 @@ void main() {
       expect(NavTab.collections.index, equals(1));
     });
 
-    test('search имеет index 2', () {
-      expect(NavTab.search.index, equals(2));
+    test('wishlist имеет index 2', () {
+      expect(NavTab.wishlist.index, equals(2));
     });
 
-    test('settings имеет index 3', () {
-      expect(NavTab.settings.index, equals(3));
+    test('search имеет index 3', () {
+      expect(NavTab.search.index, equals(3));
     });
 
-    test('содержит 4 значения', () {
-      expect(NavTab.values.length, equals(4));
+    test('settings имеет index 4', () {
+      expect(NavTab.settings.index, equals(4));
+    });
+
+    test('содержит 5 значений', () {
+      expect(NavTab.values.length, equals(5));
     });
 
     test('все значения уникальны', () {
@@ -72,6 +77,7 @@ void main() {
       return ProviderScope(
         overrides: <Override>[
           sharedPreferencesProvider.overrideWithValue(prefs),
+          activeWishlistCountProvider.overrideWithValue(0),
         ],
         child: MaterialApp(
           home: MediaQuery(
@@ -97,14 +103,14 @@ void main() {
         expect(find.byType(BottomNavigationBar), findsNothing);
       });
 
-      testWidgets('Rail содержит 4 destination',
+      testWidgets('Rail содержит 5 destination',
           (WidgetTester tester) async {
         await tester.pumpWidget(createShell(width: 1024));
         await tester.pump();
 
         final NavigationRail rail =
             tester.widget<NavigationRail>(find.byType(NavigationRail));
-        expect(rail.destinations.length, equals(4));
+        expect(rail.destinations.length, equals(5));
       });
 
       testWidgets('переключение таба через Rail',
@@ -116,12 +122,12 @@ void main() {
             tester.widget<NavigationRail>(find.byType(NavigationRail));
         expect(railBefore.selectedIndex, equals(0));
 
-        railBefore.onDestinationSelected!(3);
+        railBefore.onDestinationSelected!(4);
         await tester.pump();
 
         final NavigationRail railAfter =
             tester.widget<NavigationRail>(find.byType(NavigationRail));
-        expect(railAfter.selectedIndex, equals(3));
+        expect(railAfter.selectedIndex, equals(4));
       });
     });
 
@@ -135,7 +141,7 @@ void main() {
         expect(find.byType(NavigationRail), findsNothing);
       });
 
-      testWidgets('BottomBar содержит 4 items',
+      testWidgets('BottomBar содержит 5 items',
           (WidgetTester tester) async {
         await tester.pumpWidget(createShell(width: 400));
         await tester.pump();
@@ -143,7 +149,7 @@ void main() {
         final BottomNavigationBar bar =
             tester.widget<BottomNavigationBar>(
                 find.byType(BottomNavigationBar));
-        expect(bar.items.length, equals(4));
+        expect(bar.items.length, equals(5));
       });
 
       testWidgets('переключение таба через BottomBar',
@@ -156,13 +162,13 @@ void main() {
                 find.byType(BottomNavigationBar));
         expect(barBefore.currentIndex, equals(0));
 
-        barBefore.onTap!(3);
+        barBefore.onTap!(4);
         await tester.pump();
 
         final BottomNavigationBar barAfter =
             tester.widget<BottomNavigationBar>(
                 find.byType(BottomNavigationBar));
-        expect(barAfter.currentIndex, equals(3));
+        expect(barAfter.currentIndex, equals(4));
       });
     });
 
@@ -185,7 +191,7 @@ void main() {
         // Переключаемся на Settings (index 3)
         final NavigationRail rail =
             tester.widget<NavigationRail>(find.byType(NavigationRail));
-        rail.onDestinationSelected!(3);
+        rail.onDestinationSelected!(4);
         await tester.pump();
         await tester.pump(); // Navigator initial route transition
 
@@ -212,7 +218,7 @@ void main() {
         final BottomNavigationBar bar =
             tester.widget<BottomNavigationBar>(
                 find.byType(BottomNavigationBar));
-        bar.onTap!(3);
+        bar.onTap!(4);
         await tester.pump();
         await tester.pump();
 
@@ -251,7 +257,7 @@ void main() {
         // Переключаемся на Settings
         final NavigationRail rail =
             tester.widget<NavigationRail>(find.byType(NavigationRail));
-        rail.onDestinationSelected!(3);
+        rail.onDestinationSelected!(4);
         await tester.pump();
         await tester.pump();
 
@@ -271,7 +277,7 @@ void main() {
         // Повторное нажатие на Settings (index 3) — pop к корню
         final NavigationRail railAfterPush =
             tester.widget<NavigationRail>(find.byType(NavigationRail));
-        railAfterPush.onDestinationSelected!(3);
+        railAfterPush.onDestinationSelected!(4);
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
@@ -301,7 +307,7 @@ void main() {
         // Переключаемся на Settings
         final NavigationRail rail =
             tester.widget<NavigationRail>(find.byType(NavigationRail));
-        rail.onDestinationSelected!(3);
+        rail.onDestinationSelected!(4);
         await tester.pump();
         await tester.pump();
 


### PR DESCRIPTION
Add 5th navigation tab (Wishlist) with badge showing active item count. WishlistItem model, DB migration v19, repository, AsyncNotifier provider, screen with FAB/popup menu/filter/clear resolved, AddWishlistDialog with optional media type hint. Tap a note to open SearchScreen with pre-filled query. Update docs (CHANGELOG, README, FEATURES, ARCHITECTURE, ROADMAP).