### PR TITLE
feat: add Welcome Wizard onboarding (4-step PageView)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@
 
 ## [Unreleased]
 
+### Added
+- **Welcome Wizard** — 4-step onboarding shown on first launch (`lib/features/welcome/`)
+  - Step 1 «Welcome»: app capabilities, media types, works-without-keys section
+  - Step 2 «API Keys»: IGDB (required), TMDB (recommended), SteamGridDB (optional) instructions with external links
+  - Step 3 «How it works»: app structure (5 tabs), Quick Start (5 steps), sharing formats (.xcoll/.xcollx)
+  - Step 4 «Ready!»: CTA buttons — «Go to Settings» (→ NavigationShell with Settings tab) or «Skip» (→ Home)
+  - PageView with swipe, step indicators, progress bar, Skip link, Back/Next navigation, dot indicators
+  - `kWelcomeCompletedKey` flag saved in SharedPreferences
+  - Re-openable from Settings → Help → «Welcome Guide» (with `fromSettings: true` → pop on finish)
+- Added `initialTab` parameter to `NavigationShell` — allows opening app on a specific tab (used by Welcome Wizard → Settings)
+- Added «Help» section in `SettingsScreen` with «Welcome Guide» navigation row (icon: `Icons.school`)
+- Added `docs/guides/` — source-of-truth markdown for wizard content: `WELCOME.md`, `API_KEYS.md`, `HOW_IT_WORKS.md`
+- Added 173 tests for Welcome Wizard: `welcome_screen_test.dart` (32 tests), `step_indicator_test.dart` (16 tests), `welcome_step_intro_test.dart` (14 tests), `welcome_step_api_keys_test.dart` (20 tests), `welcome_step_how_it_works_test.dart` (16 tests), `welcome_step_ready_test.dart` (13 tests), plus updates to `settings_screen_test.dart`, `navigation_shell_test.dart`, `app_test.dart`
+
 ### Changed
+- Modified `SplashScreen._tryNavigate()` to check `welcome_completed` flag — routes to `WelcomeScreen` on first launch, `NavigationShell` on subsequent launches
 - Replaced `AddWishlistSheet` (bottom sheet) with `AddWishlistForm` — full-page form screen with `AutoBreadcrumbAppBar`, breadcrumb navigation ("Add" / "Edit"), and TextButton action in AppBar
 - Added title validation (minimum 2 characters) with inline `errorText` that clears on input in `AddWishlistForm`
 - Added `showCheckmark: false` to media type `ChoiceChip`s — fixes checkmark overlapping the avatar icon

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Enter it in the app under **Settings → Credentials**.
 
 </details>
 
+> [!TIP]
+> On first launch, the app will walk you through a **Welcome Wizard** that explains everything — you can also revisit it later from **Settings → Welcome Guide**.
+
 ### Step 2: Install and run
 
 ```bash
@@ -155,6 +158,8 @@ For developers and contributors:
 | [Features](docs/FEATURES.md) | Detailed feature list |
 | [Architecture](docs/ARCHITECTURE.md) | Project structure, models, database |
 | [Getting Started](docs/GETTING_STARTED.md) | Developer setup guide |
+| [API Keys Guide](docs/guides/API_KEYS.md) | Detailed API key registration instructions |
+| [How It Works](docs/guides/HOW_IT_WORKS.md) | App structure, quick start, sharing |
 | [Roadmap](docs/ROADMAP.md) | Development progress and future plans |
 | [Export Format](docs/RCOLL_FORMAT.md) | `.xcoll` / `.xcollx` file format spec |
 | [Gamepad Support](docs/GAMEPAD.md) | Xbox controller / D-pad navigation |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,22 +1,38 @@
 [← Back to README](../README.md)
 
-# 🚀 Getting Started
+# Getting Started
 
 ## Requirements
 
-- Windows 10 or 11
+- Windows 10 or 11 (or Android 8+)
 - Internet connection (for initial setup and search)
 - IGDB API credentials (for game search)
 - TMDB API key (optional, for movie/TV show search)
 
 ---
 
-## Getting IGDB API Keys
+## What works without API keys
+
+You can use these features right away — no registration needed:
+
+- **Collections** — create, edit, organize
+- **Wishlist** — quick list of items to check out later
+- **Import** `.xcoll` / `.xcollx` — share collections with friends
+- **Canvas boards** — visual boards with artwork
+- **Ratings & notes** — rate and comment on items
+
+> API keys are only needed for **searching** new games, movies & TV shows.
+
+---
+
+## Getting API Keys
+
+Detailed instructions: [docs/guides/API_KEYS.md](guides/API_KEYS.md)
+
+### IGDB (Required — Game search)
 
 > [!IMPORTANT]
-> IGDB credentials are **required** for the app to function. Game search will not work without them.
-
-Tonkatsu Box uses IGDB to fetch game metadata. You need free API credentials:
+> IGDB credentials are **required** for game search to work.
 
 1. Go to [dev.twitch.tv](https://dev.twitch.tv)
 2. Log in with Twitch account (create one if needed)
@@ -28,14 +44,10 @@ Tonkatsu Box uses IGDB to fetch game metadata. You need free API credentials:
 5. Click **Create**
 6. Copy your **Client ID** and generate a **Client Secret**
 
----
-
-## Getting TMDB API Key (Optional)
+### TMDB (Recommended — Movies, TV & Anime)
 
 > [!NOTE]
-> TMDB is **optional**. It enables searching for movies, TV shows, and animation. The app works fine without it for game-only collections.
-
-For searching movies and TV shows:
+> TMDB is **recommended**. It enables searching for movies, TV shows, and animation.
 
 1. Go to [themoviedb.org](https://www.themoviedb.org)
 2. Create an account or log in
@@ -43,12 +55,10 @@ For searching movies and TV shows:
 4. Request an API key (choose "Developer" type)
 5. Copy your **API Key (v3 auth)**
 
----
-
-## Getting SteamGridDB API Key (Optional)
+### SteamGridDB (Optional — Game artwork)
 
 > [!NOTE]
-> SteamGridDB is **optional**. It provides high-quality game artwork for the canvas board (grids, heroes, logos, icons).
+> SteamGridDB is **optional**. It provides high-quality game artwork for the canvas board.
 
 1. Go to [steamgriddb.com](https://www.steamgriddb.com)
 2. Create an account or log in
@@ -57,15 +67,41 @@ For searching movies and TV shows:
 
 ---
 
+## App Structure
+
+| Tab | Description |
+|-----|-------------|
+| **Main** | All items from all collections. Filter by type, sort by rating. |
+| **Collections** | Your collections. Grid or list view per collection. |
+| **Wishlist** | Quick list of items to check out later. No API needed. |
+| **Search** | Find games, movies & TV shows via API. Add to any collection. |
+| **Settings** | API keys, cache, database export/import, debug tools. |
+
+More details: [docs/guides/HOW_IT_WORKS.md](guides/HOW_IT_WORKS.md)
+
+---
+
 ## First Launch
 
+On first launch, a **Welcome Wizard** guides you through setup:
+
+1. Overview of what Tonkatsu Box can do
+2. How to get API keys
+3. App structure and quick start guide
+4. Go to Settings to enter your keys
+
+You can revisit the wizard anytime from **Settings → Welcome Guide**.
+
+### Manual setup
+
 1. Start Tonkatsu Box
-2. Enter your IGDB Client ID and Client Secret
-3. Click **Verify Connection**
-4. Platforms will sync automatically
-5. (Optional) Enter your TMDB API Key in the **TMDB API** section for movie/TV show search. Choose content language (Russian or English) below the key field
-6. (Optional) Enter your SteamGridDB API Key in the **SteamGridDB API** section
-7. You're ready to create collections!
+2. Go to **Settings → Credentials**
+3. Enter your IGDB Client ID and Client Secret
+4. Click **Verify Connection**
+5. Platforms will sync automatically
+6. (Optional) Enter your TMDB API Key for movie/TV show search
+7. (Optional) Enter your SteamGridDB API Key for game artwork
+8. You're ready to create collections!
 
 > [!TIP]
 > All API keys can be changed later in **Settings → Credentials**.
@@ -104,11 +140,19 @@ For searching movies and TV shows:
 
 ---
 
+## Guides
+
+- [Welcome — what Tonkatsu Box can do](guides/WELCOME.md)
+- [API Keys — detailed setup instructions](guides/API_KEYS.md)
+- [How it works — app structure & quick start](guides/HOW_IT_WORKS.md)
+
+---
+
 ## Tips
 
 > [!TIP]
 > - Use the status tracker to manage your backlog
 > - Add comments to remember why you added a game
 > - Fork interesting collections and customize them
-> - Use the star rating (1–10) to rank your favorites
+> - Use the star rating (1-10) to rank your favorites
 > - On Android, long-press items for context menus; on Windows, right-click

--- a/docs/guides/API_KEYS.md
+++ b/docs/guides/API_KEYS.md
@@ -1,0 +1,50 @@
+[← Back to Getting Started](../GETTING_STARTED.md)
+
+# Getting API Keys
+
+Free registration, takes 2-3 minutes each.
+
+---
+
+## IGDB — Game search (Required)
+
+> [!IMPORTANT]
+> IGDB credentials are **required** for game search to work.
+
+1. Go to [dev.twitch.tv/console](https://dev.twitch.tv/console/apps)
+2. Log in with Twitch account (create one if needed)
+3. **Register Your Application**:
+   - Name: anything (e.g. `Tonkatsu Box`)
+   - OAuth Redirect URLs: `http://localhost`
+   - Category: `Application Integration`
+4. Click **Create**
+5. Copy your **Client ID** and generate a **Client Secret**
+
+---
+
+## TMDB — Movies, TV Shows & Anime (Recommended)
+
+> [!NOTE]
+> TMDB is **recommended**. Enables searching for movies, TV shows, and anime.
+
+1. Go to [themoviedb.org](https://www.themoviedb.org/settings/api)
+2. Create a free account or log in
+3. Go to **Settings** → **API**
+4. Request an API key (choose **Developer** type)
+5. Copy your **API Key (v3 auth)**
+
+---
+
+## SteamGridDB — Game artwork for boards (Optional)
+
+> [!NOTE]
+> SteamGridDB is **optional**. Provides high-quality game artwork (grids, heroes, logos, icons) for canvas boards.
+
+1. Go to [steamgriddb.com](https://www.steamgriddb.com/profile/preferences/api)
+2. Create an account or log in
+3. Go to **Preferences** → **API**
+4. Copy your **API Key**
+
+---
+
+> Enter keys in **Settings → Credentials** after setup.

--- a/docs/guides/HOW_IT_WORKS.md
+++ b/docs/guides/HOW_IT_WORKS.md
@@ -1,0 +1,30 @@
+[← Back to Getting Started](../GETTING_STARTED.md)
+
+# How Tonkatsu Box Works
+
+## App structure — 5 tabs
+
+| Tab | Icon | Description |
+|-----|------|-------------|
+| **Main** | Home | All items from all collections in one view. Filter by type, sort by rating. |
+| **Collections** | Bookmark | Your collections. Create, organize, manage. Grid or list view per collection. |
+| **Wishlist** | List | Quick list of items to check out later. No API needed. |
+| **Search** | Search | Find games, movies & TV shows via API. Add to any collection. |
+| **Settings** | Gear | API keys, cache, database export/import, debug tools. |
+
+## Quick Start
+
+1. Go to **Settings → Credentials**, enter API keys
+2. Click **Verify Connection**, wait for platforms sync
+3. Go to **Collections → + New Collection**
+4. Name it, then **Add Items → Search → Add**
+5. Rate, track progress, add notes — you're set!
+
+## Sharing collections
+
+| Format | Description |
+|--------|-------------|
+| `.xcoll` | Light export — metadata only, needs internet to fetch covers |
+| `.xcollx` | Full export — with images & canvas data, works offline |
+
+Import from friends — no API keys needed!

--- a/docs/guides/WELCOME.md
+++ b/docs/guides/WELCOME.md
@@ -1,0 +1,33 @@
+[← Back to Getting Started](../GETTING_STARTED.md)
+
+# Welcome to Tonkatsu Box
+
+Organize your collections of retro games, movies, TV shows & anime.
+
+## What you can do
+
+- **Create collections** by platform, genre, or any theme
+- **Search** games, movies, TV shows & anime via APIs
+- **Track progress**, rate 1-10, add notes
+- **Visual canvas boards** with artwork
+- **Export & import** — share collections with friends
+
+## What works without API keys
+
+- Collections — create, edit, organize
+- Wishlist — quick list of items to check out later
+- Import `.xcoll` / `.xcollx` — share collections with friends
+- Canvas boards — visual boards with artwork
+- Ratings & notes — rate and comment on items
+
+> API keys are only needed for searching new games, movies & TV shows.
+> You can import collections and work with them fully offline.
+
+## Supported media types
+
+| Type | API | Color |
+|------|-----|-------|
+| Games | IGDB | Indigo |
+| Movies | TMDB | Orange |
+| TV Shows | TMDB | Lime |
+| Anime | TMDB | Purple |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1006,7 +1006,7 @@
           <div class="step__number">02</div>
           <h3 class="step__title" data-i18n="step2_title">Install & Run</h3>
           <p class="step__desc" data-i18n="step2_desc">
-            Download the latest release or build from source with Flutter. Available for <strong>Windows</strong> desktop and <strong>Android</strong>.
+            Download the latest release or build from source with Flutter. Available for <strong>Windows</strong> desktop and <strong>Android</strong>. A built-in <strong>Welcome Wizard</strong> will guide you through setup on first launch.
           </p>
         </div>
         <div class="step reveal">
@@ -1102,6 +1102,7 @@
         <li><a href="https://github.com/hacan359/tonkatsu_box" target="_blank">GitHub</a></li>
         <li><a href="https://github.com/hacan359/tonkatsu_box/releases" target="_blank" data-i18n="footer_releases">Releases</a></li>
         <li><a href="https://github.com/hacan359/tonkatsu_box/tree/main/docs" target="_blank" data-i18n="nav_docs">Docs</a></li>
+        <li><a href="https://github.com/hacan359/tonkatsu_box/blob/main/docs/guides/API_KEYS.md" target="_blank" data-i18n="footer_api_guide">API Keys Guide</a></li>
         <li><a href="https://github.com/hacan359/tonkatsu_box/issues" target="_blank" data-i18n="footer_issues">Issues</a></li>
       </ul>
     </div>
@@ -1197,6 +1198,7 @@
         cta_download: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> Download Latest Release',
         cta_star: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg> Star on GitHub',
         footer_releases: 'Releases',
+        footer_api_guide: 'API Keys Guide',
         footer_issues: 'Issues',
         signing_title: 'Code Signing Policy',
         signing_desc: 'Windows binaries are signed with a certificate provided by <a href="https://signpath.org">SignPath Foundation</a>.',
@@ -1240,7 +1242,7 @@
         step1_title: '\u041f\u043e\u043b\u0443\u0447\u0438\u0442\u0435 API-\u043a\u043b\u044e\u0447\u0438',
         step1_desc: '\u0417\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u0443\u0439\u0442\u0435\u0441\u044c \u0431\u0435\u0441\u043f\u043b\u0430\u0442\u043d\u043e \u043d\u0430 <strong>IGDB</strong> (\u0447\u0435\u0440\u0435\u0437 Twitch) \u0434\u043b\u044f \u0438\u0433\u0440 \u0438 <strong>TMDB</strong> \u0434\u043b\u044f \u0444\u0438\u043b\u044c\u043c\u043e\u0432 \u0438 \u0441\u0435\u0440\u0438\u0430\u043b\u043e\u0432. \u041e\u043f\u0446\u0438\u043e\u043d\u0430\u043b\u044c\u043d\u043e: <strong>SteamGridDB</strong> \u0434\u043b\u044f \u0430\u0440\u0442\u043e\u0432.',
         step2_title: '\u0423\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u0435',
-        step2_desc: '\u0421\u043a\u0430\u0447\u0430\u0439\u0442\u0435 \u043f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0439 \u0440\u0435\u043b\u0438\u0437 \u0438\u043b\u0438 \u0441\u043e\u0431\u0435\u0440\u0438\u0442\u0435 \u0438\u0437 \u0438\u0441\u0445\u043e\u0434\u043d\u0438\u043a\u043e\u0432 \u0447\u0435\u0440\u0435\u0437 Flutter. \u0414\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u0434\u043b\u044f <strong>Windows</strong> \u0438 <strong>Android</strong>.',
+        step2_desc: '\u0421\u043a\u0430\u0447\u0430\u0439\u0442\u0435 \u043f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0439 \u0440\u0435\u043b\u0438\u0437 \u0438\u043b\u0438 \u0441\u043e\u0431\u0435\u0440\u0438\u0442\u0435 \u0438\u0437 \u0438\u0441\u0445\u043e\u0434\u043d\u0438\u043a\u043e\u0432 \u0447\u0435\u0440\u0435\u0437 Flutter. \u0414\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u0434\u043b\u044f <strong>Windows</strong> \u0438 <strong>Android</strong>. \u0412\u0441\u0442\u0440\u043e\u0435\u043d\u043d\u044b\u0439 <strong>\u043c\u0430\u0441\u0442\u0435\u0440 \u043d\u0430\u0441\u0442\u0440\u043e\u0439\u043a\u0438</strong> \u043f\u043e\u043c\u043e\u0436\u0435\u0442 \u043f\u0440\u0438 \u043f\u0435\u0440\u0432\u043e\u043c \u0437\u0430\u043f\u0443\u0441\u043a\u0435.',
         step3_title: '\u0421\u043e\u0431\u0438\u0440\u0430\u0439\u0442\u0435!',
         step3_desc: '\u0412\u0432\u0435\u0434\u0438\u0442\u0435 API-\u043a\u043b\u044e\u0447\u0438 \u0432 \u041d\u0430\u0441\u0442\u0440\u043e\u0439\u043a\u0430\u0445, \u043d\u0430\u0439\u0434\u0438\u0442\u0435 \u043b\u044e\u0431\u0438\u043c\u044b\u0435 \u043d\u0430\u0437\u0432\u0430\u043d\u0438\u044f \u0438 \u043e\u0440\u0433\u0430\u043d\u0438\u0437\u0443\u0439\u0442\u0435 \u0438\u0445 \u0432 \u043a\u043e\u043b\u043b\u0435\u043a\u0446\u0438\u0438. \u0412\u0441\u0451!',
         sharing_label: '\u0428\u0430\u0440\u0438\u043d\u0433',
@@ -1258,6 +1260,7 @@
         cta_download: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg> \u0421\u043a\u0430\u0447\u0430\u0442\u044c \u043f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0439 \u0440\u0435\u043b\u0438\u0437',
         cta_star: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg> \u0417\u0432\u0435\u0437\u0434\u0430 \u043d\u0430 GitHub',
         footer_releases: '\u0420\u0435\u043b\u0438\u0437\u044b',
+        footer_api_guide: '\u0413\u0430\u0439\u0434 \u043f\u043e API \u043a\u043b\u044e\u0447\u0430\u043c',
         footer_issues: '\u0417\u0430\u0434\u0430\u0447\u0438',
         signing_title: '\u041f\u043e\u043b\u0438\u0442\u0438\u043a\u0430 \u043f\u043e\u0434\u043f\u0438\u0441\u0438 \u043a\u043e\u0434\u0430',
         signing_desc: '\u0411\u0438\u043d\u0430\u0440\u043d\u044b\u0435 \u0444\u0430\u0439\u043b\u044b Windows \u043f\u043e\u0434\u043f\u0438\u0441\u0430\u043d\u044b \u0441\u0435\u0440\u0442\u0438\u0444\u0438\u043a\u0430\u0442\u043e\u043c <a href="https://signpath.org">SignPath Foundation</a>.',

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -12,6 +12,7 @@ import '../providers/settings_provider.dart';
 import '../widgets/inline_text_field.dart';
 import '../widgets/settings_nav_row.dart';
 import '../widgets/settings_section.dart';
+import '../../welcome/screens/welcome_screen.dart';
 import 'cache_screen.dart';
 import 'credentials_screen.dart';
 import 'database_screen.dart';
@@ -119,6 +120,28 @@ class SettingsScreen extends ConsumerWidget {
                     );
                   },
                 ),
+            ],
+          ),
+          SizedBox(height: compact ? AppSpacing.sm : AppSpacing.md),
+          SettingsSection(
+            title: 'Help',
+            icon: Icons.help_outline,
+            compact: compact,
+            children: <Widget>[
+              SettingsNavRow(
+                title: 'Welcome Guide',
+                icon: Icons.school,
+                subtitle: 'Getting started with Tonkatsu Box',
+                compact: compact,
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext context) =>
+                          const WelcomeScreen(fromSettings: true),
+                    ),
+                  );
+                },
+              ),
             ],
           ),
           if (settings.errorMessage != null) ...<Widget>[

--- a/lib/features/welcome/screens/welcome_screen.dart
+++ b/lib/features/welcome/screens/welcome_screen.dart
@@ -1,0 +1,280 @@
+// Welcome Wizard — пошаговый онбординг при первом запуске.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../features/settings/providers/settings_provider.dart';
+import '../../../shared/navigation/navigation_shell.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../widgets/step_indicator.dart';
+import '../widgets/welcome_step_api_keys.dart';
+import '../widgets/welcome_step_how_it_works.dart';
+import '../widgets/welcome_step_intro.dart';
+import '../widgets/welcome_step_ready.dart';
+
+/// Ключ SharedPreferences для флага завершения wizard'а.
+const String kWelcomeCompletedKey = 'welcome_completed';
+
+/// Welcome Wizard — 4-шаговый онбординг.
+///
+/// При первом запуске показывается автоматически вместо [NavigationShell].
+/// Может быть открыт повторно из Settings (с [fromSettings] = true).
+class WelcomeScreen extends ConsumerStatefulWidget {
+  /// Создаёт [WelcomeScreen].
+  const WelcomeScreen({this.fromSettings = false, super.key});
+
+  /// Если true, показывается как push из Settings (не первый запуск).
+  final bool fromSettings;
+
+  @override
+  ConsumerState<WelcomeScreen> createState() => _WelcomeScreenState();
+}
+
+class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  static const int _totalSteps = 4;
+
+  static const List<String> _stepLabels = <String>[
+    'Welcome',
+    'API Keys',
+    'How it works',
+    'Ready!',
+  ];
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool compact = MediaQuery.sizeOf(context).width < 600;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            // Step bar + Skip
+            _buildStepBar(compact),
+            // Progress bar
+            _buildProgressBar(),
+            // PageView
+            Expanded(
+              child: PageView(
+                controller: _pageController,
+                onPageChanged: (int page) {
+                  setState(() => _currentPage = page);
+                },
+                children: <Widget>[
+                  const WelcomeStepIntro(),
+                  const WelcomeStepApiKeys(),
+                  const WelcomeStepHowItWorks(),
+                  WelcomeStepReady(
+                    onGoToSettings: () => _finish(goToSettings: true),
+                    onSkip: () => _finish(),
+                  ),
+                ],
+              ),
+            ),
+            // Bottom nav
+            _buildBottomNav(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStepBar(bool compact) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: AppColors.surfaceBorder.withAlpha(50),
+          ),
+        ),
+      ),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: List<Widget>.generate(_totalSteps, (int index) {
+                return StepIndicator(
+                  number: index + 1,
+                  label: _stepLabels[index],
+                  isActive: index == _currentPage,
+                  isDone: index < _currentPage,
+                  showLabel: !compact || index == _currentPage,
+                  onTap: () => _goToPage(index),
+                );
+              }),
+            ),
+          ),
+          if (_currentPage < _totalSteps - 1)
+            GestureDetector(
+              onTap: () => _goToPage(_totalSteps - 1),
+              child: const Text(
+                'Skip',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.textTertiary,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProgressBar() {
+    return SizedBox(
+      height: 2,
+      child: LinearProgressIndicator(
+        value: (_currentPage + 1) / _totalSteps,
+        backgroundColor: AppColors.surfaceBorder,
+        valueColor: const AlwaysStoppedAnimation<Color>(AppColors.brand),
+      ),
+    );
+  }
+
+  Widget _buildBottomNav() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: AppColors.surfaceBorder.withAlpha(50),
+          ),
+        ),
+      ),
+      child: Row(
+        children: <Widget>[
+          // Back
+          TextButton(
+            onPressed: _currentPage > 0
+                ? () => _goToPage(_currentPage - 1)
+                : null,
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.textSecondary,
+              disabledForegroundColor: AppColors.textTertiary.withAlpha(60),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(Icons.arrow_back, size: 14),
+                SizedBox(width: 4),
+                Text('Back', style: TextStyle(fontSize: 12)),
+              ],
+            ),
+          ),
+          const Spacer(),
+
+          // Dots
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List<Widget>.generate(_totalSteps, (int index) {
+              final bool isActive = index == _currentPage;
+              final bool isDone = index < _currentPage;
+              return GestureDetector(
+                onTap: () => _goToPage(index),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  margin: const EdgeInsets.symmetric(horizontal: 2),
+                  width: isActive ? 20 : 6,
+                  height: 6,
+                  decoration: BoxDecoration(
+                    color: isActive
+                        ? AppColors.brand
+                        : isDone
+                            ? AppColors.success
+                            : AppColors.surfaceBorder,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                ),
+              );
+            }),
+          ),
+          const Spacer(),
+
+          // Next
+          if (_currentPage < _totalSteps - 1)
+            GestureDetector(
+              onTap: () => _goToPage(_currentPage + 1),
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.brand,
+                  borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+                ),
+                child: const Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      'Next',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.black,
+                      ),
+                    ),
+                    SizedBox(width: 4),
+                    Icon(Icons.arrow_forward, size: 14, color: Colors.black),
+                  ],
+                ),
+              ),
+            )
+          else
+            const SizedBox(width: 80),
+        ],
+      ),
+    );
+  }
+
+  void _goToPage(int page) {
+    _pageController.animateToPage(
+      page,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  Future<void> _finish({bool goToSettings = false}) async {
+    final SharedPreferences prefs = ref.read(sharedPreferencesProvider);
+    await prefs.setBool(kWelcomeCompletedKey, true);
+
+    if (!mounted) return;
+
+    if (widget.fromSettings) {
+      Navigator.of(context).pop();
+      return;
+    }
+
+    if (goToSettings) {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => const NavigationShell(
+            initialTab: NavTab.settings,
+          ),
+        ),
+      );
+    } else {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => const NavigationShell(),
+        ),
+      );
+    }
+  }
+}

--- a/lib/features/welcome/widgets/step_indicator.dart
+++ b/lib/features/welcome/widgets/step_indicator.dart
@@ -1,0 +1,111 @@
+// Step indicator для Welcome Wizard — номер шага с лейблом.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+
+/// Индикатор одного шага wizard'а.
+///
+/// Показывает номер шага в кружке и опциональный лейбл.
+/// Три состояния: done (галочка, зелёный), active (brand), pending (серый).
+class StepIndicator extends StatelessWidget {
+  /// Создаёт [StepIndicator].
+  const StepIndicator({
+    required this.number,
+    required this.label,
+    required this.isActive,
+    required this.isDone,
+    this.onTap,
+    this.showLabel = true,
+    super.key,
+  });
+
+  /// Порядковый номер шага (1-based).
+  final int number;
+
+  /// Текстовый лейбл шага.
+  final String label;
+
+  /// Текущий активный шаг.
+  final bool isActive;
+
+  /// Шаг уже пройден.
+  final bool isDone;
+
+  /// Обработчик нажатия на индикатор.
+  final VoidCallback? onTap;
+
+  /// Показывать ли лейбл (на узких экранах скрываем неактивные).
+  final bool showLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color circleColor = isDone
+        ? AppColors.success
+        : isActive
+            ? AppColors.brand
+            : AppColors.surfaceBorder;
+
+    final Color textColor = isDone
+        ? AppColors.success
+        : isActive
+            ? AppColors.brand
+            : AppColors.textTertiary;
+
+    final Color bgColor = isActive
+        ? AppColors.brand.withAlpha(25)
+        : isDone
+            ? AppColors.success.withAlpha(15)
+            : Colors.transparent;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            _buildCircle(circleColor),
+            if (showLabel) ...<Widget>[
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                  color: textColor,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCircle(Color color) {
+    return Container(
+      width: 22,
+      height: 22,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: isDone
+          ? const Icon(Icons.check, size: 13, color: Colors.black)
+          : Text(
+              '$number',
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: Colors.black,
+              ),
+            ),
+    );
+  }
+}

--- a/lib/features/welcome/widgets/welcome_step_api_keys.dart
+++ b/lib/features/welcome/widgets/welcome_step_api_keys.dart
@@ -1,0 +1,337 @@
+// Шаг 2 Welcome Wizard — инструкции получения API ключей.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+
+/// Шаг 2: API Keys — подробные инструкции получения ключей.
+class WelcomeStepApiKeys extends StatelessWidget {
+  /// Создаёт [WelcomeStepApiKeys].
+  const WelcomeStepApiKeys({super.key});
+
+  /// Цвет для SteamGridDB (голубой).
+  static const Color _sgdbColor = Color(0xFF4FC3F7);
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: Column(
+        children: <Widget>[
+          // Header
+          Padding(
+            padding: const EdgeInsets.only(top: 12, bottom: 8),
+            child: Column(
+              children: <Widget>[
+                const Icon(Icons.key, size: 36, color: AppColors.brand),
+                const SizedBox(height: 8),
+                const Text(
+                  'Getting API Keys',
+                  style: AppTypography.h2,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Free registration, takes 2-3 minutes each',
+                  style: AppTypography.bodySmall.copyWith(
+                    color: AppColors.textTertiary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // IGDB
+          const _ApiSection(
+            tag: 'IGDB',
+            tagColor: AppColors.gameAccent,
+            title: 'Game search',
+            badge: 'REQUIRED',
+            badgeColor: AppColors.brand,
+            steps: <String>[
+              'Go to dev.twitch.tv/console',
+              'Log in with Twitch (create account if needed)',
+              'Register Your Application\n'
+                  'Name: anything, URL: http://localhost',
+              'Copy Client ID and Client Secret',
+            ],
+            linkTitle: 'Twitch Developer Console',
+            linkSubtitle: 'dev.twitch.tv/console/apps',
+            linkUrl: 'https://dev.twitch.tv/console/apps',
+            linkColor: AppColors.gameAccent,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // TMDB
+          const _ApiSection(
+            tag: 'TMDB',
+            tagColor: AppColors.brand,
+            title: 'Movies, TV & Anime',
+            badge: 'RECOMMENDED',
+            badgeColor: AppColors.textTertiary,
+            steps: <String>[
+              'Go to themoviedb.org',
+              'Create free account → Settings → API',
+              'Request API Key (Developer type)',
+              'Copy API Key (v3 auth)',
+            ],
+            linkTitle: 'TMDB API',
+            linkSubtitle: 'themoviedb.org — Settings → API',
+            linkUrl: 'https://www.themoviedb.org/settings/api',
+            linkColor: AppColors.brand,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // SteamGridDB
+          const _ApiSection(
+            tag: 'SGDB',
+            tagColor: _sgdbColor,
+            title: 'Game artwork for boards',
+            badge: 'OPTIONAL',
+            badgeColor: AppColors.textTertiary,
+            steps: <String>[
+              'Go to steamgriddb.com',
+              'Create account → Preferences → API',
+              'Copy API Key',
+            ],
+            linkTitle: 'SteamGridDB',
+            linkSubtitle: 'steamgriddb.com — Preferences → API',
+            linkUrl: 'https://www.steamgriddb.com/profile/preferences/api',
+            linkColor: _sgdbColor,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // Hint
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: AppColors.brand.withAlpha(12),
+              border: Border.all(color: AppColors.brand.withAlpha(30)),
+              borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+            ),
+            child: Text(
+              'Enter keys in Settings → Credentials after setup',
+              style: AppTypography.body.copyWith(color: AppColors.brandLight),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+        ],
+      ),
+    );
+  }
+}
+
+/// Секция одного API провайдера с тегом, инструкциями и ссылкой.
+class _ApiSection extends StatelessWidget {
+  const _ApiSection({
+    required this.tag,
+    required this.tagColor,
+    required this.title,
+    required this.badge,
+    required this.badgeColor,
+    required this.steps,
+    required this.linkTitle,
+    required this.linkSubtitle,
+    required this.linkUrl,
+    required this.linkColor,
+  });
+
+  final String tag;
+  final Color tagColor;
+  final String title;
+  final String badge;
+  final Color badgeColor;
+  final List<String> steps;
+  final String linkTitle;
+  final String linkSubtitle;
+  final String linkUrl;
+  final Color linkColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        border: Border.all(color: AppColors.surfaceBorder),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          // Header row: tag + title + badge
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 7,
+                  vertical: 2,
+                ),
+                decoration: BoxDecoration(
+                  color: tagColor.withAlpha(30),
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                child: Text(
+                  tag,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w700,
+                    color: tagColor,
+                  ),
+                ),
+              ),
+              Text(
+                title,
+                style: AppTypography.h3.copyWith(fontSize: 13),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 6,
+                  vertical: 2,
+                ),
+                decoration: BoxDecoration(
+                  color: badgeColor == AppColors.textTertiary
+                      ? AppColors.surfaceLight
+                      : badgeColor.withAlpha(30),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  badge,
+                  style: TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: badgeColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+
+          // Steps
+          ...List<Widget>.generate(steps.length, (int index) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  SizedBox(
+                    width: 18,
+                    child: Text(
+                      '${index + 1}.',
+                      style: AppTypography.body.copyWith(
+                        color: AppColors.textTertiary,
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      steps[index],
+                      style: AppTypography.body.copyWith(
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+          const SizedBox(height: 8),
+
+          // Link card
+          _LinkCard(
+            title: linkTitle,
+            subtitle: linkSubtitle,
+            url: linkUrl,
+            color: linkColor,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Карточка-ссылка на внешний ресурс.
+class _LinkCard extends StatelessWidget {
+  const _LinkCard({
+    required this.title,
+    required this.subtitle,
+    required this.url,
+    required this.color,
+  });
+
+  final String title;
+  final String subtitle;
+  final String url;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+        onTap: () => _openUrl(context),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            border: Border.all(color: AppColors.surfaceBorder),
+            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          ),
+          child: Row(
+            children: <Widget>[
+              Icon(Icons.open_in_new, size: 16, color: color),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      title,
+                      style: AppTypography.h3.copyWith(fontSize: 13),
+                    ),
+                    Text(
+                      subtitle,
+                      style: AppTypography.caption,
+                    ),
+                  ],
+                ),
+              ),
+              Icon(Icons.content_copy, size: 14, color: color.withAlpha(150)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openUrl(BuildContext context) async {
+    final Uri uri = Uri.parse(url);
+    final bool launched = await launchUrl(
+      uri,
+      mode: LaunchMode.externalApplication,
+    );
+    if (!launched && context.mounted) {
+      await Clipboard.setData(ClipboardData(text: url));
+      if (context.mounted) {
+        context.showAppSnackBar('URL copied to clipboard');
+      }
+    }
+  }
+}

--- a/lib/features/welcome/widgets/welcome_step_how_it_works.dart
+++ b/lib/features/welcome/widgets/welcome_step_how_it_works.dart
@@ -1,0 +1,304 @@
+// Шаг 3 Welcome Wizard — структура приложения и Quick Start.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+
+/// Шаг 3: How it works — структура приложения, Quick Start, экспорт.
+class WelcomeStepHowItWorks extends StatelessWidget {
+  /// Создаёт [WelcomeStepHowItWorks].
+  const WelcomeStepHowItWorks({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: Column(
+        children: <Widget>[
+          // Header
+          const Padding(
+            padding: EdgeInsets.only(top: 12, bottom: 8),
+            child: Column(
+              children: <Widget>[
+                Icon(
+                  Icons.menu_book,
+                  size: 36,
+                  color: AppColors.brand,
+                ),
+                SizedBox(height: 8),
+                Text(
+                  'How it works',
+                  style: AppTypography.h2,
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // App structure
+          _buildCard(
+            title: 'App structure',
+            child: Column(
+              children: <Widget>[
+                _tabRow(
+                  icon: Icons.home,
+                  tab: 'Main',
+                  desc: 'All items from all collections in one view. '
+                      'Filter by type, sort by rating.',
+                  showDivider: false,
+                ),
+                _tabRow(
+                  icon: Icons.collections_bookmark,
+                  tab: 'Collections',
+                  desc: 'Your collections. Create, organize, manage. '
+                      'Grid or list view per collection.',
+                ),
+                _tabRow(
+                  icon: Icons.bookmark,
+                  tab: 'Wishlist',
+                  desc: 'Quick list of items to check out later. '
+                      'No API needed.',
+                ),
+                _tabRow(
+                  icon: Icons.search,
+                  tab: 'Search',
+                  desc: 'Find games, movies & TV shows via API. '
+                      'Add to any collection.',
+                ),
+                _tabRow(
+                  icon: Icons.settings,
+                  tab: 'Settings',
+                  desc: 'API keys, cache, database export/import, '
+                      'debug tools.',
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // Quick Start
+          _buildCard(
+            title: 'Quick Start',
+            child: const Column(
+              children: <Widget>[
+                _QuickStartStep(
+                  number: 1,
+                  text: 'Go to Settings → Credentials, enter API keys',
+                ),
+                _QuickStartStep(
+                  number: 2,
+                  text: 'Click Verify Connection, wait for platforms sync',
+                ),
+                _QuickStartStep(
+                  number: 3,
+                  text: 'Go to Collections → + New Collection',
+                ),
+                _QuickStartStep(
+                  number: 4,
+                  text: 'Name it, then Add Items → Search → Add',
+                ),
+                _QuickStartStep(
+                  number: 5,
+                  text: "Rate, track progress, add notes — you're set!",
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // Sharing
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: AppColors.tvShowAccent.withAlpha(12),
+              border: Border.all(color: AppColors.tvShowAccent.withAlpha(30)),
+              borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    const Icon(
+                      Icons.upload,
+                      size: 16,
+                      color: AppColors.tvShowAccent,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Sharing',
+                      style: AppTypography.h3.copyWith(
+                        fontSize: 13,
+                        color: AppColors.tvShowAccent,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                RichText(
+                  text: TextSpan(
+                    style: AppTypography.body.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                    children: <InlineSpan>[
+                      const TextSpan(text: 'Export collections as '),
+                      _codeSpan('.xcoll'),
+                      const TextSpan(text: ' (light, metadata only) or '),
+                      _codeSpan('.xcollx'),
+                      const TextSpan(
+                        text: ' (full, with images & canvas — works offline). '
+                            'Import from friends — no API needed!',
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard({required String title, required Widget child}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        border: Border.all(color: AppColors.surfaceBorder),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            title,
+            style: AppTypography.h3.copyWith(fontSize: 13),
+          ),
+          const SizedBox(height: 10),
+          child,
+        ],
+      ),
+    );
+  }
+
+  Widget _tabRow({
+    required IconData icon,
+    required String tab,
+    required String desc,
+    bool showDivider = true,
+  }) {
+    return Column(
+      children: <Widget>[
+        if (showDivider)
+          Divider(height: 1, color: AppColors.surfaceBorder.withAlpha(100)),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(icon, size: 18, color: AppColors.textSecondary),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      tab,
+                      style: AppTypography.body.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 1),
+                    Text(
+                      desc,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: AppColors.textTertiary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  static InlineSpan _codeSpan(String text) {
+    return WidgetSpan(
+      alignment: PlaceholderAlignment.baseline,
+      baseline: TextBaseline.alphabetic,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+        decoration: BoxDecoration(
+          color: AppColors.surfaceLight,
+          borderRadius: BorderRadius.circular(3),
+        ),
+        child: Text(
+          text,
+          style: const TextStyle(
+            fontSize: 11,
+            fontFamily: 'monospace',
+            color: AppColors.textPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _QuickStartStep extends StatelessWidget {
+  const _QuickStartStep({required this.number, required this.text});
+
+  final int number;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            width: 20,
+            height: 20,
+            decoration: BoxDecoration(
+              color: AppColors.brand.withAlpha(30),
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              '$number',
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: AppColors.brand,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTypography.body.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/welcome/widgets/welcome_step_intro.dart
+++ b/lib/features/welcome/widgets/welcome_step_intro.dart
@@ -1,0 +1,272 @@
+// Шаг 1 Welcome Wizard — описание приложения.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_assets.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+
+/// Шаг 1: Welcome — описание приложения и возможностей.
+class WelcomeStepIntro extends StatelessWidget {
+  /// Создаёт [WelcomeStepIntro].
+  const WelcomeStepIntro({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: Column(
+        children: <Widget>[
+          // Hero
+          Padding(
+            padding: const EdgeInsets.only(top: 20, bottom: 8),
+            child: Column(
+              children: <Widget>[
+                Image.asset(AppAssets.logo, width: 80, height: 80),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'Welcome to Tonkatsu Box',
+                  style: AppTypography.h1.copyWith(fontSize: 22),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Organize your collections of retro games,\n'
+                  'movies, TV shows & anime',
+                  style: AppTypography.body.copyWith(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+
+          // What you can do
+          _buildCard(
+            title: 'What you can do',
+            child: Column(
+              children: <Widget>[
+                _featureRow(
+                  icon: Icons.inventory_2_outlined,
+                  text: 'Create collections by platform, genre, or any theme',
+                  color: AppColors.gameAccent,
+                ),
+                _featureRow(
+                  icon: Icons.search,
+                  text: 'Search games, movies, TV shows & anime via APIs',
+                  color: AppColors.brand,
+                ),
+                _featureRow(
+                  icon: Icons.bar_chart,
+                  text: 'Track progress, rate 1-10, add notes',
+                  color: AppColors.tvShowAccent,
+                ),
+                _featureRow(
+                  icon: Icons.palette_outlined,
+                  text: 'Visual canvas boards with artwork',
+                  color: AppColors.animationAccent,
+                ),
+                _featureRow(
+                  icon: Icons.upload_outlined,
+                  text: 'Export & import — share collections with friends',
+                  color: AppColors.success,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // Works without keys
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: AppColors.success.withAlpha(12),
+              border: Border.all(color: AppColors.success.withAlpha(40)),
+              borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    const Icon(
+                      Icons.check_circle,
+                      size: 16,
+                      color: AppColors.success,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      'Works without API keys',
+                      style: AppTypography.body.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.success,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                const Wrap(
+                  spacing: 6,
+                  runSpacing: 6,
+                  children: <Widget>[
+                    _FeatureChip(label: 'Collections'),
+                    _FeatureChip(label: 'Wishlist'),
+                    _FeatureChip(label: 'Import .xcoll'),
+                    _FeatureChip(label: 'Canvas boards'),
+                    _FeatureChip(label: 'Ratings & notes'),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'API keys are only needed for searching new games, '
+                  'movies & TV shows. You can import collections and '
+                  'work with them offline.',
+                  style: AppTypography.bodySmall.copyWith(
+                    color: AppColors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+
+          // Media types
+          const Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            alignment: WrapAlignment.center,
+            children: <Widget>[
+              _MediaChip(
+                label: 'Games (IGDB)',
+                color: AppColors.gameAccent,
+              ),
+              _MediaChip(
+                label: 'Movies (TMDB)',
+                color: AppColors.movieAccent,
+              ),
+              _MediaChip(
+                label: 'TV Shows (TMDB)',
+                color: AppColors.tvShowAccent,
+              ),
+              _MediaChip(
+                label: 'Anime (TMDB)',
+                color: AppColors.animationAccent,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCard({required String title, required Widget child}) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        border: Border.all(color: AppColors.surfaceBorder),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            title,
+            style: AppTypography.h3.copyWith(fontSize: 14),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          child,
+        ],
+      ),
+    );
+  }
+
+  Widget _featureRow({
+    required IconData icon,
+    required String text,
+    required Color color,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, size: 18, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTypography.body.copyWith(
+                color: AppColors.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeatureChip extends StatelessWidget {
+  const _FeatureChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: AppColors.success.withAlpha(20),
+        border: Border.all(color: AppColors.success.withAlpha(30)),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w500,
+          color: AppColors.success,
+        ),
+      ),
+    );
+  }
+}
+
+class _MediaChip extends StatelessWidget {
+  const _MediaChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: color.withAlpha(20),
+        border: Border.all(color: color.withAlpha(30)),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w500,
+          color: color,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/welcome/widgets/welcome_step_ready.dart
+++ b/lib/features/welcome/widgets/welcome_step_ready.dart
@@ -1,0 +1,121 @@
+// Шаг 4 Welcome Wizard — финальный экран с CTA.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+
+/// Шаг 4: Ready! — финальный экран с кнопками действий.
+class WelcomeStepReady extends StatelessWidget {
+  /// Создаёт [WelcomeStepReady].
+  const WelcomeStepReady({
+    required this.onGoToSettings,
+    required this.onSkip,
+    super.key,
+  });
+
+  /// Переход к Settings → Credentials.
+  final VoidCallback onGoToSettings;
+
+  /// Пропустить — перейти к Home.
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Icon(
+              Icons.celebration,
+              size: 56,
+              color: AppColors.brand,
+            ),
+            const SizedBox(height: 20),
+            Text(
+              "You're all set!",
+              style: AppTypography.h1.copyWith(fontSize: 22),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Head to Settings → Credentials to enter your API keys, '
+              'or start by importing a collection.',
+              style: AppTypography.body.copyWith(
+                color: AppColors.textSecondary,
+                fontSize: 13,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+
+            // CTA: Go to Settings
+            SizedBox(
+              width: 280,
+              child: FilledButton(
+                onPressed: onGoToSettings,
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.brand,
+                  foregroundColor: Colors.black,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(
+                      AppSpacing.radiusSm,
+                    ),
+                  ),
+                  textStyle: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Text('Go to Settings'),
+                    SizedBox(width: 4),
+                    Icon(Icons.arrow_forward, size: 16),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+
+            // Secondary: Skip
+            SizedBox(
+              width: 280,
+              child: OutlinedButton(
+                onPressed: onSkip,
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.textSecondary,
+                  side: const BorderSide(color: AppColors.surfaceBorder),
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(
+                      AppSpacing.radiusSm,
+                    ),
+                  ),
+                  textStyle: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                child: const Text('Skip — explore on my own'),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+
+            Text(
+              'You can always return here from Settings',
+              style: AppTypography.bodySmall.copyWith(
+                color: AppColors.textTertiary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/navigation/navigation_shell.dart
+++ b/lib/shared/navigation/navigation_shell.dart
@@ -57,21 +57,30 @@ enum NavTab {
 /// - B — назад (pop внутри таба или переключение на Home)
 class NavigationShell extends ConsumerStatefulWidget {
   /// Создаёт [NavigationShell].
-  const NavigationShell({super.key});
+  ///
+  /// [initialTab] позволяет открыть приложение на конкретном табе
+  /// (например, Settings после Welcome Wizard).
+  const NavigationShell({this.initialTab, super.key});
+
+  /// Начальный таб при открытии. Если null — [NavTab.home].
+  final NavTab? initialTab;
 
   @override
   ConsumerState<NavigationShell> createState() => _NavigationShellState();
 }
 
 class _NavigationShellState extends ConsumerState<NavigationShell> {
-  int _selectedIndex = NavTab.home.index;
+  late int _selectedIndex = widget.initialTab?.index ?? NavTab.home.index;
 
   /// Табы, которые уже были посещены и инициализированы.
   ///
   /// HomeScreen строится сразу, остальные — при первом переключении.
   /// Это предотвращает тяжёлую инициализацию SearchScreen (4 DB-запроса,
   /// загрузка платформ) и SettingsScreen при старте приложения.
-  final Set<int> _initializedTabs = <int>{NavTab.home.index};
+  late final Set<int> _initializedTabs = <int>{
+    NavTab.home.index,
+    if (widget.initialTab != null) widget.initialTab!.index,
+  };
 
   /// Ключи Navigator для каждого таба (nested navigation).
   ///

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -10,6 +10,7 @@ import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/features/splash/screens/splash_screen.dart';
+import 'package:xerabora/features/welcome/screens/welcome_screen.dart';
 import 'package:xerabora/shared/navigation/navigation_shell.dart';
 
 class MockCollectionRepository extends Mock implements CollectionRepository {}
@@ -73,7 +74,9 @@ void main() {
 
     testWidgets('должен показывать NavigationShell после splash анимации',
         (WidgetTester tester) async {
-      SharedPreferences.setMockInitialValues(<String, Object>{});
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        kWelcomeCompletedKey: true,
+      });
       final SharedPreferences prefs = await SharedPreferences.getInstance();
 
       await tester.pumpWidget(
@@ -93,6 +96,30 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(NavigationShell), findsOneWidget);
+    });
+
+    testWidgets('должен показывать WelcomeScreen при первом запуске',
+        (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            collectionRepositoryProvider.overrideWithValue(mockRepo),
+            databaseServiceProvider.overrideWithValue(mockDb),
+          ],
+          child: const TonkatsuBoxApp(),
+        ),
+      );
+
+      // Прокручиваем анимацию splash (2с контроллер)
+      await tester.pump(const Duration(seconds: 2));
+      // Завершаем анимацию перехода (fade 500мс)
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WelcomeScreen), findsOneWidget);
     });
 
     testWidgets('должен использовать Material 3', (WidgetTester tester) async {

--- a/test/features/settings/screens/settings_screen_test.dart
+++ b/test/features/settings/screens/settings_screen_test.dart
@@ -52,10 +52,22 @@ void main() {
         await tester.pumpWidget(createWidget());
         await tester.pumpAndSettle();
 
-        expect(find.byType(SettingsSection), findsNWidgets(2));
+        expect(find.byType(SettingsSection), findsAtLeastNWidgets(2));
         expect(find.text('Profile'), findsOneWidget);
         // "Settings" appears both as breadcrumb label and section title
         expect(find.text('Settings'), findsAtLeastNWidgets(1));
+      });
+
+      testWidgets('shows Help section after scrolling',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pumpAndSettle();
+
+        // Scroll down to reveal Help section
+        await tester.drag(find.byType(ListView), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Help'), findsOneWidget);
       });
 
       testWidgets('shows InlineTextField for author name',
@@ -165,7 +177,8 @@ void main() {
         await tester.pumpWidget(createWidget());
         await tester.pumpAndSettle();
 
-        // 4 SettingsNavRow (Credentials + Cache + Database + Debug)
+        // 4 visible SettingsNavRow (Credentials + Cache + Database + Debug)
+        // Welcome Guide is below the fold
         expect(find.byType(SettingsNavRow), findsNWidgets(4));
 
         // 4 nav row chevrons + 1 breadcrumb separator
@@ -274,6 +287,72 @@ void main() {
         );
 
         await tester.tap(debugTile);
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      });
+    });
+
+    group('Help section', () {
+      testWidgets('shows Help section with help_outline icon',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pumpAndSettle();
+
+        // Scroll down to reveal Help section
+        await tester.drag(find.byType(ListView), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Help'), findsOneWidget);
+        expect(find.byIcon(Icons.help_outline), findsOneWidget);
+      });
+
+      testWidgets('shows Welcome Guide nav row',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pumpAndSettle();
+
+        await tester.drag(find.byType(ListView), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Welcome Guide'), findsOneWidget);
+        expect(
+          find.text('Getting started with Tonkatsu Box'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('Welcome Guide has school icon',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pumpAndSettle();
+
+        await tester.drag(find.byType(ListView), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
+        final Finder welcomeTile = find.ancestor(
+          of: find.text('Welcome Guide'),
+          matching: find.byType(ListTile),
+        );
+        final ListTile tile = tester.widget<ListTile>(welcomeTile);
+        final Icon? leadingIcon = tile.leading as Icon?;
+        expect(leadingIcon!.icon, equals(Icons.school));
+      });
+
+      testWidgets('Welcome Guide tile is tappable',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pumpAndSettle();
+
+        await tester.drag(find.byType(ListView), const Offset(0, -300));
+        await tester.pumpAndSettle();
+
+        final Finder welcomeTile = find.ancestor(
+          of: find.text('Welcome Guide'),
+          matching: find.byType(ListTile),
+        );
+
+        await tester.tap(welcomeTile);
         await tester.pumpAndSettle();
 
         expect(tester.takeException(), isNull);

--- a/test/features/welcome/screens/welcome_screen_test.dart
+++ b/test/features/welcome/screens/welcome_screen_test.dart
@@ -1,0 +1,507 @@
+// Тесты для WelcomeScreen — 4-шаговый онбординг wizard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/features/welcome/screens/welcome_screen.dart';
+import 'package:xerabora/features/welcome/widgets/step_indicator.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_api_keys.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_how_it_works.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_intro.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_ready.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  Widget createWidget({bool fromSettings = false}) {
+    return ProviderScope(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: MaterialApp(
+        home: WelcomeScreen(fromSettings: fromSettings),
+      ),
+    );
+  }
+
+  group('WelcomeScreen', () {
+    group('initial state', () {
+      testWidgets('shows first step (Intro)', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.byType(WelcomeStepIntro), findsOneWidget);
+      });
+
+      testWidgets('shows 4 StepIndicators', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.byType(StepIndicator), findsNWidgets(4));
+      });
+
+      testWidgets('shows step labels', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.text('Welcome'), findsOneWidget);
+        expect(find.text('API Keys'), findsOneWidget);
+        expect(find.text('How it works'), findsOneWidget);
+        expect(find.text('Ready!'), findsOneWidget);
+      });
+
+      testWidgets('shows progress bar', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('progress bar shows 1/4 on first step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        final LinearProgressIndicator indicator =
+            tester.widget<LinearProgressIndicator>(
+          find.byType(LinearProgressIndicator),
+        );
+        expect(indicator.value, closeTo(0.25, 0.01));
+      });
+
+      testWidgets('shows Skip link', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.text('Skip'), findsOneWidget);
+      });
+
+      testWidgets('shows Next button', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.text('Next'), findsOneWidget);
+      });
+
+      testWidgets('shows Back button (disabled on first page)',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        expect(find.text('Back'), findsOneWidget);
+
+        // Back button should be disabled (TextButton with null onPressed)
+        final TextButton backButton = tester.widget<TextButton>(
+          find.widgetWithText(TextButton, 'Back'),
+        );
+        expect(backButton.onPressed, isNull);
+      });
+
+      testWidgets('shows 4 dot indicators', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // 4 AnimatedContainer dot indicators
+        expect(find.byType(AnimatedContainer), findsNWidgets(4));
+      });
+    });
+
+    group('PageView navigation', () {
+      testWidgets('Next button navigates to step 2',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Tap Next
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(WelcomeStepApiKeys), findsOneWidget);
+      });
+
+      testWidgets('progress bar updates on step 2',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+
+        final LinearProgressIndicator indicator =
+            tester.widget<LinearProgressIndicator>(
+          find.byType(LinearProgressIndicator),
+        );
+        expect(indicator.value, closeTo(0.5, 0.01));
+      });
+
+      testWidgets('Back button is enabled on step 2',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+
+        final TextButton backButton = tester.widget<TextButton>(
+          find.widgetWithText(TextButton, 'Back'),
+        );
+        expect(backButton.onPressed, isNotNull);
+      });
+
+      testWidgets('Back button navigates to previous step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Go to step 2
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+
+        // Go back to step 1
+        await tester.tap(find.widgetWithText(TextButton, 'Back'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(WelcomeStepIntro), findsOneWidget);
+      });
+
+      testWidgets('can navigate to step 3', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Next to step 2
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+
+        // Next to step 3
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(WelcomeStepHowItWorks), findsOneWidget);
+      });
+
+      testWidgets('can navigate to step 4 (Ready)',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Navigate through 3 steps
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        expect(find.byType(WelcomeStepReady), findsOneWidget);
+      });
+
+      testWidgets('Next button hidden on last step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        expect(find.text('Next'), findsNothing);
+      });
+
+      testWidgets('Skip link hidden on last step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        expect(find.text('Skip'), findsNothing);
+      });
+
+      testWidgets('progress bar shows 4/4 on last step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        final LinearProgressIndicator indicator =
+            tester.widget<LinearProgressIndicator>(
+          find.byType(LinearProgressIndicator),
+        );
+        expect(indicator.value, closeTo(1.0, 0.01));
+      });
+    });
+
+    group('Skip functionality', () {
+      testWidgets('Skip jumps to last step', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        await tester.tap(find.text('Skip'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(WelcomeStepReady), findsOneWidget);
+      });
+    });
+
+    group('dot indicators', () {
+      testWidgets('tapping a dot navigates to that page',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Dots are wrapped in GestureDetector > AnimatedContainer
+        // Find all AnimatedContainers used as dots
+        final Finder dots = find.byType(AnimatedContainer);
+        expect(dots, findsNWidgets(4));
+
+        // Tap the 3rd dot (index 2)
+        await tester.tap(dots.at(2));
+        await tester.pumpAndSettle();
+
+        // Should show step 3
+        expect(find.byType(WelcomeStepHowItWorks), findsOneWidget);
+      });
+    });
+
+    group('step indicator tapping', () {
+      testWidgets('tapping StepIndicator navigates to that step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Find StepIndicator for "API Keys" and tap it
+        final Finder apiKeysIndicator = find.widgetWithText(
+          StepIndicator,
+          'API Keys',
+        );
+        expect(apiKeysIndicator, findsOneWidget);
+        await tester.tap(apiKeysIndicator);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(WelcomeStepApiKeys), findsOneWidget);
+      });
+    });
+
+    group('kWelcomeCompletedKey', () {
+      test('is a non-empty string', () {
+        expect(kWelcomeCompletedKey, isNotEmpty);
+        expect(kWelcomeCompletedKey, equals('welcome_completed'));
+      });
+    });
+
+    group('swipe navigation', () {
+      testWidgets('swiping left goes to next step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Fling left on PageView (fling works better than drag with nested scrollables)
+        await tester.fling(
+          find.byType(PageView),
+          const Offset(-300, 0),
+          1000,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(WelcomeStepApiKeys), findsOneWidget);
+      });
+
+      testWidgets('swiping right on first step does nothing',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Fling right — should stay on step 1
+        await tester.fling(
+          find.byType(PageView),
+          const Offset(300, 0),
+          1000,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byType(WelcomeStepIntro), findsOneWidget);
+      });
+    });
+
+    group('compact mode', () {
+      testWidgets('shows labels on narrow screen only for active step',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: <Override>[
+              sharedPreferencesProvider.overrideWithValue(prefs),
+            ],
+            child: const MaterialApp(
+              home: MediaQuery(
+                data: MediaQueryData(
+                  size: Size(500, 800),
+                ),
+                child: WelcomeScreen(),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // On narrow screens, only the active label should show
+        // Active step is "Welcome" (step 0)
+        expect(find.text('Welcome'), findsOneWidget);
+        // Other labels should be hidden on compact
+        expect(find.text('API Keys'), findsNothing);
+        expect(find.text('Ready!'), findsNothing);
+      });
+    });
+
+    group('finish actions', () {
+      testWidgets('Go to Settings saves welcome_completed',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Navigate to last step
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        // Tap "Go to Settings"
+        await tester.tap(find.text('Go to Settings'));
+        // Use pump() instead of pumpAndSettle() because navigation to
+        // NavigationShell starts shimmer animations that never settle
+        await tester.pump();
+        await tester.pump();
+
+        expect(prefs.getBool(kWelcomeCompletedKey), isTrue);
+      });
+
+      testWidgets('Skip button on step 4 saves welcome_completed',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+        await tester.pump();
+
+        // Navigate to last step
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        // Tap "Skip — explore on my own"
+        await tester.tap(find.text('Skip — explore on my own'));
+        // Use pump() — NavigationShell has shimmer that blocks pumpAndSettle
+        await tester.pump();
+        await tester.pump();
+
+        expect(prefs.getBool(kWelcomeCompletedKey), isTrue);
+      });
+    });
+
+    group('fromSettings mode', () {
+      testWidgets('pops on finish when fromSettings is true',
+          (WidgetTester tester) async {
+        // Wrap in a navigator with another screen to verify pop
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: <Override>[
+              sharedPreferencesProvider.overrideWithValue(prefs),
+            ],
+            child: MaterialApp(
+              home: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (BuildContext context) =>
+                              const WelcomeScreen(fromSettings: true),
+                        ),
+                      );
+                    },
+                    child: const Text('Open Welcome'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Navigate to Welcome
+        await tester.tap(find.text('Open Welcome'));
+        await tester.pumpAndSettle();
+
+        // Verify we're on WelcomeScreen
+        expect(find.byType(WelcomeScreen), findsOneWidget);
+
+        // Go to last step
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        // Tap "Skip — explore on my own"
+        await tester.tap(find.text('Skip — explore on my own'));
+        await tester.pumpAndSettle();
+
+        // Should pop back to original screen
+        expect(find.text('Open Welcome'), findsOneWidget);
+        expect(find.byType(WelcomeScreen), findsNothing);
+      });
+
+      testWidgets('saves welcome_completed when fromSettings',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: <Override>[
+              sharedPreferencesProvider.overrideWithValue(prefs),
+            ],
+            child: MaterialApp(
+              home: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (BuildContext context) =>
+                              const WelcomeScreen(fromSettings: true),
+                        ),
+                      );
+                    },
+                    child: const Text('Open Welcome'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open Welcome'));
+        await tester.pumpAndSettle();
+
+        // Navigate to last step and finish
+        for (int i = 0; i < 3; i++) {
+          await tester.tap(find.text('Next'));
+          await tester.pumpAndSettle();
+        }
+
+        await tester.tap(find.text('Skip — explore on my own'));
+        await tester.pumpAndSettle();
+
+        expect(prefs.getBool(kWelcomeCompletedKey), isTrue);
+      });
+    });
+  });
+}

--- a/test/features/welcome/widgets/step_indicator_test.dart
+++ b/test/features/welcome/widgets/step_indicator_test.dart
@@ -1,0 +1,258 @@
+// Тесты для StepIndicator — индикатор шага Welcome Wizard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/welcome/widgets/step_indicator.dart';
+import 'package:xerabora/shared/theme/app_colors.dart';
+
+void main() {
+  Widget createWidget({
+    int number = 1,
+    String label = 'Step',
+    bool isActive = false,
+    bool isDone = false,
+    bool showLabel = true,
+    VoidCallback? onTap,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: StepIndicator(
+          number: number,
+          label: label,
+          isActive: isActive,
+          isDone: isDone,
+          showLabel: showLabel,
+          onTap: onTap,
+        ),
+      ),
+    );
+  }
+
+  group('StepIndicator', () {
+    group('pending state', () {
+      testWidgets('shows number in circle', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(number: 3));
+
+        expect(find.text('3'), findsOneWidget);
+      });
+
+      testWidgets('shows label when showLabel is true',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(label: 'Welcome'));
+
+        expect(find.text('Welcome'), findsOneWidget);
+      });
+
+      testWidgets('hides label when showLabel is false',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(label: 'Welcome', showLabel: false));
+
+        expect(find.text('Welcome'), findsNothing);
+      });
+
+      testWidgets('uses surfaceBorder for circle color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // Find circle container by BoxDecoration with circle shape
+        final Finder circleFinder = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).shape == BoxShape.circle,
+        );
+        expect(circleFinder, findsOneWidget);
+
+        final Container circle = tester.widget<Container>(circleFinder);
+        final BoxDecoration decoration = circle.decoration! as BoxDecoration;
+        expect(decoration.color, equals(AppColors.surfaceBorder));
+      });
+
+      testWidgets('uses textTertiary for label color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(label: 'Test'));
+
+        final Text labelText = tester.widget<Text>(find.text('Test'));
+        expect(labelText.style?.color, equals(AppColors.textTertiary));
+      });
+    });
+
+    group('active state', () {
+      testWidgets('uses brand color for circle',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(isActive: true));
+
+        final Finder circleFinder = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).shape == BoxShape.circle,
+        );
+        final Container circle = tester.widget<Container>(circleFinder);
+        final BoxDecoration decoration = circle.decoration! as BoxDecoration;
+        expect(decoration.color, equals(AppColors.brand));
+      });
+
+      testWidgets('uses brand color for label text',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          createWidget(isActive: true, label: 'Active'),
+        );
+
+        final Text labelText = tester.widget<Text>(find.text('Active'));
+        expect(labelText.style?.color, equals(AppColors.brand));
+      });
+
+      testWidgets('has brand-tinted background',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(isActive: true));
+
+        // Active state has brand.withAlpha(25) background
+        final Finder containers = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).color ==
+                  AppColors.brand.withAlpha(25),
+        );
+        expect(containers, findsOneWidget);
+      });
+
+      testWidgets('shows number, not checkmark',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(number: 2, isActive: true));
+
+        expect(find.text('2'), findsOneWidget);
+        expect(find.byIcon(Icons.check), findsNothing);
+      });
+    });
+
+    group('done state', () {
+      testWidgets('shows checkmark instead of number',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(isDone: true, number: 1));
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+        expect(find.text('1'), findsNothing);
+      });
+
+      testWidgets('uses success color for circle',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(isDone: true));
+
+        final Finder circleFinder = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).shape == BoxShape.circle,
+        );
+        final Container circle = tester.widget<Container>(circleFinder);
+        final BoxDecoration decoration = circle.decoration! as BoxDecoration;
+        expect(decoration.color, equals(AppColors.success));
+      });
+
+      testWidgets('uses success color for label text',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          createWidget(isDone: true, label: 'Done'),
+        );
+
+        final Text labelText = tester.widget<Text>(find.text('Done'));
+        expect(labelText.style?.color, equals(AppColors.success));
+      });
+
+      testWidgets('has success-tinted background',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(isDone: true));
+
+        final Finder containers = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).color ==
+                  AppColors.success.withAlpha(15),
+        );
+        expect(containers, findsOneWidget);
+      });
+    });
+
+    group('interaction', () {
+      testWidgets('calls onTap when tapped', (WidgetTester tester) async {
+        bool tapped = false;
+        await tester.pumpWidget(
+          createWidget(onTap: () => tapped = true),
+        );
+
+        await tester.tap(find.byType(StepIndicator));
+        expect(tapped, isTrue);
+      });
+
+      testWidgets('does not crash when onTap is null',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        await tester.tap(find.byType(StepIndicator));
+        expect(tester.takeException(), isNull);
+      });
+    });
+
+    group('layout', () {
+      testWidgets('circle is 22x22', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // Circle container with BoxShape.circle and SizedBox 22x22
+        final Finder circleFinder = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).shape == BoxShape.circle,
+        );
+        expect(circleFinder, findsOneWidget);
+
+        // Verify rendered size
+        final Size circleSize = tester.getSize(circleFinder);
+        expect(circleSize.width, equals(22));
+        expect(circleSize.height, equals(22));
+      });
+
+      testWidgets('label has fontSize 11', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(label: 'Test'));
+
+        final Text labelText = tester.widget<Text>(find.text('Test'));
+        expect(labelText.style?.fontSize, equals(11));
+      });
+
+      testWidgets('checkmark icon is size 13',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(isDone: true));
+
+        final Icon checkIcon = tester.widget<Icon>(find.byIcon(Icons.check));
+        expect(checkIcon.size, equals(13));
+      });
+    });
+
+    group('priority: isDone overrides isActive visually', () {
+      testWidgets(
+          'when both isDone and isActive are true, shows success colors',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          createWidget(isDone: true, isActive: true, label: 'Both'),
+        );
+
+        // isDone takes priority for circle color
+        final Finder circleFinder = find.byWidgetPredicate(
+          (Widget w) =>
+              w is Container &&
+              w.decoration is BoxDecoration &&
+              (w.decoration! as BoxDecoration).shape == BoxShape.circle,
+        );
+        final Container circle = tester.widget<Container>(circleFinder);
+        final BoxDecoration decoration = circle.decoration! as BoxDecoration;
+        expect(decoration.color, equals(AppColors.success));
+
+        // Shows checkmark (isDone priority)
+        expect(find.byIcon(Icons.check), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/features/welcome/widgets/welcome_step_api_keys_test.dart
+++ b/test/features/welcome/widgets/welcome_step_api_keys_test.dart
@@ -1,0 +1,228 @@
+// Тесты для WelcomeStepApiKeys — шаг 2 Welcome Wizard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_api_keys.dart';
+import 'package:xerabora/shared/theme/app_colors.dart';
+
+void main() {
+  Widget createWidget() {
+    return const MaterialApp(
+      home: Scaffold(
+        body: WelcomeStepApiKeys(),
+      ),
+    );
+  }
+
+  group('WelcomeStepApiKeys', () {
+    group('header', () {
+      testWidgets('shows key icon', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.key), findsOneWidget);
+      });
+
+      testWidgets('shows title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Getting API Keys'), findsOneWidget);
+      });
+
+      testWidgets('shows subtitle', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.text('Free registration, takes 2-3 minutes each'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('IGDB section', () {
+      testWidgets('shows IGDB tag', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('IGDB'), findsOneWidget);
+      });
+
+      testWidgets('shows Game search title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Game search'), findsOneWidget);
+      });
+
+      testWidgets('shows REQUIRED badge', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('REQUIRED'), findsOneWidget);
+      });
+
+      testWidgets('shows 4 IGDB steps', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.textContaining('dev.twitch.tv/console'), findsWidgets);
+        expect(find.textContaining('Twitch'), findsWidgets);
+        expect(find.textContaining('Client ID'), findsOneWidget);
+      });
+
+      testWidgets('shows Twitch Developer Console link',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Twitch Developer Console'), findsOneWidget);
+      });
+    });
+
+    group('TMDB section', () {
+      testWidgets('shows TMDB tag', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('TMDB'), findsOneWidget);
+      });
+
+      testWidgets('shows Movies, TV & Anime title',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Movies, TV & Anime'), findsOneWidget);
+      });
+
+      testWidgets('shows RECOMMENDED badge', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('RECOMMENDED'), findsOneWidget);
+      });
+
+      testWidgets('shows TMDB steps', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.textContaining('themoviedb.org'), findsWidgets);
+        expect(find.textContaining('API Key'), findsWidgets);
+      });
+
+      testWidgets('shows TMDB API link', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('TMDB API'), findsOneWidget);
+      });
+    });
+
+    group('SteamGridDB section', () {
+      testWidgets('shows SGDB tag', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('SGDB'), findsOneWidget);
+      });
+
+      testWidgets('shows Game artwork for boards title',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Game artwork for boards'), findsOneWidget);
+      });
+
+      testWidgets('shows OPTIONAL badge', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('OPTIONAL'), findsOneWidget);
+      });
+
+      testWidgets('shows SteamGridDB link', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('SteamGridDB'), findsOneWidget);
+      });
+    });
+
+    group('hint section', () {
+      testWidgets('shows hint text about Settings',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('Enter keys in Settings'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('hint has brand-tinted background',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // Find hint container by its text
+        final Finder hintText =
+            find.textContaining('Enter keys in Settings');
+        expect(hintText, findsOneWidget);
+      });
+    });
+
+    group('link cards', () {
+      testWidgets('shows 3 link cards with open_in_new icons',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // 3 open_in_new icons (one per _LinkCard)
+        expect(find.byIcon(Icons.open_in_new), findsNWidgets(3));
+      });
+
+      testWidgets('shows 3 copy icons', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // 3 content_copy icons
+        expect(find.byIcon(Icons.content_copy), findsNWidgets(3));
+      });
+
+      testWidgets('IGDB link card is tappable',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // Find the Twitch Developer Console InkWell
+        final Finder linkCard = find.ancestor(
+          of: find.text('Twitch Developer Console'),
+          matching: find.byType(InkWell),
+        );
+        expect(linkCard, findsOneWidget);
+      });
+    });
+
+    group('badge colors', () {
+      testWidgets('REQUIRED badge uses brand color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final Text requiredText =
+            tester.widget<Text>(find.text('REQUIRED'));
+        expect(requiredText.style?.color, equals(AppColors.brand));
+      });
+
+      testWidgets('RECOMMENDED badge uses textTertiary color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final Text recommendedText =
+            tester.widget<Text>(find.text('RECOMMENDED'));
+        expect(
+          recommendedText.style?.color,
+          equals(AppColors.textTertiary),
+        );
+      });
+
+      testWidgets('OPTIONAL badge uses textTertiary color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final Text optionalText =
+            tester.widget<Text>(find.text('OPTIONAL'));
+        expect(optionalText.style?.color, equals(AppColors.textTertiary));
+      });
+    });
+
+    group('scrollability', () {
+      testWidgets('is scrollable', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byType(SingleChildScrollView), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/features/welcome/widgets/welcome_step_how_it_works_test.dart
+++ b/test/features/welcome/widgets/welcome_step_how_it_works_test.dart
@@ -1,0 +1,161 @@
+// Тесты для WelcomeStepHowItWorks — шаг 3 Welcome Wizard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_how_it_works.dart';
+
+void main() {
+  Widget createWidget() {
+    return const MaterialApp(
+      home: Scaffold(
+        body: WelcomeStepHowItWorks(),
+      ),
+    );
+  }
+
+  group('WelcomeStepHowItWorks', () {
+    group('header', () {
+      testWidgets('shows menu_book icon', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.menu_book), findsOneWidget);
+      });
+
+      testWidgets('shows title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('How it works'), findsOneWidget);
+      });
+    });
+
+    group('App structure section', () {
+      testWidgets('shows section title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('App structure'), findsOneWidget);
+      });
+
+      testWidgets('shows all 5 tab names', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Main'), findsOneWidget);
+        expect(find.text('Collections'), findsOneWidget);
+        expect(find.text('Wishlist'), findsOneWidget);
+        expect(find.text('Search'), findsOneWidget);
+        expect(find.text('Settings'), findsOneWidget);
+      });
+
+      testWidgets('shows tab descriptions', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('All items from all collections'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Your collections'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Quick list'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Find games'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('API keys, cache'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows tab icons', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.home), findsOneWidget);
+        expect(find.byIcon(Icons.collections_bookmark), findsOneWidget);
+        expect(find.byIcon(Icons.bookmark), findsOneWidget);
+        expect(find.byIcon(Icons.search), findsOneWidget);
+        expect(find.byIcon(Icons.settings), findsOneWidget);
+      });
+    });
+
+    group('Quick Start section', () {
+      testWidgets('shows section title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Quick Start'), findsOneWidget);
+      });
+
+      testWidgets('shows 5 numbered steps', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('1'), findsOneWidget);
+        expect(find.text('2'), findsOneWidget);
+        expect(find.text('3'), findsOneWidget);
+        expect(find.text('4'), findsOneWidget);
+        expect(find.text('5'), findsOneWidget);
+      });
+
+      testWidgets('shows step texts', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('Settings'),
+          findsWidgets,
+        );
+        expect(
+          find.textContaining('Verify Connection'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('New Collection'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('Sharing section', () {
+      testWidgets('shows sharing title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Sharing'), findsOneWidget);
+      });
+
+      testWidgets('shows upload icon', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.upload), findsOneWidget);
+      });
+
+      testWidgets('shows .xcoll format', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('.xcoll'), findsOneWidget);
+      });
+
+      testWidgets('shows .xcollx format', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('.xcollx'), findsOneWidget);
+      });
+
+      testWidgets('shows sharing description via RichText',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // Sharing description uses RichText with mixed TextSpan+WidgetSpan
+        expect(find.byType(RichText), findsWidgets);
+      });
+    });
+
+    group('scrollability', () {
+      testWidgets('is scrollable', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byType(SingleChildScrollView), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/features/welcome/widgets/welcome_step_intro_test.dart
+++ b/test/features/welcome/widgets/welcome_step_intro_test.dart
@@ -1,0 +1,152 @@
+// Тесты для WelcomeStepIntro — шаг 1 Welcome Wizard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_intro.dart';
+import 'package:xerabora/shared/theme/app_colors.dart';
+
+void main() {
+  Widget createWidget() {
+    return const MaterialApp(
+      home: Scaffold(
+        body: WelcomeStepIntro(),
+      ),
+    );
+  }
+
+  group('WelcomeStepIntro', () {
+    group('header', () {
+      testWidgets('shows app logo', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byType(Image), findsOneWidget);
+      });
+
+      testWidgets('shows welcome title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Welcome to Tonkatsu Box'), findsOneWidget);
+      });
+
+      testWidgets('shows subtitle text', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('Organize your collections'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('What you can do section', () {
+      testWidgets('shows section title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('What you can do'), findsOneWidget);
+      });
+
+      testWidgets('shows 5 feature descriptions',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('Create collections'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Search games'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Track progress'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Visual canvas boards'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('Export & import'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows feature icons', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.inventory_2_outlined), findsOneWidget);
+        expect(find.byIcon(Icons.search), findsOneWidget);
+        expect(find.byIcon(Icons.bar_chart), findsOneWidget);
+        expect(find.byIcon(Icons.palette_outlined), findsOneWidget);
+        expect(find.byIcon(Icons.upload_outlined), findsOneWidget);
+      });
+    });
+
+    group('Works without keys section', () {
+      testWidgets('shows section title', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Works without API keys'), findsOneWidget);
+      });
+
+      testWidgets('shows check circle icon', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      });
+
+      testWidgets('shows feature chips', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Collections'), findsOneWidget);
+        expect(find.text('Wishlist'), findsOneWidget);
+        expect(find.text('Import .xcoll'), findsOneWidget);
+        expect(find.text('Canvas boards'), findsOneWidget);
+        expect(find.text('Ratings & notes'), findsOneWidget);
+      });
+
+      testWidgets('shows explanation text', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('API keys are only needed'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('Media type chips', () {
+      testWidgets('shows all 4 media types', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Games (IGDB)'), findsOneWidget);
+        expect(find.text('Movies (TMDB)'), findsOneWidget);
+        expect(find.text('TV Shows (TMDB)'), findsOneWidget);
+        expect(find.text('Anime (TMDB)'), findsOneWidget);
+      });
+
+      testWidgets('media chips use correct colors',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // Games chip should have gameAccent color
+        final Text gamesText =
+            tester.widget<Text>(find.text('Games (IGDB)'));
+        expect(gamesText.style?.color, equals(AppColors.gameAccent));
+
+        // Movies chip should have movieAccent color
+        final Text moviesText =
+            tester.widget<Text>(find.text('Movies (TMDB)'));
+        expect(moviesText.style?.color, equals(AppColors.movieAccent));
+      });
+    });
+
+    group('scrollability', () {
+      testWidgets('is scrollable', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byType(SingleChildScrollView), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/features/welcome/widgets/welcome_step_ready_test.dart
+++ b/test/features/welcome/widgets/welcome_step_ready_test.dart
@@ -1,0 +1,164 @@
+// Тесты для WelcomeStepReady — шаг 4 Welcome Wizard.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/welcome/widgets/welcome_step_ready.dart';
+import 'package:xerabora/shared/theme/app_colors.dart';
+
+void main() {
+  Widget createWidget({
+    VoidCallback? onGoToSettings,
+    VoidCallback? onSkip,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: WelcomeStepReady(
+          onGoToSettings: onGoToSettings ?? () {},
+          onSkip: onSkip ?? () {},
+        ),
+      ),
+    );
+  }
+
+  group('WelcomeStepReady', () {
+    group('header', () {
+      testWidgets('shows celebration icon', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.celebration), findsOneWidget);
+      });
+
+      testWidgets('celebration icon uses brand color',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final Icon icon = tester.widget<Icon>(
+          find.byIcon(Icons.celebration),
+        );
+        expect(icon.color, equals(AppColors.brand));
+      });
+
+      testWidgets('celebration icon is size 56',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final Icon icon = tester.widget<Icon>(
+          find.byIcon(Icons.celebration),
+        );
+        expect(icon.size, equals(56));
+      });
+
+      testWidgets('shows title text', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text("You're all set!"), findsOneWidget);
+      });
+
+      testWidgets('shows description text', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.textContaining('Head to Settings'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('Go to Settings button', () {
+      testWidgets('shows button text', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.text('Go to Settings'), findsOneWidget);
+      });
+
+      testWidgets('shows arrow_forward icon', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      });
+
+      testWidgets('calls onGoToSettings when tapped',
+          (WidgetTester tester) async {
+        bool called = false;
+        await tester.pumpWidget(
+          createWidget(onGoToSettings: () => called = true),
+        );
+
+        await tester.tap(find.text('Go to Settings'));
+        expect(called, isTrue);
+      });
+
+      testWidgets('is a FilledButton', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byType(FilledButton), findsOneWidget);
+      });
+    });
+
+    group('Skip button', () {
+      testWidgets('shows button text', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.text('Skip — explore on my own'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('calls onSkip when tapped',
+          (WidgetTester tester) async {
+        bool called = false;
+        await tester.pumpWidget(
+          createWidget(onSkip: () => called = true),
+        );
+
+        await tester.tap(find.text('Skip — explore on my own'));
+        expect(called, isTrue);
+      });
+
+      testWidgets('is an OutlinedButton', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(find.byType(OutlinedButton), findsOneWidget);
+      });
+    });
+
+    group('footer', () {
+      testWidgets('shows hint about returning from Settings',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        expect(
+          find.text('You can always return here from Settings'),
+          findsOneWidget,
+        );
+      });
+    });
+
+    group('layout', () {
+      testWidgets('content is centered', (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        // WelcomeStepReady wraps content in Center
+        // (FilledButton/OutlinedButton also have internal Centers)
+        final Finder centeredContent = find.descendant(
+          of: find.byType(WelcomeStepReady),
+          matching: find.byType(Center),
+        );
+        expect(centeredContent, findsAtLeastNWidgets(1));
+      });
+
+      testWidgets('buttons have fixed width 280',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget());
+
+        final Iterable<SizedBox> sizedBoxes = tester.widgetList<SizedBox>(
+          find.byWidgetPredicate(
+            (Widget w) => w is SizedBox && w.width == 280,
+          ),
+        );
+        expect(sizedBoxes.length, equals(2));
+      });
+    });
+  });
+}

--- a/test/shared/navigation/navigation_shell_test.dart
+++ b/test/shared/navigation/navigation_shell_test.dart
@@ -73,7 +73,7 @@ void main() {
       prefs = await SharedPreferences.getInstance();
     });
 
-    Widget createShell({double width = 1024}) {
+    Widget createShell({double width = 1024, NavTab? initialTab}) {
       return ProviderScope(
         overrides: <Override>[
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -82,7 +82,7 @@ void main() {
         child: MaterialApp(
           home: MediaQuery(
             data: MediaQueryData(size: Size(width, 768)),
-            child: const NavigationShell(),
+            child: NavigationShell(initialTab: initialTab),
           ),
         ),
       );
@@ -283,6 +283,57 @@ void main() {
 
         // Видим SettingsScreen с Cache (корневой экран таба)
         expect(find.text('Cache'), findsOneWidget);
+      });
+    });
+
+    group('initialTab parameter', () {
+      testWidgets('opens on Settings tab when initialTab is settings',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          createShell(width: 1024, initialTab: NavTab.settings),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final NavigationRail rail =
+            tester.widget<NavigationRail>(find.byType(NavigationRail));
+        expect(rail.selectedIndex, equals(NavTab.settings.index));
+      });
+
+      testWidgets('Settings tab is initialized when used as initialTab',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          createShell(width: 1024, initialTab: NavTab.settings),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        // Settings content should be visible
+        expect(find.text('Credentials'), findsOneWidget);
+      });
+
+      testWidgets('defaults to home tab when initialTab is null',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createShell(width: 1024));
+        await tester.pump();
+
+        final NavigationRail rail =
+            tester.widget<NavigationRail>(find.byType(NavigationRail));
+        expect(rail.selectedIndex, equals(NavTab.home.index));
+      });
+
+      testWidgets('initialTab works with BottomBar on mobile',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          createShell(width: 400, initialTab: NavTab.settings),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final BottomNavigationBar bar =
+            tester.widget<BottomNavigationBar>(
+                find.byType(BottomNavigationBar));
+        expect(bar.currentIndex, equals(NavTab.settings.index));
       });
     });
 


### PR DESCRIPTION
4-step onboarding wizard shown on first launch: Welcome, API Keys, How it Works, Ready. Saves completion flag to SharedPreferences. Re-openable from Settings → Help → Welcome Guide. Adds initialTab parameter to NavigationShell for deep-linking to Settings tab. Includes 173 new tests and docs/guides/ markdown sources.