### PR TITLE
feat: add External Rating sort mode for collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ## [Unreleased]
 
 ### Added
+- "External Rating" sort mode (`CollectionSortMode.externalRating`) — sorts collection items by IGDB/TMDB API rating (`apiRating`, normalized 0–10), highest first, unrated items at the end. Localized in EN and RU (`collection_sort_mode.dart`, `sort_utils.dart`, `app_en.arb`, `app_ru.arb`)
+- Tests: `externalRating` coverage in `collection_sort_mode_test.dart` (6 new tests) and `sort_utils_test.dart` (6 new tests)
 - `externalUrl` field on `Game`, `Movie`, `TvShow` models — stores the IGDB/TMDB page URL. `Game.fromJson()` reads `url` from IGDB API; `Movie.fromJson()` / `TvShow.fromJson()` construct `https://www.themoviedb.org/{movie|tv}/{id}`. Included in `toDb()`, `fromDb()`, `copyWith()`, `toJson()` (Game). Persisted in SQLite (`external_url TEXT` column), exported in `.xcollx` (`game.dart`, `movie.dart`, `tv_show.dart`)
 - Clickable `SourceBadge` — when `onTap` is provided, the badge shows an `open_in_new` icon and wraps in `InkWell`. Tapping opens the external URL in the system browser (`source_badge.dart`)
 - `externalUrl` parameter on `MediaDetailView` — passes URL to `SourceBadge.onTap` via `_launchExternalUrl()` using `url_launcher` (`media_detail_view.dart`)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -68,6 +68,7 @@ Sort items within a collection:
 - **Status** — active items first: In Progress → Planned → Not Started → Completed → Dropped
 - **Name** — alphabetical A to Z
 - **Rating** — highest user rating first, unrated at the end
+- **External Rating** — highest IGDB/TMDB API rating first, unrated at the end
 - **Manual** — custom drag-and-drop order with drag handle icon
 
 Sort mode is saved per collection and persists between sessions.

--- a/lib/features/collections/providers/sort_utils.dart
+++ b/lib/features/collections/providers/sort_utils.dart
@@ -47,6 +47,14 @@ List<CollectionItem> applySortMode(
         if (b.userRating == null) return -1;
         return b.userRating!.compareTo(a.userRating!);
       });
+    case CollectionSortMode.externalRating:
+      sorted.sort((CollectionItem a, CollectionItem b) {
+        // null рейтинг в конец
+        if (a.apiRating == null && b.apiRating == null) return 0;
+        if (a.apiRating == null) return 1;
+        if (b.apiRating == null) return -1;
+        return b.apiRating!.compareTo(a.apiRating!);
+      });
   }
   if (isDescending) {
     return sorted.reversed.toList();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -36,6 +36,9 @@
   "sortRatingDisplay": "My Rating",
   "sortRatingShort": "Rating",
   "sortRatingDesc": "Highest first",
+  "sortExternalRatingDisplay": "External Rating",
+  "sortExternalRatingShort": "IGDB/TMDB",
+  "sortExternalRatingDesc": "Highest first",
 
   "searchSortRelevanceShort": "Rel",
   "searchSortRelevanceDisplay": "Relevance",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -283,6 +283,24 @@ abstract class S {
   /// **'Highest first'**
   String get sortRatingDesc;
 
+  /// No description provided for @sortExternalRatingDisplay.
+  ///
+  /// In en, this message translates to:
+  /// **'External Rating'**
+  String get sortExternalRatingDisplay;
+
+  /// No description provided for @sortExternalRatingShort.
+  ///
+  /// In en, this message translates to:
+  /// **'IGDB/TMDB'**
+  String get sortExternalRatingShort;
+
+  /// No description provided for @sortExternalRatingDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Highest first'**
+  String get sortExternalRatingDesc;
+
   /// No description provided for @searchSortRelevanceShort.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -102,6 +102,15 @@ class SEn extends S {
   String get sortRatingDesc => 'Highest first';
 
   @override
+  String get sortExternalRatingDisplay => 'External Rating';
+
+  @override
+  String get sortExternalRatingShort => 'IGDB/TMDB';
+
+  @override
+  String get sortExternalRatingDesc => 'Highest first';
+
+  @override
   String get searchSortRelevanceShort => 'Rel';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -102,6 +102,15 @@ class SRu extends S {
   String get sortRatingDesc => 'Сначала лучшие';
 
   @override
+  String get sortExternalRatingDisplay => 'Внешний рейтинг';
+
+  @override
+  String get sortExternalRatingShort => 'IGDB/TMDB';
+
+  @override
+  String get sortExternalRatingDesc => 'Сначала лучшие';
+
+  @override
   String get searchSortRelevanceShort => 'Рел';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -36,6 +36,9 @@
   "sortRatingDisplay": "Мой рейтинг",
   "sortRatingShort": "Оценка",
   "sortRatingDesc": "Сначала лучшие",
+  "sortExternalRatingDisplay": "Внешний рейтинг",
+  "sortExternalRatingShort": "IGDB/TMDB",
+  "sortExternalRatingDesc": "Сначала лучшие",
 
   "searchSortRelevanceShort": "Рел",
   "searchSortRelevanceDisplay": "Релевантность",

--- a/lib/shared/models/collection_sort_mode.dart
+++ b/lib/shared/models/collection_sort_mode.dart
@@ -17,7 +17,10 @@ enum CollectionSortMode {
   name('name', 'Name', 'A-Z', 'A to Z'),
 
   /// По пользовательскому рейтингу (userRating DESC, высшие первыми).
-  rating('rating', 'My Rating', 'Rating', 'Highest first');
+  rating('rating', 'My Rating', 'Rating', 'Highest first'),
+
+  /// По внешнему API-рейтингу (apiRating DESC, IGDB/TMDB).
+  externalRating('external_rating', 'External Rating', 'IGDB/TMDB', 'Highest first');
 
   const CollectionSortMode(
     this.value,
@@ -63,6 +66,8 @@ enum CollectionSortMode {
         return l.sortNameDisplay;
       case CollectionSortMode.rating:
         return l.sortRatingDisplay;
+      case CollectionSortMode.externalRating:
+        return l.sortExternalRatingDisplay;
     }
   }
 
@@ -79,6 +84,8 @@ enum CollectionSortMode {
         return l.sortNameShort;
       case CollectionSortMode.rating:
         return l.sortRatingShort;
+      case CollectionSortMode.externalRating:
+        return l.sortExternalRatingShort;
     }
   }
 
@@ -95,6 +102,8 @@ enum CollectionSortMode {
         return l.sortNameDesc;
       case CollectionSortMode.rating:
         return l.sortRatingDesc;
+      case CollectionSortMode.externalRating:
+        return l.sortExternalRatingDesc;
     }
   }
 }

--- a/test/shared/models/collection_sort_mode_test.dart
+++ b/test/shared/models/collection_sort_mode_test.dart
@@ -6,8 +6,8 @@ import 'package:xerabora/shared/models/collection_sort_mode.dart';
 void main() {
   group('CollectionSortMode', () {
     group('значения enum', () {
-      test('должен содержать 5 значений', () {
-        expect(CollectionSortMode.values.length, 5);
+      test('должен содержать 6 значений', () {
+        expect(CollectionSortMode.values.length, 6);
       });
 
       test('должен содержать все режимы сортировки', () {
@@ -19,6 +19,10 @@ void main() {
         expect(CollectionSortMode.values, contains(CollectionSortMode.status));
         expect(CollectionSortMode.values, contains(CollectionSortMode.name));
         expect(CollectionSortMode.values, contains(CollectionSortMode.rating));
+        expect(
+          CollectionSortMode.values,
+          contains(CollectionSortMode.externalRating),
+        );
       });
     });
 
@@ -42,6 +46,10 @@ void main() {
       test('rating должен иметь значение "rating"', () {
         expect(CollectionSortMode.rating.value, 'rating');
       });
+
+      test('externalRating должен иметь значение "external_rating"', () {
+        expect(CollectionSortMode.externalRating.value, 'external_rating');
+      });
     });
 
     group('displayLabel', () {
@@ -63,6 +71,13 @@ void main() {
 
       test('rating должен отображаться как "My Rating"', () {
         expect(CollectionSortMode.rating.displayLabel, 'My Rating');
+      });
+
+      test('externalRating должен отображаться как "External Rating"', () {
+        expect(
+          CollectionSortMode.externalRating.displayLabel,
+          'External Rating',
+        );
       });
     });
 
@@ -86,6 +101,10 @@ void main() {
       test('rating должен иметь shortLabel "Rating"', () {
         expect(CollectionSortMode.rating.shortLabel, 'Rating');
       });
+
+      test('externalRating должен иметь shortLabel "IGDB/TMDB"', () {
+        expect(CollectionSortMode.externalRating.shortLabel, 'IGDB/TMDB');
+      });
     });
 
     group('description', () {
@@ -107,6 +126,10 @@ void main() {
 
       test('rating должен иметь описание "Highest first"', () {
         expect(CollectionSortMode.rating.description, 'Highest first');
+      });
+
+      test('externalRating должен иметь описание "Highest first"', () {
+        expect(CollectionSortMode.externalRating.description, 'Highest first');
       });
     });
 
@@ -143,6 +166,13 @@ void main() {
             CollectionSortMode.fromString('rating');
 
         expect(result, CollectionSortMode.rating);
+      });
+
+      test('должен вернуть externalRating для "external_rating"', () {
+        final CollectionSortMode result =
+            CollectionSortMode.fromString('external_rating');
+
+        expect(result, CollectionSortMode.externalRating);
       });
 
       test('должен вернуть addedDate для неизвестного значения', () {


### PR DESCRIPTION
Allow sorting collection items by IGDB/TMDB API rating (apiRating 0-10), complementing the existing "My Rating" sort that uses user ratings.