### PR TITLE
refactor: unified SnackBar notification system with SnackType enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## [Unreleased]
 
 ### Added
+- Unified SnackBar notification system — `SnackType` enum (success/error/info), `context.showSnack()` extension with auto-hide, typed icons and colored borders, `loading` parameter for progress indication, `context.hideSnack()` for manual dismissal (`snackbar_extension.dart`)
+- Added 17 new tests for `SnackBarExtension`: all 3 types with icons/colors/borders, loading mode, auto-hide, action, duration, text style, SnackBar properties, `hideSnack()` (`snackbar_extension_test.dart`)
 - Auto-sync platforms on IGDB verify — `_verifyConnection()` now automatically calls `syncPlatforms()` and `_downloadLogosIfEnabled()` after successful connection (`credentials_screen.dart`)
 - API key validation — `SteamGridDbApi.validateApiKey()` method for testing SteamGridDB API keys; `SettingsNotifier.validateTmdbKey()` and `validateSteamGridDbKey()` methods (`steamgriddb_api.dart`, `settings_provider.dart`)
 - "Test" button in credentials screen — `_buildSaveRow()` now accepts optional `onValidate` callback; Test buttons shown for SteamGridDB and TMDB when API key is saved (`credentials_screen.dart`)
@@ -19,6 +21,8 @@
 - Added 6 new tests: canvas sync by (type, refId), orphan deletion without collectionItemId, non-media item preservation, edge point directions, drag offset edge points, diagonal edge selection
 
 ### Changed
+- Migrated all 85 SnackBar calls across 13 files to unified `context.showSnack()` extension — removed all direct `ScaffoldMessenger.of(context).showSnackBar()` calls, `messenger` variables, and `_showSnackBar()` helpers (`home_screen.dart`, `collection_screen.dart`, `search_screen.dart`, `credentials_screen.dart`, `database_screen.dart`, `cache_screen.dart`, `welcome_step_api_keys.dart`, 4 detail screens, 2 debug screens)
+- Simplified `snackBarTheme` in `AppTheme` — removed redundant backgroundColor, contentTextStyle, shape (now controlled by extension)
 - Search screen no longer blocks all tabs when IGDB keys are missing — each tab independently checks its required API key (`search_screen.dart`)
 - Simplified import — imported collections are now created as `CollectionType.own` (fully editable) instead of `CollectionType.imported` (`import_service.dart`)
 - Removed fork system — deleted `fork()`, `revertToOriginal()` from `CollectionRepository` and `CollectionsNotifier`; removed "Create Copy" and "Revert to Original" UI actions; all collections now use unified folder icon and gameAccent color
@@ -34,6 +38,8 @@
 - Fixed canvas not displaying items added to collection — `_syncCanvasWithItems()` was setting `collectionItemId` on created items, but `getCanvasItems()` SQL query filters by `collection_item_id IS NULL`, making them invisible. Items are now created without `collectionItemId`, consistent with `initializeCanvas()`
 
 ### Removed
+- Removed `_showSnackBar()` private helper method from `SteamGridDbDebugScreen`
+- Removed all direct `ScaffoldMessenger` usage from feature screens (13 files) — replaced by `snackbar_extension.dart`
 - Removed `CollectionRepository.fork()` and `revertToOriginal()` methods
 - Removed `CollectionsNotifier.fork()` and `revertToOriginal()` methods
 - Removed `importedCollectionsProvider` and `forkedCollectionsProvider`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ lib/
 ├── core/                     # Ядро (API, БД)
 ├── data/                     # Репозитории
 ├── features/                 # Фичи (экраны, виджеты)
-└── shared/                   # Общие модели
+└── shared/                   # Общие модели, extensions, тема
 ```
 
 ---
@@ -307,6 +307,7 @@ lib/
 | Файл | Назначение |
 |------|------------|
 | `lib/shared/constants/media_type_theme.dart` | **Тема типов медиа**. Цвета и иконки для визуального разделения: `colorFor(MediaType)`, `iconFor(MediaType)`. Делегирует к `AppColors`: gameColor (indigo), movieColor (orange), tvShowColor (lime), animationColor (purple) |
+| `lib/shared/extensions/snackbar_extension.dart` | **Unified SnackBar extension**. `SnackType` enum (success/error/info), `context.showSnack()` с auto-hide, цветными иконками и рамками, `loading` параметром. `context.hideSnack()` для ручного скрытия. Единая точка управления всеми уведомлениями в приложении. Адаптивная ширина: 360px на desktop, full-width на mobile (`kIsMobile`) |
 
 ---
 
@@ -830,7 +831,7 @@ CollectionRepository.addItem()
        |
 DatabaseService.addItemToCollection()
        |
-SnackBar "Game added to collection"
+context.showSnack("Game added", type: SnackType.success)
 ```
 
 ### 2a. Поиск фильмов/сериалов
@@ -865,7 +866,7 @@ CollectionRepository.addItem()
        |
 DatabaseService.insertCollectionItem()
        |
-SnackBar "Movie/TV show added to collection"
+context.showSnack("Added", type: SnackType.success)
 ```
 
 ### 3. Canvas (визуальный холст)
@@ -929,7 +930,7 @@ CollectionScreen._addSteamGridDbImage()
        |
 canvasNotifierProvider.addImageItem(centerX, centerY, {url})
        |
-SnackBar "Image added to canvas"
+context.showSnack("Image added to board", type: SnackType.success)
 ```
 
 ### 6. Изменение статуса

--- a/docs/SNACKBAR.md
+++ b/docs/SNACKBAR.md
@@ -1,0 +1,129 @@
+[← Back to README](../README.md)
+
+# Unified SnackBar Notification System
+
+All user-facing notifications in the app use a single extension method `context.showSnack()` defined in `lib/shared/extensions/snackbar_extension.dart`. To change the look or behavior of any notification, edit only this file.
+
+---
+
+## API
+
+### SnackType
+
+```dart
+enum SnackType { success, error, info }
+```
+
+| Type | Icon | Icon Color | Border Color |
+|------|------|------------|--------------|
+| `success` | `check_circle_outline` | `AppColors.success` (green) | `AppColors.success` at 50% alpha |
+| `error` | `error_outline` | `AppColors.error` (red) | `AppColors.error` at 50% alpha |
+| `info` | `info_outline` | `AppColors.brand` (orange) | `AppColors.surfaceBorder` |
+
+### showSnack()
+
+```dart
+context.showSnack(
+  'Message text',
+  type: SnackType.info,                        // default: info
+  duration: const Duration(seconds: 2),         // default: 2s
+  action: SnackBarAction(label: 'UNDO', ...),   // optional
+  loading: false,                                // default: false
+);
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `message` | `String` | required | Text displayed in the notification |
+| `type` | `SnackType` | `info` | Controls icon and border color |
+| `duration` | `Duration` | 2 seconds | How long the notification stays visible |
+| `action` | `SnackBarAction?` | `null` | Optional button (e.g. "UNDO", "OK") |
+| `loading` | `bool` | `false` | Replaces the icon with a `CircularProgressIndicator` |
+
+### hideSnack()
+
+```dart
+context.hideSnack();
+```
+
+Manually hides the current notification. Useful when a loading notification should be dismissed after an async operation completes.
+
+---
+
+## Behavior
+
+- **Auto-hide previous**: Calling `showSnack()` automatically hides any currently visible notification before showing the new one.
+- **Swipe to dismiss**: Users can swipe horizontally to dismiss.
+- **Platform-aware width**:
+  - **Desktop** (Windows): fixed 360px width, centered.
+  - **Mobile** (Android): full-width with 16px horizontal margin.
+- **Visual style**: Dark surface background (`AppColors.surfaceLight`), colored left border per type, floating with elevation 4.
+
+---
+
+## Usage Examples
+
+### Basic notifications
+
+```dart
+// Success after an operation
+context.showSnack('Collection renamed', type: SnackType.success);
+
+// Error with details
+context.showSnack('Failed to delete: $e', type: SnackType.error);
+
+// Informational (default type)
+context.showSnack('URL copied to clipboard');
+```
+
+### Loading indicator
+
+```dart
+// Show loading state
+context.showSnack(
+  'Preparing export...',
+  loading: true,
+  duration: const Duration(seconds: 30),
+);
+
+// After operation completes — auto-hidden by next showSnack()
+context.showSnack('Exported to $path', type: SnackType.success);
+```
+
+### With action button
+
+```dart
+context.showSnack(
+  'Exported to $path',
+  type: SnackType.success,
+  action: SnackBarAction(
+    label: 'OK',
+    onPressed: () {},
+  ),
+);
+```
+
+### Manual hide (e.g. on cancel)
+
+```dart
+if (result.isCancelled) {
+  context.hideSnack();
+}
+```
+
+---
+
+## File Location
+
+```
+lib/shared/extensions/snackbar_extension.dart   # Extension + SnackType enum
+test/shared/extensions/snackbar_extension_test.dart  # 17 tests
+```
+
+## Import
+
+```dart
+import '../../../shared/extensions/snackbar_extension.dart';
+```
+
+The import makes both `SnackType` and the `showSnack()`/`hideSnack()` extension methods available.

--- a/lib/features/collections/screens/anime_detail_screen.dart
+++ b/lib/features/collections/screens/anime_detail_screen.dart
@@ -12,6 +12,7 @@ import '../../../core/database/database_service.dart';
 import '../../../shared/widgets/auto_breadcrumb_app_bar.dart';
 import '../../../shared/widgets/breadcrumb_scope.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
@@ -127,7 +128,6 @@ class _AnimeDetailScreenState extends ConsumerState<AnimeDetailScreen>
   }
 
   Future<void> _moveToCollection(CollectionItem item) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final NavigatorState navigator = Navigator.of(context);
     final bool isUncategorized = widget.collectionId == null;
 
@@ -164,8 +164,9 @@ class _AnimeDetailScreenState extends ConsumerState<AnimeDetailScreen>
     if (!mounted) return;
 
     if (result.success) {
-      messenger.showSnackBar(
-        SnackBar(content: Text('${item.itemName} moved to $targetName')),
+      context.showSnack(
+        '${item.itemName} moved to $targetName',
+        type: SnackType.success,
       );
       if (result.sourceEmpty && widget.collectionId != null) {
         final bool? confirmed = await showDialog<bool>(
@@ -193,11 +194,7 @@ class _AnimeDetailScreenState extends ConsumerState<AnimeDetailScreen>
       }
       if (mounted) navigator.pop();
     } else {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('${item.itemName} already exists in $targetName'),
-        ),
-      );
+      context.showSnack('${item.itemName} already exists in $targetName');
     }
   }
 
@@ -232,9 +229,7 @@ class _AnimeDetailScreenState extends ConsumerState<AnimeDetailScreen>
         .removeItem(item.id, mediaType: item.mediaType);
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${item.itemName} removed')),
-      );
+      context.showSnack('${item.itemName} removed', type: SnackType.success);
       Navigator.of(context).pop();
     }
   }
@@ -731,12 +726,7 @@ class _AnimeDetailScreenState extends ConsumerState<AnimeDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Image added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Image added to board', type: SnackType.success);
     }
   }
 
@@ -768,12 +758,7 @@ class _AnimeDetailScreenState extends ConsumerState<AnimeDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Map added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Map added to board', type: SnackType.success);
     }
   }
 

--- a/lib/features/collections/screens/game_detail_screen.dart
+++ b/lib/features/collections/screens/game_detail_screen.dart
@@ -6,6 +6,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/auto_breadcrumb_app_bar.dart';
 import '../../../shared/widgets/breadcrumb_scope.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
@@ -114,7 +115,6 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
   }
 
   Future<void> _moveToCollection(CollectionItem item) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final NavigatorState navigator = Navigator.of(context);
     final bool isUncategorized = widget.collectionId == null;
 
@@ -149,8 +149,9 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
     if (!mounted) return;
 
     if (result.success) {
-      messenger.showSnackBar(
-        SnackBar(content: Text('${item.itemName} moved to $targetName')),
+      context.showSnack(
+        '${item.itemName} moved to $targetName',
+        type: SnackType.success,
       );
       if (result.sourceEmpty && widget.collectionId != null) {
         final bool? confirmed = await showDialog<bool>(
@@ -178,11 +179,7 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
       }
       if (mounted) navigator.pop();
     } else {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('${item.itemName} already exists in $targetName'),
-        ),
-      );
+      context.showSnack('${item.itemName} already exists in $targetName');
     }
   }
 
@@ -215,9 +212,7 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
         .removeItem(item.id, mediaType: item.mediaType);
 
     if (mounted) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('${item.itemName} removed')));
+      context.showSnack('${item.itemName} removed', type: SnackType.success);
       Navigator.of(context).pop();
     }
   }
@@ -516,12 +511,7 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Image added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Image added to board', type: SnackType.success);
     }
   }
 
@@ -550,12 +540,7 @@ class _GameDetailScreenState extends ConsumerState<GameDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Map added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Map added to board', type: SnackType.success);
     }
   }
 

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/import_service.dart';
 import '../../../shared/constants/platform_features.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -246,12 +247,7 @@ class HomeScreen extends ConsumerWidget {
       }
     } on Exception catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to create collection: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
-        );
+        context.showSnack('Failed to create collection: $e', type: SnackType.error);
       }
     }
   }
@@ -318,18 +314,11 @@ class HomeScreen extends ConsumerWidget {
       await ref.read(collectionsProvider.notifier).rename(collection.id, newName);
 
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Collection renamed')),
-        );
+        context.showSnack('Collection renamed', type: SnackType.success);
       }
     } on Exception catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to rename: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
-        );
+        context.showSnack('Failed to rename: $e', type: SnackType.error);
       }
     }
   }
@@ -348,18 +337,11 @@ class HomeScreen extends ConsumerWidget {
       await ref.read(collectionsProvider.notifier).delete(collection.id);
 
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Collection deleted')),
-        );
+        context.showSnack('Collection deleted', type: SnackType.success);
       }
     } on Exception catch (e) {
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to delete: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
-        );
+        context.showSnack('Failed to delete: $e', type: SnackType.error);
       }
     }
   }
@@ -408,23 +390,15 @@ class HomeScreen extends ConsumerWidget {
       ref.invalidate(collectionsProvider);
       ref.invalidate(allItemsNotifierProvider);
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Imported "${result.collection!.name}" with ${result.itemsImported} items',
-          ),
-        ),
+      context.showSnack(
+        'Imported "${result.collection!.name}" with ${result.itemsImported} items',
+        type: SnackType.success,
       );
 
       // Переходим к импортированной коллекции
       _navigateToCollection(context, result.collection!);
     } else if (!result.isCancelled && result.error != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(result.error!),
-          backgroundColor: Theme.of(context).colorScheme.error,
-        ),
-      );
+      context.showSnack(result.error!, type: SnackType.error);
     }
   }
 }

--- a/lib/features/collections/screens/movie_detail_screen.dart
+++ b/lib/features/collections/screens/movie_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/auto_breadcrumb_app_bar.dart';
 import '../../../shared/widgets/breadcrumb_scope.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
@@ -118,7 +119,6 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
   }
 
   Future<void> _moveToCollection(CollectionItem item) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final NavigatorState navigator = Navigator.of(context);
     final bool isUncategorized = widget.collectionId == null;
 
@@ -155,8 +155,9 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
     if (!mounted) return;
 
     if (result.success) {
-      messenger.showSnackBar(
-        SnackBar(content: Text('${item.itemName} moved to $targetName')),
+      context.showSnack(
+        '${item.itemName} moved to $targetName',
+        type: SnackType.success,
       );
       if (result.sourceEmpty && widget.collectionId != null) {
         final bool? confirmed = await showDialog<bool>(
@@ -184,11 +185,7 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
       }
       if (mounted) navigator.pop();
     } else {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('${item.itemName} already exists in $targetName'),
-        ),
-      );
+      context.showSnack('${item.itemName} already exists in $targetName');
     }
   }
 
@@ -223,9 +220,7 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
         .removeItem(item.id, mediaType: item.mediaType);
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${item.itemName} removed')),
-      );
+      context.showSnack('${item.itemName} removed', type: SnackType.success);
       Navigator.of(context).pop();
     }
   }
@@ -550,12 +545,7 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Image added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Image added to board', type: SnackType.success);
     }
   }
 
@@ -587,12 +577,7 @@ class _MovieDetailScreenState extends ConsumerState<MovieDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Map added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Map added to board', type: SnackType.success);
     }
   }
 

--- a/lib/features/collections/screens/tv_show_detail_screen.dart
+++ b/lib/features/collections/screens/tv_show_detail_screen.dart
@@ -12,6 +12,7 @@ import '../../../core/database/database_service.dart';
 import '../../../shared/widgets/auto_breadcrumb_app_bar.dart';
 import '../../../shared/widgets/breadcrumb_scope.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
@@ -126,7 +127,6 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
   }
 
   Future<void> _moveToCollection(CollectionItem item) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final NavigatorState navigator = Navigator.of(context);
     final bool isUncategorized = widget.collectionId == null;
 
@@ -163,8 +163,9 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
     if (!mounted) return;
 
     if (result.success) {
-      messenger.showSnackBar(
-        SnackBar(content: Text('${item.itemName} moved to $targetName')),
+      context.showSnack(
+        '${item.itemName} moved to $targetName',
+        type: SnackType.success,
       );
       if (result.sourceEmpty && widget.collectionId != null) {
         final bool? confirmed = await showDialog<bool>(
@@ -192,11 +193,7 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
       }
       if (mounted) navigator.pop();
     } else {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text('${item.itemName} already exists in $targetName'),
-        ),
-      );
+      context.showSnack('${item.itemName} already exists in $targetName');
     }
   }
 
@@ -231,9 +228,7 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
         .removeItem(item.id, mediaType: item.mediaType);
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('${item.itemName} removed')),
-      );
+      context.showSnack('${item.itemName} removed', type: SnackType.success);
       Navigator.of(context).pop();
     }
   }
@@ -622,12 +617,7 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Image added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Image added to board', type: SnackType.success);
     }
   }
 
@@ -659,12 +649,7 @@ class _TvShowDetailScreenState extends ConsumerState<TvShowDetailScreen>
         );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Map added to board'),
-          duration: Duration(seconds: 2),
-        ),
-      );
+      context.showSnack('Map added to board', type: SnackType.success);
     }
   }
 

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/constants/platform_features.dart';
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
@@ -228,7 +229,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   }
 
   Future<void> _addGameToCollection(Game game) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String gameName = game.name;
 
     final int? platformId = await _showPlatformSelectionDialog(game);
@@ -245,19 +245,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     if (mounted) {
       if (success) {
         _cacheImage(ImageType.gameCover, game.id.toString(), game.coverUrl);
-        messenger.showSnackBar(
-          SnackBar(content: Text('$gameName added to collection')),
-        );
+        context.showSnack('$gameName added to collection', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          const SnackBar(content: Text('Game already in collection')),
-        );
+        context.showSnack('Game already in collection', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addGameToAnyCollection(Game game) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String gameName = game.name;
 
     final CollectionChoice? choice =
@@ -293,17 +288,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     if (mounted) {
       if (success) {
         _cacheImage(ImageType.gameCover, game.id.toString(), game.coverUrl);
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$gameName added to $collectionName'),
-          ),
-        );
+        context.showSnack('$gameName added to $collectionName', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$gameName already in $collectionName'),
-          ),
-        );
+        context.showSnack('$gameName already in $collectionName', type: SnackType.info);
       }
     }
   }
@@ -383,7 +370,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   }
 
   Future<void> _addMovieToCollection(Movie movie) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = movie.title;
 
     final bool success = await ref
@@ -401,19 +387,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           movie.tmdbId.toString(),
           movie.posterUrl,
         );
-        messenger.showSnackBar(
-          SnackBar(content: Text('$title added to collection')),
-        );
+        context.showSnack('$title added to collection', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          const SnackBar(content: Text('Movie already in collection')),
-        );
+        context.showSnack('Movie already in collection', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addMovieToAnyCollection(Movie movie) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = movie.title;
 
     final CollectionChoice? choice =
@@ -449,23 +430,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           movie.tmdbId.toString(),
           movie.posterUrl,
         );
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title added to $collectionName'),
-          ),
-        );
+        context.showSnack('$title added to $collectionName', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title already in $collectionName'),
-          ),
-        );
+        context.showSnack('$title already in $collectionName', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addTvShowToCollection(TvShow tvShow) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = tvShow.title;
 
     final bool success = await ref
@@ -484,19 +456,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           tvShow.posterUrl,
         );
         _preloadSeasons(tvShow.tmdbId);
-        messenger.showSnackBar(
-          SnackBar(content: Text('$title added to collection')),
-        );
+        context.showSnack('$title added to collection', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          const SnackBar(content: Text('TV show already in collection')),
-        );
+        context.showSnack('TV show already in collection', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addTvShowToAnyCollection(TvShow tvShow) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = tvShow.title;
 
     final CollectionChoice? choice =
@@ -533,17 +500,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           tvShow.posterUrl,
         );
         _preloadSeasons(tvShow.tmdbId);
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title added to $collectionName'),
-          ),
-        );
+        context.showSnack('$title added to $collectionName', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title already in $collectionName'),
-          ),
-        );
+        context.showSnack('$title already in $collectionName', type: SnackType.info);
       }
     }
   }
@@ -551,7 +510,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   // ==================== Animation actions ====================
 
   Future<void> _addAnimationMovieToCollection(Movie movie) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = movie.title;
 
     final bool success = await ref
@@ -570,19 +528,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           movie.tmdbId.toString(),
           movie.posterUrl,
         );
-        messenger.showSnackBar(
-          SnackBar(content: Text('$title added to collection')),
-        );
+        context.showSnack('$title added to collection', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          const SnackBar(content: Text('Already in collection')),
-        );
+        context.showSnack('Already in collection', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addAnimationTvShowToCollection(TvShow tvShow) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = tvShow.title;
 
     final bool success = await ref
@@ -602,19 +555,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           tvShow.posterUrl,
         );
         _preloadSeasons(tvShow.tmdbId);
-        messenger.showSnackBar(
-          SnackBar(content: Text('$title added to collection')),
-        );
+        context.showSnack('$title added to collection', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          const SnackBar(content: Text('Already in collection')),
-        );
+        context.showSnack('Already in collection', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addAnimationMovieToAnyCollection(Movie movie) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = movie.title;
 
     final CollectionChoice? choice =
@@ -651,23 +599,14 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           movie.tmdbId.toString(),
           movie.posterUrl,
         );
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title added to $collectionName'),
-          ),
-        );
+        context.showSnack('$title added to $collectionName', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title already in $collectionName'),
-          ),
-        );
+        context.showSnack('$title already in $collectionName', type: SnackType.info);
       }
     }
   }
 
   Future<void> _addAnimationTvShowToAnyCollection(TvShow tvShow) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String title = tvShow.title;
 
     final CollectionChoice? choice =
@@ -705,17 +644,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
           tvShow.posterUrl,
         );
         _preloadSeasons(tvShow.tmdbId);
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title added to $collectionName'),
-          ),
-        );
+        context.showSnack('$title added to $collectionName', type: SnackType.success);
       } else {
-        messenger.showSnackBar(
-          SnackBar(
-            content: Text('$title already in $collectionName'),
-          ),
-        );
+        context.showSnack('$title already in $collectionName', type: SnackType.info);
       }
     }
   }

--- a/lib/features/settings/screens/cache_screen.dart
+++ b/lib/features/settings/screens/cache_screen.dart
@@ -154,7 +154,7 @@ class _CacheScreenState extends ConsumerState<CacheScreen> {
       if (!mounted) return;
       _refreshFutures();
       setState(() {});
-      context.showAppSnackBar('Cache folder updated');
+      context.showSnack('Cache folder updated', type: SnackType.success);
     }
   }
 
@@ -186,7 +186,7 @@ class _CacheScreenState extends ConsumerState<CacheScreen> {
       if (!mounted) return;
       _refreshFutures();
       setState(() {});
-      context.showAppSnackBar('Cache cleared');
+      context.showSnack('Cache cleared', type: SnackType.success);
     }
   }
 }

--- a/lib/features/settings/screens/credentials_screen.dart
+++ b/lib/features/settings/screens/credentials_screen.dart
@@ -113,7 +113,7 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
             Clipboard.setData(
               const ClipboardData(text: _twitchConsoleUrl),
             );
-            context.showAppSnackBar(
+            context.showSnack(
               'URL copied: $_twitchConsoleUrl',
             );
           },
@@ -370,9 +370,9 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
     final String clientSecret = _clientSecret.trim();
 
     if (clientId.isEmpty || clientSecret.isEmpty) {
-      context.showAppSnackBar(
+      context.showSnack(
         'Please enter both Client ID and Client Secret',
-        isError: true,
+        type: SnackType.error,
       );
       return;
     }
@@ -390,12 +390,15 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
       final bool syncOk = await notifier.syncPlatforms();
       if (mounted) {
         if (syncOk) {
-          context.showAppSnackBar('Connected & platforms synced!');
+          context.showSnack(
+            'Connected & platforms synced!',
+            type: SnackType.success,
+          );
           await _downloadLogosIfEnabled();
         } else {
-          context.showAppSnackBar(
+          context.showSnack(
             'Connected, but platform sync failed',
-            isError: true,
+            type: SnackType.error,
           );
         }
       }
@@ -408,7 +411,10 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
     final bool success = await notifier.syncPlatforms();
 
     if (success && mounted) {
-      context.showAppSnackBar('Platforms synced successfully!');
+      context.showSnack(
+        'Platforms synced successfully!',
+        type: SnackType.success,
+      );
       await _downloadLogosIfEnabled();
     }
   }
@@ -425,12 +431,10 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
 
     if (!mounted) return;
 
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-    messenger.showSnackBar(
-      const SnackBar(
-        content: Text('Downloading platform logos...'),
-        duration: Duration(seconds: 60),
-      ),
+    context.showSnack(
+      'Downloading platform logos...',
+      loading: true,
+      duration: const Duration(seconds: 60),
     );
 
     final List<ImageDownloadTask> tasks = platforms
@@ -447,14 +451,18 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
         tasks: tasks,
       );
 
-      messenger.hideCurrentSnackBar();
       if (mounted) {
-        context.showAppSnackBar('Downloaded $downloaded logos');
+        context.showSnack(
+          'Downloaded $downloaded logos',
+          type: SnackType.success,
+        );
       }
     } on Exception {
-      messenger.hideCurrentSnackBar();
       if (mounted) {
-        context.showAppSnackBar('Failed to download logos', isError: true);
+        context.showSnack(
+          'Failed to download logos',
+          type: SnackType.error,
+        );
       }
     }
   }
@@ -503,9 +511,12 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
     final bool valid = await notifier.validateSteamGridDbKey();
     if (mounted) {
       if (valid) {
-        context.showAppSnackBar('SteamGridDB API key is valid');
+        context.showSnack(
+          'SteamGridDB API key is valid',
+          type: SnackType.success,
+        );
       } else {
-        context.showAppSnackBar('SteamGridDB API key is invalid', isError: true);
+        context.showSnack('SteamGridDB API key is invalid', type: SnackType.error);
       }
     }
   }
@@ -516,9 +527,12 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
     final bool valid = await notifier.validateTmdbKey();
     if (mounted) {
       if (valid) {
-        context.showAppSnackBar('TMDB API key is valid');
+        context.showSnack(
+          'TMDB API key is valid',
+          type: SnackType.success,
+        );
       } else {
-        context.showAppSnackBar('TMDB API key is invalid', isError: true);
+        context.showSnack('TMDB API key is invalid', type: SnackType.error);
       }
     }
   }
@@ -545,14 +559,14 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
   }) async {
     final String apiKey = value.trim();
     if (apiKey.isEmpty) {
-      context.showAppSnackBar(emptyMessage, isError: true);
+      context.showSnack(emptyMessage, type: SnackType.error);
       return;
     }
 
     await setter(apiKey);
 
     if (mounted) {
-      context.showAppSnackBar(successMessage);
+      context.showSnack(successMessage, type: SnackType.success);
     }
   }
 

--- a/lib/features/settings/screens/database_screen.dart
+++ b/lib/features/settings/screens/database_screen.dart
@@ -133,9 +133,12 @@ class DatabaseScreen extends ConsumerWidget {
     if (!context.mounted) return;
 
     if (result.success) {
-      context.showAppSnackBar('Config exported to ${result.filePath}');
+      context.showSnack(
+        'Config exported to ${result.filePath}',
+        type: SnackType.success,
+      );
     } else if (result.error != null) {
-      context.showAppSnackBar(result.error!, isError: true);
+      context.showSnack(result.error!, type: SnackType.error);
     }
   }
 
@@ -147,9 +150,12 @@ class DatabaseScreen extends ConsumerWidget {
     if (!context.mounted) return;
 
     if (result.success) {
-      context.showAppSnackBar('Config imported successfully');
+      context.showSnack(
+        'Config imported successfully',
+        type: SnackType.success,
+      );
     } else if (result.error != null) {
-      context.showAppSnackBar(result.error!, isError: true);
+      context.showSnack(result.error!, type: SnackType.error);
     }
   }
 
@@ -195,7 +201,10 @@ class DatabaseScreen extends ConsumerWidget {
       ref.invalidate(collectedAnimationIdsProvider);
 
       if (context.mounted) {
-        context.showAppSnackBar('Database has been reset');
+        context.showSnack(
+          'Database has been reset',
+          type: SnackType.success,
+        );
         Navigator.of(context, rootNavigator: true).pushReplacement(
           MaterialPageRoute<void>(
             builder: (_) => const NavigationShell(),

--- a/lib/features/settings/screens/image_debug_screen.dart
+++ b/lib/features/settings/screens/image_debug_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/media_type.dart';
@@ -329,12 +330,7 @@ class _ImageDebugTile extends StatelessWidget {
             tooltip: 'Copy URL',
             onPressed: () {
               Clipboard.setData(ClipboardData(text: url));
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('URL copied'),
-                  duration: Duration(seconds: 1),
-                ),
-              );
+              context.showSnack('URL copied');
             },
           ),
       ],

--- a/lib/features/settings/screens/steamgriddb_debug_screen.dart
+++ b/lib/features/settings/screens/steamgriddb_debug_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/steamgriddb_api.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/steamgriddb_game.dart';
 import '../../../shared/models/steamgriddb_image.dart';
 import '../../../shared/widgets/auto_breadcrumb_app_bar.dart';
@@ -217,7 +218,7 @@ class _SteamGridDbDebugScreenState
                           : null,
                       onTap: () {
                         _gameIdController.text = game.id.toString();
-                        _showSnackBar(
+                        context.showSnack(
                           'Game ID ${game.id} copied to image tabs',
                         );
                       },
@@ -413,13 +414,6 @@ class _SteamGridDbDebugScreenState
           ),
         ),
       ),
-    );
-  }
-
-  void _showSnackBar(String message) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
     );
   }
 }

--- a/lib/features/welcome/widgets/welcome_step_api_keys.dart
+++ b/lib/features/welcome/widgets/welcome_step_api_keys.dart
@@ -330,7 +330,7 @@ class _LinkCard extends StatelessWidget {
     if (!launched && context.mounted) {
       await Clipboard.setData(ClipboardData(text: url));
       if (context.mounted) {
-        context.showAppSnackBar('URL copied to clipboard');
+        context.showSnack('URL copied to clipboard');
       }
     }
   }

--- a/lib/shared/extensions/snackbar_extension.dart
+++ b/lib/shared/extensions/snackbar_extension.dart
@@ -1,21 +1,112 @@
-// Extension для показа SnackBar из BuildContext.
+// Extension для показа compact SnackBar уведомлений.
 
 import 'package:flutter/material.dart';
 
+import '../constants/platform_features.dart';
 import '../theme/app_colors.dart';
+import '../theme/app_spacing.dart';
 
-/// Extension на [BuildContext] для удобного показа SnackBar.
+/// Тип уведомления SnackBar.
+enum SnackType {
+  /// Успешная операция (зелёный акцент).
+  success,
+
+  /// Ошибка или сбой (красный акцент).
+  error,
+
+  /// Информационное уведомление (brand акцент).
+  info,
+}
+
+/// Extension на [BuildContext] для единого показа compact SnackBar.
+///
+/// Все уведомления в приложении должны использовать [showSnack].
+/// Для изменения стиля достаточно изменить этот файл.
 extension SnackBarExtension on BuildContext {
-  /// Показывает SnackBar с заданным сообщением.
+  /// Показывает compact floating SnackBar.
   ///
-  /// По умолчанию фон — [AppColors.brand] (success).
-  /// При [isError] = true — [AppColors.error].
-  void showAppSnackBar(String message, {bool isError = false}) {
-    ScaffoldMessenger.of(this).showSnackBar(
+  /// Автоматически скрывает предыдущий SnackBar.
+  /// По умолчанию [type] = [SnackType.info], [duration] = 2 секунды.
+  /// [loading] заменяет иконку на [CircularProgressIndicator].
+  void showSnack(
+    String message, {
+    SnackType type = SnackType.info,
+    Duration duration = const Duration(seconds: 2),
+    SnackBarAction? action,
+    bool loading = false,
+  }) {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(this);
+    messenger.hideCurrentSnackBar();
+
+    final Widget leadingIcon = loading
+        ? const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: AppColors.textSecondary,
+            ),
+          )
+        : Icon(
+            switch (type) {
+              SnackType.success => Icons.check_circle_outline,
+              SnackType.error => Icons.error_outline,
+              SnackType.info => Icons.info_outline,
+            },
+            size: 18,
+            color: switch (type) {
+              SnackType.success => AppColors.success,
+              SnackType.error => AppColors.error,
+              SnackType.info => AppColors.brand,
+            },
+          );
+
+    final Color borderColor = switch (type) {
+      SnackType.success => AppColors.success.withAlpha(128),
+      SnackType.error => AppColors.error.withAlpha(128),
+      SnackType.info => AppColors.surfaceBorder,
+    };
+
+    messenger.showSnackBar(
       SnackBar(
-        content: Text(message),
-        backgroundColor: isError ? AppColors.error : AppColors.brand,
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            leadingIcon,
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                message,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 13,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        backgroundColor: AppColors.surfaceLight,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          side: BorderSide(color: borderColor),
+        ),
+        width: kIsMobile ? null : 360,
+        margin: kIsMobile
+            ? const EdgeInsets.symmetric(horizontal: 16, vertical: 8)
+            : null,
+        elevation: 4,
+        duration: duration,
+        action: action,
+        dismissDirection: DismissDirection.horizontal,
       ),
     );
+  }
+
+  /// Скрывает текущий SnackBar (если есть).
+  void hideSnack() {
+    ScaffoldMessenger.of(this).hideCurrentSnackBar();
   }
 }

--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -123,13 +123,9 @@ abstract final class AppTheme {
       color: AppColors.surfaceBorder,
       thickness: 1,
     ),
-    snackBarTheme: SnackBarThemeData(
-      backgroundColor: AppColors.surfaceLight,
-      contentTextStyle: const TextStyle(color: AppColors.textPrimary),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
-      ),
+    snackBarTheme: const SnackBarThemeData(
       behavior: SnackBarBehavior.floating,
+      elevation: 4,
     ),
     popupMenuTheme: PopupMenuThemeData(
       color: AppColors.surface,

--- a/test/shared/extensions/snackbar_extension_test.dart
+++ b/test/shared/extensions/snackbar_extension_test.dart
@@ -1,0 +1,455 @@
+// Тесты для unified SnackBar extension.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:xerabora/shared/extensions/snackbar_extension.dart';
+import 'package:xerabora/shared/theme/app_colors.dart';
+
+void main() {
+  group('SnackType', () {
+    test('has 3 values', () {
+      expect(SnackType.values.length, 3);
+    });
+
+    test('contains success, error, info', () {
+      expect(SnackType.values, contains(SnackType.success));
+      expect(SnackType.values, contains(SnackType.error));
+      expect(SnackType.values, contains(SnackType.info));
+    });
+  });
+
+  group('showSnack', () {
+    testWidgets('shows SnackBar with message text', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack('Test message'),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Test message'), findsOneWidget);
+    });
+
+    testWidgets('success type shows check_circle_outline icon',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'Success',
+                    type: SnackType.success,
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final Icon icon = tester.widget<Icon>(
+        find.byIcon(Icons.check_circle_outline),
+      );
+      expect(icon.color, AppColors.success);
+      expect(icon.size, 18);
+    });
+
+    testWidgets('error type shows error_outline icon',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'Error',
+                    type: SnackType.error,
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final Icon icon = tester.widget<Icon>(
+        find.byIcon(Icons.error_outline),
+      );
+      expect(icon.color, AppColors.error);
+      expect(icon.size, 18);
+    });
+
+    testWidgets('info type shows info_outline icon (default)',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack('Info'),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final Icon icon = tester.widget<Icon>(
+        find.byIcon(Icons.info_outline),
+      );
+      expect(icon.color, AppColors.brand);
+      expect(icon.size, 18);
+    });
+
+    testWidgets('loading replaces icon with CircularProgressIndicator',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'Loading...',
+                    loading: true,
+                    duration: const Duration(seconds: 30),
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pump();
+
+      // Should show CircularProgressIndicator, not an icon
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsNothing);
+      expect(find.text('Loading...'), findsOneWidget);
+    });
+
+    testWidgets('auto-hides previous SnackBar before showing new one',
+        (WidgetTester tester) async {
+      late BuildContext savedContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                savedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Show first SnackBar
+      savedContext.showSnack('First message');
+      await tester.pumpAndSettle();
+      expect(find.text('First message'), findsOneWidget);
+
+      // Show second SnackBar — first should be auto-hidden
+      savedContext.showSnack('Second message');
+      await tester.pumpAndSettle();
+      expect(find.text('Second message'), findsOneWidget);
+      expect(find.text('First message'), findsNothing);
+    });
+
+    testWidgets('passes action to SnackBar', (WidgetTester tester) async {
+      bool actionPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'With action',
+                    action: SnackBarAction(
+                      label: 'UNDO',
+                      onPressed: () => actionPressed = true,
+                    ),
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('UNDO'), findsOneWidget);
+      await tester.tap(find.text('UNDO'));
+      expect(actionPressed, isTrue);
+    });
+
+    testWidgets('uses custom duration', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'Quick',
+                    duration: const Duration(milliseconds: 500),
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pump();
+      expect(find.text('Quick'), findsOneWidget);
+
+      // Verify the SnackBar was created with the correct duration
+      final SnackBar snackBar = tester.widget<SnackBar>(
+        find.byType(SnackBar),
+      );
+      expect(snackBar.duration, const Duration(milliseconds: 500));
+    });
+
+    testWidgets('message text has correct style', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack('Styled text'),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final Text messageText = tester.widget<Text>(find.text('Styled text'));
+      expect(messageText.style?.color, AppColors.textPrimary);
+      expect(messageText.style?.fontSize, 13);
+      expect(messageText.maxLines, 2);
+      expect(messageText.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('SnackBar has surfaceLight background',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack('BG test'),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final SnackBar snackBar = tester.widget<SnackBar>(
+        find.byType(SnackBar),
+      );
+      expect(snackBar.backgroundColor, AppColors.surfaceLight);
+      expect(snackBar.elevation, 4);
+      expect(snackBar.behavior, SnackBarBehavior.floating);
+      expect(snackBar.dismissDirection, DismissDirection.horizontal);
+    });
+
+    testWidgets('success border color is green with alpha',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'Success border',
+                    type: SnackType.success,
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final SnackBar snackBar = tester.widget<SnackBar>(
+        find.byType(SnackBar),
+      );
+      final RoundedRectangleBorder shape =
+          snackBar.shape! as RoundedRectangleBorder;
+      final BorderSide side = shape.side;
+      expect(side.color, AppColors.success.withAlpha(128));
+    });
+
+    testWidgets('error border color is red with alpha',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack(
+                    'Error border',
+                    type: SnackType.error,
+                  ),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final SnackBar snackBar = tester.widget<SnackBar>(
+        find.byType(SnackBar),
+      );
+      final RoundedRectangleBorder shape =
+          snackBar.shape! as RoundedRectangleBorder;
+      final BorderSide side = shape.side;
+      expect(side.color, AppColors.error.withAlpha(128));
+    });
+
+    testWidgets('info border color is surfaceBorder',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  onPressed: () => context.showSnack('Info border'),
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      final SnackBar snackBar = tester.widget<SnackBar>(
+        find.byType(SnackBar),
+      );
+      final RoundedRectangleBorder shape =
+          snackBar.shape! as RoundedRectangleBorder;
+      final BorderSide side = shape.side;
+      expect(side.color, AppColors.surfaceBorder);
+    });
+  });
+
+  group('hideSnack', () {
+    testWidgets('hides currently visible SnackBar',
+        (WidgetTester tester) async {
+      late BuildContext savedContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                savedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Show a SnackBar
+      savedContext.showSnack(
+        'Visible',
+        duration: const Duration(seconds: 30),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Visible'), findsOneWidget);
+
+      // Hide it
+      savedContext.hideSnack();
+      await tester.pumpAndSettle();
+      expect(find.text('Visible'), findsNothing);
+    });
+
+    testWidgets('does not throw when no SnackBar is visible',
+        (WidgetTester tester) async {
+      late BuildContext savedContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                savedContext = context;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Should not throw
+      expect(() => savedContext.hideSnack(), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
Replace all 85 direct ScaffoldMessenger.showSnackBar() calls across 13 files with a single context.showSnack() extension. Introduces SnackType enum (success/error/info) with typed icons, colored borders, and auto-hide behavior. Adds loading parameter for progress indication and context.hideSnack() for manual dismissal. Platform-aware width (360px desktop, full-width mobile).