### PR TITLE
feat: add demo collections generator — CLI scripts + Debug Panel screen

### DIFF
--- a/lib/core/api/tmdb_api.dart
+++ b/lib/core/api/tmdb_api.dart
@@ -723,6 +723,7 @@ class TmdbApi {
   Future<List<Movie>> discoverMovies({
     int? genreId,
     int? year,
+    int? voteCountGte,
     String sortBy = 'popularity.desc',
     int page = 1,
   }) async {
@@ -737,6 +738,7 @@ class TmdbApi {
       };
       if (genreId != null) params['with_genres'] = genreId;
       if (year != null) params['primary_release_year'] = year;
+      if (voteCountGte != null) params['vote_count.gte'] = voteCountGte;
 
       final Response<dynamic> response = await _dio.get<dynamic>(
         '$_baseUrl/discover/movie',
@@ -760,6 +762,7 @@ class TmdbApi {
   Future<List<TvShow>> discoverTvShows({
     int? genreId,
     int? year,
+    int? voteCountGte,
     String sortBy = 'popularity.desc',
     int page = 1,
   }) async {
@@ -774,6 +777,7 @@ class TmdbApi {
       };
       if (genreId != null) params['with_genres'] = genreId;
       if (year != null) params['first_air_date_year'] = year;
+      if (voteCountGte != null) params['vote_count.gte'] = voteCountGte;
 
       final Response<dynamic> response = await _dio.get<dynamic>(
         '$_baseUrl/discover/tv',

--- a/lib/features/settings/screens/debug_hub_screen.dart
+++ b/lib/features/settings/screens/debug_hub_screen.dart
@@ -10,6 +10,7 @@ import '../../../shared/widgets/breadcrumb_scope.dart';
 import '../providers/settings_provider.dart';
 import '../widgets/settings_nav_row.dart';
 import '../widgets/settings_section.dart';
+import 'demo_collections_screen.dart';
 import 'gamepad_debug_screen.dart';
 import 'image_debug_screen.dart';
 import 'steamgriddb_debug_screen.dart';
@@ -89,6 +90,27 @@ class DebugHubScreen extends ConsumerWidget {
                             const BreadcrumbScope(
                           label: 'Debug',
                           child: GamepadDebugScreen(),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                SettingsNavRow(
+                  title: 'Demo Collections Generator',
+                  icon: Icons.library_books,
+                  subtitle: settings.hasCredentials && settings.hasTmdbKey
+                      ? 'Generate .xcollx files for tonkatsu-collections'
+                      : 'Set IGDB + TMDB keys first',
+                  enabled: settings.hasCredentials && settings.hasTmdbKey,
+                  showDivider: true,
+                  compact: compact,
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (BuildContext context) =>
+                            const BreadcrumbScope(
+                          label: 'Debug',
+                          child: DemoCollectionsScreen(),
                         ),
                       ),
                     );

--- a/lib/features/settings/screens/demo_collections_screen.dart
+++ b/lib/features/settings/screens/demo_collections_screen.dart
@@ -1,0 +1,789 @@
+// Экран генерации демо-коллекций (.xcollx) для tonkatsu-collections.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/igdb_api.dart';
+import '../../../core/api/tmdb_api.dart';
+import '../../../core/services/xcoll_file.dart';
+import '../../../shared/models/game.dart';
+import '../../../shared/models/movie.dart';
+import '../../../shared/models/tv_show.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/widgets/auto_breadcrumb_app_bar.dart';
+import '../../../shared/widgets/breadcrumb_scope.dart';
+import '../providers/settings_provider.dart';
+
+/// IGDB platform IDs.
+const int _kPlatformSnes = 19;
+const int _kPlatformPs1 = 7;
+const int _kPlatformNes = 18;
+const int _kPlatformGenesis = 29;
+const int _kPlatformN64 = 4;
+const int _kPlatformGameBoy = 33;
+
+/// TMDB animation genre ID.
+const int _kTmdbAnimationGenreId = 16;
+
+/// Описание одной коллекции для генерации.
+class _CollectionSpec {
+  const _CollectionSpec({
+    required this.name,
+    required this.description,
+    required this.fileName,
+    required this.type,
+    this.platformId,
+    this.genreId,
+  });
+
+  final String name;
+  final String description;
+  final String fileName;
+  final _CollectionType type;
+  final int? platformId;
+  final int? genreId;
+}
+
+enum _CollectionType {
+  igdbPlatform,
+  tmdbTopMovies,
+  tmdbTopTvShows,
+  tmdbAnimeMovies,
+  tmdbAnimeSeries,
+}
+
+/// Все 10 коллекций для генерации.
+const List<_CollectionSpec> _collections = <_CollectionSpec>[
+  // 6 игровых
+  _CollectionSpec(
+    name: 'Top SNES Games',
+    description: 'Top 50 highest rated Super Nintendo games of all time',
+    fileName: 'top_snes_games',
+    type: _CollectionType.igdbPlatform,
+    platformId: _kPlatformSnes,
+  ),
+  _CollectionSpec(
+    name: 'Top PS1 Games',
+    description: 'Top 50 highest rated PlayStation 1 games of all time',
+    fileName: 'top_ps1_games',
+    type: _CollectionType.igdbPlatform,
+    platformId: _kPlatformPs1,
+  ),
+  _CollectionSpec(
+    name: 'Top NES Games',
+    description: 'Top 50 highest rated Nintendo Entertainment System games',
+    fileName: 'top_nes_games',
+    type: _CollectionType.igdbPlatform,
+    platformId: _kPlatformNes,
+  ),
+  _CollectionSpec(
+    name: 'Top Sega Genesis Games',
+    description: 'Top 50 highest rated Sega Genesis / Mega Drive games',
+    fileName: 'top_genesis_games',
+    type: _CollectionType.igdbPlatform,
+    platformId: _kPlatformGenesis,
+  ),
+  _CollectionSpec(
+    name: 'Top N64 Games',
+    description: 'Top 50 highest rated Nintendo 64 games of all time',
+    fileName: 'top_n64_games',
+    type: _CollectionType.igdbPlatform,
+    platformId: _kPlatformN64,
+  ),
+  _CollectionSpec(
+    name: 'Top Game Boy Games',
+    description: 'Top 50 highest rated Game Boy games of all time',
+    fileName: 'top_gameboy_games',
+    type: _CollectionType.igdbPlatform,
+    platformId: _kPlatformGameBoy,
+  ),
+  // 4 медиа
+  _CollectionSpec(
+    name: 'Top Rated Movies',
+    description: 'Top 50 highest rated movies of all time (TMDB)',
+    fileName: 'top_rated_movies',
+    type: _CollectionType.tmdbTopMovies,
+  ),
+  _CollectionSpec(
+    name: 'Top Rated TV Shows',
+    description: 'Top 50 highest rated TV shows of all time (TMDB)',
+    fileName: 'top_rated_tv_shows',
+    type: _CollectionType.tmdbTopTvShows,
+  ),
+  _CollectionSpec(
+    name: 'Best Anime Series',
+    description: 'Top 50 highest rated anime TV series (TMDB)',
+    fileName: 'best_anime_series',
+    type: _CollectionType.tmdbAnimeSeries,
+    genreId: _kTmdbAnimationGenreId,
+  ),
+  _CollectionSpec(
+    name: 'Best Anime Movies',
+    description: 'Top 50 highest rated anime movies (TMDB)',
+    fileName: 'best_anime_movies',
+    type: _CollectionType.tmdbAnimeMovies,
+    genreId: _kTmdbAnimationGenreId,
+  ),
+];
+
+/// Экран генерации демо-коллекций.
+class DemoCollectionsScreen extends ConsumerStatefulWidget {
+  /// Создаёт [DemoCollectionsScreen].
+  const DemoCollectionsScreen({super.key});
+
+  @override
+  ConsumerState<DemoCollectionsScreen> createState() =>
+      _DemoCollectionsScreenState();
+}
+
+class _DemoCollectionsScreenState
+    extends ConsumerState<DemoCollectionsScreen> {
+  final List<String> _log = <String>[];
+  final ScrollController _scrollController = ScrollController();
+  bool _isRunning = false;
+  bool _isCancelled = false;
+  String? _outputDir;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _addLog(String message) {
+    if (!mounted) return;
+    setState(() {
+      _log.add('[${_timestamp()}] $message');
+    });
+    // Scroll to bottom after frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  String _timestamp() {
+    final DateTime now = DateTime.now();
+    return '${now.hour.toString().padLeft(2, '0')}:'
+        '${now.minute.toString().padLeft(2, '0')}:'
+        '${now.second.toString().padLeft(2, '0')}';
+  }
+
+  Future<void> _pickDirectoryAndGenerate() async {
+    final String? dir = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: 'Select output folder for .xcollx files',
+    );
+    if (dir == null) return;
+
+    setState(() {
+      _outputDir = dir;
+      _isRunning = true;
+      _isCancelled = false;
+      _log.clear();
+    });
+
+    _addLog('Output directory: $dir');
+    _addLog('Starting generation of ${_collections.length} collections...');
+    _addLog('');
+
+    final IgdbApi igdbApi = ref.read(igdbApiProvider);
+    final TmdbApi tmdbApi = ref.read(tmdbApiProvider);
+    final SettingsState settings = ref.read(settingsNotifierProvider);
+
+    // Ensure IGDB credentials are set.
+    if (settings.accessToken != null && settings.clientId != null) {
+      igdbApi.setCredentials(
+        clientId: settings.clientId!,
+        accessToken: settings.accessToken!,
+      );
+    }
+    if (settings.tmdbApiKey != null) {
+      tmdbApi.setApiKey(settings.tmdbApiKey!);
+    }
+
+    final Dio imageDio = Dio();
+    int successCount = 0;
+
+    try {
+      for (int i = 0; i < _collections.length; i++) {
+        if (_isCancelled) {
+          _addLog('Cancelled by user.');
+          break;
+        }
+
+        final _CollectionSpec spec = _collections[i];
+        _addLog('--- [${i + 1}/${_collections.length}] ${spec.name} ---');
+
+        try {
+          final XcollFile xcoll = await _generateCollection(
+            spec: spec,
+            igdbApi: igdbApi,
+            tmdbApi: tmdbApi,
+            imageDio: imageDio,
+          );
+
+          if (_isCancelled) break;
+
+          // Write file.
+          final String filePath = '$dir/${spec.fileName}.xcollx';
+          final String jsonString = xcoll.toJsonString();
+          final File file = File(filePath);
+          await file.writeAsString(jsonString);
+
+          final int sizeKb = jsonString.length ~/ 1024;
+          _addLog('Saved: ${spec.fileName}.xcollx ($sizeKb KB)');
+          _addLog('');
+          successCount++;
+        } catch (e) {
+          _addLog('ERROR generating ${spec.name}: $e');
+          _addLog('');
+        }
+      }
+
+      _addLog('===================================');
+      _addLog('Done! $successCount/${_collections.length} files saved to $dir');
+    } finally {
+      imageDio.close();
+      if (mounted) {
+        setState(() {
+          _isRunning = false;
+        });
+      }
+    }
+  }
+
+  Future<XcollFile> _generateCollection({
+    required _CollectionSpec spec,
+    required IgdbApi igdbApi,
+    required TmdbApi tmdbApi,
+    required Dio imageDio,
+  }) async {
+    switch (spec.type) {
+      case _CollectionType.igdbPlatform:
+        return _generateGameCollection(
+          spec: spec,
+          igdbApi: igdbApi,
+          imageDio: imageDio,
+        );
+      case _CollectionType.tmdbTopMovies:
+        return _generateMovieCollection(
+          spec: spec,
+          tmdbApi: tmdbApi,
+          imageDio: imageDio,
+        );
+      case _CollectionType.tmdbTopTvShows:
+        return _generateTvShowCollection(
+          spec: spec,
+          tmdbApi: tmdbApi,
+          imageDio: imageDio,
+        );
+      case _CollectionType.tmdbAnimeMovies:
+        return _generateAnimeMovieCollection(
+          spec: spec,
+          tmdbApi: tmdbApi,
+          imageDio: imageDio,
+        );
+      case _CollectionType.tmdbAnimeSeries:
+        return _generateAnimeSeriesCollection(
+          spec: spec,
+          tmdbApi: tmdbApi,
+          imageDio: imageDio,
+        );
+    }
+  }
+
+  // ===== Game collections (IGDB) =====
+
+  Future<XcollFile> _generateGameCollection({
+    required _CollectionSpec spec,
+    required IgdbApi igdbApi,
+    required Dio imageDio,
+  }) async {
+    _addLog('Fetching top games for platform ${spec.platformId}...');
+
+    final List<Game> games = await igdbApi.getTopGamesByPlatform(
+      platformId: spec.platformId!,
+      limit: 50,
+    );
+    _addLog('Got ${games.length} games');
+
+    // Rate limit delay for IGDB.
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+
+    // Build items and media.
+    final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+    final List<Map<String, dynamic>> mediaGames = <Map<String, dynamic>>[];
+
+    for (final Game game in games) {
+      items.add(<String, dynamic>{
+        'media_type': 'game',
+        'external_id': game.id,
+        'platform_id': spec.platformId,
+      });
+      mediaGames.add(game.toDb());
+    }
+
+    // Download covers.
+    final Map<String, String> images = await _downloadGameCovers(
+      games: games,
+      imageDio: imageDio,
+    );
+
+    return XcollFile(
+      version: xcollFormatVersion,
+      format: ExportFormat.full,
+      name: spec.name,
+      author: 'Tonkatsu Box',
+      created: DateTime.now().toUtc(),
+      description: spec.description,
+      items: items,
+      images: images,
+      media: <String, dynamic>{
+        'games': mediaGames,
+      },
+    );
+  }
+
+  Future<Map<String, String>> _downloadGameCovers({
+    required List<Game> games,
+    required Dio imageDio,
+  }) async {
+    final Map<String, String> images = <String, String>{};
+    final List<Game> gamesWithCovers =
+        games.where((Game g) => g.coverUrl != null).toList();
+    _addLog('Downloading ${gamesWithCovers.length} game covers...');
+
+    // Download in chunks of 5.
+    for (int i = 0; i < gamesWithCovers.length; i += 5) {
+      if (_isCancelled) break;
+      final int end = (i + 5).clamp(0, gamesWithCovers.length);
+      final List<Game> chunk = gamesWithCovers.sublist(i, end);
+
+      final List<String?> results = await Future.wait(
+        chunk.map((Game g) => _downloadImageBase64(imageDio, g.coverUrl!)),
+      );
+
+      for (int j = 0; j < chunk.length; j++) {
+        if (results[j] != null) {
+          images['game_covers/${chunk[j].id}'] = results[j]!;
+        }
+      }
+
+      if (i % 20 == 0 && i > 0) {
+        _addLog('  ...${images.length} covers downloaded');
+      }
+    }
+
+    _addLog('Downloaded ${images.length} covers');
+    return images;
+  }
+
+  // ===== Movie collections (TMDB) =====
+
+  Future<XcollFile> _generateMovieCollection({
+    required _CollectionSpec spec,
+    required TmdbApi tmdbApi,
+    required Dio imageDio,
+  }) async {
+    _addLog('Fetching top rated movies...');
+
+    final List<Movie> allMovies = <Movie>[];
+    for (int page = 1; page <= 3 && allMovies.length < 50; page++) {
+      final List<Movie> movies = await tmdbApi.getTopRatedMovies(page: page);
+      allMovies.addAll(movies);
+    }
+    final List<Movie> movies = allMovies.take(50).toList();
+    _addLog('Got ${movies.length} movies');
+
+    return _buildMovieXcoll(
+      spec: spec,
+      movies: movies,
+      imageDio: imageDio,
+      mediaType: 'movie',
+    );
+  }
+
+  Future<XcollFile> _generateAnimeMovieCollection({
+    required _CollectionSpec spec,
+    required TmdbApi tmdbApi,
+    required Dio imageDio,
+  }) async {
+    _addLog('Fetching top anime movies...');
+
+    final List<Movie> allMovies = <Movie>[];
+    for (int page = 1; page <= 3 && allMovies.length < 50; page++) {
+      final List<Movie> movies = await tmdbApi.discoverMovies(
+        genreId: spec.genreId,
+        voteCountGte: 100,
+        sortBy: 'vote_average.desc',
+        page: page,
+      );
+      allMovies.addAll(movies);
+    }
+    final List<Movie> movies = allMovies.take(50).toList();
+    _addLog('Got ${movies.length} anime movies');
+
+    return _buildMovieXcoll(
+      spec: spec,
+      movies: movies,
+      imageDio: imageDio,
+      mediaType: 'animation',
+    );
+  }
+
+  Future<XcollFile> _buildMovieXcoll({
+    required _CollectionSpec spec,
+    required List<Movie> movies,
+    required Dio imageDio,
+    required String mediaType,
+  }) async {
+    final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+    final List<Map<String, dynamic>> mediaMovies = <Map<String, dynamic>>[];
+
+    for (final Movie movie in movies) {
+      items.add(<String, dynamic>{
+        'media_type': mediaType,
+        'external_id': movie.tmdbId,
+      });
+      mediaMovies.add(movie.toDb());
+    }
+
+    final Map<String, String> images = await _downloadMoviePosters(
+      movies: movies,
+      imageDio: imageDio,
+    );
+
+    return XcollFile(
+      version: xcollFormatVersion,
+      format: ExportFormat.full,
+      name: spec.name,
+      author: 'Tonkatsu Box',
+      created: DateTime.now().toUtc(),
+      description: spec.description,
+      items: items,
+      images: images,
+      media: <String, dynamic>{
+        'movies': mediaMovies,
+      },
+    );
+  }
+
+  Future<Map<String, String>> _downloadMoviePosters({
+    required List<Movie> movies,
+    required Dio imageDio,
+  }) async {
+    final Map<String, String> images = <String, String>{};
+    final List<Movie> moviesWithPosters =
+        movies.where((Movie m) => m.posterUrl != null).toList();
+    _addLog('Downloading ${moviesWithPosters.length} movie posters...');
+
+    for (int i = 0; i < moviesWithPosters.length; i += 5) {
+      if (_isCancelled) break;
+      final int end = (i + 5).clamp(0, moviesWithPosters.length);
+      final List<Movie> chunk = moviesWithPosters.sublist(i, end);
+
+      final List<String?> results = await Future.wait(
+        chunk.map((Movie m) => _downloadImageBase64(imageDio, m.posterUrl!)),
+      );
+
+      for (int j = 0; j < chunk.length; j++) {
+        if (results[j] != null) {
+          images['movie_posters/${chunk[j].tmdbId}'] = results[j]!;
+        }
+      }
+
+      if (i % 20 == 0 && i > 0) {
+        _addLog('  ...${images.length} posters downloaded');
+      }
+    }
+
+    _addLog('Downloaded ${images.length} posters');
+    return images;
+  }
+
+  // ===== TV Show collections (TMDB) =====
+
+  Future<XcollFile> _generateTvShowCollection({
+    required _CollectionSpec spec,
+    required TmdbApi tmdbApi,
+    required Dio imageDio,
+  }) async {
+    _addLog('Fetching top rated TV shows...');
+
+    final List<TvShow> allShows = <TvShow>[];
+    for (int page = 1; page <= 3 && allShows.length < 50; page++) {
+      final List<TvShow> shows = await tmdbApi.getTopRatedTvShows(page: page);
+      allShows.addAll(shows);
+    }
+    final List<TvShow> shows = allShows.take(50).toList();
+    _addLog('Got ${shows.length} TV shows');
+
+    return _buildTvShowXcoll(
+      spec: spec,
+      shows: shows,
+      imageDio: imageDio,
+      mediaType: 'tv_show',
+    );
+  }
+
+  Future<XcollFile> _generateAnimeSeriesCollection({
+    required _CollectionSpec spec,
+    required TmdbApi tmdbApi,
+    required Dio imageDio,
+  }) async {
+    _addLog('Fetching top anime series...');
+
+    final List<TvShow> allShows = <TvShow>[];
+    for (int page = 1; page <= 3 && allShows.length < 50; page++) {
+      final List<TvShow> shows = await tmdbApi.discoverTvShows(
+        genreId: spec.genreId,
+        voteCountGte: 100,
+        sortBy: 'vote_average.desc',
+        page: page,
+      );
+      allShows.addAll(shows);
+    }
+    final List<TvShow> shows = allShows.take(50).toList();
+    _addLog('Got ${shows.length} anime series');
+
+    return _buildTvShowXcoll(
+      spec: spec,
+      shows: shows,
+      imageDio: imageDio,
+      mediaType: 'animation',
+    );
+  }
+
+  Future<XcollFile> _buildTvShowXcoll({
+    required _CollectionSpec spec,
+    required List<TvShow> shows,
+    required Dio imageDio,
+    required String mediaType,
+  }) async {
+    final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+    final List<Map<String, dynamic>> mediaTvShows = <Map<String, dynamic>>[];
+
+    for (final TvShow show in shows) {
+      items.add(<String, dynamic>{
+        'media_type': mediaType,
+        'external_id': show.tmdbId,
+      });
+      mediaTvShows.add(show.toDb());
+    }
+
+    final Map<String, String> images = await _downloadTvShowPosters(
+      shows: shows,
+      imageDio: imageDio,
+    );
+
+    return XcollFile(
+      version: xcollFormatVersion,
+      format: ExportFormat.full,
+      name: spec.name,
+      author: 'Tonkatsu Box',
+      created: DateTime.now().toUtc(),
+      description: spec.description,
+      items: items,
+      images: images,
+      media: <String, dynamic>{
+        'tv_shows': mediaTvShows,
+      },
+    );
+  }
+
+  Future<Map<String, String>> _downloadTvShowPosters({
+    required List<TvShow> shows,
+    required Dio imageDio,
+  }) async {
+    final Map<String, String> images = <String, String>{};
+    final List<TvShow> showsWithPosters =
+        shows.where((TvShow s) => s.posterUrl != null).toList();
+    _addLog('Downloading ${showsWithPosters.length} TV show posters...');
+
+    for (int i = 0; i < showsWithPosters.length; i += 5) {
+      if (_isCancelled) break;
+      final int end = (i + 5).clamp(0, showsWithPosters.length);
+      final List<TvShow> chunk = showsWithPosters.sublist(i, end);
+
+      final List<String?> results = await Future.wait(
+        chunk.map((TvShow s) => _downloadImageBase64(imageDio, s.posterUrl!)),
+      );
+
+      for (int j = 0; j < chunk.length; j++) {
+        if (results[j] != null) {
+          images['tv_show_posters/${chunk[j].tmdbId}'] = results[j]!;
+        }
+      }
+
+      if (i % 20 == 0 && i > 0) {
+        _addLog('  ...${images.length} posters downloaded');
+      }
+    }
+
+    _addLog('Downloaded ${images.length} posters');
+    return images;
+  }
+
+  // ===== Image download helper =====
+
+  Future<String?> _downloadImageBase64(Dio dio, String url) async {
+    try {
+      final Response<List<int>> response = await dio.get<List<int>>(
+        url,
+        options: Options(responseType: ResponseType.bytes),
+      );
+      if (response.statusCode == 200 && response.data != null) {
+        return base64Encode(response.data!);
+      }
+    } catch (_) {
+      // Skip failed images silently.
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool compact = MediaQuery.sizeOf(context).width < 600;
+
+    return BreadcrumbScope(
+      label: 'Demo Generator',
+      child: Scaffold(
+        appBar: const AutoBreadcrumbAppBar(),
+        body: Padding(
+          padding: EdgeInsets.all(compact ? AppSpacing.sm : AppSpacing.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              // Header.
+              Text(
+                'Demo Collections Generator',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                'Generates 10 .xcollx files (6 game + 4 media) '
+                'with embedded posters for tonkatsu-collections repo.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              // Buttons.
+              Wrap(
+                spacing: AppSpacing.sm,
+                runSpacing: AppSpacing.xs,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  FilledButton.icon(
+                    onPressed: _isRunning ? null : _pickDirectoryAndGenerate,
+                    icon: const Icon(Icons.play_arrow),
+                    label: const Text('Generate All (10 collections)'),
+                  ),
+                  if (_isRunning) ...<Widget>[
+                    OutlinedButton.icon(
+                      onPressed: () {
+                        setState(() {
+                          _isCancelled = true;
+                        });
+                      },
+                      icon: const Icon(Icons.stop),
+                      label: const Text('Cancel'),
+                    ),
+                    const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ],
+                ],
+              ),
+              if (_outputDir != null) ...<Widget>[
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  'Output: $_outputDir',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: AppColors.textTertiary,
+                      ),
+                ),
+              ],
+              const SizedBox(height: AppSpacing.md),
+              // Log area.
+              Expanded(
+                child: Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: AppColors.surfaceBorder),
+                  ),
+                  child: _log.isEmpty
+                      ? Center(
+                          child: Text(
+                            'Press "Generate All" to start...',
+                            style:
+                                Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                      color: AppColors.textTertiary,
+                                    ),
+                          ),
+                        )
+                      : ListView.builder(
+                          controller: _scrollController,
+                          padding: const EdgeInsets.all(AppSpacing.sm),
+                          itemCount: _log.length,
+                          itemBuilder: (BuildContext context, int index) {
+                            final String line = _log[index];
+                            final bool isError =
+                                line.contains('ERROR');
+                            final bool isDone =
+                                line.contains('Done!');
+                            final bool isSaved =
+                                line.contains('Saved:');
+                            final bool isHeader =
+                                line.contains('---');
+
+                            Color textColor = AppColors.textSecondary;
+                            if (isError) {
+                              textColor = AppColors.error;
+                            } else if (isDone) {
+                              textColor = AppColors.success;
+                            } else if (isSaved) {
+                              textColor = AppColors.brand;
+                            } else if (isHeader) {
+                              textColor = AppColors.textPrimary;
+                            }
+
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(
+                                vertical: 1,
+                              ),
+                              child: Text(
+                                line,
+                                style: TextStyle(
+                                  fontFamily: 'monospace',
+                                  fontSize: 12,
+                                  color: textColor,
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/core/api/tmdb_api_test.dart
+++ b/test/core/api/tmdb_api_test.dart
@@ -3634,6 +3634,56 @@ void main() {
           throwsA(isA<TmdbApiException>()),
         );
       });
+
+      test('должен передать voteCountGte в queryParameters как vote_count.gte', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.discoverMovies(voteCountGte: 100);
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params['vote_count.gte'], equals(100));
+      });
+
+      test('не должен передать vote_count.gte когда voteCountGte == null', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.discoverMovies();
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params.containsKey('vote_count.gte'), isFalse);
+      });
     });
 
     // ----- discoverTvShows -----
@@ -3908,6 +3958,56 @@ void main() {
           () => sut.discoverTvShows(),
           throwsA(isA<TmdbApiException>()),
         );
+      });
+
+      test('должен передать voteCountGte в queryParameters как vote_count.gte', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.discoverTvShows(voteCountGte: 200);
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params['vote_count.gte'], equals(200));
+      });
+
+      test('не должен передать vote_count.gte когда voteCountGte == null', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: <String, dynamic>{
+                'results': <Map<String, dynamic>>[],
+              },
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        await sut.discoverTvShows();
+
+        final VerificationResult verification = verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: captureAny(named: 'queryParameters'),
+            ));
+        verification.called(1);
+
+        final Map<String, dynamic> params =
+            verification.captured.first as Map<String, dynamic>;
+        expect(params.containsKey('vote_count.gte'), isFalse);
       });
     });
 

--- a/test/features/settings/screens/debug_hub_screen_test.dart
+++ b/test/features/settings/screens/debug_hub_screen_test.dart
@@ -121,8 +121,8 @@ void main() {
       await tester.pumpWidget(createWidget());
       await tester.pumpAndSettle();
 
-      // 3 ListTile chevrons + 2 breadcrumb separators
-      expect(find.byIcon(Icons.chevron_right), findsNWidgets(5));
+      // 4 ListTile chevrons + 2 breadcrumb separators
+      expect(find.byIcon(Icons.chevron_right), findsNWidgets(6));
     });
 
     testWidgets('Использует SettingsSection виджет',
@@ -138,7 +138,7 @@ void main() {
       await tester.pumpWidget(createWidget());
       await tester.pumpAndSettle();
 
-      expect(find.byType(SettingsNavRow), findsNWidgets(3));
+      expect(find.byType(SettingsNavRow), findsNWidgets(4));
     });
 
     testWidgets('Показывает заголовок Debug Tools',
@@ -181,6 +181,36 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.bug_report), findsOneWidget);
+    });
+
+    testWidgets('Показывает плитку Demo Collections Generator',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(createWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Demo Collections Generator'), findsOneWidget);
+    });
+
+    testWidgets('Demo Collections отключена когда нет IGDB и TMDB ключей',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(createWidget());
+      await tester.pumpAndSettle();
+
+      final Finder demoTile = find.ancestor(
+        of: find.text('Demo Collections Generator'),
+        matching: find.byType(ListTile),
+      );
+
+      final ListTile tile = tester.widget<ListTile>(demoTile);
+      expect(tile.enabled, false);
+    });
+
+    testWidgets('Demo Collections показывает иконку library_books',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(createWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.library_books), findsOneWidget);
     });
   });
 }

--- a/tool/README.md
+++ b/tool/README.md
@@ -1,0 +1,56 @@
+# Tool Scripts
+
+Standalone Dart CLI scripts for generating `.xcollx` demo collection files.
+No Flutter dependencies — only `dart:io` and `dart:convert`.
+
+## Prerequisites
+
+- Dart SDK (comes with Flutter)
+- IGDB API credentials (Twitch Client ID + Client Secret)
+- TMDB API key (v3)
+
+## Scripts
+
+### generate_demo_collections.dart
+
+Generates 10 curated `.xcollx` collections (6 game + 4 media) with embedded cover art.
+
+**Game collections (IGDB):** Top 50 by rating for SNES, PS1, NES, Sega Genesis, N64, Game Boy.
+
+**Media collections (TMDB):** Top Rated Movies, Top Rated TV Shows, Best Anime Series, Best Anime Movies.
+
+```bash
+dart tool/generate_demo_collections.dart \
+  --igdb-client-id=<id> \
+  --igdb-client-secret=<secret> \
+  --tmdb-key=<api_key_v3> \
+  --output=<dir>
+```
+
+Or via environment variables: `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `TMDB_KEY`, `OUTPUT_DIR`.
+
+### generate_all_snes.dart
+
+Fetches **all** games for a given IGDB platform into a single `.xcollx` file with covers and IGDB URLs as author comments.
+
+```bash
+dart tool/generate_all_snes.dart \
+  --igdb-client-id=<id> \
+  --igdb-client-secret=<secret> \
+  --output=<dir> \
+  --platform=19
+```
+
+Or via environment variables: `IGDB_CLIENT_ID`, `IGDB_CLIENT_SECRET`, `OUTPUT_DIR`.
+
+**Platform IDs:** SNES=19, PS1=7, NES=18, Genesis=29, N64=4, GameBoy=33.
+
+**Example output:** `all_platform_19_games.xcollx` — 1972 SNES games, 1827 covers, ~10 MB.
+
+## Notes
+
+- IGDB covers use `t_cover_small` (90x128) to keep file size reasonable
+- Images are downloaded 5 in parallel with 15s timeout
+- IGDB requests are rate-limited (300ms between paginated calls)
+- TMDB requires VPN in some regions
+- Output files are JSON with base64-encoded images (`.xcollx` format v2)

--- a/tool/generate_all_snes.dart
+++ b/tool/generate_all_snes.dart
@@ -1,0 +1,261 @@
+// Fetch ALL games for a given IGDB platform into one .xcollx file.
+//
+// Usage:
+//   dart tool/generate_all_snes.dart \
+//     --igdb-client-id=<id> \
+//     --igdb-client-secret=<secret> \
+//     --output=<dir> \
+//     [--platform=19]
+//
+// Platform IDs: SNES=19, PS1=7, NES=18, Genesis=29, N64=4, GameBoy=33
+import 'dart:convert';
+import 'dart:io';
+
+final HttpClient _http = HttpClient()
+  ..connectionTimeout = const Duration(seconds: 15)
+  ..idleTimeout = const Duration(seconds: 15);
+
+Future<dynamic> _postIgdb(
+  Uri uri, {
+  required String clientId,
+  required String accessToken,
+  required String body,
+}) async {
+  final HttpClientRequest request = await _http.postUrl(uri);
+  request.headers.set('Client-ID', clientId);
+  request.headers.set('Authorization', 'Bearer $accessToken');
+  request.headers.contentType = ContentType('text', 'plain');
+  request.write(body);
+  final HttpClientResponse response =
+      await request.close().timeout(const Duration(seconds: 30));
+  final String responseBody = await response
+      .transform(utf8.decoder)
+      .join()
+      .timeout(const Duration(seconds: 30));
+  if (response.statusCode != 200) {
+    throw HttpException('POST $uri -> ${response.statusCode}: $responseBody');
+  }
+  return jsonDecode(responseBody);
+}
+
+Future<String> _getToken(String clientId, String clientSecret) async {
+  final HttpClientRequest request = await _http.postUrl(Uri.parse(
+    'https://id.twitch.tv/oauth2/token'
+    '?client_id=$clientId&client_secret=$clientSecret'
+    '&grant_type=client_credentials',
+  ));
+  final HttpClientResponse response =
+      await request.close().timeout(const Duration(seconds: 15));
+  final String body = await response.transform(utf8.decoder).join();
+  return (jsonDecode(body) as Map<String, dynamic>)['access_token'] as String;
+}
+
+Future<String?> _downloadImageBase64(String url) async {
+  try {
+    final HttpClientRequest request =
+        await _http.getUrl(Uri.parse(url)).timeout(const Duration(seconds: 10));
+    final HttpClientResponse response =
+        await request.close().timeout(const Duration(seconds: 15));
+    if (response.statusCode != 200) return null;
+    final List<int> bytes = <int>[];
+    await for (final List<int> chunk in response) {
+      bytes.addAll(chunk);
+    }
+    return base64Encode(bytes);
+  } catch (_) {
+    return null;
+  }
+}
+
+String? _coverUrl(Map<String, dynamic> json) {
+  if (json['cover'] != null) {
+    final String? imageId =
+        (json['cover'] as Map<String, dynamic>)['image_id'] as String?;
+    if (imageId != null) {
+      return 'https://images.igdb.com/igdb/image/upload/t_cover_small/$imageId.jpg';
+    }
+  }
+  return null;
+}
+
+Map<String, dynamic> _gameToDb(Map<String, dynamic> json) {
+  final String? coverUrl = _coverUrl(json);
+  String? genres;
+  if (json['genres'] != null) {
+    genres = (json['genres'] as List<dynamic>)
+        .map((dynamic g) => (g as Map<String, dynamic>)['name'] as String)
+        .join('|');
+  }
+  String? platformIds;
+  if (json['platforms'] != null) {
+    platformIds = (json['platforms'] as List<dynamic>)
+        .map((dynamic p) => p.toString())
+        .join(',');
+  }
+  final int cachedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  return <String, dynamic>{
+    'id': json['id'],
+    'name': json['name'],
+    'summary': json['summary'],
+    'cover_url': coverUrl,
+    'release_date': json['first_release_date'],
+    'rating': (json['rating'] as num?)?.toDouble(),
+    'rating_count': json['rating_count'],
+    'genres': genres,
+    'platform_ids': platformIds,
+    'cached_at': cachedAt,
+  };
+}
+
+String? _getArg(List<String> args, String name) {
+  for (final String arg in args) {
+    if (arg.startsWith('--$name=')) {
+      return arg.substring('--$name='.length);
+    }
+  }
+  return Platform.environment[name.replaceAll('-', '_').toUpperCase()];
+}
+
+Future<void> main(List<String> args) async {
+  final String? clientId =
+      _getArg(args, 'igdb-client-id') ?? _getArg(args, 'igdb_client_id');
+  final String? clientSecret =
+      _getArg(args, 'igdb-client-secret') ?? _getArg(args, 'igdb_client_secret');
+  final String? outputDir =
+      _getArg(args, 'output') ?? _getArg(args, 'output_dir');
+  final int platformId =
+      int.tryParse(_getArg(args, 'platform') ?? '') ?? 19; // default: SNES
+
+  if (clientId == null || clientSecret == null || outputDir == null) {
+    stderr.write(
+      'Usage:\n'
+      '  dart tool/generate_all_snes.dart \\\n'
+      '    --igdb-client-id=<id> \\\n'
+      '    --igdb-client-secret=<secret> \\\n'
+      '    --output=<dir> \\\n'
+      '    [--platform=19]\n'
+      '\n'
+      'Or set env vars: IGDB_CLIENT_ID, IGDB_CLIENT_SECRET, OUTPUT_DIR\n'
+      '\n'
+      'Platform IDs: SNES=19, PS1=7, NES=18, Genesis=29, N64=4, GameBoy=33\n',
+    );
+    exit(1);
+  }
+
+  final String outputPath = '$outputDir/all_platform_${platformId}_games.xcollx';
+
+  stdout.write('Getting IGDB token...\n');
+  final String token = await _getToken(clientId, clientSecret);
+  stdout.write('OK\n\n');
+
+  // Fetch ALL SNES games with pagination (max 500 per request).
+  final List<Map<String, dynamic>> allGames = <Map<String, dynamic>>[];
+  int offset = 0;
+
+  while (true) {
+    stdout.write('Fetching games offset=$offset...\n');
+    final String body =
+        'fields id, name, summary, rating, rating_count, '
+        'first_release_date, cover.image_id, genres.name, platforms, url; '
+        'where platforms = ($platformId); '
+        'sort id asc; '
+        'limit 500; '
+        'offset $offset;';
+
+    final dynamic result = await _postIgdb(
+      Uri.parse('https://api.igdb.com/v4/games'),
+      clientId: clientId,
+      accessToken: token,
+      body: body,
+    );
+    final List<dynamic> games = result as List<dynamic>;
+    stdout.write('  Got ${games.length} games\n');
+
+    if (games.isEmpty) break;
+    allGames.addAll(games.cast<Map<String, dynamic>>());
+    offset += 500;
+
+    // IGDB rate limit.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+  }
+
+  stdout.write('\nTotal: ${allGames.length} SNES games\n');
+
+  // Build items + media (without images first to check size).
+  final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+  final List<Map<String, dynamic>> mediaGames = <Map<String, dynamic>>[];
+
+  for (final Map<String, dynamic> game in allGames) {
+    items.add(<String, dynamic>{
+      'media_type': 'game',
+      'external_id': game['id'],
+      'platform_id': platformId,
+      if (game['url'] != null) 'comment': game['url'] as String,
+    });
+    mediaGames.add(_gameToDb(game));
+  }
+
+  // Download all covers.
+  final Map<String, String> urlMap = <String, String>{};
+  for (final Map<String, dynamic> game in allGames) {
+    final String? url = _coverUrl(game);
+    if (url != null) {
+      urlMap['game_covers/${game['id']}'] = url;
+    }
+  }
+  stdout.write('Downloading ${urlMap.length} covers (5 parallel)...\n');
+
+  final Map<String, String> images = <String, String>{};
+  final List<MapEntry<String, String>> entries = urlMap.entries.toList();
+  int failed = 0;
+
+  for (int i = 0; i < entries.length; i += 5) {
+    final int end = (i + 5).clamp(0, entries.length);
+    final List<MapEntry<String, String>> chunk = entries.sublist(i, end);
+
+    final List<String?> bases = await Future.wait(
+      chunk.map((MapEntry<String, String> e) => _downloadImageBase64(e.value)),
+    );
+
+    for (int j = 0; j < chunk.length; j++) {
+      if (bases[j] != null) {
+        images[chunk[j].key] = bases[j]!;
+      } else {
+        failed++;
+      }
+    }
+
+    if (i % 50 == 0 && i > 0) {
+      stdout.write('  ${images.length} downloaded, $failed failed '
+          '(${i + chunk.length}/${entries.length})\n');
+    }
+  }
+
+  stdout.write('Downloaded ${images.length} covers ($failed failed)\n\n');
+
+  // Build xcollx.
+  final Map<String, dynamic> xcollx = <String, dynamic>{
+    'version': 2,
+    'format': 'full',
+    'name': 'All Platform $platformId Games',
+    'author': 'Tonkatsu Box',
+    'created': DateTime.now().toUtc().toIso8601String(),
+    'description': 'Complete platform $platformId library — ${allGames.length} games from IGDB',
+    'items': items,
+    'images': images,
+    'media': <String, dynamic>{'games': mediaGames},
+  };
+
+  const JsonEncoder encoder = JsonEncoder.withIndent('  ');
+  final String jsonString = encoder.convert(xcollx);
+  File(outputPath).writeAsStringSync(jsonString);
+
+  final int sizeMb = jsonString.length ~/ (1024 * 1024);
+  final int sizeKb = jsonString.length ~/ 1024;
+  stdout.write('SAVED: ${outputPath.split('/').last.split('\\').last}\n');
+  stdout.write('  Games: ${allGames.length}\n');
+  stdout.write('  Covers: ${images.length}\n');
+  stdout.write('  Size: $sizeKb KB ($sizeMb MB)\n');
+
+  _http.close();
+}

--- a/tool/generate_demo_collections.dart
+++ b/tool/generate_demo_collections.dart
@@ -1,0 +1,813 @@
+// Standalone CLI script to generate 10 demo .xcollx collection files.
+//
+// Usage:
+//   dart tool/generate_demo_collections.dart \
+//     --igdb-client-id=<id> \
+//     --igdb-client-secret=<secret> \
+//     --tmdb-key=<key> \
+//     --output=<dir>
+//
+// No Flutter dependencies — uses only dart:io and dart:convert.
+
+import 'dart:convert';
+import 'dart:io';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const int _kPlatformSnes = 19;
+const int _kPlatformPs1 = 7;
+const int _kPlatformNes = 18;
+const int _kPlatformGenesis = 29;
+const int _kPlatformN64 = 4;
+const int _kPlatformGameBoy = 33;
+const int _kTmdbAnimationGenreId = 16;
+
+enum CollectionType {
+  igdbPlatform,
+  tmdbTopMovies,
+  tmdbTopTvShows,
+  tmdbAnimeMovies,
+  tmdbAnimeSeries,
+}
+
+class CollectionSpec {
+  const CollectionSpec({
+    required this.name,
+    required this.description,
+    required this.fileName,
+    required this.type,
+    this.platformId,
+    this.genreId,
+  });
+
+  final String name;
+  final String description;
+  final String fileName;
+  final CollectionType type;
+  final int? platformId;
+  final int? genreId;
+}
+
+const List<CollectionSpec> collections = <CollectionSpec>[
+  CollectionSpec(
+    name: 'Top SNES Games',
+    description: 'Top 50 highest rated Super Nintendo games of all time',
+    fileName: 'top_snes_games',
+    type: CollectionType.igdbPlatform,
+    platformId: _kPlatformSnes,
+  ),
+  CollectionSpec(
+    name: 'Top PS1 Games',
+    description: 'Top 50 highest rated PlayStation 1 games of all time',
+    fileName: 'top_ps1_games',
+    type: CollectionType.igdbPlatform,
+    platformId: _kPlatformPs1,
+  ),
+  CollectionSpec(
+    name: 'Top NES Games',
+    description: 'Top 50 highest rated Nintendo Entertainment System games',
+    fileName: 'top_nes_games',
+    type: CollectionType.igdbPlatform,
+    platformId: _kPlatformNes,
+  ),
+  CollectionSpec(
+    name: 'Top Sega Genesis Games',
+    description: 'Top 50 highest rated Sega Genesis / Mega Drive games',
+    fileName: 'top_genesis_games',
+    type: CollectionType.igdbPlatform,
+    platformId: _kPlatformGenesis,
+  ),
+  CollectionSpec(
+    name: 'Top N64 Games',
+    description: 'Top 50 highest rated Nintendo 64 games of all time',
+    fileName: 'top_n64_games',
+    type: CollectionType.igdbPlatform,
+    platformId: _kPlatformN64,
+  ),
+  CollectionSpec(
+    name: 'Top Game Boy Games',
+    description: 'Top 50 highest rated Game Boy games of all time',
+    fileName: 'top_gameboy_games',
+    type: CollectionType.igdbPlatform,
+    platformId: _kPlatformGameBoy,
+  ),
+  CollectionSpec(
+    name: 'Top Rated Movies',
+    description: 'Top 50 highest rated movies of all time (TMDB)',
+    fileName: 'top_rated_movies',
+    type: CollectionType.tmdbTopMovies,
+  ),
+  CollectionSpec(
+    name: 'Top Rated TV Shows',
+    description: 'Top 50 highest rated TV shows of all time (TMDB)',
+    fileName: 'top_rated_tv_shows',
+    type: CollectionType.tmdbTopTvShows,
+  ),
+  CollectionSpec(
+    name: 'Best Anime Series',
+    description: 'Top 50 highest rated anime TV series (TMDB)',
+    fileName: 'best_anime_series',
+    type: CollectionType.tmdbAnimeSeries,
+    genreId: _kTmdbAnimationGenreId,
+  ),
+  CollectionSpec(
+    name: 'Best Anime Movies',
+    description: 'Top 50 highest rated anime movies (TMDB)',
+    fileName: 'best_anime_movies',
+    type: CollectionType.tmdbAnimeMovies,
+    genreId: _kTmdbAnimationGenreId,
+  ),
+];
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+final HttpClient _http = HttpClient()
+  ..connectionTimeout = const Duration(seconds: 15)
+  ..idleTimeout = const Duration(seconds: 15);
+
+Future<dynamic> _getJson(Uri uri, {Map<String, String>? headers}) async {
+  final HttpClientRequest request = await _http.getUrl(uri);
+  headers?.forEach((String k, String v) => request.headers.set(k, v));
+  final HttpClientResponse response =
+      await request.close().timeout(const Duration(seconds: 30));
+  final String body =
+      await response.transform(utf8.decoder).join().timeout(const Duration(seconds: 30));
+  if (response.statusCode != 200) {
+    throw HttpException(
+      'GET $uri → ${response.statusCode}: $body',
+      uri: uri,
+    );
+  }
+  return jsonDecode(body);
+}
+
+Future<dynamic> _postJson(
+  Uri uri, {
+  Map<String, String>? headers,
+  String? body,
+}) async {
+  final HttpClientRequest request = await _http.postUrl(uri);
+  headers?.forEach((String k, String v) => request.headers.set(k, v));
+  if (body != null) {
+    request.headers.contentType = ContentType('application', 'x-www-form-urlencoded');
+    request.write(body);
+  }
+  final HttpClientResponse response = await request.close();
+  final String responseBody = await response.transform(utf8.decoder).join();
+  if (response.statusCode != 200) {
+    throw HttpException(
+      'POST $uri → ${response.statusCode}: $responseBody',
+      uri: uri,
+    );
+  }
+  return jsonDecode(responseBody);
+}
+
+Future<dynamic> _postIgdb(
+  Uri uri, {
+  required String clientId,
+  required String accessToken,
+  required String body,
+}) async {
+  final HttpClientRequest request = await _http.postUrl(uri);
+  request.headers.set('Client-ID', clientId);
+  request.headers.set('Authorization', 'Bearer $accessToken');
+  request.headers.contentType = ContentType('text', 'plain');
+  request.write(body);
+  final HttpClientResponse response = await request.close();
+  final String responseBody = await response.transform(utf8.decoder).join();
+  if (response.statusCode != 200) {
+    throw HttpException(
+      'POST $uri → ${response.statusCode}: $responseBody',
+      uri: uri,
+    );
+  }
+  return jsonDecode(responseBody);
+}
+
+Future<String?> _downloadImageBase64(String url) async {
+  try {
+    final HttpClientRequest request = await _http.getUrl(Uri.parse(url));
+    final HttpClientResponse response = await request.close();
+    if (response.statusCode != 200) return null;
+    final List<int> bytes = <int>[];
+    await for (final List<int> chunk in response) {
+      bytes.addAll(chunk);
+    }
+    return base64Encode(bytes);
+  } catch (_) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IGDB
+// ---------------------------------------------------------------------------
+
+Future<String> _getIgdbToken(String clientId, String clientSecret) async {
+  final Uri uri = Uri.parse(
+    'https://id.twitch.tv/oauth2/token'
+    '?client_id=$clientId'
+    '&client_secret=$clientSecret'
+    '&grant_type=client_credentials',
+  );
+  final dynamic result = await _postJson(uri);
+  return (result as Map<String, dynamic>)['access_token'] as String;
+}
+
+Future<List<Map<String, dynamic>>> _fetchIgdbGames({
+  required String clientId,
+  required String accessToken,
+  required int platformId,
+  int limit = 50,
+}) async {
+  final String body = 'fields id, name, summary, rating, rating_count, '
+      'first_release_date, cover.image_id, genres.name, platforms; '
+      'where platforms = ($platformId) '
+      '& rating_count >= 20 & rating != null; '
+      'sort rating desc; '
+      'limit $limit;';
+
+  final dynamic result = await _postIgdb(
+    Uri.parse('https://api.igdb.com/v4/games'),
+    clientId: clientId,
+    accessToken: accessToken,
+    body: body,
+  );
+  return (result as List<dynamic>).cast<Map<String, dynamic>>();
+}
+
+Map<String, dynamic> _gameToDb(Map<String, dynamic> json) {
+  // Cover URL
+  String? coverUrl;
+  if (json['cover'] != null) {
+    final String? imageId =
+        (json['cover'] as Map<String, dynamic>)['image_id'] as String?;
+    if (imageId != null) {
+      coverUrl =
+          'https://images.igdb.com/igdb/image/upload/t_cover_big/$imageId.jpg';
+    }
+  }
+
+  // Genres — pipe-separated
+  String? genres;
+  if (json['genres'] != null) {
+    genres = (json['genres'] as List<dynamic>)
+        .map((dynamic g) => (g as Map<String, dynamic>)['name'] as String)
+        .join('|');
+  }
+
+  // Platforms — comma-separated
+  String? platformIds;
+  if (json['platforms'] != null) {
+    platformIds = (json['platforms'] as List<dynamic>)
+        .map((dynamic p) => p.toString())
+        .join(',');
+  }
+
+  // Release date — unix timestamp
+  int? releaseDate;
+  if (json['first_release_date'] != null) {
+    releaseDate = json['first_release_date'] as int;
+  }
+
+  final int cachedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  return <String, dynamic>{
+    'id': json['id'],
+    'name': json['name'],
+    'summary': json['summary'],
+    'cover_url': coverUrl,
+    'release_date': releaseDate,
+    'rating': (json['rating'] as num?)?.toDouble(),
+    'rating_count': json['rating_count'],
+    'genres': genres,
+    'platform_ids': platformIds,
+    'cached_at': cachedAt,
+  };
+}
+
+String? _gameCoverUrl(Map<String, dynamic> json) {
+  if (json['cover'] != null) {
+    final String? imageId =
+        (json['cover'] as Map<String, dynamic>)['image_id'] as String?;
+    if (imageId != null) {
+      return 'https://images.igdb.com/igdb/image/upload/t_cover_big/$imageId.jpg';
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// TMDB
+// ---------------------------------------------------------------------------
+
+Future<List<Map<String, dynamic>>> _fetchTmdbMoviesTopRated(
+  String apiKey, {
+  int pages = 3,
+}) async {
+  final List<Map<String, dynamic>> all = <Map<String, dynamic>>[];
+  for (int page = 1; page <= pages && all.length < 50; page++) {
+    final dynamic result = await _getJson(
+      Uri.parse(
+        'https://api.themoviedb.org/3/movie/top_rated'
+        '?api_key=$apiKey&page=$page&language=en-US',
+      ),
+    );
+    final List<dynamic> results =
+        (result as Map<String, dynamic>)['results'] as List<dynamic>;
+    all.addAll(results.cast<Map<String, dynamic>>());
+  }
+  return all.take(50).toList();
+}
+
+Future<List<Map<String, dynamic>>> _fetchTmdbTvShowsTopRated(
+  String apiKey, {
+  int pages = 3,
+}) async {
+  final List<Map<String, dynamic>> all = <Map<String, dynamic>>[];
+  for (int page = 1; page <= pages && all.length < 50; page++) {
+    final dynamic result = await _getJson(
+      Uri.parse(
+        'https://api.themoviedb.org/3/tv/top_rated'
+        '?api_key=$apiKey&page=$page&language=en-US',
+      ),
+    );
+    final List<dynamic> results =
+        (result as Map<String, dynamic>)['results'] as List<dynamic>;
+    all.addAll(results.cast<Map<String, dynamic>>());
+  }
+  return all.take(50).toList();
+}
+
+Future<List<Map<String, dynamic>>> _fetchTmdbDiscover(
+  String apiKey, {
+  required String mediaType, // 'movie' or 'tv'
+  int? genreId,
+  int voteCountGte = 100,
+  String sortBy = 'vote_average.desc',
+  int pages = 3,
+}) async {
+  final List<Map<String, dynamic>> all = <Map<String, dynamic>>[];
+  for (int page = 1; page <= pages && all.length < 50; page++) {
+    final StringBuffer url = StringBuffer(
+      'https://api.themoviedb.org/3/discover/$mediaType'
+      '?api_key=$apiKey&page=$page&language=en-US&sort_by=$sortBy'
+      '&vote_count.gte=$voteCountGte',
+    );
+    if (genreId != null) {
+      url.write('&with_genres=$genreId');
+    }
+    final dynamic result = await _getJson(Uri.parse(url.toString()));
+    final List<dynamic> results =
+        (result as Map<String, dynamic>)['results'] as List<dynamic>;
+    all.addAll(results.cast<Map<String, dynamic>>());
+  }
+  return all.take(50).toList();
+}
+
+Map<String, dynamic> _movieToDb(Map<String, dynamic> json) {
+  String? posterUrl;
+  final String? posterPath = json['poster_path'] as String?;
+  if (posterPath != null) {
+    posterUrl = 'https://image.tmdb.org/t/p/w342$posterPath';
+  }
+
+  String? backdropUrl;
+  final String? backdropPath = json['backdrop_path'] as String?;
+  if (backdropPath != null) {
+    backdropUrl = 'https://image.tmdb.org/t/p/w780$backdropPath';
+  }
+
+  int? releaseYear;
+  final String? releaseDate = json['release_date'] as String?;
+  if (releaseDate != null && releaseDate.length >= 4) {
+    releaseYear = int.tryParse(releaseDate.substring(0, 4));
+  }
+
+  // genre_ids from discover/top_rated results
+  List<String>? genres;
+  if (json['genre_ids'] != null) {
+    genres = (json['genre_ids'] as List<dynamic>)
+        .map((dynamic id) => id.toString())
+        .toList();
+  }
+
+  final int cachedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  return <String, dynamic>{
+    'tmdb_id': json['id'],
+    'title': json['title'],
+    'original_title': json['original_title'],
+    'poster_url': posterUrl,
+    'backdrop_url': backdropUrl,
+    'overview': json['overview'],
+    'genres': genres != null ? jsonEncode(genres) : null,
+    'release_year': releaseYear,
+    'rating': (json['vote_average'] as num?)?.toDouble(),
+    'runtime': json['runtime'],
+    'cached_at': cachedAt,
+  };
+}
+
+Map<String, dynamic> _tvShowToDb(Map<String, dynamic> json) {
+  String? posterUrl;
+  final String? posterPath = json['poster_path'] as String?;
+  if (posterPath != null) {
+    posterUrl = 'https://image.tmdb.org/t/p/w342$posterPath';
+  }
+
+  String? backdropUrl;
+  final String? backdropPath = json['backdrop_path'] as String?;
+  if (backdropPath != null) {
+    backdropUrl = 'https://image.tmdb.org/t/p/w780$backdropPath';
+  }
+
+  int? firstAirYear;
+  final String? firstAirDate = json['first_air_date'] as String?;
+  if (firstAirDate != null && firstAirDate.length >= 4) {
+    firstAirYear = int.tryParse(firstAirDate.substring(0, 4));
+  }
+
+  List<String>? genres;
+  if (json['genre_ids'] != null) {
+    genres = (json['genre_ids'] as List<dynamic>)
+        .map((dynamic id) => id.toString())
+        .toList();
+  }
+
+  final int cachedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  return <String, dynamic>{
+    'tmdb_id': json['id'],
+    'title': json['name'] ?? json['title'],
+    'original_title': json['original_name'] ?? json['original_title'],
+    'poster_url': posterUrl,
+    'backdrop_url': backdropUrl,
+    'overview': json['overview'],
+    'genres': genres != null ? jsonEncode(genres) : null,
+    'first_air_year': firstAirYear,
+    'total_seasons': json['number_of_seasons'],
+    'total_episodes': json['number_of_episodes'],
+    'rating': (json['vote_average'] as num?)?.toDouble(),
+    'status': json['status'],
+    'cached_at': cachedAt,
+  };
+}
+
+String? _tmdbPosterUrl(Map<String, dynamic> json) {
+  final String? posterPath = json['poster_path'] as String?;
+  if (posterPath != null) {
+    return 'https://image.tmdb.org/t/p/w342$posterPath';
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Image download (chunked, 5 parallel)
+// ---------------------------------------------------------------------------
+
+Future<Map<String, String>> _downloadImages({
+  required Map<String, String> urlMap, // key → url
+}) async {
+  final Map<String, String> result = <String, String>{};
+  final List<MapEntry<String, String>> entries = urlMap.entries.toList();
+
+  for (int i = 0; i < entries.length; i += 5) {
+    final int end = (i + 5).clamp(0, entries.length);
+    final List<MapEntry<String, String>> chunk = entries.sublist(i, end);
+
+    final List<String?> bases = await Future.wait(
+      chunk.map((MapEntry<String, String> e) => _downloadImageBase64(e.value)),
+    );
+
+    for (int j = 0; j < chunk.length; j++) {
+      if (bases[j] != null) {
+        result[chunk[j].key] = bases[j]!;
+      }
+    }
+
+    if (i > 0 && i % 20 == 0) {
+      stdout.write('  ...${result.length} images downloaded\n');
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// XcollFile builder
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _buildXcollx({
+  required String name,
+  required String description,
+  required List<Map<String, dynamic>> items,
+  required Map<String, String> images,
+  required Map<String, dynamic> media,
+}) {
+  return <String, dynamic>{
+    'version': 2,
+    'format': 'full',
+    'name': name,
+    'author': 'Tonkatsu Box',
+    'created': DateTime.now().toUtc().toIso8601String(),
+    'description': description,
+    'items': items,
+    'images': images,
+    'media': media,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Collection generators
+// ---------------------------------------------------------------------------
+
+Future<Map<String, dynamic>> _generateGameCollection({
+  required CollectionSpec spec,
+  required String clientId,
+  required String accessToken,
+}) async {
+  stdout.write('  Fetching top games for platform ${spec.platformId}...\n');
+
+  final List<Map<String, dynamic>> games = await _fetchIgdbGames(
+    clientId: clientId,
+    accessToken: accessToken,
+    platformId: spec.platformId!,
+  );
+  stdout.write('  Got ${games.length} games\n');
+
+  // Rate limit.
+  await Future<void>.delayed(const Duration(milliseconds: 300));
+
+  // Build items + media.
+  final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+  final List<Map<String, dynamic>> mediaGames = <Map<String, dynamic>>[];
+
+  for (final Map<String, dynamic> game in games) {
+    items.add(<String, dynamic>{
+      'media_type': 'game',
+      'external_id': game['id'],
+      'platform_id': spec.platformId,
+    });
+    mediaGames.add(_gameToDb(game));
+  }
+
+  // Download covers.
+  final Map<String, String> urlMap = <String, String>{};
+  for (final Map<String, dynamic> game in games) {
+    final String? url = _gameCoverUrl(game);
+    if (url != null) {
+      urlMap['game_covers/${game['id']}'] = url;
+    }
+  }
+  stdout.write('  Downloading ${urlMap.length} covers...\n');
+  final Map<String, String> images = await _downloadImages(urlMap: urlMap);
+  stdout.write('  Downloaded ${images.length} covers\n');
+
+  return _buildXcollx(
+    name: spec.name,
+    description: spec.description,
+    items: items,
+    images: images,
+    media: <String, dynamic>{'games': mediaGames},
+  );
+}
+
+Future<Map<String, dynamic>> _generateMovieCollection({
+  required CollectionSpec spec,
+  required String tmdbKey,
+  required String mediaType, // 'movie' or 'animation'
+}) async {
+  List<Map<String, dynamic>> movies;
+
+  if (spec.type == CollectionType.tmdbTopMovies) {
+    stdout.write('  Fetching top rated movies...\n');
+    movies = await _fetchTmdbMoviesTopRated(tmdbKey);
+  } else {
+    stdout.write('  Fetching anime movies (discover)...\n');
+    movies = await _fetchTmdbDiscover(
+      tmdbKey,
+      mediaType: 'movie',
+      genreId: spec.genreId,
+      voteCountGte: 100,
+      sortBy: 'vote_average.desc',
+    );
+  }
+  stdout.write('  Got ${movies.length} movies\n');
+
+  final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+  final List<Map<String, dynamic>> mediaMovies = <Map<String, dynamic>>[];
+
+  for (final Map<String, dynamic> m in movies) {
+    items.add(<String, dynamic>{
+      'media_type': mediaType,
+      'external_id': m['id'],
+    });
+    mediaMovies.add(_movieToDb(m));
+  }
+
+  // Download posters.
+  final Map<String, String> urlMap = <String, String>{};
+  for (final Map<String, dynamic> m in movies) {
+    final String? url = _tmdbPosterUrl(m);
+    if (url != null) {
+      urlMap['movie_posters/${m['id']}'] = url;
+    }
+  }
+  stdout.write('  Downloading ${urlMap.length} posters...\n');
+  final Map<String, String> images = await _downloadImages(urlMap: urlMap);
+  stdout.write('  Downloaded ${images.length} posters\n');
+
+  return _buildXcollx(
+    name: spec.name,
+    description: spec.description,
+    items: items,
+    images: images,
+    media: <String, dynamic>{'movies': mediaMovies},
+  );
+}
+
+Future<Map<String, dynamic>> _generateTvShowCollection({
+  required CollectionSpec spec,
+  required String tmdbKey,
+  required String mediaType, // 'tv_show' or 'animation'
+}) async {
+  List<Map<String, dynamic>> shows;
+
+  if (spec.type == CollectionType.tmdbTopTvShows) {
+    stdout.write('  Fetching top rated TV shows...\n');
+    shows = await _fetchTmdbTvShowsTopRated(tmdbKey);
+  } else {
+    stdout.write('  Fetching anime series (discover)...\n');
+    shows = await _fetchTmdbDiscover(
+      tmdbKey,
+      mediaType: 'tv',
+      genreId: spec.genreId,
+      voteCountGte: 100,
+      sortBy: 'vote_average.desc',
+    );
+  }
+  stdout.write('  Got ${shows.length} TV shows\n');
+
+  final List<Map<String, dynamic>> items = <Map<String, dynamic>>[];
+  final List<Map<String, dynamic>> mediaTvShows = <Map<String, dynamic>>[];
+
+  for (final Map<String, dynamic> s in shows) {
+    items.add(<String, dynamic>{
+      'media_type': mediaType,
+      'external_id': s['id'],
+    });
+    mediaTvShows.add(_tvShowToDb(s));
+  }
+
+  // Download posters.
+  final Map<String, String> urlMap = <String, String>{};
+  for (final Map<String, dynamic> s in shows) {
+    final String? url = _tmdbPosterUrl(s);
+    if (url != null) {
+      urlMap['tv_show_posters/${s['id']}'] = url;
+    }
+  }
+  stdout.write('  Downloading ${urlMap.length} posters...\n');
+  final Map<String, String> images = await _downloadImages(urlMap: urlMap);
+  stdout.write('  Downloaded ${images.length} posters\n');
+
+  return _buildXcollx(
+    name: spec.name,
+    description: spec.description,
+    items: items,
+    images: images,
+    media: <String, dynamic>{'tv_shows': mediaTvShows},
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI args parser
+// ---------------------------------------------------------------------------
+
+String? _getArg(List<String> args, String name) {
+  for (final String arg in args) {
+    if (arg.startsWith('--$name=')) {
+      return arg.substring('--$name='.length);
+    }
+  }
+  return Platform.environment[name.replaceAll('-', '_').toUpperCase()];
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+Future<void> main(List<String> args) async {
+  final String? igdbClientId =
+      _getArg(args, 'igdb-client-id') ?? _getArg(args, 'igdb_client_id');
+  final String? igdbClientSecret =
+      _getArg(args, 'igdb-client-secret') ?? _getArg(args, 'igdb_client_secret');
+  final String? tmdbKey =
+      _getArg(args, 'tmdb-key') ?? _getArg(args, 'tmdb_key');
+  final String? outputDir =
+      _getArg(args, 'output') ?? _getArg(args, 'output_dir');
+
+  if (igdbClientId == null ||
+      igdbClientSecret == null ||
+      tmdbKey == null ||
+      outputDir == null) {
+    stderr.write(
+      'Usage:\n'
+      '  dart tool/generate_demo_collections.dart \\\n'
+      '    --igdb-client-id=<id> \\\n'
+      '    --igdb-client-secret=<secret> \\\n'
+      '    --tmdb-key=<bearer_token> \\\n'
+      '    --output=<dir>\n'
+      '\n'
+      'Or set env vars: IGDB_CLIENT_ID, IGDB_CLIENT_SECRET, TMDB_KEY, OUTPUT_DIR\n',
+    );
+    exit(1);
+  }
+
+  // Ensure output dir exists.
+  final Directory dir = Directory(outputDir);
+  if (!dir.existsSync()) {
+    dir.createSync(recursive: true);
+    stdout.write('Created output directory: $outputDir\n');
+  }
+
+  stdout.write('=== Demo Collections Generator ===\n');
+  stdout.write('Output: $outputDir\n\n');
+
+  // Get IGDB access token.
+  stdout.write('Authenticating with IGDB (Twitch)...\n');
+  final String igdbToken = await _getIgdbToken(igdbClientId, igdbClientSecret);
+  stdout.write('Got IGDB access token.\n\n');
+
+  int successCount = 0;
+
+  for (int i = 0; i < collections.length; i++) {
+    final CollectionSpec spec = collections[i];
+    stdout.write('--- [${i + 1}/${collections.length}] ${spec.name} ---\n');
+
+    try {
+      late Map<String, dynamic> xcollx;
+
+      switch (spec.type) {
+        case CollectionType.igdbPlatform:
+          xcollx = await _generateGameCollection(
+            spec: spec,
+            clientId: igdbClientId,
+            accessToken: igdbToken,
+          );
+          break;
+        case CollectionType.tmdbTopMovies:
+          xcollx = await _generateMovieCollection(
+            spec: spec,
+            tmdbKey: tmdbKey,
+            mediaType: 'movie',
+          );
+          break;
+        case CollectionType.tmdbAnimeMovies:
+          xcollx = await _generateMovieCollection(
+            spec: spec,
+            tmdbKey: tmdbKey,
+            mediaType: 'animation',
+          );
+          break;
+        case CollectionType.tmdbTopTvShows:
+          xcollx = await _generateTvShowCollection(
+            spec: spec,
+            tmdbKey: tmdbKey,
+            mediaType: 'tv_show',
+          );
+          break;
+        case CollectionType.tmdbAnimeSeries:
+          xcollx = await _generateTvShowCollection(
+            spec: spec,
+            tmdbKey: tmdbKey,
+            mediaType: 'animation',
+          );
+          break;
+      }
+
+      // Write file.
+      final String filePath = '$outputDir/${spec.fileName}.xcollx';
+      const JsonEncoder encoder = JsonEncoder.withIndent('  ');
+      final String jsonString = encoder.convert(xcollx);
+      File(filePath).writeAsStringSync(jsonString);
+
+      final int sizeKb = jsonString.length ~/ 1024;
+      stdout.write('  SAVED: ${spec.fileName}.xcollx ($sizeKb KB)\n\n');
+      successCount++;
+    } catch (e) {
+      stderr.write('  ERROR: $e\n\n');
+    }
+  }
+
+  stdout.write('===================================\n');
+  stdout.write('Done! $successCount/${collections.length} files generated.\n');
+
+  _http.close();
+}


### PR DESCRIPTION
Add tooling to generate .xcollx demo collection files with embedded cover art for the tonkatsu-collections repository.

Changes:
- Add IgdbApi.getTopGamesByPlatform() for fetching top-rated games
- Add voteCountGte parameter to TmdbApi discover methods
- Add DemoCollectionsScreen in Debug Hub (Settings → Developer Tools)
- Add tool/generate_demo_collections.dart — generates 10 curated collections
- Add tool/generate_all_snes.dart — fetches all games for a given platform
- Add tool/README.md with usage documentation