### PR TITLE
chore: remove SignPath references + fix credits card alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 - `CanvasView` media card rendering now uses `CanvasItem` unified accessors instead of inline switch statements (`canvas_view.dart`)
 - `ExportService` now uses `CollectionItem.dataSource` accessor instead of switch-on-mediaType (`export_service.dart`)
 
+### Removed
+- Removed SignPath code signing policy section from `README.md` (certificate info, team roles, privacy policy)
+- Removed SignPath code signing policy block, CSS styles, and i18n translations (EN + RU) from landing page (`docs/index.html`)
+
 ## [0.15.0] - 2026-02-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -236,18 +236,6 @@ Flutter 3.38+ / Dart 3.10+ · Riverpod · SQLite · Dio · Material Design 3
 
 Contributions are welcome! See the [Contributing Guide](docs/CONTRIBUTING.md) for details.
 
-## Code Signing Policy
-
-Windows binaries are signed with a certificate provided by [SignPath Foundation](https://signpath.org).
-
-Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
-
-**Team roles:**
-- Committers and reviewers: [hacan359](https://github.com/hacan359)
-- Approvers: [hacan359](https://github.com/hacan359)
-
-**Privacy policy:** This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it. The application uses third-party APIs (IGDB, TMDB, SteamGridDB) only when the user explicitly initiates a search or data fetch.
-
 ## Credits
 
 - Movie, TV show, and anime data provided by [TMDB](https://www.themoviedb.org/). This product uses the TMDB API but is not endorsed or certified by TMDB.

--- a/docs/index.html
+++ b/docs/index.html
@@ -734,26 +734,6 @@
 
     .footer__links a:hover { color: var(--text-secondary); }
 
-    .code-signing-policy {
-      max-width: 600px;
-      margin: 0 auto;
-      padding: 24px 0;
-      font-size: 12px;
-      color: var(--text-tertiary);
-      text-align: center;
-      line-height: 1.6;
-    }
-    .code-signing-policy a {
-      color: var(--text-secondary);
-      text-decoration: underline;
-    }
-    .code-signing-policy h3 {
-      font-size: 13px;
-      font-weight: 600;
-      margin-bottom: 8px;
-      color: var(--text-secondary);
-    }
-
     .footer__attribution {
       display: flex;
       align-items: center;
@@ -1317,25 +1297,6 @@
         <li><a href="https://github.com/hacan359/tonkatsu_box/issues" target="_blank" data-i18n="footer_issues">Issues</a></li>
       </ul>
     </div>
-    <!-- Code Signing Policy -->
-    <div class="code-signing-policy">
-      <h3 data-i18n="signing_title">Code Signing Policy</h3>
-      <p data-i18n="signing_desc">
-        Windows binaries are signed with a certificate provided by
-        <a href="https://signpath.org">SignPath Foundation</a>.
-      </p>
-      <p data-i18n="signing_credit">
-        Free code signing provided by
-        <a href="https://signpath.io">SignPath.io</a>,
-        certificate by
-        <a href="https://signpath.org">SignPath Foundation</a>.
-      </p>
-      <p data-i18n="signing_privacy">
-        <strong>Privacy policy:</strong> This program will not transfer any
-        information to other networked systems unless specifically requested
-        by the user or the person installing or operating it.
-      </p>
-    </div>
     <div class="footer__attribution">
       <span data-i18n="footer_data_by">Data by</span>
       <a href="https://www.themoviedb.org/" target="_blank" rel="noopener"><img src="assets/tmdb_logo.svg" alt="TMDB"></a>
@@ -1502,10 +1463,6 @@
         footer_releases: 'Releases',
         footer_api_guide: 'API Keys Guide',
         footer_issues: 'Issues',
-        signing_title: 'Code Signing Policy',
-        signing_desc: 'Windows binaries are signed with a certificate provided by <a href="https://signpath.org">SignPath Foundation</a>.',
-        signing_credit: 'Free code signing provided by <a href="https://signpath.io">SignPath.io</a>, certificate by <a href="https://signpath.org">SignPath Foundation</a>.',
-        signing_privacy: '<strong>Privacy policy:</strong> This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it.',
         footer_data_by: 'Data by',
       },
       ru: {
@@ -1578,10 +1535,6 @@
         footer_releases: '\u0420\u0435\u043b\u0438\u0437\u044b',
         footer_api_guide: '\u0413\u0430\u0439\u0434 \u043f\u043e API \u043a\u043b\u044e\u0447\u0430\u043c',
         footer_issues: '\u0417\u0430\u0434\u0430\u0447\u0438',
-        signing_title: '\u041f\u043e\u043b\u0438\u0442\u0438\u043a\u0430 \u043f\u043e\u0434\u043f\u0438\u0441\u0438 \u043a\u043e\u0434\u0430',
-        signing_desc: '\u0411\u0438\u043d\u0430\u0440\u043d\u044b\u0435 \u0444\u0430\u0439\u043b\u044b Windows \u043f\u043e\u0434\u043f\u0438\u0441\u0430\u043d\u044b \u0441\u0435\u0440\u0442\u0438\u0444\u0438\u043a\u0430\u0442\u043e\u043c <a href="https://signpath.org">SignPath Foundation</a>.',
-        signing_credit: '\u0411\u0435\u0441\u043f\u043b\u0430\u0442\u043d\u0430\u044f \u043f\u043e\u0434\u043f\u0438\u0441\u044c \u043a\u043e\u0434\u0430 \u043f\u0440\u0435\u0434\u043e\u0441\u0442\u0430\u0432\u043b\u0435\u043d\u0430 <a href="https://signpath.io">SignPath.io</a>, \u0441\u0435\u0440\u0442\u0438\u0444\u0438\u043a\u0430\u0442 \u043e\u0442 <a href="https://signpath.org">SignPath Foundation</a>.',
-        signing_privacy: '<strong>\u041f\u043e\u043b\u0438\u0442\u0438\u043a\u0430 \u043a\u043e\u043d\u0444\u0438\u0434\u0435\u043d\u0446\u0438\u0430\u043b\u044c\u043d\u043e\u0441\u0442\u0438:</strong> \u041f\u0440\u0438\u043b\u043e\u0436\u0435\u043d\u0438\u0435 \u043d\u0435 \u043f\u0435\u0440\u0435\u0434\u0430\u0451\u0442 \u0434\u0430\u043d\u043d\u044b\u0435 \u0432 \u0441\u0435\u0442\u044c \u0431\u0435\u0437 \u044f\u0432\u043d\u043e\u0433\u043e \u0437\u0430\u043f\u0440\u043e\u0441\u0430 \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f.',
         footer_data_by: 'Данные от',
       }
     };

--- a/lib/features/settings/content/credits_content.dart
+++ b/lib/features/settings/content/credits_content.dart
@@ -31,7 +31,7 @@ class CreditsContent extends StatelessWidget {
 
     final S l10n = S.of(context);
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         _SectionHeader(
           title: l10n.creditsDataProviders,


### PR DESCRIPTION
Remove code signing policy section from README and landing page (CSS, HTML, i18n). Fix uneven card widths in Credits settings by switching Column crossAxisAlignment from start to stretch.