### PR TITLE
docs: add Code Signing Policy for SignPath Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ Flutter 3.38+ / Dart 3.10+ · Riverpod · SQLite · Dio · Material Design 3
 
 Contributions are welcome! See the [Contributing Guide](docs/CONTRIBUTING.md) for details.
 
+## Code Signing Policy
+
+Windows binaries are signed with a certificate provided by [SignPath Foundation](https://signpath.org).
+
+Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+**Team roles:**
+- Committers and reviewers: [hacan359](https://github.com/hacan359)
+- Approvers: [hacan359](https://github.com/hacan359)
+
+**Privacy policy:** This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it. The application uses third-party APIs (IGDB, TMDB, SteamGridDB) only when the user explicitly initiates a search or data fetch.
+
 ## License
 
 MIT

--- a/docs/index.html
+++ b/docs/index.html
@@ -727,6 +727,26 @@
 
     .footer__links a:hover { color: var(--text-secondary); }
 
+    .code-signing-policy {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 24px 0;
+      font-size: 12px;
+      color: var(--text-tertiary);
+      text-align: center;
+      line-height: 1.6;
+    }
+    .code-signing-policy a {
+      color: var(--text-secondary);
+      text-decoration: underline;
+    }
+    .code-signing-policy h3 {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: var(--text-secondary);
+    }
+
     /* ═══════════════════════════════════════
        Animations
        ═══════════════════════════════════════ */
@@ -1079,6 +1099,25 @@
         <li><a href="https://github.com/hacan359/tonkatsu_box/issues" target="_blank" data-i18n="footer_issues">Issues</a></li>
       </ul>
     </div>
+    <!-- Code Signing Policy -->
+    <div class="code-signing-policy">
+      <h3 data-i18n="signing_title">Code Signing Policy</h3>
+      <p data-i18n="signing_desc">
+        Windows binaries are signed with a certificate provided by
+        <a href="https://signpath.org">SignPath Foundation</a>.
+      </p>
+      <p data-i18n="signing_credit">
+        Free code signing provided by
+        <a href="https://signpath.io">SignPath.io</a>,
+        certificate by
+        <a href="https://signpath.org">SignPath Foundation</a>.
+      </p>
+      <p data-i18n="signing_privacy">
+        <strong>Privacy policy:</strong> This program will not transfer any
+        information to other networked systems unless specifically requested
+        by the user or the person installing or operating it.
+      </p>
+    </div>
   </footer>
 
   <!-- Scroll Reveal -->
@@ -1153,6 +1192,10 @@
         cta_star: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg> Star on GitHub',
         footer_releases: 'Releases',
         footer_issues: 'Issues',
+        signing_title: 'Code Signing Policy',
+        signing_desc: 'Windows binaries are signed with a certificate provided by <a href="https://signpath.org">SignPath Foundation</a>.',
+        signing_credit: 'Free code signing provided by <a href="https://signpath.io">SignPath.io</a>, certificate by <a href="https://signpath.org">SignPath Foundation</a>.',
+        signing_privacy: '<strong>Privacy policy:</strong> This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.',
       },
       ru: {
         nav_features: '\u0424\u0443\u043d\u043a\u0446\u0438\u0438',
@@ -1210,6 +1253,10 @@
         cta_star: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg> \u0417\u0432\u0435\u0437\u0434\u0430 \u043d\u0430 GitHub',
         footer_releases: '\u0420\u0435\u043b\u0438\u0437\u044b',
         footer_issues: '\u0417\u0430\u0434\u0430\u0447\u0438',
+        signing_title: '\u041f\u043e\u043b\u0438\u0442\u0438\u043a\u0430 \u043f\u043e\u0434\u043f\u0438\u0441\u0438 \u043a\u043e\u0434\u0430',
+        signing_desc: '\u0411\u0438\u043d\u0430\u0440\u043d\u044b\u0435 \u0444\u0430\u0439\u043b\u044b Windows \u043f\u043e\u0434\u043f\u0438\u0441\u0430\u043d\u044b \u0441\u0435\u0440\u0442\u0438\u0444\u0438\u043a\u0430\u0442\u043e\u043c <a href="https://signpath.org">SignPath Foundation</a>.',
+        signing_credit: '\u0411\u0435\u0441\u043f\u043b\u0430\u0442\u043d\u0430\u044f \u043f\u043e\u0434\u043f\u0438\u0441\u044c \u043a\u043e\u0434\u0430 \u043f\u0440\u0435\u0434\u043e\u0441\u0442\u0430\u0432\u043b\u0435\u043d\u0430 <a href="https://signpath.io">SignPath.io</a>, \u0441\u0435\u0440\u0442\u0438\u0444\u0438\u043a\u0430\u0442 \u043e\u0442 <a href="https://signpath.org">SignPath Foundation</a>.',
+        signing_privacy: '<strong>\u041f\u043e\u043b\u0438\u0442\u0438\u043a\u0430 \u043a\u043e\u043d\u0444\u0438\u0434\u0435\u043d\u0446\u0438\u0430\u043b\u044c\u043d\u043e\u0441\u0442\u0438:</strong> \u041f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0435 \u043d\u0435 \u043f\u0435\u0440\u0435\u0434\u0430\u0451\u0442 \u0434\u0430\u043d\u043d\u044b\u0435 \u0432 \u0441\u0435\u0442\u044c \u0431\u0435\u0437 \u044f\u0432\u043d\u043e\u0433\u043e \u0437\u0430\u043f\u0440\u043e\u0441\u0430 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f.',
       }
     };
 

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,7 +89,7 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "Tonkatsu_Box" "\0"
+            VALUE "CompanyName", "Tonkatsu Box" "\0"
             VALUE "FileDescription", "Tonkatsu Box" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "tonkatsu_box" "\0"


### PR DESCRIPTION
Required for obtaining a free code signing certificate from SignPath Foundation. Adds policy section to README and landing page footer, fixes CompanyName in Runner.rc metadata.