### PR TITLE
feat: add update checker with GitHub Releases API and dismissible banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+### Added
+- Added update checker — queries GitHub Releases API on app launch and shows a dismissible banner when a newer version is available (`lib/core/services/update_service.dart`, `lib/shared/widgets/update_banner.dart`)
+  - `UpdateService` with semver comparison, 24-hour throttle via SharedPreferences, and silent error handling
+  - `UpdateBanner` widget embedded in `NavigationShell` (both desktop and mobile layouts)
+  - "Update" button opens the release page via `url_launcher`; dismiss button hides the banner until next launch
+- Added `package_info_plus` dependency for reading current app version
+- Added 27 tests: `update_service_test.dart` (19 tests — semver, throttle, cache, errors), `update_banner_test.dart` (8 tests — show/hide/dismiss/loading/error states)
+
 ### Changed
 - Replaced debug signing with release keystore for Android APK (`android/app/build.gradle.kts`)
   - Signing config reads from environment variables (CI) with fallback to `key.properties` (local)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,7 @@ lib/
 | `lib/core/services/xcoll_file.dart` | **Модель файла экспорта/импорта**. Формат v2 (.xcoll/.xcollx, items + canvas + images). Классы: `XcollFile`, `ExportFormat` (light/full), `ExportCanvas`. Файлы v1 выбрасывают `FormatException` |
 | `lib/core/services/export_service.dart` | **Сервис экспорта**. Создаёт XcollFile из коллекции. Режимы: v2 light (.xcoll — ID элементов), v2 full (.xcollx — + canvas + per-item canvas + base64 обложки). Зависимости: `CanvasRepository`, `ImageCacheService`. Методы: `createLightExport()`, `createFullExport()`, `exportToFile()` |
 | `lib/core/services/import_service.dart` | **Сервис импорта**. Импортирует XcollFile в коллекцию. items + canvas (viewport/items/connections) + per-item canvas + восстановление обложек из base64. Прогресс через `ImportStage` enum и `ImportProgressCallback`. Зависимости: `DatabaseService`, `CanvasRepository`, `GameRepository`, `ImageCacheService` |
+| `lib/core/services/update_service.dart` | **Сервис проверки обновлений**. Класс `UpdateInfo` (currentVersion, latestVersion, releaseUrl, hasUpdate, releaseNotes). Класс `UpdateService` — запрос GitHub Releases API, semver сравнение (`isNewer()`), 24-часовой throttle через SharedPreferences. Провайдеры: `updateServiceProvider`, `updateCheckProvider` (FutureProvider) |
 
 </details>
 
@@ -297,6 +298,7 @@ lib/
 | `lib/shared/widgets/source_badge.dart` | **Бейдж источника данных**. Enum `DataSource` (igdb, tmdb, steamGridDb, vgMaps). Размеры: small, medium, large. Цветовая маркировка и текстовая метка |
 | `lib/shared/widgets/media_type_badge.dart` | **Бейдж типа медиа**. Цветная иконка по `MediaType`: синий (игры), красный (фильмы), зелёный (сериалы) |
 | `lib/shared/widgets/collection_picker_dialog.dart` | **Диалог выбора коллекции**. Sealed class `CollectionChoice` (`ChosenCollection(int id)` / `WithoutCollection`). Функция `showCollectionPickerDialog()` — диалог со списком коллекций. Параметры: `excludeCollectionId` (скрыть текущую), `showUncategorized` (показать "Without Collection"), `title` (заголовок). Используется в Search (добавление) и Detail Screens (перемещение) |
+| `lib/shared/widgets/update_banner.dart` | **Баннер обновления**. `UpdateBanner` (ConsumerWidget) — читает `updateCheckProvider`, показывает баннер при наличии новой версии. `_UpdateBannerContent` (StatefulWidget) — dismiss state, кнопка "Update" (url_launcher), крестик закрытия. Стиль: AppColors.brand |
 
 </details>
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -298,6 +298,16 @@ Built with 5 reusable widgets: `SettingsSection`, `SettingsRow`, `SettingsNavRow
 > [!WARNING]
 > **Reset Database** clears all collections, items, and board data. API keys and settings are preserved. This action cannot be undone.
 
+## 🔄 Update Checker
+
+On app launch, queries the GitHub Releases API for the latest version. Shows a dismissible banner at the bottom of the screen (below content, above navigation bar on mobile) when a newer version is available.
+
+- **Semver comparison** — compares major.minor.patch
+- **24-hour throttle** — caches result in SharedPreferences; skips API call if checked within the last 24 hours
+- **Silent errors** — network failures are swallowed; banner simply doesn't appear
+- **Dismiss** — close button hides the banner until next app launch
+- **Update button** — opens the GitHub release page in the default browser
+
 ## 📴 Offline Mode
 
 After initial setup, most features work offline: browse collections, update status, add comments. Only search requires internet.

--- a/lib/core/services/update_service.dart
+++ b/lib/core/services/update_service.dart
@@ -1,0 +1,179 @@
+// Update checker — проверяет GitHub Releases API на наличие новой версии.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../features/settings/providers/settings_provider.dart';
+
+/// Информация о доступном обновлении.
+class UpdateInfo {
+  /// Создаёт информацию об обновлении.
+  const UpdateInfo({
+    required this.currentVersion,
+    required this.latestVersion,
+    required this.releaseUrl,
+    required this.hasUpdate,
+    this.releaseNotes,
+  });
+
+  /// Текущая версия приложения.
+  final String currentVersion;
+
+  /// Последняя версия на GitHub.
+  final String latestVersion;
+
+  /// URL страницы релиза.
+  final String releaseUrl;
+
+  /// Есть ли более новая версия.
+  final bool hasUpdate;
+
+  /// Заметки к релизу (markdown).
+  final String? releaseNotes;
+}
+
+/// Сервис проверки обновлений через GitHub Releases API.
+class UpdateService {
+  /// Создаёт сервис проверки обновлений.
+  ///
+  /// [currentVersionOverride] используется в тестах вместо
+  /// `PackageInfo.fromPlatform()`.
+  UpdateService({
+    required SharedPreferences prefs,
+    required Dio dio,
+    String? currentVersionOverride,
+  })  : _prefs = prefs,
+        _dio = dio,
+        _currentVersionOverride = currentVersionOverride;
+
+  final SharedPreferences _prefs;
+  final Dio _dio;
+  final String? _currentVersionOverride;
+
+  static const String _repoOwner = 'hacan359';
+  static const String _repoName = 'tonkatsu_box';
+  static const String _apiUrl =
+      'https://api.github.com/repos/$_repoOwner/$_repoName/releases/latest';
+
+  static const String _lastCheckKey = 'update_last_check';
+  static const String _latestVersionKey = 'update_latest_version';
+  static const String _releaseUrlKey = 'update_release_url';
+
+  static const int _throttleDurationMs = 86400000; // 24 часа
+
+  /// Проверяет наличие обновления.
+  ///
+  /// Возвращает `null` при ошибке сети или если не удалось проверить.
+  /// Не чаще раза в 24 часа — при повторном вызове возвращает
+  /// кешированный результат.
+  Future<UpdateInfo?> checkForUpdate() async {
+    try {
+      final String currentVersion;
+      if (_currentVersionOverride != null) {
+        currentVersion = _currentVersionOverride;
+      } else {
+        final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+        currentVersion = packageInfo.version;
+      }
+
+      // Проверяем throttle
+      final int? lastCheck = _prefs.getInt(_lastCheckKey);
+      final int now = DateTime.now().millisecondsSinceEpoch;
+
+      if (lastCheck != null && (now - lastCheck) < _throttleDurationMs) {
+        return _getCachedResult(currentVersion);
+      }
+
+      final Response<Map<String, dynamic>> response =
+          await _dio.get<Map<String, dynamic>>(
+        _apiUrl,
+        options: Options(
+          headers: <String, String>{
+            'Accept': 'application/vnd.github.v3+json',
+          },
+          receiveTimeout: const Duration(seconds: 10),
+        ),
+      );
+
+      final Map<String, dynamic> data = response.data!;
+      final String tagName = data['tag_name'] as String;
+      final String latestVersion = tagName.replaceFirst('v', '');
+      final String releaseUrl = data['html_url'] as String;
+      final String? body = data['body'] as String?;
+
+      // Сохранить результат и timestamp
+      await _prefs.setInt(_lastCheckKey, now);
+      await _prefs.setString(_latestVersionKey, latestVersion);
+      await _prefs.setString(_releaseUrlKey, releaseUrl);
+
+      final bool hasUpdate = isNewer(latestVersion, currentVersion);
+
+      return UpdateInfo(
+        currentVersion: currentVersion,
+        latestVersion: latestVersion,
+        releaseUrl: releaseUrl,
+        hasUpdate: hasUpdate,
+        releaseNotes: body,
+      );
+    } on DioException {
+      return null;
+    } on Exception {
+      return null;
+    }
+  }
+
+  /// Возвращает кешированный результат из SharedPreferences.
+  UpdateInfo? _getCachedResult(String currentVersion) {
+    final String? savedVersion = _prefs.getString(_latestVersionKey);
+    final String? savedUrl = _prefs.getString(_releaseUrlKey);
+
+    if (savedVersion != null && savedUrl != null) {
+      return UpdateInfo(
+        currentVersion: currentVersion,
+        latestVersion: savedVersion,
+        releaseUrl: savedUrl,
+        hasUpdate: isNewer(savedVersion, currentVersion),
+      );
+    }
+    return null;
+  }
+
+  /// Сравнивает semver: возвращает `true` если [latest] > [current].
+  bool isNewer(String latest, String current) {
+    final List<int> latestParts = _parseSemver(latest);
+    final List<int> currentParts = _parseSemver(current);
+
+    for (int i = 0; i < 3; i++) {
+      if (latestParts[i] > currentParts[i]) return true;
+      if (latestParts[i] < currentParts[i]) return false;
+    }
+    return false;
+  }
+
+  List<int> _parseSemver(String version) {
+    final List<String> parts = version.split('.');
+    return List<int>.generate(
+      3,
+      (int i) => i < parts.length ? (int.tryParse(parts[i]) ?? 0) : 0,
+    );
+  }
+}
+
+/// Провайдер сервиса проверки обновлений.
+final Provider<UpdateService> updateServiceProvider =
+    Provider<UpdateService>((Ref ref) {
+  return UpdateService(
+    prefs: ref.watch(sharedPreferencesProvider),
+    dio: Dio(),
+  );
+});
+
+/// Проверяет обновление один раз при первом чтении.
+///
+/// [FutureProvider] автоматически кеширует результат на время жизни scope.
+final FutureProvider<UpdateInfo?> updateCheckProvider =
+    FutureProvider<UpdateInfo?>((Ref ref) {
+  return ref.read(updateServiceProvider).checkForUpdate();
+});

--- a/lib/shared/navigation/navigation_shell.dart
+++ b/lib/shared/navigation/navigation_shell.dart
@@ -16,6 +16,7 @@ import '../gamepad/widgets/gamepad_listener.dart';
 import '../theme/app_assets.dart';
 import '../theme/app_colors.dart';
 import '../widgets/breadcrumb_scope.dart';
+import '../widgets/update_banner.dart';
 
 /// Порог ширины для переключения NavigationRail ↔ BottomNavigationBar.
 const double navigationBreakpoint = 800;
@@ -115,7 +116,14 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
           _handleBack();
         },
         child: Scaffold(
-          body: useRail ? _buildRailLayout() : _buildContent(),
+          body: useRail
+              ? _buildRailLayout()
+              : Column(
+                  children: <Widget>[
+                    Expanded(child: _buildContent()),
+                    const UpdateBanner(),
+                  ],
+                ),
           bottomNavigationBar: useRail ? null : _buildBottomNav(),
         ),
       ),
@@ -197,7 +205,14 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
           width: 1,
           color: AppColors.surfaceBorder,
         ),
-        Expanded(child: _buildContent()),
+        Expanded(
+          child: Column(
+            children: <Widget>[
+              Expanded(child: _buildContent()),
+              const UpdateBanner(),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/lib/shared/widgets/update_banner.dart
+++ b/lib/shared/widgets/update_banner.dart
@@ -1,0 +1,108 @@
+// Баннер уведомления о доступном обновлении приложения.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/services/update_service.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_spacing.dart';
+import '../theme/app_typography.dart';
+
+/// Баннер, показывающий уведомление о доступном обновлении.
+///
+/// Читает [updateCheckProvider] и показывает баннер если есть
+/// более новая версия. Можно закрыть крестиком — баннер исчезает
+/// до следующего запуска приложения.
+class UpdateBanner extends ConsumerWidget {
+  /// Создаёт баннер обновления.
+  const UpdateBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<UpdateInfo?> updateAsync = ref.watch(updateCheckProvider);
+
+    return updateAsync.when(
+      data: (UpdateInfo? info) {
+        if (info == null || !info.hasUpdate) return const SizedBox.shrink();
+        return _UpdateBannerContent(info: info);
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (Object error, StackTrace stack) => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _UpdateBannerContent extends StatefulWidget {
+  const _UpdateBannerContent({required this.info});
+
+  final UpdateInfo info;
+
+  @override
+  State<_UpdateBannerContent> createState() => _UpdateBannerContentState();
+}
+
+class _UpdateBannerContentState extends State<_UpdateBannerContent> {
+  bool _dismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed) return const SizedBox.shrink();
+
+    return Container(
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.brand.withAlpha(20),
+        border: Border.all(color: AppColors.brand.withAlpha(60)),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+      ),
+      child: Row(
+        children: <Widget>[
+          const Icon(Icons.system_update, color: AppColors.brand, size: 20),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  'Update available: v${widget.info.latestVersion}',
+                  style: AppTypography.body.copyWith(
+                    color: AppColors.brand,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  'Current: v${widget.info.currentVersion}',
+                  style: AppTypography.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              launchUrl(
+                Uri.parse(widget.info.releaseUrl),
+                mode: LaunchMode.externalApplication,
+              );
+            },
+            child: const Text('Update'),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, size: 16),
+            onPressed: () => setState(() => _dismissed = true),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -472,6 +472,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,9 @@ dependencies:
   # URL
   url_launcher: ^6.2.0
 
+  # App Info
+  package_info_plus: ^8.0.0
+
   # WebView
   webview_windows: ^0.4.0
 

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:xerabora/app.dart';
 import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/core/services/update_service.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/shared/models/collection.dart';
@@ -45,6 +46,7 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             collectionRepositoryProvider.overrideWithValue(mockRepo),
             databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
           ],
           child: const TonkatsuBoxApp(),
         ),
@@ -64,6 +66,7 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             collectionRepositoryProvider.overrideWithValue(mockRepo),
             databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
           ],
           child: const TonkatsuBoxApp(),
         ),
@@ -85,6 +88,7 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             collectionRepositoryProvider.overrideWithValue(mockRepo),
             databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
           ],
           child: const TonkatsuBoxApp(),
         ),
@@ -109,6 +113,7 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             collectionRepositoryProvider.overrideWithValue(mockRepo),
             databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
           ],
           child: const TonkatsuBoxApp(),
         ),
@@ -132,6 +137,7 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             collectionRepositoryProvider.overrideWithValue(mockRepo),
             databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
           ],
           child: const TonkatsuBoxApp(),
         ),
@@ -153,6 +159,7 @@ void main() {
             sharedPreferencesProvider.overrideWithValue(prefs),
             collectionRepositoryProvider.overrideWithValue(mockRepo),
             databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
           ],
           child: const TonkatsuBoxApp(),
         ),

--- a/test/core/services/update_service_test.dart
+++ b/test/core/services/update_service_test.dart
@@ -1,0 +1,266 @@
+// Тесты для UpdateService — проверка обновлений через GitHub Releases API.
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/core/services/update_service.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UpdateService sut;
+  late MockDio mockDio;
+
+  const String latestVersion = '0.10.0';
+  const String releaseUrl = 'https://github.com/hacan359/tonkatsu_box/releases/tag/v0.10.0';
+  const String releaseNotes = 'New features and bug fixes';
+
+  final Map<String, dynamic> successResponse = <String, dynamic>{
+    'tag_name': 'v$latestVersion',
+    'html_url': releaseUrl,
+    'body': releaseNotes,
+  };
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    mockDio = MockDio();
+    sut = UpdateService(
+      prefs: prefs,
+      dio: mockDio,
+      currentVersionOverride: '0.9.0',
+    );
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Options());
+  });
+
+  group('UpdateInfo', () {
+    test('должен создать объект с обязательными полями', () {
+      const UpdateInfo info = UpdateInfo(
+        currentVersion: '0.9.0',
+        latestVersion: '0.10.0',
+        releaseUrl: releaseUrl,
+        hasUpdate: true,
+      );
+
+      expect(info.currentVersion, equals('0.9.0'));
+      expect(info.latestVersion, equals('0.10.0'));
+      expect(info.releaseUrl, equals(releaseUrl));
+      expect(info.hasUpdate, isTrue);
+      expect(info.releaseNotes, isNull);
+    });
+
+    test('должен создать объект с releaseNotes', () {
+      const UpdateInfo info = UpdateInfo(
+        currentVersion: '0.9.0',
+        latestVersion: '0.10.0',
+        releaseUrl: releaseUrl,
+        hasUpdate: true,
+        releaseNotes: 'Some notes',
+      );
+
+      expect(info.releaseNotes, equals('Some notes'));
+    });
+  });
+
+  group('UpdateService', () {
+    group('isNewer', () {
+      test('major: 1.0.0 > 0.9.0', () {
+        expect(sut.isNewer('1.0.0', '0.9.0'), isTrue);
+      });
+
+      test('minor: 0.10.0 > 0.9.0', () {
+        expect(sut.isNewer('0.10.0', '0.9.0'), isTrue);
+      });
+
+      test('patch: 0.9.1 > 0.9.0', () {
+        expect(sut.isNewer('0.9.1', '0.9.0'), isTrue);
+      });
+
+      test('equal: 0.9.0 == 0.9.0', () {
+        expect(sut.isNewer('0.9.0', '0.9.0'), isFalse);
+      });
+
+      test('older: 0.8.0 < 0.9.0', () {
+        expect(sut.isNewer('0.8.0', '0.9.0'), isFalse);
+      });
+
+      test('older patch: 0.9.0 < 0.9.1', () {
+        expect(sut.isNewer('0.9.0', '0.9.1'), isFalse);
+      });
+
+      test('handles short version: 1.0 vs 0.9.0', () {
+        expect(sut.isNewer('1.0', '0.9.0'), isTrue);
+      });
+
+      test('handles single number: 2 vs 1.0.0', () {
+        expect(sut.isNewer('2', '1.0.0'), isTrue);
+      });
+
+      test('handles invalid parts gracefully', () {
+        expect(sut.isNewer('abc', '0.9.0'), isFalse);
+      });
+    });
+
+    group('checkForUpdate', () {
+      test('должен вернуть UpdateInfo при наличии обновления', () async {
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+              data: successResponse,
+              statusCode: 200,
+              requestOptions: RequestOptions(path: ''),
+            ));
+
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNotNull);
+        expect(result!.latestVersion, equals(latestVersion));
+        expect(result.releaseUrl, equals(releaseUrl));
+        expect(result.hasUpdate, isTrue);
+        expect(result.releaseNotes, equals(releaseNotes));
+      });
+
+      test('должен вернуть hasUpdate=false если версия актуальна', () async {
+        // Ответ где latest == current (currentVersionOverride = '0.9.0')
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+              data: <String, dynamic>{
+                'tag_name': 'v0.9.0',
+                'html_url': releaseUrl,
+                'body': null,
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(path: ''),
+            ));
+
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNotNull);
+        expect(result!.hasUpdate, isFalse);
+        expect(result.releaseNotes, isNull);
+      });
+
+      test('должен вернуть null при DioException', () async {
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenThrow(DioException(
+              requestOptions: RequestOptions(path: ''),
+              type: DioExceptionType.connectionTimeout,
+            ));
+
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNull);
+      });
+
+      test('должен вернуть null при общей ошибке', () async {
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenThrow(Exception('Unknown error'));
+
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNull);
+      });
+
+      test('должен использовать правильный URL', () async {
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+              data: successResponse,
+              statusCode: 200,
+              requestOptions: RequestOptions(path: ''),
+            ));
+
+        await sut.checkForUpdate();
+
+        verify(() => mockDio.get<Map<String, dynamic>>(
+              'https://api.github.com/repos/hacan359/tonkatsu_box/releases/latest',
+              options: any(named: 'options'),
+            )).called(1);
+      });
+    });
+
+    group('throttle', () {
+      test('должен вернуть кеш при повторном вызове в течение 24ч', () async {
+        // Первый вызов — реальный запрос
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+              data: successResponse,
+              statusCode: 200,
+              requestOptions: RequestOptions(path: ''),
+            ));
+
+        await sut.checkForUpdate();
+
+        // Второй вызов — должен использовать кеш, без нового запроса
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNotNull);
+        expect(result!.latestVersion, equals(latestVersion));
+        // Dio.get должен быть вызван только 1 раз
+        verify(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).called(1);
+      });
+
+      test('должен вернуть null если кеш пуст и throttle активен', () async {
+        // Записываем только timestamp без данных
+        final SharedPreferences prefs = await SharedPreferences.getInstance();
+        await prefs.setInt(
+          'update_last_check',
+          DateTime.now().millisecondsSinceEpoch,
+        );
+
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNull);
+        verifyNever(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            ));
+      });
+
+      test('должен сделать запрос если прошло больше 24ч', () async {
+        // Записываем старый timestamp (>24ч назад)
+        final SharedPreferences prefs = await SharedPreferences.getInstance();
+        await prefs.setInt(
+          'update_last_check',
+          DateTime.now().millisecondsSinceEpoch - 86400001,
+        );
+
+        when(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+              data: successResponse,
+              statusCode: 200,
+              requestOptions: RequestOptions(path: ''),
+            ));
+
+        final UpdateInfo? result = await sut.checkForUpdate();
+
+        expect(result, isNotNull);
+        verify(() => mockDio.get<Map<String, dynamic>>(
+              any(),
+              options: any(named: 'options'),
+            )).called(1);
+      });
+    });
+  });
+}

--- a/test/shared/navigation/navigation_shell_test.dart
+++ b/test/shared/navigation/navigation_shell_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/core/services/update_service.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/features/wishlist/providers/wishlist_provider.dart';
 import 'package:xerabora/shared/navigation/navigation_shell.dart';
@@ -78,6 +79,9 @@ void main() {
         overrides: <Override>[
           sharedPreferencesProvider.overrideWithValue(prefs),
           activeWishlistCountProvider.overrideWithValue(0),
+          updateCheckProvider.overrideWith(
+            (Ref ref) async => null,
+          ),
         ],
         child: MaterialApp(
           home: MediaQuery(

--- a/test/shared/widgets/update_banner_test.dart
+++ b/test/shared/widgets/update_banner_test.dart
@@ -1,0 +1,174 @@
+// Тесты для UpdateBanner — баннер уведомления об обновлении.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/core/services/update_service.dart';
+import 'package:xerabora/shared/widgets/update_banner.dart';
+
+void main() {
+  const UpdateInfo updateAvailable = UpdateInfo(
+    currentVersion: '0.9.0',
+    latestVersion: '0.10.0',
+    releaseUrl: 'https://github.com/hacan359/tonkatsu_box/releases/tag/v0.10.0',
+    hasUpdate: true,
+    releaseNotes: 'New features',
+  );
+
+  const UpdateInfo noUpdate = UpdateInfo(
+    currentVersion: '0.10.0',
+    latestVersion: '0.10.0',
+    releaseUrl: 'https://github.com/hacan359/tonkatsu_box/releases/tag/v0.10.0',
+    hasUpdate: false,
+  );
+
+  Widget buildWidget({required AsyncValue<UpdateInfo?> value}) {
+    return ProviderScope(
+      overrides: <Override>[
+        updateCheckProvider.overrideWith(
+          (Ref ref) => value.when(
+            data: (UpdateInfo? data) => Future<UpdateInfo?>.value(data),
+            loading: () => Completer<UpdateInfo?>().future,
+            error: (Object e, StackTrace s) => Future<UpdateInfo?>.error(e, s),
+          ),
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: <Widget>[
+              Expanded(child: SizedBox.shrink()),
+              UpdateBanner(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('UpdateBanner', () {
+    testWidgets('должен показать баннер при наличии обновления', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(value: const AsyncValue<UpdateInfo?>.data(updateAvailable)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Update available: v0.10.0'), findsOneWidget);
+      expect(find.text('Current: v0.9.0'), findsOneWidget);
+      expect(find.text('Update'), findsOneWidget);
+    });
+
+    testWidgets('должен скрыть баннер если обновления нет', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(value: const AsyncValue<UpdateInfo?>.data(noUpdate)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Update available: v0.10.0'), findsNothing);
+    });
+
+    testWidgets('должен скрыть баннер если данных нет (null)', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(value: const AsyncValue<UpdateInfo?>.data(null)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(UpdateBanner), findsOneWidget);
+      expect(find.text('Update available'), findsNothing);
+    });
+
+    testWidgets('должен скрыть баннер при ошибке', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(
+          value: AsyncValue<UpdateInfo?>.error(
+            Exception('Network error'),
+            StackTrace.current,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Update available'), findsNothing);
+    });
+
+    testWidgets('должен скрыть баннер при загрузке', (
+      WidgetTester tester,
+    ) async {
+      // Completer никогда не завершится — провайдер останется в loading state
+      // без pending timers (в отличие от Future.delayed).
+      final Completer<UpdateInfo?> completer = Completer<UpdateInfo?>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            updateCheckProvider.overrideWith(
+              (Ref ref) => completer.future,
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: <Widget>[
+                  Expanded(child: SizedBox.shrink()),
+                  UpdateBanner(),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Update available'), findsNothing);
+    });
+
+    testWidgets('должен скрыть баннер при нажатии крестика', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(value: const AsyncValue<UpdateInfo?>.data(updateAvailable)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Update available: v0.10.0'), findsOneWidget);
+
+      // Нажимаем крестик
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Update available: v0.10.0'), findsNothing);
+    });
+
+    testWidgets('должен содержать кнопку Update', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(value: const AsyncValue<UpdateInfo?>.data(updateAvailable)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextButton, 'Update'), findsOneWidget);
+    });
+
+    testWidgets('должен показывать иконку system_update', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildWidget(value: const AsyncValue<UpdateInfo?>.data(updateAvailable)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.system_update), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Check for newer app version on launch via GitHub Releases API with 24-hour throttle caching. Show a dismissible banner in NavigationShell with "Update" button linking to the release page.