### PR TITLE
feat: refactor search with pluggable source/filter architecture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,7 @@ lib/
 
 | Файл | Назначение |
 |------|------------|
-| `lib/core/api/igdb_api.dart` | **IGDB API клиент**. OAuth через Twitch, поиск игр, загрузка платформ. Методы: `getAccessToken()`, `searchGames()`, `fetchPlatforms()` |
+| `lib/core/api/igdb_api.dart` | **IGDB API клиент**. OAuth через Twitch, поиск игр, загрузка платформ, browse с фильтрами, жанры. Методы: `getAccessToken()`, `searchGames()`, `fetchPlatforms()`, `browseGames()`, `getGenres()`, `getTopGamesByPlatform()` |
 | `lib/core/api/steamgriddb_api.dart` | **SteamGridDB API клиент**. Bearer token авторизация. Методы: `searchGames()`, `getGrids()`, `getHeroes()`, `getLogos()`, `getIcons()`, `validateApiKey()` |
 | `lib/core/api/tmdb_api.dart` | **TMDB API клиент**. Bearer token авторизация. Методы: `searchMovies(query, {year})`, `searchTvShows(query, {firstAirDateYear})`, `multiSearch()`, `getMovieDetails()`, `getTvShowDetails()`, `getPopularMovies()`, `getPopularTvShows()`, `getMovieGenres()`, `getTvGenres()`, `getSeasonEpisodes(tmdbShowId, seasonNumber)`, `setLanguage(language)`, `getMovieRecommendations()`, `getTvShowRecommendations()`, `getMovieReviews()`, `getTvShowReviews()`, `discoverMovies()`, `discoverTvShows()`. Lazy-cached genre map (`_movieGenreMap`, `_tvGenreMap`) — resolves `genre_ids` to `genres` in all list endpoints. Cache cleared on `setLanguage()` and `clearApiKey()` |
 | `lib/shared/constants/platform_features.dart` | **Флаги платформы**. `kCanvasEnabled` (true на всех платформах), `kVgMapsEnabled` (только Windows), `kScreenshotEnabled` (только Windows). VGMaps скрыт на не-Windows платформах |
@@ -228,39 +228,93 @@ lib/
 
 ### 🔍 Features: Search (Поиск)
 
+#### Архитектура
+
+Поиск построен на pluggable-архитектуре с абстракциями `SearchSource` и `SearchFilter`:
+
+- **SearchSource** — описывает источник данных (IGDB, TMDB movies/tv/anime). Объявляет фильтры, сортировки, методы browse/search
+- **SearchFilter** — описывает один фильтр (жанр, год, платформа, тип). `cacheKey` различает фильтры с одинаковым `key` но разными наборами опций
+- **BrowseNotifier** — единый state manager для Browse/Search режимов с пагинацией и переключением источников
+
 #### Экраны
 
 | Файл | Назначение |
 |------|------------|
-| `lib/features/search/screens/search_screen.dart` | **Экран поиска**. TabBar с 4 табами: Games / Movies / TV Shows / Animation. Общее поле ввода с debounce, фильтр платформ (только Games), сортировка (SortSelector), фильтры медиа (год, жанры через MediaFilterSheet). Animation tab объединяет animated movies + TV shows (genre_id=16), исключая их из Movies/TV Shows табов. При `collectionId` — добавляет игры/фильмы/сериалы/анимацию в коллекцию через `collectionItemsNotifierProvider`. Bottom sheet с деталями. Параметр `initialQuery` — предзаполнение поиска из Wishlist |
+| `lib/features/search/screens/search_screen.dart` | **Экран поиска**. Два режима: Browse (FilterBar + Discover feed / BrowseGrid) и Search (поле поиска + BrowseGrid). SourceDropdown переключает между 4 источниками. При `collectionId` — добавляет элементы в коллекцию (с upsert в БД). Bottom sheet с деталями. `initialQuery` — предзаполнение из Wishlist |
 
 <details>
-<summary><strong>Виджеты и провайдеры поиска</strong> — развернуть таблицу</summary>
+<summary><strong>Модели и абстракции</strong> — развернуть таблицу</summary>
+
+| Файл | Назначение |
+|------|------------|
+| `lib/features/search/models/search_source.dart` | **Абстракции**. `SearchSource` (id, label, icon, filters, browse, search, sortOptions), `SearchFilter` (key, cacheKey, placeholder, options, allOption), `FilterOption`, `BrowseSortOption`, `BrowseResult` |
+
+</details>
+
+<details>
+<summary><strong>Источники данных (Sources)</strong> — развернуть таблицу</summary>
+
+| Файл | Назначение |
+|------|------------|
+| `lib/features/search/sources/tmdb_movies_source.dart` | **Фильмы TMDB**. Browse через discoverMoviesFiltered (исключая анимацию), search через searchMovies. Фильтры: жанр + год. Сортировка: popular/top_rated/newest |
+| `lib/features/search/sources/tmdb_tv_source.dart` | **Сериалы TMDB**. Browse через discoverTvShowsFiltered (исключая анимацию), search через searchTvShows. Фильтры: жанр + год. Сортировка: popular/top_rated/newest |
+| `lib/features/search/sources/tmdb_anime_source.dart` | **Анимация TMDB**. Объединяет animated movies + TV shows (genre_id=16). Фильтры: тип (series/movies) + жанр + год |
+| `lib/features/search/sources/igdb_games_source.dart` | **Игры IGDB**. Browse через browseGames, search через searchGames. Фильтры: жанр + платформа. Сортировка: popular/rating/newest |
+
+</details>
+
+<details>
+<summary><strong>Фильтры</strong> — развернуть таблицу</summary>
+
+| Файл | Назначение |
+|------|------------|
+| `lib/features/search/filters/tmdb_genre_filter.dart` | **Жанры TMDB**. `TmdbGenreFilter(type: 'movie'/'tv')`. cacheKey: `genre_movie`/`genre_tv`. Загрузка из movieGenresProvider/tvGenresProvider |
+| `lib/features/search/filters/igdb_genre_filter.dart` | **Жанры IGDB**. `IgdbGenreFilter`. cacheKey: `genre_igdb`. Модель `IgdbGenre`. Загрузка из igdbGenresProvider |
+| `lib/features/search/filters/year_filter.dart` | **Фильтр по году**. Группировка по декадам (2020s, 2010s, ..., Before 1970). Статические опции |
+| `lib/features/search/filters/igdb_platform_filter.dart` | **Фильтр по платформе IGDB**. Загрузка платформ из БД |
+| `lib/features/search/filters/anime_type_filter.dart` | **Фильтр типа анимации**. Series / Movies |
+
+</details>
+
+<details>
+<summary><strong>Виджеты поиска</strong> — развернуть таблицу</summary>
 
 #### Виджеты
 
 | Файл | Назначение |
 |------|------------|
-| ~~`lib/features/search/widgets/game_card.dart`~~ | **Удалён**. Заменён на `MediaPosterCard` в grid-сетке поиска |
-| ~~`lib/features/search/widgets/movie_card.dart`~~ | **Удалён**. Заменён на `MediaPosterCard` в grid-сетке поиска |
-| ~~`lib/features/search/widgets/tv_show_card.dart`~~ | **Удалён**. Заменён на `MediaPosterCard` в grid-сетке поиска |
-| `lib/features/search/widgets/animation_card.dart` | **Карточка анимации**. Обёртка над `MediaCard`: принимает `Movie?` или `TvShow?` + флаг `isMovie`. SourceBadge TMDB, бейдж "Movie"/"Series", subtitle (год, рейтинг, runtime или seasons) |
-| `lib/features/search/widgets/platform_filter_sheet.dart` | **Bottom sheet фильтра платформ**. Мультивыбор платформ с поиском. Кнопки Clear All / Apply |
-| `lib/features/search/widgets/sort_selector.dart` | **Селектор сортировки**. SegmentedButton с 3 опциями (Relevance, Date, Rating). Переключение направления при клике на активный сегмент. Визуальный индикатор |
-| `lib/features/search/widgets/media_filter_sheet.dart` | **Bottom sheet фильтров медиа**. DraggableScrollableSheet с фильтрами: Release Year (TextField), Genres (FilterChip). Кнопка Clear All |
+| `lib/features/search/widgets/browse_grid.dart` | **Грид результатов**. ConsumerStatefulWidget. Бесконечный скролл (пагинация). Grid delegate совпадает с CollectionScreen (maxCrossAxisExtent:150 на desktop, childAspectRatio:0.55). `_collectedIdsProvider` для маркировки "в коллекции" (зелёный чек). Shimmer-загрузка |
+| `lib/features/search/widgets/filter_bar.dart` | **Горизонтальная строка фильтров**. SourceDropdown + FilterDropdown-ы + SortDropdown. ValueKey по source+cacheKey для пересоздания при смене источника |
+| `lib/features/search/widgets/filter_dropdown.dart` | **Дропдаун фильтра**. `FilterDropdown` — PopupMenuButton с async-загрузкой опций, generation-based cancellation, sentinel для "All". `SortDropdown` — дропдаун сортировки |
+| `lib/features/search/widgets/source_dropdown.dart` | **Дропдаун источника**. Переключение между Movies/TV/Anime/Games с иконками |
 | `lib/features/search/widgets/media_details_sheet.dart` | **Bottom sheet деталей медиа**. DraggableScrollableSheet с постером, заголовком, годом, рейтингом, жанровыми чипами, описанием и кнопкой "Add to Collection" |
+| `lib/features/search/widgets/game_details_sheet.dart` | **Bottom sheet деталей игры**. Обложка, название, год, рейтинг, жанры, платформы, описание, кнопка "Add to Collection" |
 | `lib/features/search/widgets/discover_feed.dart` | **Лента Discover**. ConsumerWidget. Показывается при пустом поиске. Горизонтальные ряды: Trending, Top Rated Movies, Popular TV Shows, Upcoming, Anime, Top Rated TV Shows. Shimmer-загрузка. Скрытие элементов из коллекций через `_existingTmdbIdsProvider` |
 | `lib/features/search/widgets/discover_row.dart` | **Горизонтальный ряд постеров Discover**. `DiscoverItem` модель (title, tmdbId, posterUrl, year, rating, isOwned, isMovie). `DiscoverRow` StatefulWidget с `ScrollableRowWithArrows`. `_DiscoverPosterCard` — постер с рейтингом и отметкой коллекции |
 | `lib/features/search/widgets/discover_customize_sheet.dart` | **Bottom sheet настройки Discover**. Toggle секций (SwitchListTile), переключатель "Hide items in collections" |
+
+</details>
+
+<details>
+<summary><strong>Провайдеры поиска</strong> — развернуть таблицу</summary>
 
 #### Провайдеры
 
 | Файл | Назначение |
 |------|------------|
-| `lib/features/search/providers/game_search_provider.dart` | **State поиска игр**. Debounce 400ms, минимум 2 символа. Фильтр по платформам. Сортировка (relevance/date/rating). Состояние: query, results, isLoading, error, currentSort |
-| `lib/features/search/providers/media_search_provider.dart` | **State поиска фильмов/сериалов/анимации**. Debounce 400ms через TMDB API. Enum `MediaSearchTab` (movies, tvShows, animation). Animation tab: `Future.wait([searchMovies, searchTvShows])` -> фильтрация по genre_id=16. Movies/TV Shows табы исключают анимацию. Состояние: query, movieResults, tvShowResults, animationMovieResults, animationTvShowResults, isLoading, error, activeTab, currentSort, selectedYear, selectedGenreIds. Кэширование через `upsertMovies()`/`upsertTvShows()` |
-| `lib/features/search/providers/genre_provider.dart` | **Провайдеры жанров**. `movieGenresProvider`, `tvGenresProvider` — FutureProvider для кэширования списков жанров из TMDB API. `movieGenreMapProvider`, `tvGenreMapProvider` — маппинг ID->имя для быстрого резолвинга genre_ids. DB-first стратегия: загрузка из таблицы `tmdb_genres`, при пустом кэше — запрос к API и сохранение |
-| `lib/features/search/providers/discover_provider.dart` | **State Discover ленты**. `DiscoverSettings` (enabledSections, hideOwned). `DiscoverSectionId` enum (trending, topRatedMovies, popularTvShows, upcoming, anime, topRatedTvShows). `discoverSettingsProvider` (NotifierProvider, SharedPreferences). FutureProvider-ы для каждой секции: `discoverTrendingMoviesProvider`, `discoverTopRatedMoviesProvider`, `discoverPopularTvShowsProvider`, `discoverUpcomingMoviesProvider`, `discoverAnimeProvider`, `discoverTopRatedTvShowsProvider`, `discoverTrendingTvShowsProvider` |
+| `lib/features/search/providers/browse_provider.dart` | **State Browse/Search**. `BrowseState` (sourceId, filterValues, sortBy, items, pagination, isSearchMode, searchQuery, error). `BrowseNotifier` — NotifierProvider. Методы: setSource, setFilter, setSort, loadMore, enterSearchMode, exitSearchMode, search. Pagination через `BrowseResult.hasMore`. Сброс фильтров при смене источника |
+| `lib/features/search/providers/igdb_genre_provider.dart` | **Кэш жанров IGDB**. `igdbGenresProvider` — FutureProvider, загружает жанры через `IgdbApi.getGenres()` |
+| `lib/features/search/providers/genre_provider.dart` | **Провайдеры жанров TMDB**. `movieGenresProvider`, `tvGenresProvider` — FutureProvider для кэширования списков жанров из TMDB API. `movieGenreMapProvider`, `tvGenreMapProvider` — маппинг ID->имя. DB-first стратегия |
+| `lib/features/search/providers/discover_provider.dart` | **State Discover ленты**. `DiscoverSettings` (enabledSections, hideOwned). `DiscoverSectionId` enum. `discoverSettingsProvider` (NotifierProvider, SharedPreferences). FutureProvider-ы для каждой секции |
+
+</details>
+
+<details>
+<summary><strong>Утилиты поиска</strong> — развернуть таблицу</summary>
+
+| Файл | Назначение |
+|------|------------|
+| `lib/features/search/utils/genre_utils.dart` | **Утилиты жанров**. `isAnimationGenre()` — проверка genre string на анимацию |
 
 </details>
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -75,26 +75,33 @@ Sort mode is saved per collection and persists between sessions.
 
 ## 🔍 Universal Search
 
-Search across multiple media types via tabbed interface:
+Browse and search across multiple media sources via pluggable source architecture:
 
-| Tab | Source | Features |
-|-----|--------|----------|
-| **Games** | IGDB | 200k+ titles, covers, genres, platform filter |
-| **Movies** | TMDB | Posters, genres, runtime, year/genre filter |
-| **TV Shows** | TMDB | Seasons/episodes, show status, year/genre filter |
-| **Animation** | TMDB | Combined animated movies + series, "Movie"/"Series" badge |
+| Source | API | Filters | Sort |
+|--------|-----|---------|------|
+| **Movies** | TMDB | Genre, Year (decades) | Popular, Top Rated, Newest |
+| **TV Shows** | TMDB | Genre, Year (decades) | Popular, Top Rated, Newest |
+| **Animation** | TMDB | Type (Series/Movies), Genre, Year | Popular, Top Rated, Newest |
+| **Games** | IGDB | Genre, Platform | Popular, Rating, Newest |
 
 > [!TIP]
-> The Animation tab automatically filters by genre Animation (ID=16). Movies and TV Shows tabs exclude animated content, so there's no overlap.
+> The Animation source automatically filters by genre Animation (ID=16). Movies and TV Shows sources exclude animated content, so there's no overlap.
 
-- **Sorting** — by relevance, date, or rating (toggle ascending/descending)
-- **Filtering** — by release year (1900–2100), genres (multi-select), active filter chips
-- **Per-tab API key checks** — each tab independently checks its required API key (IGDB for Games, TMDB for Movies/TV/Animation); missing key shows "Go to Settings" button
-- **Smart error handling** — network errors (connection/timeout/socket) show "No internet connection" with retry; API errors show the error message with retry
+Two modes:
+- **Browse mode** — source dropdown + filter bar + sort dropdown. When no filters are active, shows Discover feed (TMDB sources). With filters, shows paginated grid
+- **Search mode** — text search field with results in the same grid
+
+Features:
+- **Source switching** — dropdown to switch between Movies/TV/Anime/Games; filters reset on source change
+- **Filter bar** — horizontal scrollable row with genre/year/platform dropdowns and sort selector
+- **In-collection markers** — green checkmark badge on items already in any collection (`_collectedIdsProvider`)
+- **Consistent card sizes** — grid delegate matches collection screen (desktop: maxCrossAxisExtent 150px, childAspectRatio 0.55)
+- **Infinite scroll** — automatic pagination with shimmer loading indicators
+- **Smart error handling** — network errors show "No internet connection" with retry; API errors show the error message with retry
 
 ### Discover Feed
 
-When the search field is empty, a curated Discover feed is shown with horizontal poster rows:
+When in Browse mode without filters (TMDB sources), a curated Discover feed is shown with horizontal poster rows:
 
 - **Trending** — interleaved trending movies and TV shows
 - **Top Rated Movies** — highest-rated movies from TMDB

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,9 +2,9 @@
 
 # 🗺️ Roadmap
 
-![Progress](https://img.shields.io/badge/overall_progress-~87%25-brightgreen?style=for-the-badge)
+![Progress](https://img.shields.io/badge/overall_progress-~90%25-brightgreen?style=for-the-badge)
 
-> Approximate completion: **~87%** — Core features, canvas system, media integrations, Android Lite, UI redesign, and Wishlist are done. A few restoration tasks and future plans remain.
+> Approximate completion: **~90%** — Core features, canvas system, media integrations, Android Lite, UI redesign, Wishlist, and Search refactoring are done. Future plans remain.
 
 ---
 
@@ -81,12 +81,12 @@
 - [x] Image caching — eager download on add, magic bytes validation, Windows file lock fix
 - [x] StatusChipRow + StatusRibbon — piano-style segmented status bar (icon-only, flat color, full-width), Material icon ribbon on list cards, Material icon badge on poster cards
 
-### 📋 UI Restoration (remaining)
+### 📋 UI Restoration (completed)
 
 - [x] Canvas mode restoration — Board toggle IconButton in AppBar, CanvasView + SteamGridDB/VGMaps panels in unified `ItemDetailScreen`
 - [x] Episode Tracker restoration — shared `EpisodeTrackerSection` widget with `accentColor`, used for TV Show and Animation (tvShow source) in `ItemDetailScreen`
 - [x] Activity Dates restoration — inline compact horizontal `Wrap` under My Rating with editable Started/Completed date chips
-- [ ] Search filters restoration — Platform Filter, Media Filter, Sort Selector
+- [x] Search refactoring — pluggable SearchSource/SearchFilter architecture, Browse/Search mode, source dropdown, filter bar, BrowseGrid, in-collection markers, consistent card sizes
 
 ---
 

--- a/lib/core/api/tmdb_api.dart
+++ b/lib/core/api/tmdb_api.dart
@@ -720,9 +720,19 @@ class TmdbApi {
   // ===== Discover =====
 
   /// Discover фильмов с фильтрами.
+  ///
+  /// [genreId] — ID жанра (один жанр).
+  /// [genreIds] — строка жанров через запятую (например '16,28').
+  /// [year] — конкретный год выпуска.
+  /// [releaseDateGte] — дата начала диапазона (YYYY-MM-DD), для декад.
+  /// [releaseDateLte] — дата конца диапазона (YYYY-MM-DD), для декад.
+  /// [voteCountGte] — минимальное количество голосов.
   Future<List<Movie>> discoverMovies({
     int? genreId,
+    String? genreIds,
     int? year,
+    String? releaseDateGte,
+    String? releaseDateLte,
     int? voteCountGte,
     String sortBy = 'popularity.desc',
     int page = 1,
@@ -736,8 +746,18 @@ class TmdbApi {
         'sort_by': sortBy,
         'page': page,
       };
-      if (genreId != null) params['with_genres'] = genreId;
+      if (genreIds != null) {
+        params['with_genres'] = genreIds;
+      } else if (genreId != null) {
+        params['with_genres'] = genreId;
+      }
       if (year != null) params['primary_release_year'] = year;
+      if (releaseDateGte != null) {
+        params['primary_release_date.gte'] = releaseDateGte;
+      }
+      if (releaseDateLte != null) {
+        params['primary_release_date.lte'] = releaseDateLte;
+      }
       if (voteCountGte != null) params['vote_count.gte'] = voteCountGte;
 
       final Response<dynamic> response = await _dio.get<dynamic>(
@@ -759,10 +779,22 @@ class TmdbApi {
   }
 
   /// Discover сериалов с фильтрами.
+  ///
+  /// [genreId] — ID жанра (один жанр).
+  /// [genreIds] — строка жанров через запятую (например '16,10765').
+  /// [year] — конкретный год первого эфира.
+  /// [firstAirDateGte] — дата начала диапазона (YYYY-MM-DD), для декад.
+  /// [firstAirDateLte] — дата конца диапазона (YYYY-MM-DD), для декад.
+  /// [voteCountGte] — минимальное количество голосов.
+  /// [withoutGenreIds] — исключить жанры (например [16] для анимации).
   Future<List<TvShow>> discoverTvShows({
     int? genreId,
+    String? genreIds,
     int? year,
+    String? firstAirDateGte,
+    String? firstAirDateLte,
     int? voteCountGte,
+    List<int>? withoutGenreIds,
     String sortBy = 'popularity.desc',
     int page = 1,
   }) async {
@@ -775,9 +807,22 @@ class TmdbApi {
         'sort_by': sortBy,
         'page': page,
       };
-      if (genreId != null) params['with_genres'] = genreId;
+      if (genreIds != null) {
+        params['with_genres'] = genreIds;
+      } else if (genreId != null) {
+        params['with_genres'] = genreId;
+      }
       if (year != null) params['first_air_date_year'] = year;
+      if (firstAirDateGte != null) {
+        params['first_air_date.gte'] = firstAirDateGte;
+      }
+      if (firstAirDateLte != null) {
+        params['first_air_date.lte'] = firstAirDateLte;
+      }
       if (voteCountGte != null) params['vote_count.gte'] = voteCountGte;
+      if (withoutGenreIds != null && withoutGenreIds.isNotEmpty) {
+        params['without_genres'] = withoutGenreIds.join(',');
+      }
 
       final Response<dynamic> response = await _dio.get<dynamic>(
         '$_baseUrl/discover/tv',

--- a/lib/features/search/filters/anime_type_filter.dart
+++ b/lib/features/search/filters/anime_type_filter.dart
@@ -1,0 +1,40 @@
+// Фильтр типа анимации — сериалы, фильмы или всё.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart' show WidgetRef;
+
+import '../../../l10n/app_localizations.dart';
+import '../models/search_source.dart';
+
+/// Фильтр типа анимации.
+///
+/// Позволяет выбрать: анимационные сериалы, анимационные фильмы, или все.
+class AnimeTypeFilter extends SearchFilter {
+  @override
+  String get key => 'animeType';
+
+  @override
+  String placeholder(S l) => l.browseFilterType;
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'all',
+        label: 'All',
+        value: null,
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, S l) async {
+    return <FilterOption>[
+      FilterOption(
+        id: 'series',
+        label: l.browseAnimeTypeSeries,
+        value: 'series',
+      ),
+      FilterOption(
+        id: 'movies',
+        label: l.browseAnimeTypeMovies,
+        value: 'movies',
+      ),
+    ];
+  }
+}

--- a/lib/features/search/filters/igdb_genre_filter.dart
+++ b/lib/features/search/filters/igdb_genre_filter.dart
@@ -1,0 +1,63 @@
+// Фильтр жанров IGDB — свой набор жанров для игр.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart' show WidgetRef;
+
+import '../../../l10n/app_localizations.dart';
+import '../models/search_source.dart';
+import '../providers/igdb_genre_provider.dart';
+
+/// Модель жанра IGDB.
+class IgdbGenre {
+  /// Создаёт [IgdbGenre].
+  const IgdbGenre({required this.id, required this.name});
+
+  /// Создаёт [IgdbGenre] из JSON ответа IGDB API.
+  factory IgdbGenre.fromJson(Map<String, dynamic> json) {
+    return IgdbGenre(
+      id: json['id'] as int,
+      name: json['name'] as String,
+    );
+  }
+
+  /// ID жанра.
+  final int id;
+
+  /// Название жанра.
+  final String name;
+}
+
+/// Фильтр жанров IGDB.
+///
+/// Загружает жанры из IGDB API через [igdbGenresProvider].
+class IgdbGenreFilter extends SearchFilter {
+  @override
+  String get key => 'genre';
+
+  @override
+  String get cacheKey => '${key}_igdb';
+
+  @override
+  String placeholder(S l) => l.browseFilterGenre;
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'any',
+        label: 'All',
+        value: null,
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, S l) async {
+    final List<IgdbGenre> genres =
+        await ref.read(igdbGenresProvider.future);
+    return genres
+        .map(
+          (IgdbGenre g) => FilterOption(
+            id: g.id.toString(),
+            label: g.name,
+            value: g.id,
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/features/search/filters/igdb_platform_filter.dart
+++ b/lib/features/search/filters/igdb_platform_filter.dart
@@ -1,0 +1,47 @@
+// Фильтр по платформе IGDB.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart' show WidgetRef;
+
+import '../../../core/database/database_service.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/platform.dart' as app_platform;
+import '../models/search_source.dart';
+
+/// Фильтр по игровой платформе IGDB.
+///
+/// Загружает список платформ из БД-кэша.
+class IgdbPlatformFilter extends SearchFilter {
+  @override
+  String get key => 'platform';
+
+  @override
+  String placeholder(S l) => l.browseFilterPlatform;
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'any',
+        label: 'All',
+        value: null,
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, S l) async {
+    final DatabaseService db = ref.read(databaseServiceProvider);
+    final List<app_platform.Platform> platforms =
+        await db.getAllPlatforms();
+    // Сортируем по имени для удобства
+    platforms.sort(
+      (app_platform.Platform a, app_platform.Platform b) =>
+          a.name.compareTo(b.name),
+    );
+    return platforms
+        .map(
+          (app_platform.Platform p) => FilterOption(
+            id: p.id.toString(),
+            label: p.name,
+            value: p.id,
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/features/search/filters/tmdb_genre_filter.dart
+++ b/lib/features/search/filters/tmdb_genre_filter.dart
@@ -1,0 +1,54 @@
+// Фильтр жанров TMDB — используется Movies, TV, Anime.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart' show WidgetRef;
+
+import '../../../core/api/tmdb_api.dart';
+import '../../../l10n/app_localizations.dart';
+import '../models/search_source.dart';
+import '../providers/genre_provider.dart';
+
+/// Фильтр жанров из TMDB.
+///
+/// Поддерживает жанры фильмов ('movie') и сериалов ('tv').
+/// Данные загружаются из кэша через [movieGenresProvider] / [tvGenresProvider].
+class TmdbGenreFilter extends SearchFilter {
+  /// Создаёт [TmdbGenreFilter].
+  ///
+  /// [type] — 'movie' или 'tv'.
+  TmdbGenreFilter({required this.type});
+
+  /// Тип контента: 'movie' или 'tv'.
+  final String type;
+
+  @override
+  String get key => 'genre';
+
+  @override
+  String get cacheKey => '${key}_$type';
+
+  @override
+  String placeholder(S l) => l.browseFilterGenre;
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'any',
+        label: 'All',
+        value: null,
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, S l) async {
+    final List<TmdbGenre> genres = type == 'movie'
+        ? await ref.read(movieGenresProvider.future)
+        : await ref.read(tvGenresProvider.future);
+    return genres
+        .map(
+          (TmdbGenre g) => FilterOption(
+            id: g.id.toString(),
+            label: g.name,
+            value: g.id,
+          ),
+        )
+        .toList();
+  }
+}

--- a/lib/features/search/filters/year_filter.dart
+++ b/lib/features/search/filters/year_filter.dart
@@ -1,0 +1,37 @@
+// Фильтр по году выпуска — общий для всех источников.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart' show WidgetRef;
+
+import '../../../l10n/app_localizations.dart';
+import '../models/search_source.dart';
+
+/// Фильтр по году выпуска.
+///
+/// Генерирует список годов от текущего до 2000,
+/// плюс декады (1990s, 1980s, 1970s).
+class YearFilter extends SearchFilter {
+  @override
+  String get key => 'year';
+
+  @override
+  String placeholder(S l) => l.browseFilterYear;
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'any',
+        label: 'Any',
+        value: null,
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, S l) async {
+    final int currentYear = DateTime.now().year;
+    return <FilterOption>[
+      for (int y = currentYear; y >= 2000; y--)
+        FilterOption(id: y.toString(), label: y.toString(), value: y),
+      const FilterOption(id: '1990s', label: '1990s', value: (1990, 1999)),
+      const FilterOption(id: '1980s', label: '1980s', value: (1980, 1989)),
+      const FilterOption(id: '1970s', label: '1970s', value: (1970, 1979)),
+    ];
+  }
+}

--- a/lib/features/search/models/search_source.dart
+++ b/lib/features/search/models/search_source.dart
@@ -1,0 +1,181 @@
+// Абстракции для поисковых источников данных.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/media_type.dart';
+
+/// ID жанра Animation в TMDB. Используется для фильтрации анимации.
+const int tmdbAnimationGenreId = 16;
+
+/// Вариант фильтра.
+class FilterOption {
+  /// Создаёт [FilterOption].
+  const FilterOption({
+    required this.id,
+    required this.label,
+    this.icon,
+    this.value,
+  });
+
+  /// Уникальный идентификатор варианта.
+  final String id;
+
+  /// Отображаемое название.
+  final String label;
+
+  /// Иконка (опционально).
+  final IconData? icon;
+
+  /// Значение для передачи в API.
+  final Object? value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FilterOption &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'FilterOption($id, $label)';
+}
+
+/// Вариант сортировки для Browse mode.
+class BrowseSortOption {
+  /// Создаёт [BrowseSortOption].
+  const BrowseSortOption({
+    required this.id,
+    required this.apiValue,
+  });
+
+  /// Уникальный идентификатор (используется как ключ локализации).
+  final String id;
+
+  /// Значение для API запроса.
+  final String apiValue;
+
+  /// Локализованное название сортировки.
+  String label(S l) => switch (id) {
+        'popular' => l.browseSortPopular,
+        'top_rated' || 'rating' => l.browseSortTopRated,
+        'newest' => l.browseSortNewest,
+        _ => id,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BrowseSortOption &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}
+
+/// Описание одного фильтра.
+///
+/// Каждый фильтр объявляет свой ключ, placeholder и список вариантов.
+abstract class SearchFilter {
+  /// Уникальный ключ фильтра ("genre", "year", "platform").
+  String get key;
+
+  /// Отображаемое имя когда ничего не выбрано.
+  String placeholder(S l);
+
+  /// Список вариантов (загружается асинхронно).
+  ///
+  /// [l] — объект локализации для переведённых названий опций.
+  Future<List<FilterOption>> options(WidgetRef ref, S l);
+
+  /// Ключ для кэширования/сравнения (по умолчанию = [key]).
+  ///
+  /// Переопределяйте, если несколько фильтров имеют одинаковый [key],
+  /// но разные наборы опций (например, жанры Movie vs TV vs IGDB).
+  String get cacheKey => key;
+
+  /// Значение "все" (сброс фильтра).
+  FilterOption get allOption;
+}
+
+/// Результат Browse-запроса (Discover с фильтрами).
+class BrowseResult {
+  /// Создаёт [BrowseResult].
+  const BrowseResult({
+    required this.items,
+    required this.mediaType,
+    this.hasMore = false,
+    this.totalPages = 1,
+    this.currentPage = 1,
+  });
+
+  /// Список элементов (Game, Movie, TvShow).
+  final List<Object> items;
+
+  /// Тип медиа для отображения.
+  final MediaType mediaType;
+
+  /// Есть ли ещё страницы.
+  final bool hasMore;
+
+  /// Общее количество страниц.
+  final int totalPages;
+
+  /// Текущая страница.
+  final int currentPage;
+}
+
+/// Описание источника данных для поиска.
+///
+/// Каждый источник объявляет свои фильтры, API-методы
+/// и UI-конфигурацию. Добавление нового источника —
+/// создать реализацию и зарегистрировать в списке.
+abstract class SearchSource {
+  /// Уникальный идентификатор.
+  String get id;
+
+  /// Отображаемое имя (локализованное).
+  String label(S l);
+
+  /// Иконка для дропдауна.
+  IconData get icon;
+
+  /// Список фильтров, которые поддерживает этот источник.
+  /// Порядок = порядок отображения в фильтр-баре.
+  List<SearchFilter> get filters;
+
+  /// Есть ли Browse mode (Discover без поискового запроса).
+  bool get supportsBrowse;
+
+  /// Загрузить контент для Browse mode с фильтрами.
+  Future<BrowseResult> browse(
+    Ref ref, {
+    required Map<String, Object?> filterValues,
+    required String sortBy,
+    required int page,
+  });
+
+  /// Поиск по текстовому запросу.
+  Future<BrowseResult> search(
+    Ref ref, {
+    required String query,
+    required int page,
+  });
+
+  /// Виджет Discover feed для режима без фильтров (null = нет Discover).
+  Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref);
+
+  /// Доступные варианты сортировки.
+  List<BrowseSortOption> get sortOptions;
+
+  /// Сортировка по умолчанию.
+  BrowseSortOption get defaultSort => sortOptions.first;
+
+  /// Подсказка для поля поиска (локализованная).
+  String searchHint(S l);
+}

--- a/lib/features/search/providers/browse_provider.dart
+++ b/lib/features/search/providers/browse_provider.dart
@@ -1,0 +1,344 @@
+// Провайдер Browse mode для поиска с фильтрами.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../settings/providers/settings_provider.dart';
+import '../models/search_source.dart';
+import '../sources/search_sources.dart';
+
+/// Ключи SharedPreferences для сохранения состояния Browse.
+abstract final class BrowseSettingsKeys {
+  /// Выбранный источник.
+  static const String sourceId = 'browse_source_id';
+}
+
+/// Состояние Browse mode.
+class BrowseState {
+  /// Создаёт [BrowseState].
+  const BrowseState({
+    required this.sourceId,
+    this.filterValues = const <String, Object?>{},
+    this.sortBy,
+    this.items = const <Object>[],
+    this.isLoading = false,
+    this.isLoadingMore = false,
+    this.currentPage = 1,
+    this.hasMore = false,
+    this.error,
+    this.isSearchMode = false,
+    this.searchQuery = '',
+  });
+
+  /// ID текущего источника.
+  final String sourceId;
+
+  /// Значения фильтров: {"genre": 28, "year": 2024, "platform": 19}.
+  final Map<String, Object?> filterValues;
+
+  /// Текущая сортировка (API-значение).
+  final String? sortBy;
+
+  /// Список элементов (Game, Movie, TvShow).
+  final List<Object> items;
+
+  /// Загрузка первой страницы.
+  final bool isLoading;
+
+  /// Загрузка следующей страницы (пагинация).
+  final bool isLoadingMore;
+
+  /// Текущая страница.
+  final int currentPage;
+
+  /// Есть ли ещё страницы.
+  final bool hasMore;
+
+  /// Сообщение об ошибке.
+  final String? error;
+
+  /// Режим поиска (вместо Browse).
+  final bool isSearchMode;
+
+  /// Текстовый поисковый запрос.
+  final String searchQuery;
+
+  /// Есть ли активные фильтры (не null).
+  bool get hasFilters =>
+      filterValues.values.any((Object? v) => v != null);
+
+  /// Пустое состояние.
+  bool get isEmpty => items.isEmpty && !isLoading;
+
+  /// Текущий источник.
+  SearchSource get source => getSearchSourceById(sourceId);
+
+  /// Текущая сортировка или дефолтная.
+  String get effectiveSortBy => sortBy ?? source.defaultSort.apiValue;
+
+  /// Копирование с изменениями.
+  BrowseState copyWith({
+    String? sourceId,
+    Map<String, Object?>? filterValues,
+    String? sortBy,
+    List<Object>? items,
+    bool? isLoading,
+    bool? isLoadingMore,
+    int? currentPage,
+    bool? hasMore,
+    String? error,
+    bool? isSearchMode,
+    String? searchQuery,
+    bool clearError = false,
+    bool clearSortBy = false,
+  }) {
+    return BrowseState(
+      sourceId: sourceId ?? this.sourceId,
+      filterValues: filterValues ?? this.filterValues,
+      sortBy: clearSortBy ? null : (sortBy ?? this.sortBy),
+      items: items ?? this.items,
+      isLoading: isLoading ?? this.isLoading,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      currentPage: currentPage ?? this.currentPage,
+      hasMore: hasMore ?? this.hasMore,
+      error: clearError ? null : (error ?? this.error),
+      isSearchMode: isSearchMode ?? this.isSearchMode,
+      searchQuery: searchQuery ?? this.searchQuery,
+    );
+  }
+}
+
+/// Провайдер состояния Browse.
+final NotifierProvider<BrowseNotifier, BrowseState> browseProvider =
+    NotifierProvider<BrowseNotifier, BrowseState>(BrowseNotifier.new);
+
+/// Notifier для Browse mode.
+class BrowseNotifier extends Notifier<BrowseState> {
+  late SharedPreferences _prefs;
+
+  @override
+  BrowseState build() {
+    _prefs = ref.watch(sharedPreferencesProvider);
+    final String savedSourceId =
+        _prefs.getString(BrowseSettingsKeys.sourceId) ?? 'movies';
+    return BrowseState(sourceId: savedSourceId);
+  }
+
+  /// Сменить источник — сбросить фильтры и контент.
+  void setSource(String sourceId) {
+    _generation++;
+    state = BrowseState(sourceId: sourceId);
+    _prefs.setString(BrowseSettingsKeys.sourceId, sourceId);
+  }
+
+  /// Монотонный счётчик для защиты от race condition.
+  ///
+  /// Каждая новая операция (fetch/search/loadMore) инкрементирует счётчик.
+  /// Если после await счётчик изменился — результат игнорируется.
+  int _generation = 0;
+
+  /// Установить значение фильтра и перезагрузить.
+  Future<void> setFilter(String key, Object? value) async {
+    final Map<String, Object?> updated =
+        Map<String, Object?>.from(state.filterValues);
+    updated[key] = value;
+
+    state = state.copyWith(
+      filterValues: updated,
+      items: const <Object>[],
+      currentPage: 1,
+      hasMore: false,
+      clearError: true,
+    );
+
+    await _fetch();
+  }
+
+  /// Сменить сортировку и перезагрузить.
+  Future<void> setSort(String sortBy) async {
+    state = state.copyWith(
+      sortBy: sortBy,
+      items: const <Object>[],
+      currentPage: 1,
+      hasMore: false,
+      clearError: true,
+    );
+
+    await _fetch();
+  }
+
+  /// Сбросить все фильтры.
+  void clearFilters() {
+    _generation++;
+    state = state.copyWith(
+      filterValues: const <String, Object?>{},
+      items: const <Object>[],
+      currentPage: 1,
+      hasMore: false,
+      clearError: true,
+      clearSortBy: true,
+    );
+  }
+
+  /// Перейти в режим поиска.
+  void enterSearchMode() {
+    _generation++;
+    state = state.copyWith(
+      isSearchMode: true,
+      items: const <Object>[],
+      searchQuery: '',
+      currentPage: 1,
+      hasMore: false,
+      clearError: true,
+    );
+  }
+
+  /// Выйти из режима поиска (вернуться в Browse).
+  void exitSearchMode() {
+    _generation++;
+    state = state.copyWith(
+      isSearchMode: false,
+      items: const <Object>[],
+      searchQuery: '',
+      currentPage: 1,
+      hasMore: false,
+      clearError: true,
+    );
+
+    // Если были фильтры — перезагрузить
+    if (state.hasFilters) {
+      _fetch();
+    }
+  }
+
+  /// Выполнить текстовый поиск.
+  Future<void> search(String query) async {
+    if (query.trim().length < 2) return;
+
+    final int gen = ++_generation;
+
+    state = state.copyWith(
+      searchQuery: query.trim(),
+      items: const <Object>[],
+      currentPage: 1,
+      hasMore: false,
+      isLoading: true,
+      clearError: true,
+    );
+
+    try {
+      final SearchSource source = state.source;
+      final BrowseResult result = await source.search(
+        ref,
+        query: query.trim(),
+        page: 1,
+      );
+
+      if (_generation != gen) return; // stale result
+
+      state = state.copyWith(
+        items: result.items,
+        hasMore: result.hasMore,
+        currentPage: 1,
+        isLoading: false,
+      );
+    } on Exception catch (e) {
+      if (_generation != gen) return;
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Загрузить следующую страницу.
+  Future<void> loadMore() async {
+    if (state.isLoading || state.isLoadingMore || !state.hasMore) return;
+
+    final int gen = ++_generation;
+
+    state = state.copyWith(isLoadingMore: true);
+
+    try {
+      final SearchSource source = state.source;
+      final int nextPage = state.currentPage + 1;
+
+      final BrowseResult result;
+      if (state.isSearchMode && state.searchQuery.isNotEmpty) {
+        result = await source.search(
+          ref,
+          query: state.searchQuery,
+          page: nextPage,
+        );
+      } else {
+        result = await source.browse(
+          ref,
+          filterValues: state.filterValues,
+          sortBy: state.effectiveSortBy,
+          page: nextPage,
+        );
+      }
+
+      if (_generation != gen) return; // stale result
+
+      state = state.copyWith(
+        items: <Object>[...state.items, ...result.items],
+        hasMore: result.hasMore,
+        currentPage: nextPage,
+        isLoadingMore: false,
+      );
+    } on Exception catch (e) {
+      if (_generation != gen) return;
+      state = state.copyWith(
+        isLoadingMore: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Загрузить/перезагрузить контент с текущими фильтрами.
+  Future<void> _fetch() async {
+    if (!state.hasFilters) return;
+
+    final int gen = ++_generation;
+
+    state = state.copyWith(
+      isLoading: true,
+      clearError: true,
+    );
+
+    try {
+      final SearchSource source = state.source;
+      final BrowseResult result = await source.browse(
+        ref,
+        filterValues: state.filterValues,
+        sortBy: state.effectiveSortBy,
+        page: 1,
+      );
+
+      if (_generation != gen) return; // stale result
+
+      state = state.copyWith(
+        items: result.items,
+        hasMore: result.hasMore,
+        currentPage: 1,
+        isLoading: false,
+      );
+    } on Exception catch (e) {
+      if (_generation != gen) return;
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Принудительная перезагрузка.
+  Future<void> refresh() async {
+    if (state.isSearchMode && state.searchQuery.isNotEmpty) {
+      await search(state.searchQuery);
+    } else if (state.hasFilters) {
+      await _fetch();
+    }
+  }
+}

--- a/lib/features/search/providers/discover_provider.dart
+++ b/lib/features/search/providers/discover_provider.dart
@@ -9,6 +9,7 @@ import '../../../core/api/tmdb_api.dart';
 import '../../../shared/models/movie.dart';
 import '../../../shared/models/tv_show.dart';
 import '../../settings/providers/settings_provider.dart';
+import '../utils/genre_utils.dart';
 import 'genre_provider.dart';
 
 /// Ключи настроек Discover.
@@ -170,36 +171,6 @@ class DiscoverSettingsNotifier extends Notifier<DiscoverSettings> {
 
 // ===== Провайдеры данных =====
 
-/// Резолвит числовые genre_ids в читаемые названия жанров для фильмов.
-List<Movie> _resolveMovieGenres(
-  List<Movie> movies,
-  Map<String, String> genreMap,
-) {
-  if (genreMap.isEmpty) return movies;
-  return movies.map((Movie m) {
-    if (m.genres == null || m.genres!.isEmpty) return m;
-    final List<String> resolved = m.genres!
-        .map((String id) => genreMap[id] ?? id)
-        .toList();
-    return m.copyWith(genres: resolved);
-  }).toList();
-}
-
-/// Резолвит числовые genre_ids в читаемые названия жанров для сериалов.
-List<TvShow> _resolveTvGenres(
-  List<TvShow> shows,
-  Map<String, String> genreMap,
-) {
-  if (genreMap.isEmpty) return shows;
-  return shows.map((TvShow s) {
-    if (s.genres == null || s.genres!.isEmpty) return s;
-    final List<String> resolved = s.genres!
-        .map((String id) => genreMap[id] ?? id)
-        .toList();
-    return s.copyWith(genres: resolved);
-  }).toList();
-}
-
 /// Трендовые фильмы.
 final FutureProvider<List<Movie>> discoverTrendingMoviesProvider =
     FutureProvider<List<Movie>>((Ref ref) async {
@@ -210,7 +181,7 @@ final FutureProvider<List<Movie>> discoverTrendingMoviesProvider =
   final Map<String, String> genreMap =
       await ref.watch(movieGenreMapProvider.future);
   final List<Movie> movies = await tmdb.getTrendingMovies();
-  return _resolveMovieGenres(movies, genreMap);
+  return resolveMovieGenres(movies, genreMap);
 });
 
 /// Трендовые сериалы.
@@ -222,7 +193,7 @@ final FutureProvider<List<TvShow>> discoverTrendingTvShowsProvider =
   final Map<String, String> genreMap =
       await ref.watch(tvGenreMapProvider.future);
   final List<TvShow> shows = await tmdb.getTrendingTvShows();
-  return _resolveTvGenres(shows, genreMap);
+  return resolveTvGenres(shows, genreMap);
 });
 
 /// Лучшие фильмы.
@@ -234,7 +205,7 @@ final FutureProvider<List<Movie>> discoverTopRatedMoviesProvider =
   final Map<String, String> genreMap =
       await ref.watch(movieGenreMapProvider.future);
   final List<Movie> movies = await tmdb.getTopRatedMovies();
-  return _resolveMovieGenres(movies, genreMap);
+  return resolveMovieGenres(movies, genreMap);
 });
 
 /// Популярные сериалы.
@@ -246,7 +217,7 @@ final FutureProvider<List<TvShow>> discoverPopularTvShowsProvider =
   final Map<String, String> genreMap =
       await ref.watch(tvGenreMapProvider.future);
   final List<TvShow> shows = await tmdb.getPopularTvShows();
-  return _resolveTvGenres(shows, genreMap);
+  return resolveTvGenres(shows, genreMap);
 });
 
 /// Скоро в кино.
@@ -258,7 +229,7 @@ final FutureProvider<List<Movie>> discoverUpcomingMoviesProvider =
   final Map<String, String> genreMap =
       await ref.watch(movieGenreMapProvider.future);
   final List<Movie> movies = await tmdb.getUpcomingMovies();
-  return _resolveMovieGenres(movies, genreMap);
+  return resolveMovieGenres(movies, genreMap);
 });
 
 /// Аниме (TV с жанром Animation = 16).
@@ -270,7 +241,7 @@ final FutureProvider<List<TvShow>> discoverAnimeProvider =
   final Map<String, String> genreMap =
       await ref.watch(tvGenreMapProvider.future);
   final List<TvShow> shows = await tmdb.discoverTvShows(genreId: 16);
-  return _resolveTvGenres(shows, genreMap);
+  return resolveTvGenres(shows, genreMap);
 });
 
 /// Лучшие сериалы.
@@ -282,5 +253,5 @@ final FutureProvider<List<TvShow>> discoverTopRatedTvShowsProvider =
   final Map<String, String> genreMap =
       await ref.watch(tvGenreMapProvider.future);
   final List<TvShow> shows = await tmdb.getTopRatedTvShows();
-  return _resolveTvGenres(shows, genreMap);
+  return resolveTvGenres(shows, genreMap);
 });

--- a/lib/features/search/providers/igdb_genre_provider.dart
+++ b/lib/features/search/providers/igdb_genre_provider.dart
@@ -1,0 +1,44 @@
+// Провайдер для кэширования жанров IGDB.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/igdb_api.dart';
+import '../../../core/database/database_service.dart';
+import '../../settings/providers/settings_provider.dart';
+import '../filters/igdb_genre_filter.dart';
+
+/// Провайдер жанров IGDB.
+///
+/// Загружает жанры из БД-кэша. Если кэш пуст — загружает из IGDB API и сохраняет.
+final FutureProvider<List<IgdbGenre>> igdbGenresProvider =
+    FutureProvider<List<IgdbGenre>>((Ref ref) async {
+  // Пересчитать при смене учётных данных IGDB
+  ref.watch(
+    settingsNotifierProvider.select((SettingsState s) => s.accessToken),
+  );
+
+  final DatabaseService db = ref.watch(databaseServiceProvider);
+  final IgdbApi igdb = ref.watch(igdbApiProvider);
+
+  // Пробуем загрузить из БД-кэша
+  final List<Map<String, dynamic>> cached = await db.getIgdbGenres();
+  if (cached.isNotEmpty) {
+    return cached
+        .map(
+          (Map<String, dynamic> row) => IgdbGenre(
+            id: row['id'] as int,
+            name: row['name'] as String,
+          ),
+        )
+        .toList();
+  }
+
+  // Кэш пуст — загружаем из API
+  final List<Map<String, dynamic>> genresJson = await igdb.fetchGenres();
+
+  if (genresJson.isNotEmpty) {
+    await db.cacheIgdbGenres(genresJson);
+  }
+
+  return genresJson.map(IgdbGenre.fromJson).toList();
+});

--- a/lib/features/search/sources/igdb_games_source.dart
+++ b/lib/features/search/sources/igdb_games_source.dart
@@ -1,0 +1,115 @@
+// Источник данных: игры из IGDB.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/igdb_api.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/game.dart';
+import '../../../shared/models/media_type.dart';
+import '../filters/igdb_genre_filter.dart';
+import '../filters/igdb_platform_filter.dart';
+import '../filters/year_filter.dart';
+import '../models/search_source.dart';
+
+/// Источник данных — игры из IGDB.
+class IgdbGamesSource extends SearchSource {
+  @override
+  String get id => 'games';
+
+  @override
+  String label(S l) => l.mediaTypeGame;
+
+  @override
+  IconData get icon => Icons.videogame_asset_outlined;
+
+  @override
+  bool get supportsBrowse => true;
+
+  @override
+  List<SearchFilter> get filters => <SearchFilter>[
+        IgdbGenreFilter(),
+        IgdbPlatformFilter(),
+        YearFilter(),
+      ];
+
+  @override
+  List<BrowseSortOption> get sortOptions => const <BrowseSortOption>[
+        BrowseSortOption(id: 'rating', apiValue: 'rating desc'),
+        BrowseSortOption(id: 'newest', apiValue: 'first_release_date desc'),
+        BrowseSortOption(id: 'popular', apiValue: 'total_rating_count desc'),
+      ];
+
+  @override
+  String searchHint(S l) => l.searchHintGames;
+
+  @override
+  Future<BrowseResult> browse(
+    Ref ref, {
+    required Map<String, Object?> filterValues,
+    required String sortBy,
+    required int page,
+  }) async {
+    final IgdbApi igdb = ref.read(igdbApiProvider);
+
+    final int? genreId = filterValues['genre'] as int?;
+    final int? platformId = filterValues['platform'] as int?;
+    final Object? yearValue = filterValues['year'];
+
+    int? year;
+    (int, int)? decade;
+    if (yearValue is int) {
+      year = yearValue;
+    } else if (yearValue is (int, int)) {
+      decade = yearValue;
+    }
+
+    const int pageSize = 20;
+    final int offset = (page - 1) * pageSize;
+
+    final List<Game> games = await igdb.browseGames(
+      genreId: genreId,
+      platformId: platformId,
+      year: year,
+      decade: decade,
+      sortBy: sortBy,
+      limit: pageSize,
+      offset: offset,
+    );
+
+    return BrowseResult(
+      items: games,
+      mediaType: MediaType.game,
+      hasMore: games.length >= pageSize,
+      currentPage: page,
+    );
+  }
+
+  @override
+  Future<BrowseResult> search(
+    Ref ref, {
+    required String query,
+    required int page,
+  }) async {
+    final IgdbApi igdb = ref.read(igdbApiProvider);
+
+    const int pageSize = 50;
+    final int offset = (page - 1) * pageSize;
+
+    final List<Game> games = await igdb.searchGames(
+      query: query,
+      limit: pageSize,
+      offset: offset,
+    );
+
+    return BrowseResult(
+      items: games,
+      mediaType: MediaType.game,
+      hasMore: games.length >= pageSize,
+      currentPage: page,
+    );
+  }
+
+  @override
+  Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) => null;
+}

--- a/lib/features/search/sources/search_sources.dart
+++ b/lib/features/search/sources/search_sources.dart
@@ -1,0 +1,28 @@
+// Реестр источников поиска.
+
+import '../models/search_source.dart';
+import 'igdb_games_source.dart';
+import 'tmdb_anime_source.dart';
+import 'tmdb_movies_source.dart';
+import 'tmdb_tv_source.dart';
+
+/// Все зарегистрированные источники поиска.
+///
+/// Порядок = порядок в дропдауне.
+/// Добавление нового источника — добавить в этот список.
+final List<SearchSource> searchSources = List<SearchSource>.unmodifiable(
+  <SearchSource>[
+    TmdbMoviesSource(),
+    TmdbTvSource(),
+    TmdbAnimeSource(),
+    IgdbGamesSource(),
+  ],
+);
+
+/// Возвращает источник по ID или первый по умолчанию.
+SearchSource getSearchSourceById(String id) {
+  return searchSources.firstWhere(
+    (SearchSource s) => s.id == id,
+    orElse: () => searchSources.first,
+  );
+}

--- a/lib/features/search/sources/tmdb_anime_source.dart
+++ b/lib/features/search/sources/tmdb_anime_source.dart
@@ -1,0 +1,280 @@
+// Источник данных: анимация из TMDB.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/tmdb_api.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/movie.dart';
+import '../../../shared/models/tv_show.dart';
+import '../filters/anime_type_filter.dart';
+import '../filters/tmdb_genre_filter.dart';
+import '../filters/year_filter.dart';
+import '../models/search_source.dart';
+import '../providers/genre_provider.dart';
+import '../utils/genre_utils.dart';
+
+/// Источник данных — анимация из TMDB (фильмы и сериалы с жанром Animation).
+class TmdbAnimeSource extends SearchSource {
+  @override
+  String get id => 'anime';
+
+  @override
+  String label(S l) => l.mediaTypeAnimation;
+
+  @override
+  IconData get icon => Icons.animation_outlined;
+
+  @override
+  bool get supportsBrowse => true;
+
+  @override
+  List<SearchFilter> get filters => <SearchFilter>[
+        TmdbGenreFilter(type: 'tv'),
+        YearFilter(),
+        AnimeTypeFilter(),
+      ];
+
+  @override
+  List<BrowseSortOption> get sortOptions => const <BrowseSortOption>[
+        BrowseSortOption(id: 'popular', apiValue: 'popularity.desc'),
+        BrowseSortOption(id: 'top_rated', apiValue: 'vote_average.desc'),
+        BrowseSortOption(id: 'newest', apiValue: 'first_air_date.desc'),
+      ];
+
+  @override
+  String searchHint(S l) => l.searchHintAnime;
+
+  @override
+  Future<BrowseResult> browse(
+    Ref ref, {
+    required Map<String, Object?> filterValues,
+    required String sortBy,
+    required int page,
+  }) async {
+    final TmdbApi tmdb = ref.read(tmdbApiProvider);
+    final String? animeType = filterValues['animeType'] as String?;
+
+    final Object? yearValue = filterValues['year'];
+    int? year;
+    String? dateGte;
+    String? dateLte;
+
+    if (yearValue is int) {
+      year = yearValue;
+    } else if (yearValue is (int, int)) {
+      dateGte = '${yearValue.$1}-01-01';
+      dateLte = '${yearValue.$2}-12-31';
+    }
+
+    // Жанр из фильтра + обязательный Animation (16)
+    final int? extraGenreId = filterValues['genre'] as int?;
+    final int? voteCountGte =
+        sortBy == 'vote_average.desc' ? 100 : null;
+
+    if (animeType == 'movies') {
+      return _browseMovies(
+        tmdb,
+        ref,
+        extraGenreId: extraGenreId,
+        year: year,
+        releaseDateGte: dateGte,
+        releaseDateLte: dateLte,
+        voteCountGte: voteCountGte,
+        sortBy: sortBy,
+        page: page,
+      );
+    }
+
+    if (animeType == 'series') {
+      return _browseTvShows(
+        tmdb,
+        ref,
+        extraGenreId: extraGenreId,
+        year: year,
+        firstAirDateGte: dateGte,
+        firstAirDateLte: dateLte,
+        voteCountGte: voteCountGte,
+        sortBy: sortBy,
+        page: page,
+      );
+    }
+
+    // animeType == null → показываем и сериалы, и фильмы
+    final List<BrowseResult> results =
+        await Future.wait(<Future<BrowseResult>>[
+      _browseTvShows(
+        tmdb,
+        ref,
+        extraGenreId: extraGenreId,
+        year: year,
+        firstAirDateGte: dateGte,
+        firstAirDateLte: dateLte,
+        voteCountGte: voteCountGte,
+        sortBy: sortBy,
+        page: page,
+      ),
+      _browseMovies(
+        tmdb,
+        ref,
+        extraGenreId: extraGenreId,
+        year: year,
+        releaseDateGte: dateGte,
+        releaseDateLte: dateLte,
+        voteCountGte: voteCountGte,
+        sortBy: sortBy,
+        page: page,
+      ),
+    ]);
+
+    final List<Object> combined = <Object>[
+      ...results[0].items,
+      ...results[1].items,
+    ];
+
+    return BrowseResult(
+      items: combined,
+      mediaType: MediaType.animation,
+      hasMore: results[0].hasMore || results[1].hasMore,
+      currentPage: page,
+    );
+  }
+
+  Future<BrowseResult> _browseMovies(
+    TmdbApi tmdb,
+    Ref ref, {
+    int? extraGenreId,
+    int? year,
+    String? releaseDateGte,
+    String? releaseDateLte,
+    int? voteCountGte,
+    required String sortBy,
+    required int page,
+  }) async {
+    final Map<String, String> genreMap =
+        await ref.read(movieGenreMapProvider.future);
+
+    // Жанр Animation + дополнительный жанр
+    final String genreString = extraGenreId != null
+        ? '$tmdbAnimationGenreId,$extraGenreId'
+        : '$tmdbAnimationGenreId';
+
+    final List<Movie> movies = await tmdb.discoverMovies(
+      genreIds: genreString,
+      year: year,
+      releaseDateGte: releaseDateGte,
+      releaseDateLte: releaseDateLte,
+      voteCountGte: voteCountGte,
+      sortBy: sortBy,
+      page: page,
+    );
+
+    final List<Movie> resolved = resolveMovieGenres(movies, genreMap);
+
+    return BrowseResult(
+      items: resolved,
+      mediaType: MediaType.animation,
+      hasMore: movies.length >= 20,
+      currentPage: page,
+    );
+  }
+
+  Future<BrowseResult> _browseTvShows(
+    TmdbApi tmdb,
+    Ref ref, {
+    int? extraGenreId,
+    int? year,
+    String? firstAirDateGte,
+    String? firstAirDateLte,
+    int? voteCountGte,
+    required String sortBy,
+    required int page,
+  }) async {
+    final Map<String, String> genreMap =
+        await ref.read(tvGenreMapProvider.future);
+
+    final String genreString = extraGenreId != null
+        ? '$tmdbAnimationGenreId,$extraGenreId'
+        : '$tmdbAnimationGenreId';
+
+    final List<TvShow> shows = await tmdb.discoverTvShows(
+      genreIds: genreString,
+      year: year,
+      firstAirDateGte: firstAirDateGte,
+      firstAirDateLte: firstAirDateLte,
+      voteCountGte: voteCountGte,
+      sortBy: sortBy,
+      page: page,
+    );
+
+    final List<TvShow> resolved = resolveTvGenres(shows, genreMap);
+
+    return BrowseResult(
+      items: resolved,
+      mediaType: MediaType.animation,
+      hasMore: shows.length >= 20,
+      currentPage: page,
+    );
+  }
+
+  @override
+  Future<BrowseResult> search(
+    Ref ref, {
+    required String query,
+    required int page,
+  }) async {
+    final TmdbApi tmdb = ref.read(tmdbApiProvider);
+    final Map<String, String> tvGenreMap =
+        await ref.read(tvGenreMapProvider.future);
+    final Map<String, String> movieGenreMap =
+        await ref.read(movieGenreMapProvider.future);
+
+    // Ищем сериалы и фильмы параллельно
+    final List<Object> results = await Future.wait(<Future<Object>>[
+      tmdb.searchTvShowsPaged(query, page: page),
+      tmdb.searchMoviesPaged(query, page: page),
+    ]);
+
+    final TmdbPagedResult<TvShow> tvResult =
+        results[0] as TmdbPagedResult<TvShow>;
+    final TmdbPagedResult<Movie> movieResult =
+        results[1] as TmdbPagedResult<Movie>;
+
+    // Фильтруем только анимацию
+    final List<TvShow> animeTv = tvResult.results
+        .where(
+          (TvShow s) =>
+              s.genres != null && s.genres!.any(isAnimationGenre),
+        )
+        .toList();
+
+    final List<Movie> animeMovies = movieResult.results
+        .where(
+          (Movie m) =>
+              m.genres != null && m.genres!.any(isAnimationGenre),
+        )
+        .toList();
+
+    final List<TvShow> resolvedTv =
+        resolveTvGenres(animeTv, tvGenreMap);
+    final List<Movie> resolvedMovies =
+        resolveMovieGenres(animeMovies, movieGenreMap);
+
+    // Объединяем: сериалы + фильмы
+    final List<Object> combined = <Object>[
+      ...resolvedTv,
+      ...resolvedMovies,
+    ];
+
+    return BrowseResult(
+      items: combined,
+      mediaType: MediaType.animation,
+      hasMore: tvResult.hasMore || movieResult.hasMore,
+      currentPage: page,
+    );
+  }
+
+  @override
+  Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) => null;
+}

--- a/lib/features/search/sources/tmdb_movies_source.dart
+++ b/lib/features/search/sources/tmdb_movies_source.dart
@@ -1,0 +1,126 @@
+// Источник данных: фильмы из TMDB.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/tmdb_api.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/movie.dart';
+import '../filters/tmdb_genre_filter.dart';
+import '../filters/year_filter.dart';
+import '../models/search_source.dart';
+import '../providers/genre_provider.dart';
+import '../utils/genre_utils.dart';
+
+/// Источник данных — фильмы из TMDB.
+class TmdbMoviesSource extends SearchSource {
+  @override
+  String get id => 'movies';
+
+  @override
+  String label(S l) => l.mediaTypeMovie;
+
+  @override
+  IconData get icon => Icons.movie_outlined;
+
+  @override
+  bool get supportsBrowse => true;
+
+  @override
+  List<SearchFilter> get filters => <SearchFilter>[
+        TmdbGenreFilter(type: 'movie'),
+        YearFilter(),
+      ];
+
+  @override
+  List<BrowseSortOption> get sortOptions => const <BrowseSortOption>[
+        BrowseSortOption(id: 'popular', apiValue: 'popularity.desc'),
+        BrowseSortOption(id: 'top_rated', apiValue: 'vote_average.desc'),
+        BrowseSortOption(
+          id: 'newest',
+          apiValue: 'primary_release_date.desc',
+        ),
+      ];
+
+  @override
+  String searchHint(S l) => l.searchHintMovies;
+
+  @override
+  Future<BrowseResult> browse(
+    Ref ref, {
+    required Map<String, Object?> filterValues,
+    required String sortBy,
+    required int page,
+  }) async {
+    final TmdbApi tmdb = ref.read(tmdbApiProvider);
+    final Map<String, String> genreMap =
+        await ref.read(movieGenreMapProvider.future);
+
+    final Object? yearValue = filterValues['year'];
+    int? year;
+    String? releaseDateGte;
+    String? releaseDateLte;
+
+    if (yearValue is int) {
+      year = yearValue;
+    } else if (yearValue is (int, int)) {
+      releaseDateGte = '${yearValue.$1}-01-01';
+      releaseDateLte = '${yearValue.$2}-12-31';
+    }
+
+    final int? genreId = filterValues['genre'] as int?;
+
+    // Для top_rated добавляем минимум голосов
+    final int? voteCountGte =
+        sortBy == 'vote_average.desc' ? 200 : null;
+
+    final List<Movie> movies = await tmdb.discoverMovies(
+      genreId: genreId,
+      year: year,
+      releaseDateGte: releaseDateGte,
+      releaseDateLte: releaseDateLte,
+      voteCountGte: voteCountGte,
+      sortBy: sortBy,
+      page: page,
+    );
+
+    // Резолвим жанры
+    final List<Movie> resolved = resolveMovieGenres(movies, genreMap);
+
+    return BrowseResult(
+      items: resolved,
+      mediaType: MediaType.movie,
+      hasMore: movies.length >= 20,
+      currentPage: page,
+    );
+  }
+
+  @override
+  Future<BrowseResult> search(
+    Ref ref, {
+    required String query,
+    required int page,
+  }) async {
+    final TmdbApi tmdb = ref.read(tmdbApiProvider);
+    final Map<String, String> genreMap =
+        await ref.read(movieGenreMapProvider.future);
+    final TmdbPagedResult<Movie> result =
+        await tmdb.searchMoviesPaged(query, page: page);
+    final List<Movie> resolved = resolveMovieGenres(result.results, genreMap);
+
+    return BrowseResult(
+      items: resolved,
+      mediaType: MediaType.movie,
+      hasMore: result.hasMore,
+      currentPage: result.page,
+      totalPages: result.totalPages,
+    );
+  }
+
+  @override
+  Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) {
+    // Discover feed переиспользуется через существующий виджет
+    return null;
+  }
+}

--- a/lib/features/search/sources/tmdb_tv_source.dart
+++ b/lib/features/search/sources/tmdb_tv_source.dart
@@ -1,0 +1,128 @@
+// Источник данных: сериалы из TMDB.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/tmdb_api.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/tv_show.dart';
+import '../filters/tmdb_genre_filter.dart';
+import '../filters/year_filter.dart';
+import '../models/search_source.dart';
+import '../providers/genre_provider.dart';
+import '../utils/genre_utils.dart';
+
+/// Источник данных — сериалы из TMDB (без анимации).
+class TmdbTvSource extends SearchSource {
+  @override
+  String get id => 'tv';
+
+  @override
+  String label(S l) => l.mediaTypeTvShow;
+
+  @override
+  IconData get icon => Icons.tv_outlined;
+
+  @override
+  bool get supportsBrowse => true;
+
+  @override
+  List<SearchFilter> get filters => <SearchFilter>[
+        TmdbGenreFilter(type: 'tv'),
+        YearFilter(),
+      ];
+
+  @override
+  List<BrowseSortOption> get sortOptions => const <BrowseSortOption>[
+        BrowseSortOption(id: 'popular', apiValue: 'popularity.desc'),
+        BrowseSortOption(id: 'top_rated', apiValue: 'vote_average.desc'),
+        BrowseSortOption(id: 'newest', apiValue: 'first_air_date.desc'),
+      ];
+
+  @override
+  String searchHint(S l) => l.searchHintTv;
+
+  @override
+  Future<BrowseResult> browse(
+    Ref ref, {
+    required Map<String, Object?> filterValues,
+    required String sortBy,
+    required int page,
+  }) async {
+    final TmdbApi tmdb = ref.read(tmdbApiProvider);
+    final Map<String, String> genreMap =
+        await ref.read(tvGenreMapProvider.future);
+
+    final Object? yearValue = filterValues['year'];
+    int? year;
+    String? firstAirDateGte;
+    String? firstAirDateLte;
+
+    if (yearValue is int) {
+      year = yearValue;
+    } else if (yearValue is (int, int)) {
+      firstAirDateGte = '${yearValue.$1}-01-01';
+      firstAirDateLte = '${yearValue.$2}-12-31';
+    }
+
+    final int? genreId = filterValues['genre'] as int?;
+    final int? voteCountGte =
+        sortBy == 'vote_average.desc' ? 200 : null;
+
+    // Исключаем анимацию — добавляем without_genres=16
+    final List<TvShow> tvShows = await tmdb.discoverTvShows(
+      genreId: genreId,
+      year: year,
+      firstAirDateGte: firstAirDateGte,
+      firstAirDateLte: firstAirDateLte,
+      voteCountGte: voteCountGte,
+      withoutGenreIds: <int>[tmdbAnimationGenreId],
+      sortBy: sortBy,
+      page: page,
+    );
+
+    final List<TvShow> resolved = resolveTvGenres(tvShows, genreMap);
+
+    return BrowseResult(
+      items: resolved,
+      mediaType: MediaType.tvShow,
+      hasMore: tvShows.length >= 20,
+      currentPage: page,
+    );
+  }
+
+  @override
+  Future<BrowseResult> search(
+    Ref ref, {
+    required String query,
+    required int page,
+  }) async {
+    final TmdbApi tmdb = ref.read(tmdbApiProvider);
+    final Map<String, String> genreMap =
+        await ref.read(tvGenreMapProvider.future);
+    final TmdbPagedResult<TvShow> result =
+        await tmdb.searchTvShowsPaged(query, page: page);
+
+    // Фильтруем анимацию из результатов поиска
+    final List<TvShow> filtered = result.results
+        .where(
+          (TvShow s) =>
+              s.genres == null || !s.genres!.any(isAnimationGenre),
+        )
+        .toList();
+
+    final List<TvShow> resolved = resolveTvGenres(filtered, genreMap);
+
+    return BrowseResult(
+      items: resolved,
+      mediaType: MediaType.tvShow,
+      hasMore: result.hasMore,
+      currentPage: result.page,
+      totalPages: result.totalPages,
+    );
+  }
+
+  @override
+  Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) => null;
+}

--- a/lib/features/search/utils/genre_utils.dart
+++ b/lib/features/search/utils/genre_utils.dart
@@ -1,0 +1,37 @@
+// Утилиты для работы с жанрами в поисковых источниках.
+
+import '../../../shared/models/movie.dart';
+import '../../../shared/models/tv_show.dart';
+import '../models/search_source.dart' show tmdbAnimationGenreId;
+
+/// Проверяет, является ли строка жанра анимацией (TMDB genre ID 16).
+bool isAnimationGenre(String genre) =>
+    genre == '$tmdbAnimationGenreId' || genre == 'Animation';
+
+/// Резолвит ID жанров в названия для списка фильмов.
+List<Movie> resolveMovieGenres(
+  List<Movie> movies,
+  Map<String, String> genreMap,
+) {
+  if (genreMap.isEmpty) return movies;
+  return movies.map((Movie m) {
+    if (m.genres == null || m.genres!.isEmpty) return m;
+    final List<String> resolved =
+        m.genres!.map((String id) => genreMap[id] ?? id).toList();
+    return m.copyWith(genres: resolved);
+  }).toList();
+}
+
+/// Резолвит ID жанров в названия для списка сериалов.
+List<TvShow> resolveTvGenres(
+  List<TvShow> shows,
+  Map<String, String> genreMap,
+) {
+  if (genreMap.isEmpty) return shows;
+  return shows.map((TvShow s) {
+    if (s.genres == null || s.genres!.isEmpty) return s;
+    final List<String> resolved =
+        s.genres!.map((String id) => genreMap[id] ?? id).toList();
+    return s.copyWith(genres: resolved);
+  }).toList();
+}

--- a/lib/features/search/widgets/browse_grid.dart
+++ b/lib/features/search/widgets/browse_grid.dart
@@ -1,0 +1,329 @@
+// Вертикальный грид результатов Browse/Search.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/services/image_cache_service.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/game.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/movie.dart';
+import '../../../shared/models/tv_show.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/media_poster_card.dart';
+import '../utils/genre_utils.dart' show isAnimationGenre;
+import '../../../shared/widgets/shimmer_loading.dart' show ShimmerPosterCard;
+import '../../../shared/models/collected_item_info.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../providers/browse_provider.dart';
+
+/// Множества ID элементов, которые уже есть в коллекциях.
+final FutureProvider<({Set<int> tmdbIds, Set<int> gameIds})>
+    _collectedIdsProvider =
+    FutureProvider<({Set<int> tmdbIds, Set<int> gameIds})>((Ref ref) async {
+  final Map<int, List<CollectedItemInfo>> movies =
+      await ref.watch(collectedMovieIdsProvider.future);
+  final Map<int, List<CollectedItemInfo>> tvShows =
+      await ref.watch(collectedTvShowIdsProvider.future);
+  final Map<int, List<CollectedItemInfo>> animations =
+      await ref.watch(collectedAnimationIdsProvider.future);
+  final Map<int, List<CollectedItemInfo>> games =
+      await ref.watch(collectedGameIdsProvider.future);
+  return (
+    tmdbIds: <int>{...movies.keys, ...tvShows.keys, ...animations.keys},
+    gameIds: games.keys.toSet(),
+  );
+});
+
+/// Грид результатов Browse/Search mode.
+///
+/// Отображает постерные карточки в виде сетки.
+/// Поддерживает бесконечный скролл (пагинацию).
+class BrowseGrid extends ConsumerStatefulWidget {
+  /// Создаёт [BrowseGrid].
+  const BrowseGrid({
+    required this.onItemTap,
+    super.key,
+  });
+
+  /// Callback при тапе на элемент.
+  final void Function(Object item, MediaType mediaType) onItemTap;
+
+  @override
+  ConsumerState<BrowseGrid> createState() => _BrowseGridState();
+}
+
+class _BrowseGridState extends ConsumerState<BrowseGrid> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 300) {
+      ref.read(browseProvider.notifier).loadMore();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final BrowseState state = ref.watch(browseProvider);
+    final S l = S.of(context);
+
+    // Loading state
+    if (state.isLoading && state.items.isEmpty) {
+      return _buildShimmerGrid(context);
+    }
+
+    // Error state
+    if (state.error != null && state.items.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const Icon(
+                Icons.error_outline,
+                size: 48,
+                color: AppColors.textTertiary,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                state.error!,
+                style: AppTypography.body.copyWith(
+                  color: AppColors.textSecondary,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Empty state
+    if (state.isEmpty && state.hasFilters) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const Icon(
+                Icons.search_off,
+                size: 48,
+                color: AppColors.textTertiary,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                l.browseEmptyResults,
+                style: AppTypography.body.copyWith(
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Empty — no filters, no Discover
+    if (state.isEmpty && !state.hasFilters && !state.isSearchMode) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const Icon(
+                Icons.filter_alt_outlined,
+                size: 48,
+                color: AppColors.textTertiary,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                l.browseEmptyFilters,
+                style: AppTypography.body.copyWith(
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Collected IDs для маркировки "уже в коллекции"
+    final AsyncValue<({Set<int> tmdbIds, Set<int> gameIds})> collectedIds =
+        ref.watch(_collectedIdsProvider);
+    final Set<int> tmdbIds =
+        collectedIds.valueOrNull?.tmdbIds ?? const <int>{};
+    final Set<int> gameIds =
+        collectedIds.valueOrNull?.gameIds ?? const <int>{};
+
+    // Results grid
+    final SliverGridDelegate gridDelegate = _buildGridDelegate(context);
+
+    return GridView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      gridDelegate: gridDelegate,
+      itemCount: state.items.length + (state.isLoadingMore ? 3 : 0),
+      itemBuilder: (BuildContext context, int index) {
+        // Loading more indicators
+        if (index >= state.items.length) {
+          return const ShimmerPosterCard();
+        }
+
+        final Object item = state.items[index];
+        return _buildCard(item, state.source.id, tmdbIds, gameIds);
+      },
+    );
+  }
+
+  Widget _buildCard(
+    Object item,
+    String sourceId,
+    Set<int> tmdbIds,
+    Set<int> gameIds,
+  ) {
+    if (item is Movie) {
+      return MediaPosterCard(
+        variant: CardVariant.grid,
+        title: item.title,
+        imageUrl: item.posterUrl ?? '',
+        cacheImageType: ImageType.moviePoster,
+        cacheImageId: item.tmdbId.toString(),
+        apiRating: item.rating,
+        year: item.releaseYear,
+        subtitle: item.genresString,
+        mediaType: MediaType.movie,
+        isInCollection: tmdbIds.contains(item.tmdbId),
+        onTap: () => widget.onItemTap(item, MediaType.movie),
+      );
+    }
+
+    if (item is TvShow) {
+      final MediaType type = _isAnimation(item)
+          ? MediaType.animation
+          : MediaType.tvShow;
+      return MediaPosterCard(
+        variant: CardVariant.grid,
+        title: item.title,
+        imageUrl: item.posterUrl ?? '',
+        cacheImageType: ImageType.tvShowPoster,
+        cacheImageId: item.tmdbId.toString(),
+        apiRating: item.rating,
+        year: item.firstAirYear,
+        subtitle: item.genresString,
+        mediaType: type,
+        isInCollection: tmdbIds.contains(item.tmdbId),
+        onTap: () => widget.onItemTap(item, type),
+      );
+    }
+
+    if (item is Game) {
+      return MediaPosterCard(
+        variant: CardVariant.grid,
+        title: item.name,
+        imageUrl: item.coverUrl ?? '',
+        cacheImageType: ImageType.gameCover,
+        cacheImageId: item.id.toString(),
+        apiRating: item.rating != null ? item.rating! / 10.0 : null,
+        year: item.releaseYear,
+        subtitle: item.genresString,
+        mediaType: MediaType.game,
+        isInCollection: gameIds.contains(item.id),
+        onTap: () => widget.onItemTap(item, MediaType.game),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  bool _isAnimation(TvShow show) {
+    if (show.genres == null) return false;
+    return show.genres!.any(isAnimationGenre);
+  }
+
+  /// Максимальная ширина карточки на десктопе (как в collection_screen).
+  static const double _desktopMaxCardWidth = 150;
+
+  /// Aspect ratio карточки (как в collection_screen).
+  static const double _cardAspectRatio = 0.55;
+
+  SliverGridDelegate _buildGridDelegate(BuildContext context) {
+    final double width = MediaQuery.sizeOf(context).width;
+    if (width >= 800) {
+      return const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: _desktopMaxCardWidth,
+        childAspectRatio: _cardAspectRatio,
+        crossAxisSpacing: AppSpacing.sm,
+        mainAxisSpacing: AppSpacing.sm,
+      );
+    }
+    final int crossAxisCount = width >= 500
+        ? AppSpacing.gridColumnsTablet
+        : AppSpacing.gridColumnsMobile;
+    return SliverGridDelegateWithFixedCrossAxisCount(
+      crossAxisCount: crossAxisCount,
+      childAspectRatio: _cardAspectRatio,
+      crossAxisSpacing: AppSpacing.sm,
+      mainAxisSpacing: AppSpacing.sm,
+    );
+  }
+
+  Widget _buildShimmerGrid(BuildContext context) {
+    final SliverGridDelegate gridDelegate = _buildGridDelegate(context);
+    final double width = MediaQuery.sizeOf(context).width;
+    final int shimmerCount = width >= 800
+        ? 18
+        : (width >= 500
+            ? AppSpacing.gridColumnsTablet * 3
+            : AppSpacing.gridColumnsMobile * 3);
+
+    return GridView.builder(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      gridDelegate: gridDelegate,
+      itemCount: shimmerCount,
+      itemBuilder: (BuildContext context, int index) {
+        return const ShimmerPosterCard();
+      },
+    );
+  }
+}
+
+/// Placeholder для шиммера.
+class AspectRatioPlaceholder extends StatelessWidget {
+  /// Создаёт [AspectRatioPlaceholder].
+  const AspectRatioPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+    );
+  }
+}

--- a/lib/features/search/widgets/filter_bar.dart
+++ b/lib/features/search/widgets/filter_bar.dart
@@ -1,0 +1,69 @@
+// Горизонтальная строка фильтров.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../shared/theme/app_spacing.dart';
+import '../models/search_source.dart';
+import '../providers/browse_provider.dart';
+import 'filter_dropdown.dart';
+import 'source_dropdown.dart';
+
+/// Горизонтальная строка фильтров для Browse mode.
+///
+/// Содержит: Source dropdown + Filter dropdowns + Sort dropdown.
+/// Горизонтальный скролл если фильтров много.
+class FilterBar extends ConsumerWidget {
+  /// Создаёт [FilterBar].
+  const FilterBar({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final BrowseState browseState = ref.watch(browseProvider);
+    final SearchSource source = browseState.source;
+    final List<SearchFilter> filters = source.filters;
+
+    return SizedBox(
+      height: 36,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+        ),
+        children: <Widget>[
+          // Source dropdown
+          SourceDropdown(
+            current: source,
+            onChanged: (SearchSource newSource) {
+              ref.read(browseProvider.notifier).setSource(newSource.id);
+            },
+          ),
+          const SizedBox(width: 6),
+          // Filter dropdowns
+          for (final SearchFilter filter in filters) ...<Widget>[
+            FilterDropdown(
+              key: ValueKey<String>('${source.id}_${filter.cacheKey}'),
+              filter: filter,
+              value: browseState.filterValues[filter.key],
+              onChanged: (Object? value) {
+                ref
+                    .read(browseProvider.notifier)
+                    .setFilter(filter.key, value);
+              },
+            ),
+            const SizedBox(width: 6),
+          ],
+          // Sort dropdown
+          if (source.sortOptions.isNotEmpty)
+            SortDropdown(
+              options: source.sortOptions,
+              current: browseState.effectiveSortBy,
+              onChanged: (String sortBy) {
+                ref.read(browseProvider.notifier).setSort(sortBy);
+              },
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/search/widgets/filter_dropdown.dart
+++ b/lib/features/search/widgets/filter_dropdown.dart
@@ -1,0 +1,305 @@
+// Универсальный дропдаун фильтра.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../models/search_source.dart';
+
+/// Sentinel-объект для сброса фильтра.
+///
+/// PopupMenuButton трактует null как закрытие меню (не вызывает onSelected),
+/// поэтому для "All" опции используется уникальный sentinel.
+const String _resetSentinel = '__filter_reset__';
+
+/// Универсальный дропдаун для одного фильтра.
+///
+/// Показывает текущее значение фильтра или placeholder.
+/// При тапе открывает PopupMenu с вариантами.
+class FilterDropdown extends ConsumerStatefulWidget {
+  /// Создаёт [FilterDropdown].
+  const FilterDropdown({
+    required this.filter,
+    required this.value,
+    required this.onChanged,
+    super.key,
+  });
+
+  /// Описание фильтра.
+  final SearchFilter filter;
+
+  /// Текущее выбранное значение (null = не выбрано).
+  final Object? value;
+
+  /// Callback при выборе нового значения.
+  final ValueChanged<Object?> onChanged;
+
+  @override
+  ConsumerState<FilterDropdown> createState() => _FilterDropdownState();
+}
+
+class _FilterDropdownState extends ConsumerState<FilterDropdown> {
+  List<FilterOption>? _options;
+  Map<Object, String>? _labelCache;
+  bool _isLoadingOptions = false;
+  bool _initialLoadDone = false;
+  int _loadGeneration = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_initialLoadDone) {
+      _initialLoadDone = true;
+      _loadOptions();
+    }
+  }
+
+  @override
+  void didUpdateWidget(FilterDropdown oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.filter.cacheKey != widget.filter.cacheKey) {
+      _options = null;
+      _labelCache = null;
+      _loadOptions();
+    }
+  }
+
+  Future<void> _loadOptions() async {
+    if (_isLoadingOptions) return;
+    final int gen = ++_loadGeneration;
+    setState(() => _isLoadingOptions = true);
+
+    try {
+      final S l = S.of(context);
+      final List<FilterOption> options =
+          await widget.filter.options(ref, l);
+      if (_loadGeneration != gen || !mounted) return;
+      setState(() {
+        _options = options;
+        _labelCache = <Object, String>{
+          for (final FilterOption opt in options)
+            if (opt.value != null) opt.value!: opt.label,
+        };
+        _isLoadingOptions = false;
+      });
+    } on Exception {
+      if (_loadGeneration != gen || !mounted) return;
+      setState(() => _isLoadingOptions = false);
+    }
+  }
+
+  String _getSelectedLabel(S l) {
+    if (widget.value == null) {
+      return widget.filter.placeholder(l);
+    }
+
+    if (_labelCache == null) return '...';
+
+    return _labelCache![widget.value] ?? widget.value.toString();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    final bool isActive = widget.value != null;
+    final String label = _getSelectedLabel(l);
+
+    return PopupMenuButton<Object>(
+      onSelected: (Object value) {
+        widget.onChanged(value == _resetSentinel ? null : value);
+      },
+      offset: const Offset(0, 36),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      color: AppColors.surface,
+      constraints: const BoxConstraints(maxHeight: 400),
+      itemBuilder: (BuildContext context) {
+        if (_options == null || _isLoadingOptions) {
+          return <PopupMenuEntry<Object>>[
+            const PopupMenuItem<Object>(
+              enabled: false,
+              child: SizedBox(
+                height: 24,
+                width: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          ];
+        }
+
+        return <PopupMenuEntry<Object>>[
+          // "All" option для сброса (sentinel вместо null)
+          PopupMenuItem<Object>(
+            value: _resetSentinel,
+            height: 36,
+            child: Text(
+              l.browseFilterAll,
+              style: AppTypography.body.copyWith(
+                color: widget.value == null
+                    ? AppColors.brand
+                    : AppColors.textSecondary,
+                fontWeight: widget.value == null
+                    ? FontWeight.w600
+                    : FontWeight.normal,
+              ),
+            ),
+          ),
+          const PopupMenuDivider(height: 1),
+          // Варианты фильтра
+          for (final FilterOption option in _options!)
+            if (option.value != null)
+              PopupMenuItem<Object>(
+                value: option.value,
+                height: 36,
+                child: Text(
+                  option.label,
+                  style: AppTypography.body.copyWith(
+                    color: option.value == widget.value
+                        ? AppColors.brand
+                        : AppColors.textPrimary,
+                    fontWeight: option.value == widget.value
+                        ? FontWeight.w600
+                        : FontWeight.normal,
+                  ),
+                ),
+              ),
+        ];
+      },
+      child: Container(
+        height: 32,
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        decoration: BoxDecoration(
+          color: isActive
+              ? AppColors.brand.withValues(alpha: 0.12)
+              : AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          border: Border.all(
+            color: isActive ? AppColors.brand : AppColors.surfaceBorder,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              label,
+              style: AppTypography.body.copyWith(
+                color: isActive
+                    ? AppColors.brand
+                    : AppColors.textTertiary,
+                fontWeight:
+                    isActive ? FontWeight.w600 : FontWeight.normal,
+              ),
+            ),
+            const SizedBox(width: 4),
+            Icon(
+              Icons.keyboard_arrow_down,
+              size: 16,
+              color: isActive
+                  ? AppColors.brand
+                  : AppColors.textTertiary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Дропдаун сортировки.
+class SortDropdown extends StatelessWidget {
+  /// Создаёт [SortDropdown].
+  const SortDropdown({
+    required this.options,
+    required this.current,
+    required this.onChanged,
+    super.key,
+  });
+
+  /// Доступные варианты сортировки.
+  final List<BrowseSortOption> options;
+
+  /// Текущее значение сортировки (API).
+  final String current;
+
+  /// Callback при выборе нового значения.
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+
+    // Найти текущий label
+    String currentLabel = l.browseSort;
+    for (final BrowseSortOption option in options) {
+      if (option.apiValue == current) {
+        currentLabel = option.label(l);
+        break;
+      }
+    }
+
+    return PopupMenuButton<String>(
+      onSelected: onChanged,
+      offset: const Offset(0, 36),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      color: AppColors.surface,
+      itemBuilder: (BuildContext context) {
+        final S menuL = S.of(context);
+        return options.map((BrowseSortOption option) {
+          final bool isSelected = option.apiValue == current;
+          return PopupMenuItem<String>(
+            value: option.apiValue,
+            height: 36,
+            child: Text(
+              option.label(menuL),
+              style: AppTypography.body.copyWith(
+                color: isSelected
+                    ? AppColors.brand
+                    : AppColors.textPrimary,
+                fontWeight:
+                    isSelected ? FontWeight.w600 : FontWeight.normal,
+              ),
+            ),
+          );
+        }).toList();
+      },
+      child: Container(
+        height: 32,
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          border: Border.all(color: AppColors.surfaceBorder),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(
+              Icons.sort,
+              size: 14,
+              color: AppColors.textTertiary,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              currentLabel,
+              style: AppTypography.body.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+            const SizedBox(width: 4),
+            const Icon(
+              Icons.keyboard_arrow_down,
+              size: 16,
+              color: AppColors.textTertiary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/search/widgets/source_dropdown.dart
+++ b/lib/features/search/widgets/source_dropdown.dart
@@ -1,0 +1,106 @@
+// Дропдаун выбора источника данных (Movies, TV, Anime, Games).
+
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../models/search_source.dart';
+import '../sources/search_sources.dart';
+
+/// Дропдаун для выбора источника поиска.
+class SourceDropdown extends StatelessWidget {
+  /// Создаёт [SourceDropdown].
+  const SourceDropdown({
+    required this.current,
+    required this.onChanged,
+    super.key,
+  });
+
+  /// Текущий источник.
+  final SearchSource current;
+
+  /// Callback при выборе нового источника.
+  final ValueChanged<SearchSource> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+
+    return PopupMenuButton<String>(
+      onSelected: (String id) {
+        final SearchSource source = getSearchSourceById(id);
+        if (source.id != current.id) {
+          onChanged(source);
+        }
+      },
+      offset: const Offset(0, 36),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      color: AppColors.surface,
+      itemBuilder: (BuildContext context) {
+        return searchSources.map((SearchSource source) {
+          final bool isSelected = source.id == current.id;
+          return PopupMenuItem<String>(
+            value: source.id,
+            height: 40,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(
+                  source.icon,
+                  size: 18,
+                  color: isSelected
+                      ? AppColors.brand
+                      : AppColors.textSecondary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Text(
+                  source.label(l),
+                  style: AppTypography.body.copyWith(
+                    color: isSelected
+                        ? AppColors.brand
+                        : AppColors.textPrimary,
+                    fontWeight:
+                        isSelected ? FontWeight.w600 : FontWeight.normal,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList();
+      },
+      child: Container(
+        height: 32,
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          border: Border.all(color: AppColors.surfaceBorder),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(current.icon, size: 16, color: AppColors.brand),
+            const SizedBox(width: 6),
+            Text(
+              current.label(l),
+              style: AppTypography.body.copyWith(
+                color: AppColors.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 4),
+            const Icon(
+              Icons.keyboard_arrow_down,
+              size: 16,
+              color: AppColors.textTertiary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -539,7 +539,9 @@
 
   "searchTabTv": "TV",
   "searchTabGames": "Games",
+  "searchHintMovies": "Search movies...",
   "searchHintTv": "Search TV...",
+  "searchHintAnime": "Search anime...",
   "searchHintGames": "Search games...",
   "searchSelectPlatform": "Select Platform",
   "searchAddToCollection": "Add to Collection",
@@ -886,5 +888,22 @@
   "settingsShowRecommendationsSubtitle": "Show recommendations and reviews on item details",
 
   "uncategorizedBanner": "Add to a collection to unlock Board and episode tracking",
-  "uncategorizedBannerAction": "Add to Collection"
+  "uncategorizedBannerAction": "Add to Collection",
+
+  "browseFilterGenre": "Genre",
+  "browseFilterYear": "Year",
+  "browseFilterPlatform": "Platform",
+  "browseFilterType": "Type",
+  "browseFilterAll": "All",
+  "browseFilterAny": "Any",
+  "browseSort": "Sort",
+  "browseSortPopular": "Popular",
+  "browseSortTopRated": "Top Rated",
+  "browseSortNewest": "Newest",
+  "browseAnimeTypeSeries": "Series",
+  "browseAnimeTypeMovies": "Movies",
+  "browseEmptyFilters": "Choose a filter or search",
+  "browseEmptyResults": "No results found",
+  "browseSearchHint": "Search...",
+  "browseBackToBrowse": "Back to browse"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2125,11 +2125,23 @@ abstract class S {
   /// **'Games'**
   String get searchTabGames;
 
+  /// No description provided for @searchHintMovies.
+  ///
+  /// In en, this message translates to:
+  /// **'Search movies...'**
+  String get searchHintMovies;
+
   /// No description provided for @searchHintTv.
   ///
   /// In en, this message translates to:
   /// **'Search TV...'**
   String get searchHintTv;
+
+  /// No description provided for @searchHintAnime.
+  ///
+  /// In en, this message translates to:
+  /// **'Search anime...'**
+  String get searchHintAnime;
 
   /// No description provided for @searchHintGames.
   ///
@@ -3444,6 +3456,102 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Add to Collection'**
   String get uncategorizedBannerAction;
+
+  /// No description provided for @browseFilterGenre.
+  ///
+  /// In en, this message translates to:
+  /// **'Genre'**
+  String get browseFilterGenre;
+
+  /// No description provided for @browseFilterYear.
+  ///
+  /// In en, this message translates to:
+  /// **'Year'**
+  String get browseFilterYear;
+
+  /// No description provided for @browseFilterPlatform.
+  ///
+  /// In en, this message translates to:
+  /// **'Platform'**
+  String get browseFilterPlatform;
+
+  /// No description provided for @browseFilterType.
+  ///
+  /// In en, this message translates to:
+  /// **'Type'**
+  String get browseFilterType;
+
+  /// No description provided for @browseFilterAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get browseFilterAll;
+
+  /// No description provided for @browseFilterAny.
+  ///
+  /// In en, this message translates to:
+  /// **'Any'**
+  String get browseFilterAny;
+
+  /// No description provided for @browseSort.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort'**
+  String get browseSort;
+
+  /// No description provided for @browseSortPopular.
+  ///
+  /// In en, this message translates to:
+  /// **'Popular'**
+  String get browseSortPopular;
+
+  /// No description provided for @browseSortTopRated.
+  ///
+  /// In en, this message translates to:
+  /// **'Top Rated'**
+  String get browseSortTopRated;
+
+  /// No description provided for @browseSortNewest.
+  ///
+  /// In en, this message translates to:
+  /// **'Newest'**
+  String get browseSortNewest;
+
+  /// No description provided for @browseAnimeTypeSeries.
+  ///
+  /// In en, this message translates to:
+  /// **'Series'**
+  String get browseAnimeTypeSeries;
+
+  /// No description provided for @browseAnimeTypeMovies.
+  ///
+  /// In en, this message translates to:
+  /// **'Movies'**
+  String get browseAnimeTypeMovies;
+
+  /// No description provided for @browseEmptyFilters.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a filter or search'**
+  String get browseEmptyFilters;
+
+  /// No description provided for @browseEmptyResults.
+  ///
+  /// In en, this message translates to:
+  /// **'No results found'**
+  String get browseEmptyResults;
+
+  /// No description provided for @browseSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search...'**
+  String get browseSearchHint;
+
+  /// No description provided for @browseBackToBrowse.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to browse'**
+  String get browseBackToBrowse;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1140,7 +1140,13 @@ class SEn extends S {
   String get searchTabGames => 'Games';
 
   @override
+  String get searchHintMovies => 'Search movies...';
+
+  @override
   String get searchHintTv => 'Search TV...';
+
+  @override
+  String get searchHintAnime => 'Search anime...';
 
   @override
   String get searchHintGames => 'Search games...';
@@ -1872,4 +1878,52 @@ class SEn extends S {
 
   @override
   String get uncategorizedBannerAction => 'Add to Collection';
+
+  @override
+  String get browseFilterGenre => 'Genre';
+
+  @override
+  String get browseFilterYear => 'Year';
+
+  @override
+  String get browseFilterPlatform => 'Platform';
+
+  @override
+  String get browseFilterType => 'Type';
+
+  @override
+  String get browseFilterAll => 'All';
+
+  @override
+  String get browseFilterAny => 'Any';
+
+  @override
+  String get browseSort => 'Sort';
+
+  @override
+  String get browseSortPopular => 'Popular';
+
+  @override
+  String get browseSortTopRated => 'Top Rated';
+
+  @override
+  String get browseSortNewest => 'Newest';
+
+  @override
+  String get browseAnimeTypeSeries => 'Series';
+
+  @override
+  String get browseAnimeTypeMovies => 'Movies';
+
+  @override
+  String get browseEmptyFilters => 'Choose a filter or search';
+
+  @override
+  String get browseEmptyResults => 'No results found';
+
+  @override
+  String get browseSearchHint => 'Search...';
+
+  @override
+  String get browseBackToBrowse => 'Back to browse';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1151,7 +1151,13 @@ class SRu extends S {
   String get searchTabGames => 'Игры';
 
   @override
+  String get searchHintMovies => 'Поиск фильмов...';
+
+  @override
   String get searchHintTv => 'Поиск ТВ...';
+
+  @override
+  String get searchHintAnime => 'Поиск аниме...';
 
   @override
   String get searchHintGames => 'Поиск игр...';
@@ -1891,4 +1897,52 @@ class SRu extends S {
 
   @override
   String get uncategorizedBannerAction => 'Добавить в коллекцию';
+
+  @override
+  String get browseFilterGenre => 'Жанр';
+
+  @override
+  String get browseFilterYear => 'Год';
+
+  @override
+  String get browseFilterPlatform => 'Платформа';
+
+  @override
+  String get browseFilterType => 'Тип';
+
+  @override
+  String get browseFilterAll => 'Все';
+
+  @override
+  String get browseFilterAny => 'Любой';
+
+  @override
+  String get browseSort => 'Сортировка';
+
+  @override
+  String get browseSortPopular => 'Популярные';
+
+  @override
+  String get browseSortTopRated => 'Лучшие';
+
+  @override
+  String get browseSortNewest => 'Новинки';
+
+  @override
+  String get browseAnimeTypeSeries => 'Сериалы';
+
+  @override
+  String get browseAnimeTypeMovies => 'Фильмы';
+
+  @override
+  String get browseEmptyFilters => 'Выберите фильтр или выполните поиск';
+
+  @override
+  String get browseEmptyResults => 'Ничего не найдено';
+
+  @override
+  String get browseSearchHint => 'Поиск...';
+
+  @override
+  String get browseBackToBrowse => 'Назад к обзору';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -407,7 +407,9 @@
 
   "searchTabTv": "ТВ",
   "searchTabGames": "Игры",
+  "searchHintMovies": "Поиск фильмов...",
   "searchHintTv": "Поиск ТВ...",
+  "searchHintAnime": "Поиск аниме...",
   "searchHintGames": "Поиск игр...",
   "searchSelectPlatform": "Выбрать платформу",
   "searchAddToCollection": "Добавить в коллекцию",
@@ -672,5 +674,22 @@
   "settingsShowRecommendationsSubtitle": "Показывать рекомендации и отзывы на странице элемента",
 
   "uncategorizedBanner": "Добавьте в коллекцию, чтобы открыть Доску и отслеживание серий",
-  "uncategorizedBannerAction": "Добавить в коллекцию"
+  "uncategorizedBannerAction": "Добавить в коллекцию",
+
+  "browseFilterGenre": "Жанр",
+  "browseFilterYear": "Год",
+  "browseFilterPlatform": "Платформа",
+  "browseFilterType": "Тип",
+  "browseFilterAll": "Все",
+  "browseFilterAny": "Любой",
+  "browseSort": "Сортировка",
+  "browseSortPopular": "Популярные",
+  "browseSortTopRated": "Лучшие",
+  "browseSortNewest": "Новинки",
+  "browseAnimeTypeSeries": "Сериалы",
+  "browseAnimeTypeMovies": "Фильмы",
+  "browseEmptyFilters": "Выберите фильтр или выполните поиск",
+  "browseEmptyResults": "Ничего не найдено",
+  "browseSearchHint": "Поиск...",
+  "browseBackToBrowse": "Назад к обзору"
 }

--- a/test/features/search/filters/anime_type_filter_test.dart
+++ b/test/features/search/filters/anime_type_filter_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/features/search/filters/anime_type_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+
+class MockWidgetRef extends Mock implements WidgetRef {}
+
+class MockS extends Mock implements S {}
+
+void main() {
+  group('AnimeTypeFilter', () {
+    late AnimeTypeFilter filter;
+    late MockS mockL;
+
+    setUp(() {
+      filter = AnimeTypeFilter();
+      mockL = MockS();
+      when(() => mockL.browseAnimeTypeSeries).thenReturn('Series');
+      when(() => mockL.browseAnimeTypeMovies).thenReturn('Movies');
+    });
+
+    test('key is "animeType"', () {
+      expect(filter.key, 'animeType');
+    });
+
+    test('allOption has id "all" and null value', () {
+      final FilterOption all = filter.allOption;
+
+      expect(all.id, 'all');
+      expect(all.label, 'All');
+      expect(all.value, isNull);
+    });
+
+    test('options contains Series and Movies', () async {
+      final MockWidgetRef ref = MockWidgetRef();
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      expect(options, hasLength(2));
+    });
+
+    test('first option is Series', () async {
+      final MockWidgetRef ref = MockWidgetRef();
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      expect(options[0].id, 'series');
+      expect(options[0].label, 'Series');
+      expect(options[0].value, 'series');
+    });
+
+    test('second option is Movies', () async {
+      final MockWidgetRef ref = MockWidgetRef();
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      expect(options[1].id, 'movies');
+      expect(options[1].label, 'Movies');
+      expect(options[1].value, 'movies');
+    });
+
+    test('options returns same length on multiple calls', () async {
+      final MockWidgetRef ref = MockWidgetRef();
+      final List<FilterOption> first = await filter.options(ref, mockL);
+      final List<FilterOption> second = await filter.options(ref, mockL);
+
+      expect(first.length, second.length);
+      for (int i = 0; i < first.length; i++) {
+        expect(first[i].id, second[i].id);
+      }
+    });
+  });
+}

--- a/test/features/search/filters/igdb_genre_filter_test.dart
+++ b/test/features/search/filters/igdb_genre_filter_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/igdb_genre_filter.dart';
+import 'package:xerabora/features/search/filters/tmdb_genre_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+
+void main() {
+  group('IgdbGenre', () {
+    test('creates from constructor', () {
+      const IgdbGenre genre = IgdbGenre(id: 12, name: 'Role-playing (RPG)');
+
+      expect(genre.id, 12);
+      expect(genre.name, 'Role-playing (RPG)');
+    });
+
+    test('creates from JSON', () {
+      final IgdbGenre genre = IgdbGenre.fromJson(<String, dynamic>{
+        'id': 5,
+        'name': 'Shooter',
+      });
+
+      expect(genre.id, 5);
+      expect(genre.name, 'Shooter');
+    });
+
+    test('fromJson handles different id types', () {
+      final IgdbGenre genre = IgdbGenre.fromJson(<String, dynamic>{
+        'id': 31,
+        'name': 'Adventure',
+      });
+
+      expect(genre.id, 31);
+    });
+  });
+
+  group('IgdbGenreFilter', () {
+    late IgdbGenreFilter filter;
+
+    setUp(() {
+      filter = IgdbGenreFilter();
+    });
+
+    test('key is "genre"', () {
+      expect(filter.key, 'genre');
+    });
+
+    test('allOption has id "any" and null value', () {
+      final FilterOption all = filter.allOption;
+
+      expect(all.id, 'any');
+      expect(all.label, 'All');
+      expect(all.value, isNull);
+    });
+
+    test('cacheKey is "genre_igdb"', () {
+      expect(filter.cacheKey, 'genre_igdb');
+    });
+
+    test('cacheKey differs from TmdbGenreFilter', () {
+      final TmdbGenreFilter tmdbFilter = TmdbGenreFilter(type: 'movie');
+
+      expect(filter.cacheKey, isNot(tmdbFilter.cacheKey));
+    });
+  });
+}

--- a/test/features/search/filters/igdb_platform_filter_test.dart
+++ b/test/features/search/filters/igdb_platform_filter_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/igdb_platform_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+
+void main() {
+  group('IgdbPlatformFilter', () {
+    late IgdbPlatformFilter filter;
+
+    setUp(() {
+      filter = IgdbPlatformFilter();
+    });
+
+    test('key is "platform"', () {
+      expect(filter.key, 'platform');
+    });
+
+    test('allOption has id "any" and null value', () {
+      final FilterOption all = filter.allOption;
+
+      expect(all.id, 'any');
+      expect(all.label, 'All');
+      expect(all.value, isNull);
+    });
+  });
+}

--- a/test/features/search/filters/tmdb_genre_filter_test.dart
+++ b/test/features/search/filters/tmdb_genre_filter_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/tmdb_genre_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+
+void main() {
+  group('TmdbGenreFilter', () {
+    test('key is "genre"', () {
+      final TmdbGenreFilter filter = TmdbGenreFilter(type: 'movie');
+
+      expect(filter.key, 'genre');
+    });
+
+    test('stores type field', () {
+      final TmdbGenreFilter movieFilter = TmdbGenreFilter(type: 'movie');
+      final TmdbGenreFilter tvFilter = TmdbGenreFilter(type: 'tv');
+
+      expect(movieFilter.type, 'movie');
+      expect(tvFilter.type, 'tv');
+    });
+
+    test('allOption has id "any" and null value', () {
+      final TmdbGenreFilter filter = TmdbGenreFilter(type: 'movie');
+      final FilterOption all = filter.allOption;
+
+      expect(all.id, 'any');
+      expect(all.label, 'All');
+      expect(all.value, isNull);
+    });
+
+    test('different types create distinct instances', () {
+      final TmdbGenreFilter a = TmdbGenreFilter(type: 'movie');
+      final TmdbGenreFilter b = TmdbGenreFilter(type: 'tv');
+
+      // Same key but different type
+      expect(a.key, b.key);
+      expect(a.type, isNot(b.type));
+    });
+
+    test('cacheKey includes type suffix', () {
+      final TmdbGenreFilter movieFilter = TmdbGenreFilter(type: 'movie');
+      final TmdbGenreFilter tvFilter = TmdbGenreFilter(type: 'tv');
+
+      expect(movieFilter.cacheKey, 'genre_movie');
+      expect(tvFilter.cacheKey, 'genre_tv');
+    });
+
+    test('cacheKey differs between movie and tv', () {
+      final TmdbGenreFilter movieFilter = TmdbGenreFilter(type: 'movie');
+      final TmdbGenreFilter tvFilter = TmdbGenreFilter(type: 'tv');
+
+      expect(movieFilter.cacheKey, isNot(tvFilter.cacheKey));
+    });
+  });
+}

--- a/test/features/search/filters/year_filter_test.dart
+++ b/test/features/search/filters/year_filter_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/features/search/filters/year_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+
+class MockWidgetRef extends Mock implements WidgetRef {}
+
+class MockS extends Mock implements S {}
+
+void main() {
+  group('YearFilter', () {
+    late YearFilter filter;
+    late MockWidgetRef ref;
+    late MockS mockL;
+
+    setUp(() {
+      filter = YearFilter();
+      ref = MockWidgetRef();
+      mockL = MockS();
+    });
+
+    test('key is "year"', () {
+      expect(filter.key, 'year');
+    });
+
+    test('allOption has id "any" and null value', () {
+      final FilterOption all = filter.allOption;
+
+      expect(all.id, 'any');
+      expect(all.label, 'Any');
+      expect(all.value, isNull);
+    });
+
+    test('options starts with current year', () async {
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      final int currentYear = DateTime.now().year;
+      expect(options.first.id, currentYear.toString());
+      expect(options.first.label, currentYear.toString());
+      expect(options.first.value, currentYear);
+    });
+
+    test('options contains individual years from current to 2000', () async {
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      final int currentYear = DateTime.now().year;
+      final int expectedYearCount = currentYear - 2000 + 1;
+
+      // Первые N элементов — отдельные годы
+      for (int i = 0; i < expectedYearCount; i++) {
+        final int expectedYear = currentYear - i;
+        expect(options[i].id, expectedYear.toString());
+        expect(options[i].value, expectedYear);
+      }
+    });
+
+    test('options ends with decades 1990s, 1980s, 1970s', () async {
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      final int len = options.length;
+
+      // Последние 3 — декады
+      expect(options[len - 3].id, '1990s');
+      expect(options[len - 3].label, '1990s');
+      expect(options[len - 3].value, (1990, 1999));
+
+      expect(options[len - 2].id, '1980s');
+      expect(options[len - 2].label, '1980s');
+      expect(options[len - 2].value, (1980, 1989));
+
+      expect(options[len - 1].id, '1970s');
+      expect(options[len - 1].label, '1970s');
+      expect(options[len - 1].value, (1970, 1979));
+    });
+
+    test('total options count is correct', () async {
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      final int currentYear = DateTime.now().year;
+      final int yearCount = currentYear - 2000 + 1;
+      const int decadeCount = 3;
+
+      expect(options.length, yearCount + decadeCount);
+    });
+
+    test('year 2000 is included in individual years', () async {
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      final Iterable<FilterOption> year2000 =
+          options.where((FilterOption o) => o.id == '2000');
+      expect(year2000, hasLength(1));
+      expect(year2000.first.value, 2000);
+    });
+
+    test('decade values are record tuples', () async {
+      final List<FilterOption> options = await filter.options(ref, mockL);
+
+      final FilterOption decade90 =
+          options.firstWhere((FilterOption o) => o.id == '1990s');
+      final (int, int) value = decade90.value! as (int, int);
+      expect(value.$1, 1990);
+      expect(value.$2, 1999);
+    });
+  });
+}

--- a/test/features/search/models/search_source_test.dart
+++ b/test/features/search/models/search_source_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+void main() {
+  group('FilterOption', () {
+    test('creates with required fields', () {
+      const FilterOption option = FilterOption(
+        id: 'action',
+        label: 'Action',
+        value: 28,
+      );
+
+      expect(option.id, 'action');
+      expect(option.label, 'Action');
+      expect(option.value, 28);
+      expect(option.icon, isNull);
+    });
+
+    test('creates with icon', () {
+      const FilterOption option = FilterOption(
+        id: 'test',
+        label: 'Test',
+        icon: Icons.star,
+        value: 'val',
+      );
+
+      expect(option.icon, Icons.star);
+    });
+
+    test('creates with null value', () {
+      const FilterOption option = FilterOption(
+        id: 'any',
+        label: 'All',
+      );
+
+      expect(option.value, isNull);
+    });
+
+    test('equality is based on id only', () {
+      const FilterOption a = FilterOption(
+        id: 'genre',
+        label: 'Genre A',
+        value: 1,
+      );
+      const FilterOption b = FilterOption(
+        id: 'genre',
+        label: 'Genre B',
+        value: 2,
+      );
+      const FilterOption c = FilterOption(
+        id: 'other',
+        label: 'Genre A',
+        value: 1,
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('hashCode is based on id', () {
+      const FilterOption a = FilterOption(id: 'x', label: 'X');
+      const FilterOption b = FilterOption(id: 'x', label: 'Y', value: 42);
+
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('toString returns readable format', () {
+      const FilterOption option = FilterOption(
+        id: 'action',
+        label: 'Action',
+      );
+
+      expect(option.toString(), 'FilterOption(action, Action)');
+    });
+
+    test('can be used in Set correctly', () {
+      const FilterOption a = FilterOption(id: 'a', label: 'A');
+      const FilterOption a2 = FilterOption(id: 'a', label: 'A2');
+      const FilterOption b = FilterOption(id: 'b', label: 'B');
+
+      final Set<FilterOption> set = <FilterOption>{a, a2, b};
+      expect(set.length, 2);
+    });
+  });
+
+  group('BrowseSortOption', () {
+    test('creates with required fields', () {
+      const BrowseSortOption option = BrowseSortOption(
+        id: 'popular',
+        apiValue: 'popularity.desc',
+      );
+
+      expect(option.id, 'popular');
+      expect(option.apiValue, 'popularity.desc');
+    });
+
+    test('equality is based on id', () {
+      const BrowseSortOption a = BrowseSortOption(
+        id: 'pop',
+        apiValue: 'popularity.desc',
+      );
+      const BrowseSortOption b = BrowseSortOption(
+        id: 'pop',
+        apiValue: 'other',
+      );
+      const BrowseSortOption c = BrowseSortOption(
+        id: 'new',
+        apiValue: 'popularity.desc',
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('hashCode is based on id', () {
+      const BrowseSortOption a = BrowseSortOption(
+        id: 'x',
+        apiValue: 'x',
+      );
+      const BrowseSortOption b = BrowseSortOption(
+        id: 'x',
+        apiValue: 'y',
+      );
+
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('BrowseResult', () {
+    test('creates with required fields', () {
+      const BrowseResult result = BrowseResult(
+        items: <Object>[],
+        mediaType: MediaType.movie,
+      );
+
+      expect(result.items, isEmpty);
+      expect(result.mediaType, MediaType.movie);
+      expect(result.hasMore, isFalse);
+      expect(result.totalPages, 1);
+      expect(result.currentPage, 1);
+    });
+
+    test('creates with all fields', () {
+      const BrowseResult result = BrowseResult(
+        items: <Object>['item1', 'item2'],
+        mediaType: MediaType.game,
+        hasMore: true,
+        totalPages: 5,
+        currentPage: 2,
+      );
+
+      expect(result.items, hasLength(2));
+      expect(result.mediaType, MediaType.game);
+      expect(result.hasMore, isTrue);
+      expect(result.totalPages, 5);
+      expect(result.currentPage, 2);
+    });
+
+    test('creates with tvShow media type', () {
+      const BrowseResult result = BrowseResult(
+        items: <Object>[],
+        mediaType: MediaType.tvShow,
+        hasMore: true,
+      );
+
+      expect(result.mediaType, MediaType.tvShow);
+      expect(result.hasMore, isTrue);
+    });
+
+    test('creates with animation media type', () {
+      const BrowseResult result = BrowseResult(
+        items: <Object>[],
+        mediaType: MediaType.animation,
+      );
+
+      expect(result.mediaType, MediaType.animation);
+    });
+  });
+
+  group('SearchFilter (abstract)', () {
+    test('subclass implements all required members', () {
+      final _TestFilter filter = _TestFilter();
+
+      expect(filter.key, 'test');
+      expect(filter.allOption.id, 'all');
+    });
+
+    test('cacheKey defaults to key', () {
+      final _TestFilter filter = _TestFilter();
+
+      expect(filter.cacheKey, filter.key);
+      expect(filter.cacheKey, 'test');
+    });
+  });
+
+  group('SearchSource (abstract)', () {
+    test('defaultSort returns first sort option', () {
+      final SearchSource source = _TestSource();
+
+      expect(
+        source.defaultSort.id,
+        source.sortOptions.first.id,
+      );
+    });
+
+    test('subclass implements all required members', () {
+      final SearchSource source = _TestSource();
+
+      expect(source.id, 'test_source');
+      expect(source.icon, Icons.star);
+      expect(source.supportsBrowse, isTrue);
+      expect(source.filters, hasLength(1));
+      expect(source.sortOptions, hasLength(2));
+    });
+  });
+}
+
+// -- Test doubles --
+
+class _TestFilter extends SearchFilter {
+  @override
+  String get key => 'test';
+
+  @override
+  String placeholder(dynamic l) => 'Test';
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'all',
+        label: 'All',
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, dynamic l) async {
+    return const <FilterOption>[];
+  }
+}
+
+class _TestSource extends SearchSource {
+  @override
+  String get id => 'test_source';
+
+  @override
+  String label(dynamic l) => 'Test Source';
+
+  @override
+  IconData get icon => Icons.star;
+
+  @override
+  bool get supportsBrowse => true;
+
+  @override
+  List<SearchFilter> get filters => <SearchFilter>[_TestFilter()];
+
+  @override
+  List<BrowseSortOption> get sortOptions => const <BrowseSortOption>[
+        BrowseSortOption(id: 'a', apiValue: 'a'),
+        BrowseSortOption(id: 'b', apiValue: 'b'),
+      ];
+
+  @override
+  String searchHint(dynamic l) => 'Search...';
+
+  @override
+  Future<BrowseResult> browse(
+    Ref ref, {
+    required Map<String, Object?> filterValues,
+    required String sortBy,
+    required int page,
+  }) async {
+    return const BrowseResult(items: <Object>[], mediaType: MediaType.movie);
+  }
+
+  @override
+  Future<BrowseResult> search(
+    Ref ref, {
+    required String query,
+    required int page,
+  }) async {
+    return const BrowseResult(items: <Object>[], mediaType: MediaType.movie);
+  }
+
+  @override
+  Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) => null;
+}

--- a/test/features/search/providers/browse_provider_test.dart
+++ b/test/features/search/providers/browse_provider_test.dart
@@ -1,0 +1,284 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/providers/browse_provider.dart';
+import 'package:xerabora/features/search/sources/tmdb_movies_source.dart';
+
+void main() {
+  group('BrowseSettingsKeys', () {
+    test('sourceId constant value', () {
+      expect(BrowseSettingsKeys.sourceId, 'browse_source_id');
+    });
+  });
+
+  group('BrowseState', () {
+    group('constructor', () {
+      test('creates with default values', () {
+        const BrowseState state = BrowseState(sourceId: 'movies');
+
+        expect(state.sourceId, 'movies');
+        expect(state.filterValues, isEmpty);
+        expect(state.sortBy, isNull);
+        expect(state.items, isEmpty);
+        expect(state.isLoading, isFalse);
+        expect(state.isLoadingMore, isFalse);
+        expect(state.currentPage, 1);
+        expect(state.hasMore, isFalse);
+        expect(state.error, isNull);
+        expect(state.isSearchMode, isFalse);
+        expect(state.searchQuery, isEmpty);
+      });
+
+      test('creates with all fields', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'games',
+          filterValues: <String, Object?>{'genre': 12},
+          sortBy: 'rating desc',
+          items: <Object>['a', 'b'],
+          isLoading: true,
+          isLoadingMore: true,
+          currentPage: 3,
+          hasMore: true,
+          error: 'fail',
+          isSearchMode: true,
+          searchQuery: 'zelda',
+        );
+
+        expect(state.sourceId, 'games');
+        expect(state.filterValues, <String, Object?>{'genre': 12});
+        expect(state.sortBy, 'rating desc');
+        expect(state.items, hasLength(2));
+        expect(state.isLoading, isTrue);
+        expect(state.isLoadingMore, isTrue);
+        expect(state.currentPage, 3);
+        expect(state.hasMore, isTrue);
+        expect(state.error, 'fail');
+        expect(state.isSearchMode, isTrue);
+        expect(state.searchQuery, 'zelda');
+      });
+    });
+
+    group('hasFilters', () {
+      test('returns false for empty filterValues', () {
+        const BrowseState state = BrowseState(sourceId: 'movies');
+        expect(state.hasFilters, isFalse);
+      });
+
+      test('returns false when all values are null', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'movies',
+          filterValues: <String, Object?>{'genre': null, 'year': null},
+        );
+        expect(state.hasFilters, isFalse);
+      });
+
+      test('returns true when at least one value is not null', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'movies',
+          filterValues: <String, Object?>{'genre': 28, 'year': null},
+        );
+        expect(state.hasFilters, isTrue);
+      });
+
+      test('returns true when all values are not null', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'movies',
+          filterValues: <String, Object?>{'genre': 28, 'year': 2024},
+        );
+        expect(state.hasFilters, isTrue);
+      });
+    });
+
+    group('isEmpty', () {
+      test('returns true when items empty and not loading', () {
+        const BrowseState state = BrowseState(sourceId: 'movies');
+        expect(state.isEmpty, isTrue);
+      });
+
+      test('returns false when items not empty', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'movies',
+          items: <Object>['item'],
+        );
+        expect(state.isEmpty, isFalse);
+      });
+
+      test('returns false when loading', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'movies',
+          isLoading: true,
+        );
+        expect(state.isEmpty, isFalse);
+      });
+    });
+
+    group('source', () {
+      test('returns TmdbMoviesSource for "movies"', () {
+        const BrowseState state = BrowseState(sourceId: 'movies');
+        expect(state.source, isA<TmdbMoviesSource>());
+      });
+
+      test('returns default source for unknown id', () {
+        const BrowseState state = BrowseState(sourceId: 'unknown');
+        // getSearchSourceById returns first source for unknown
+        expect(state.source.id, 'movies');
+      });
+    });
+
+    group('effectiveSortBy', () {
+      test('returns sortBy when set', () {
+        const BrowseState state = BrowseState(
+          sourceId: 'movies',
+          sortBy: 'custom_sort',
+        );
+        expect(state.effectiveSortBy, 'custom_sort');
+      });
+
+      test('returns default sort when sortBy is null', () {
+        const BrowseState state = BrowseState(sourceId: 'movies');
+        // TmdbMoviesSource defaultSort is 'popularity.desc'
+        expect(state.effectiveSortBy, 'popularity.desc');
+      });
+    });
+
+    group('copyWith', () {
+      test('copies all fields when specified', () {
+        const BrowseState original = BrowseState(sourceId: 'movies');
+
+        final BrowseState copied = original.copyWith(
+          sourceId: 'games',
+          filterValues: const <String, Object?>{'key': 'val'},
+          sortBy: 'rating',
+          items: const <Object>['x'],
+          isLoading: true,
+          isLoadingMore: true,
+          currentPage: 5,
+          hasMore: true,
+          error: 'err',
+          isSearchMode: true,
+          searchQuery: 'query',
+        );
+
+        expect(copied.sourceId, 'games');
+        expect(copied.filterValues, <String, Object?>{'key': 'val'});
+        expect(copied.sortBy, 'rating');
+        expect(copied.items, <Object>['x']);
+        expect(copied.isLoading, isTrue);
+        expect(copied.isLoadingMore, isTrue);
+        expect(copied.currentPage, 5);
+        expect(copied.hasMore, isTrue);
+        expect(copied.error, 'err');
+        expect(copied.isSearchMode, isTrue);
+        expect(copied.searchQuery, 'query');
+      });
+
+      test('preserves original values when not specified', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'games',
+          sortBy: 'rating',
+          isLoading: true,
+          currentPage: 3,
+          error: 'old error',
+        );
+
+        final BrowseState copied = original.copyWith(isLoading: false);
+
+        expect(copied.sourceId, 'games');
+        expect(copied.sortBy, 'rating');
+        expect(copied.isLoading, isFalse);
+        expect(copied.currentPage, 3);
+        expect(copied.error, 'old error');
+      });
+
+      test('clearError sets error to null', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          error: 'some error',
+        );
+
+        final BrowseState copied = original.copyWith(clearError: true);
+
+        expect(copied.error, isNull);
+      });
+
+      test('clearError does not clear when false', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          error: 'some error',
+        );
+
+        final BrowseState copied = original.copyWith(clearError: false);
+
+        expect(copied.error, 'some error');
+      });
+
+      test('clearSortBy sets sortBy to null', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          sortBy: 'custom',
+        );
+
+        final BrowseState copied = original.copyWith(clearSortBy: true);
+
+        expect(copied.sortBy, isNull);
+      });
+
+      test('clearSortBy does not clear when false', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          sortBy: 'custom',
+        );
+
+        final BrowseState copied = original.copyWith(clearSortBy: false);
+
+        expect(copied.sortBy, 'custom');
+      });
+
+      test('new error overrides when clearError is false', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          error: 'old',
+        );
+
+        final BrowseState copied =
+            original.copyWith(error: 'new', clearError: false);
+
+        expect(copied.error, 'new');
+      });
+
+      test('new sortBy overrides when clearSortBy is false', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          sortBy: 'old',
+        );
+
+        final BrowseState copied =
+            original.copyWith(sortBy: 'new', clearSortBy: false);
+
+        expect(copied.sortBy, 'new');
+      });
+
+      test('clearSortBy takes precedence over sortBy', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          sortBy: 'old',
+        );
+
+        final BrowseState copied =
+            original.copyWith(sortBy: 'new', clearSortBy: true);
+
+        expect(copied.sortBy, isNull);
+      });
+
+      test('clearError takes precedence over error', () {
+        const BrowseState original = BrowseState(
+          sourceId: 'movies',
+          error: 'old',
+        );
+
+        final BrowseState copied =
+            original.copyWith(error: 'new', clearError: true);
+
+        expect(copied.error, isNull);
+      });
+    });
+  });
+}

--- a/test/features/search/sources/igdb_games_source_test.dart
+++ b/test/features/search/sources/igdb_games_source_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/igdb_genre_filter.dart';
+import 'package:xerabora/features/search/filters/igdb_platform_filter.dart';
+import 'package:xerabora/features/search/filters/year_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/sources/igdb_games_source.dart';
+
+void main() {
+  group('IgdbGamesSource', () {
+    late IgdbGamesSource source;
+
+    setUp(() {
+      source = IgdbGamesSource();
+    });
+
+    group('properties', () {
+      test('id is "games"', () {
+        expect(source.id, 'games');
+      });
+
+      test('icon is videogame_asset_outlined', () {
+        expect(source.icon, Icons.videogame_asset_outlined);
+      });
+
+      test('supportsBrowse is true', () {
+        expect(source.supportsBrowse, isTrue);
+      });
+    });
+
+    group('filters', () {
+      test('has 3 filters', () {
+        expect(source.filters, hasLength(3));
+      });
+
+      test('first filter is IgdbGenreFilter', () {
+        expect(source.filters[0], isA<IgdbGenreFilter>());
+      });
+
+      test('second filter is IgdbPlatformFilter', () {
+        expect(source.filters[1], isA<IgdbPlatformFilter>());
+      });
+
+      test('third filter is YearFilter', () {
+        expect(source.filters[2], isA<YearFilter>());
+      });
+    });
+
+    group('sortOptions', () {
+      test('has 3 sort options', () {
+        expect(source.sortOptions, hasLength(3));
+      });
+
+      test('first option is Top Rated', () {
+        final BrowseSortOption first = source.sortOptions[0];
+        expect(first.id, 'rating');
+        // label is now a method: label(S l) — tested via widget tests
+        expect(first.apiValue, 'rating desc');
+      });
+
+      test('second option is Newest', () {
+        final BrowseSortOption second = source.sortOptions[1];
+        expect(second.id, 'newest');
+        expect(second.apiValue, 'first_release_date desc');
+      });
+
+      test('third option is Popular', () {
+        final BrowseSortOption third = source.sortOptions[2];
+        expect(third.id, 'popular');
+        expect(third.apiValue, 'total_rating_count desc');
+      });
+    });
+
+    group('defaultSort', () {
+      test('returns first sort option (Top Rated)', () {
+        expect(source.defaultSort.id, 'rating');
+      });
+    });
+  });
+}

--- a/test/features/search/sources/search_sources_test.dart
+++ b/test/features/search/sources/search_sources_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/sources/igdb_games_source.dart';
+import 'package:xerabora/features/search/sources/search_sources.dart';
+import 'package:xerabora/features/search/sources/tmdb_anime_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_movies_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_tv_source.dart';
+
+void main() {
+  group('searchSources', () {
+    test('contains 4 sources', () {
+      expect(searchSources, hasLength(4));
+    });
+
+    test('first source is TmdbMoviesSource', () {
+      expect(searchSources[0], isA<TmdbMoviesSource>());
+    });
+
+    test('second source is TmdbTvSource', () {
+      expect(searchSources[1], isA<TmdbTvSource>());
+    });
+
+    test('third source is TmdbAnimeSource', () {
+      expect(searchSources[2], isA<TmdbAnimeSource>());
+    });
+
+    test('fourth source is IgdbGamesSource', () {
+      expect(searchSources[3], isA<IgdbGamesSource>());
+    });
+
+    test('all sources have unique ids', () {
+      final Set<String> ids =
+          searchSources.map((SearchSource s) => s.id).toSet();
+      expect(ids.length, searchSources.length);
+    });
+
+    test('source ids match expected values', () {
+      final List<String> ids =
+          searchSources.map((SearchSource s) => s.id).toList();
+      expect(ids, <String>['movies', 'tv', 'anime', 'games']);
+    });
+  });
+
+  group('getSearchSourceById', () {
+    test('returns correct source for "movies"', () {
+      final SearchSource source = getSearchSourceById('movies');
+      expect(source, isA<TmdbMoviesSource>());
+    });
+
+    test('returns correct source for "tv"', () {
+      final SearchSource source = getSearchSourceById('tv');
+      expect(source, isA<TmdbTvSource>());
+    });
+
+    test('returns correct source for "anime"', () {
+      final SearchSource source = getSearchSourceById('anime');
+      expect(source, isA<TmdbAnimeSource>());
+    });
+
+    test('returns correct source for "games"', () {
+      final SearchSource source = getSearchSourceById('games');
+      expect(source, isA<IgdbGamesSource>());
+    });
+
+    test('returns first source for unknown id', () {
+      final SearchSource source = getSearchSourceById('unknown');
+      expect(source, isA<TmdbMoviesSource>());
+      expect(source.id, 'movies');
+    });
+
+    test('returns first source for empty string', () {
+      final SearchSource source = getSearchSourceById('');
+      expect(source.id, 'movies');
+    });
+  });
+}

--- a/test/features/search/sources/tmdb_anime_source_test.dart
+++ b/test/features/search/sources/tmdb_anime_source_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/anime_type_filter.dart';
+import 'package:xerabora/features/search/filters/tmdb_genre_filter.dart';
+import 'package:xerabora/features/search/filters/year_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_anime_source.dart';
+
+void main() {
+  group('TmdbAnimeSource', () {
+    late TmdbAnimeSource source;
+
+    setUp(() {
+      source = TmdbAnimeSource();
+    });
+
+    group('properties', () {
+      test('id is "anime"', () {
+        expect(source.id, 'anime');
+      });
+
+      test('icon is animation_outlined', () {
+        expect(source.icon, Icons.animation_outlined);
+      });
+
+      test('supportsBrowse is true', () {
+        expect(source.supportsBrowse, isTrue);
+      });
+    });
+
+    group('filters', () {
+      test('has 3 filters', () {
+        expect(source.filters, hasLength(3));
+      });
+
+      test('first filter is TmdbGenreFilter with type tv', () {
+        final SearchFilter first = source.filters[0];
+        expect(first, isA<TmdbGenreFilter>());
+        expect((first as TmdbGenreFilter).type, 'tv');
+      });
+
+      test('second filter is YearFilter', () {
+        expect(source.filters[1], isA<YearFilter>());
+      });
+
+      test('third filter is AnimeTypeFilter', () {
+        expect(source.filters[2], isA<AnimeTypeFilter>());
+      });
+    });
+
+    group('sortOptions', () {
+      test('has 3 sort options', () {
+        expect(source.sortOptions, hasLength(3));
+      });
+
+      test('first option is Popular', () {
+        final BrowseSortOption first = source.sortOptions[0];
+        expect(first.id, 'popular');
+        expect(first.apiValue, 'popularity.desc');
+      });
+
+      test('second option is Top Rated', () {
+        final BrowseSortOption second = source.sortOptions[1];
+        expect(second.id, 'top_rated');
+        expect(second.apiValue, 'vote_average.desc');
+      });
+
+      test('third option is Newest', () {
+        final BrowseSortOption third = source.sortOptions[2];
+        expect(third.id, 'newest');
+        expect(third.apiValue, 'first_air_date.desc');
+      });
+    });
+
+    group('defaultSort', () {
+      test('returns first sort option (Popular)', () {
+        expect(source.defaultSort.id, 'popular');
+      });
+    });
+  });
+}

--- a/test/features/search/sources/tmdb_movies_source_test.dart
+++ b/test/features/search/sources/tmdb_movies_source_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/tmdb_genre_filter.dart';
+import 'package:xerabora/features/search/filters/year_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_movies_source.dart';
+
+void main() {
+  group('TmdbMoviesSource', () {
+    late TmdbMoviesSource source;
+
+    setUp(() {
+      source = TmdbMoviesSource();
+    });
+
+    group('properties', () {
+      test('id is "movies"', () {
+        expect(source.id, 'movies');
+      });
+
+      test('icon is movie_outlined', () {
+        expect(source.icon, Icons.movie_outlined);
+      });
+
+      test('supportsBrowse is true', () {
+        expect(source.supportsBrowse, isTrue);
+      });
+    });
+
+    group('filters', () {
+      test('has 2 filters', () {
+        expect(source.filters, hasLength(2));
+      });
+
+      test('first filter is TmdbGenreFilter with type movie', () {
+        final SearchFilter first = source.filters[0];
+        expect(first, isA<TmdbGenreFilter>());
+        expect((first as TmdbGenreFilter).type, 'movie');
+      });
+
+      test('second filter is YearFilter', () {
+        expect(source.filters[1], isA<YearFilter>());
+      });
+    });
+
+    group('sortOptions', () {
+      test('has 3 sort options', () {
+        expect(source.sortOptions, hasLength(3));
+      });
+
+      test('first option is Popular', () {
+        final BrowseSortOption first = source.sortOptions[0];
+        expect(first.id, 'popular');
+        // label is now a method: label(S l) — tested via widget tests
+        expect(first.apiValue, 'popularity.desc');
+      });
+
+      test('second option is Top Rated', () {
+        final BrowseSortOption second = source.sortOptions[1];
+        expect(second.id, 'top_rated');
+        expect(second.apiValue, 'vote_average.desc');
+      });
+
+      test('third option is Newest', () {
+        final BrowseSortOption third = source.sortOptions[2];
+        expect(third.id, 'newest');
+        expect(third.apiValue, 'primary_release_date.desc');
+      });
+    });
+
+    group('defaultSort', () {
+      test('returns first sort option (Popular)', () {
+        expect(source.defaultSort.id, 'popular');
+      });
+    });
+
+    group('buildDiscoverFeed', () {
+      test('returns null', () {
+        // Can't test with real context, but method should exist
+        expect(source.buildDiscoverFeed, isNotNull);
+      });
+    });
+  });
+}

--- a/test/features/search/sources/tmdb_tv_source_test.dart
+++ b/test/features/search/sources/tmdb_tv_source_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/tmdb_genre_filter.dart';
+import 'package:xerabora/features/search/filters/year_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_tv_source.dart';
+
+void main() {
+  group('TmdbTvSource', () {
+    late TmdbTvSource source;
+
+    setUp(() {
+      source = TmdbTvSource();
+    });
+
+    group('properties', () {
+      test('id is "tv"', () {
+        expect(source.id, 'tv');
+      });
+
+      test('icon is tv_outlined', () {
+        expect(source.icon, Icons.tv_outlined);
+      });
+
+      test('supportsBrowse is true', () {
+        expect(source.supportsBrowse, isTrue);
+      });
+    });
+
+    group('filters', () {
+      test('has 2 filters', () {
+        expect(source.filters, hasLength(2));
+      });
+
+      test('first filter is TmdbGenreFilter with type tv', () {
+        final SearchFilter first = source.filters[0];
+        expect(first, isA<TmdbGenreFilter>());
+        expect((first as TmdbGenreFilter).type, 'tv');
+      });
+
+      test('second filter is YearFilter', () {
+        expect(source.filters[1], isA<YearFilter>());
+      });
+    });
+
+    group('sortOptions', () {
+      test('has 3 sort options', () {
+        expect(source.sortOptions, hasLength(3));
+      });
+
+      test('first option is Popular', () {
+        final BrowseSortOption first = source.sortOptions[0];
+        expect(first.id, 'popular');
+        expect(first.apiValue, 'popularity.desc');
+      });
+
+      test('second option is Top Rated', () {
+        final BrowseSortOption second = source.sortOptions[1];
+        expect(second.id, 'top_rated');
+        expect(second.apiValue, 'vote_average.desc');
+      });
+
+      test('third option is Newest', () {
+        final BrowseSortOption third = source.sortOptions[2];
+        expect(third.id, 'newest');
+        expect(third.apiValue, 'first_air_date.desc');
+      });
+    });
+
+    group('defaultSort', () {
+      test('returns first sort option (Popular)', () {
+        expect(source.defaultSort.id, 'popular');
+      });
+    });
+  });
+}

--- a/test/features/search/utils/genre_utils_test.dart
+++ b/test/features/search/utils/genre_utils_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/utils/genre_utils.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+
+void main() {
+  group('isAnimationGenre', () {
+    test('returns true for genre ID "16"', () {
+      expect(isAnimationGenre('16'), isTrue);
+    });
+
+    test('returns true for genre name "Animation"', () {
+      expect(isAnimationGenre('Animation'), isTrue);
+    });
+
+    test('returns false for other genre ID', () {
+      expect(isAnimationGenre('28'), isFalse);
+    });
+
+    test('returns false for other genre name', () {
+      expect(isAnimationGenre('Action'), isFalse);
+    });
+
+    test('returns false for empty string', () {
+      expect(isAnimationGenre(''), isFalse);
+    });
+
+    test('returns false for partial match "16-something"', () {
+      expect(isAnimationGenre('16-something'), isFalse);
+    });
+  });
+
+  group('resolveMovieGenres', () {
+    test('returns same list when genreMap is empty', () {
+      const List<Movie> movies = <Movie>[
+        Movie(tmdbId: 1, title: 'A', genres: <String>['28']),
+      ];
+
+      final List<Movie> result =
+          resolveMovieGenres(movies, const <String, String>{});
+      expect(result, same(movies));
+    });
+
+    test('resolves genre IDs to names', () {
+      const List<Movie> movies = <Movie>[
+        Movie(tmdbId: 1, title: 'A', genres: <String>['28', '12']),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '28': 'Action',
+        '12': 'Adventure',
+      };
+
+      final List<Movie> result = resolveMovieGenres(movies, genreMap);
+      expect(result[0].genres, <String>['Action', 'Adventure']);
+    });
+
+    test('keeps original ID when no mapping found', () {
+      const List<Movie> movies = <Movie>[
+        Movie(tmdbId: 1, title: 'A', genres: <String>['28', '999']),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '28': 'Action',
+      };
+
+      final List<Movie> result = resolveMovieGenres(movies, genreMap);
+      expect(result[0].genres, <String>['Action', '999']);
+    });
+
+    test('skips movies with null genres', () {
+      const List<Movie> movies = <Movie>[
+        Movie(tmdbId: 1, title: 'A'),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '28': 'Action',
+      };
+
+      final List<Movie> result = resolveMovieGenres(movies, genreMap);
+      expect(result[0].genres, isNull);
+    });
+
+    test('skips movies with empty genres', () {
+      const List<Movie> movies = <Movie>[
+        Movie(tmdbId: 1, title: 'A', genres: <String>[]),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '28': 'Action',
+      };
+
+      final List<Movie> result = resolveMovieGenres(movies, genreMap);
+      expect(result[0].genres, isEmpty);
+    });
+
+    test('handles multiple movies', () {
+      const List<Movie> movies = <Movie>[
+        Movie(tmdbId: 1, title: 'A', genres: <String>['28']),
+        Movie(tmdbId: 2, title: 'B', genres: <String>['12']),
+        Movie(tmdbId: 3, title: 'C'),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '28': 'Action',
+        '12': 'Adventure',
+      };
+
+      final List<Movie> result = resolveMovieGenres(movies, genreMap);
+      expect(result, hasLength(3));
+      expect(result[0].genres, <String>['Action']);
+      expect(result[1].genres, <String>['Adventure']);
+      expect(result[2].genres, isNull);
+    });
+  });
+
+  group('resolveTvGenres', () {
+    test('returns same list when genreMap is empty', () {
+      const List<TvShow> shows = <TvShow>[
+        TvShow(tmdbId: 1, title: 'A', genres: <String>['18']),
+      ];
+
+      final List<TvShow> result =
+          resolveTvGenres(shows, const <String, String>{});
+      expect(result, same(shows));
+    });
+
+    test('resolves genre IDs to names', () {
+      const List<TvShow> shows = <TvShow>[
+        TvShow(tmdbId: 1, title: 'A', genres: <String>['18', '10765']),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '18': 'Drama',
+        '10765': 'Sci-Fi & Fantasy',
+      };
+
+      final List<TvShow> result = resolveTvGenres(shows, genreMap);
+      expect(result[0].genres, <String>['Drama', 'Sci-Fi & Fantasy']);
+    });
+
+    test('skips shows with null genres', () {
+      const List<TvShow> shows = <TvShow>[
+        TvShow(tmdbId: 1, title: 'A'),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '18': 'Drama',
+      };
+
+      final List<TvShow> result = resolveTvGenres(shows, genreMap);
+      expect(result[0].genres, isNull);
+    });
+
+    test('skips shows with empty genres', () {
+      const List<TvShow> shows = <TvShow>[
+        TvShow(tmdbId: 1, title: 'A', genres: <String>[]),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '18': 'Drama',
+      };
+
+      final List<TvShow> result = resolveTvGenres(shows, genreMap);
+      expect(result[0].genres, isEmpty);
+    });
+
+    test('keeps original ID when no mapping found', () {
+      const List<TvShow> shows = <TvShow>[
+        TvShow(tmdbId: 1, title: 'A', genres: <String>['18', '999']),
+      ];
+      const Map<String, String> genreMap = <String, String>{
+        '18': 'Drama',
+      };
+
+      final List<TvShow> result = resolveTvGenres(shows, genreMap);
+      expect(result[0].genres, <String>['Drama', '999']);
+    });
+  });
+}

--- a/test/features/search/widgets/browse_grid_test.dart
+++ b/test/features/search/widgets/browse_grid_test.dart
@@ -1,0 +1,395 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/shared/models/collected_item_info.dart';
+import 'package:xerabora/features/search/providers/browse_provider.dart';
+import 'package:xerabora/features/search/widgets/browse_grid.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  /// Создаёт пустые override для провайдеров collected IDs.
+  List<Override> emptyCollectedOverrides() {
+    return <Override>[
+      collectedMovieIdsProvider.overrideWith(
+        (Ref ref) async => const <int, List<CollectedItemInfo>>{},
+      ),
+      collectedTvShowIdsProvider.overrideWith(
+        (Ref ref) async => const <int, List<CollectedItemInfo>>{},
+      ),
+      collectedAnimationIdsProvider.overrideWith(
+        (Ref ref) async => const <int, List<CollectedItemInfo>>{},
+      ),
+      collectedGameIdsProvider.overrideWith(
+        (Ref ref) async => const <int, List<CollectedItemInfo>>{},
+      ),
+    ];
+  }
+
+  /// Создаёт override с конкретными ID в коллекции.
+  List<Override> collectedOverrides({
+    Map<int, List<CollectedItemInfo>> movies =
+        const <int, List<CollectedItemInfo>>{},
+    Map<int, List<CollectedItemInfo>> tvShows =
+        const <int, List<CollectedItemInfo>>{},
+    Map<int, List<CollectedItemInfo>> animations =
+        const <int, List<CollectedItemInfo>>{},
+    Map<int, List<CollectedItemInfo>> games =
+        const <int, List<CollectedItemInfo>>{},
+  }) {
+    return <Override>[
+      collectedMovieIdsProvider.overrideWith((Ref ref) async => movies),
+      collectedTvShowIdsProvider.overrideWith((Ref ref) async => tvShows),
+      collectedAnimationIdsProvider.overrideWith(
+        (Ref ref) async => animations,
+      ),
+      collectedGameIdsProvider.overrideWith((Ref ref) async => games),
+    ];
+  }
+
+  Widget buildWidget({
+    BrowseState? initialState,
+    void Function(Object item, MediaType mediaType)? onItemTap,
+    List<Override>? extraOverrides,
+  }) {
+    return ProviderScope(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        ...emptyCollectedOverrides(),
+        if (initialState != null)
+          browseProvider.overrideWith(() {
+            return _TestBrowseNotifier(initialState);
+          }),
+        ...?extraOverrides,
+      ],
+      child: MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(
+          body: BrowseGrid(
+            onItemTap: onItemTap ?? (_, _) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('BrowseGrid', () {
+    testWidgets('shows shimmer grid when loading with no items',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            isLoading: true,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Should show shimmer grid (GridView exists)
+      expect(find.byType(GridView), findsOneWidget);
+    });
+
+    testWidgets('shows error state when error and no items',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            error: 'Network error',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('Network error'), findsOneWidget);
+    });
+
+    testWidgets('shows empty results state when empty with filters',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            filterValues: <String, Object?>{'genre': 28},
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.search_off), findsOneWidget);
+    });
+
+    testWidgets('shows empty filter state when empty without filters',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.filter_alt_outlined), findsOneWidget);
+    });
+
+    testWidgets('renders movie items in grid', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            filterValues: <String, Object?>{'genre': 28},
+            items: <Object>[
+              Movie(
+                tmdbId: 1,
+                title: 'Test Movie 1',
+                releaseYear: 2024,
+                posterUrl: 'https://example.com/1.jpg',
+              ),
+              Movie(
+                tmdbId: 2,
+                title: 'Test Movie 2',
+                releaseYear: 2023,
+                posterUrl: 'https://example.com/2.jpg',
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GridView), findsOneWidget);
+      expect(find.text('Test Movie 1'), findsOneWidget);
+      expect(find.text('Test Movie 2'), findsOneWidget);
+    });
+
+    testWidgets('calls onItemTap when movie tapped',
+        (WidgetTester tester) async {
+      Object? tappedItem;
+      MediaType? tappedType;
+
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            filterValues: <String, Object?>{'genre': 28},
+            items: <Object>[
+              Movie(
+                tmdbId: 1,
+                title: 'Tap Me',
+                releaseYear: 2024,
+                posterUrl: 'https://example.com/1.jpg',
+              ),
+            ],
+          ),
+          onItemTap: (Object item, MediaType type) {
+            tappedItem = item;
+            tappedType = type;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Tap Me'));
+      await tester.pumpAndSettle();
+
+      expect(tappedItem, isA<Movie>());
+      expect(tappedType, MediaType.movie);
+    });
+
+    testWidgets('marks movie as in collection when tmdbId matches',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            filterValues: <String, Object?>{'genre': 28},
+            items: <Object>[
+              Movie(
+                tmdbId: 42,
+                title: 'Collected Movie',
+                releaseYear: 2024,
+                posterUrl: 'https://example.com/c.jpg',
+              ),
+              Movie(
+                tmdbId: 99,
+                title: 'Not Collected',
+                releaseYear: 2024,
+                posterUrl: 'https://example.com/nc.jpg',
+              ),
+            ],
+          ),
+          extraOverrides: collectedOverrides(
+            movies: <int, List<CollectedItemInfo>>{
+              42: const <CollectedItemInfo>[
+                CollectedItemInfo(recordId: 1, collectionId: 1, collectionName: 'Coll'),
+              ],
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Зелёная галочка check_circle для tmdbId=42
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('marks game as in collection when id matches',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'games',
+            filterValues: <String, Object?>{'genre': 5},
+            items: <Object>[
+              Game(
+                id: 100,
+                name: 'Collected Game',
+                coverUrl: 'https://example.com/g.jpg',
+              ),
+            ],
+          ),
+          extraOverrides: collectedOverrides(
+            games: <int, List<CollectedItemInfo>>{
+              100: const <CollectedItemInfo>[
+                CollectedItemInfo(recordId: 1, collectionId: 1, collectionName: 'Coll'),
+              ],
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('marks tv show as in collection when tmdbId matches',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'tv',
+            filterValues: <String, Object?>{'genre': 18},
+            items: <Object>[
+              TvShow(
+                tmdbId: 55,
+                title: 'Collected Show',
+                posterUrl: 'https://example.com/tv.jpg',
+              ),
+            ],
+          ),
+          extraOverrides: collectedOverrides(
+            tvShows: <int, List<CollectedItemInfo>>{
+              55: const <CollectedItemInfo>[
+                CollectedItemInfo(recordId: 1, collectionId: 1, collectionName: 'Coll'),
+              ],
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('no collection mark when item not collected',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            filterValues: <String, Object?>{'genre': 28},
+            items: <Object>[
+              Movie(
+                tmdbId: 999,
+                title: 'Not In Collection',
+                releaseYear: 2024,
+                posterUrl: 'https://example.com/nc.jpg',
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('uses MaxCrossAxisExtent delegate on desktop width',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            isLoading: true,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final GridView grid =
+          tester.widget<GridView>(find.byType(GridView));
+      expect(
+        grid.gridDelegate,
+        isA<SliverGridDelegateWithMaxCrossAxisExtent>(),
+      );
+    });
+
+    testWidgets('uses FixedCrossAxisCount delegate on mobile width',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        buildWidget(
+          initialState: const BrowseState(
+            sourceId: 'movies',
+            isLoading: true,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final GridView grid =
+          tester.widget<GridView>(find.byType(GridView));
+      expect(
+        grid.gridDelegate,
+        isA<SliverGridDelegateWithFixedCrossAxisCount>(),
+      );
+    });
+  });
+}
+
+/// Тестовый нотифайер с начальным состоянием.
+class _TestBrowseNotifier extends BrowseNotifier {
+  _TestBrowseNotifier(this._initialState);
+
+  final BrowseState _initialState;
+
+  @override
+  BrowseState build() => _initialState;
+}

--- a/test/features/search/widgets/filter_bar_test.dart
+++ b/test/features/search/widgets/filter_bar_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/features/search/widgets/filter_bar.dart';
+import 'package:xerabora/features/search/widgets/filter_dropdown.dart';
+import 'package:xerabora/features/search/widgets/source_dropdown.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  Widget buildWidget() {
+    return ProviderScope(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        locale: Locale('en'),
+        home: Scaffold(
+          body: FilterBar(),
+        ),
+      ),
+    );
+  }
+
+  group('FilterBar', () {
+    testWidgets('renders SourceDropdown', (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SourceDropdown), findsOneWidget);
+    });
+
+    testWidgets('renders FilterDropdowns for current source filters',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      // TmdbMoviesSource (default) has 2 filters: genre + year
+      expect(find.byType(FilterDropdown), findsNWidgets(2));
+    });
+
+    testWidgets('renders SortDropdown', (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SortDropdown), findsOneWidget);
+    });
+
+    testWidgets('is wrapped in horizontal ListView',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      final Finder listView = find.byType(ListView);
+      expect(listView, findsOneWidget);
+    });
+
+    testWidgets('has fixed height of 36', (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      final SizedBox sizedBox = tester.widget<SizedBox>(
+        find.ancestor(
+          of: find.byType(ListView),
+          matching: find.byType(SizedBox),
+        ).first,
+      );
+      expect(sizedBox.height, 36);
+    });
+  });
+}

--- a/test/features/search/widgets/filter_dropdown_test.dart
+++ b/test/features/search/widgets/filter_dropdown_test.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/filters/anime_type_filter.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/widgets/filter_dropdown.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+
+void main() {
+  Widget buildFilterDropdown({
+    SearchFilter? filter,
+    Object? value,
+    ValueChanged<Object?>? onChanged,
+  }) {
+    return ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(
+          body: FilterDropdown(
+            filter: filter ?? AnimeTypeFilter(),
+            value: value,
+            onChanged: onChanged ?? (_) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget buildSortDropdown({
+    List<BrowseSortOption>? options,
+    String? current,
+    ValueChanged<String>? onChanged,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: S.localizationsDelegates,
+      supportedLocales: S.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: SortDropdown(
+          options: options ??
+              const <BrowseSortOption>[
+                BrowseSortOption(
+                  id: 'popular',
+                  apiValue: 'popularity.desc',
+                ),
+                BrowseSortOption(
+                  id: 'newest',
+                  apiValue: 'date.desc',
+                ),
+              ],
+          current: current ?? 'popularity.desc',
+          onChanged: onChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  group('FilterDropdown', () {
+    testWidgets('renders dropdown arrow icon', (WidgetTester tester) async {
+      await tester.pumpWidget(buildFilterDropdown());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.keyboard_arrow_down), findsOneWidget);
+    });
+
+    testWidgets('shows placeholder when value is null',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildFilterDropdown(value: null));
+      await tester.pumpAndSettle();
+
+      // AnimeTypeFilter placeholder is l.browseFilterType
+      // The exact text depends on localization but should be visible
+      expect(find.byType(FilterDropdown), findsOneWidget);
+    });
+
+    testWidgets('shows label when value is set',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildFilterDropdown(value: 'series'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Series'), findsOneWidget);
+    });
+
+    testWidgets('opens popup menu on tap', (WidgetTester tester) async {
+      await tester.pumpWidget(buildFilterDropdown());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(FilterDropdown));
+      await tester.pumpAndSettle();
+
+      // AnimeTypeFilter has 2 options + "All" = 3 items
+      // Plus the divider
+      expect(find.text('All'), findsOneWidget);
+      expect(find.text('Series'), findsOneWidget);
+      expect(find.text('Movies'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when option selected',
+        (WidgetTester tester) async {
+      Object? selectedValue = 'not_set';
+
+      await tester.pumpWidget(
+        buildFilterDropdown(
+          onChanged: (Object? v) => selectedValue = v,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open popup
+      await tester.tap(find.byType(FilterDropdown));
+      await tester.pumpAndSettle();
+
+      // Select "Series"
+      await tester.tap(find.text('Series'));
+      await tester.pumpAndSettle();
+
+      expect(selectedValue, 'series');
+    });
+
+    testWidgets('calls onChanged with null when "All" selected',
+        (WidgetTester tester) async {
+      Object? selectedValue = 'initial';
+
+      await tester.pumpWidget(
+        buildFilterDropdown(
+          value: 'series',
+          onChanged: (Object? v) => selectedValue = v,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open popup
+      await tester.tap(find.byType(FilterDropdown));
+      await tester.pumpAndSettle();
+
+      // Select "All"
+      await tester.tap(find.text('All'));
+      await tester.pumpAndSettle();
+
+      expect(selectedValue, isNull);
+    });
+  });
+
+  group('SortDropdown', () {
+    testWidgets('renders sort icon', (WidgetTester tester) async {
+      await tester.pumpWidget(buildSortDropdown());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.sort), findsOneWidget);
+    });
+
+    testWidgets('renders dropdown arrow icon', (WidgetTester tester) async {
+      await tester.pumpWidget(buildSortDropdown());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.keyboard_arrow_down), findsOneWidget);
+    });
+
+    testWidgets('shows current sort label', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildSortDropdown(current: 'popularity.desc'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Popular'), findsOneWidget);
+    });
+
+    testWidgets('opens popup menu on tap', (WidgetTester tester) async {
+      await tester.pumpWidget(buildSortDropdown());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(SortDropdown));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Popular'), findsAtLeast(1));
+      expect(find.text('Newest'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when option selected',
+        (WidgetTester tester) async {
+      String? selectedSort;
+
+      await tester.pumpWidget(
+        buildSortDropdown(
+          onChanged: (String v) => selectedSort = v,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open popup
+      await tester.tap(find.byType(SortDropdown));
+      await tester.pumpAndSettle();
+
+      // Select "Newest"
+      await tester.tap(find.text('Newest'));
+      await tester.pumpAndSettle();
+
+      expect(selectedSort, 'date.desc');
+    });
+
+    testWidgets('shows fallback label for unknown current value',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildSortDropdown(current: 'unknown_sort'),
+      );
+      await tester.pumpAndSettle();
+
+      // Should show the browseSort localization string (fallback)
+      expect(find.byType(SortDropdown), findsOneWidget);
+    });
+  });
+}

--- a/test/features/search/widgets/source_dropdown_test.dart
+++ b/test/features/search/widgets/source_dropdown_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/models/search_source.dart';
+import 'package:xerabora/features/search/sources/search_sources.dart';
+import 'package:xerabora/features/search/sources/tmdb_movies_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_tv_source.dart';
+import 'package:xerabora/features/search/widgets/source_dropdown.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+
+void main() {
+  Widget buildWidget({
+    SearchSource? current,
+    ValueChanged<SearchSource>? onChanged,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: S.localizationsDelegates,
+      supportedLocales: S.supportedLocales,
+      locale: const Locale('en'),
+      home: Scaffold(
+        body: SourceDropdown(
+          current: current ?? TmdbMoviesSource(),
+          onChanged: onChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  group('SourceDropdown', () {
+    testWidgets('renders current source icon', (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.movie_outlined), findsOneWidget);
+    });
+
+    testWidgets('renders dropdown arrow icon', (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.keyboard_arrow_down), findsOneWidget);
+    });
+
+    testWidgets('opens popup menu on tap', (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      // Tap the dropdown
+      await tester.tap(find.byType(SourceDropdown));
+      await tester.pumpAndSettle();
+
+      // Should show all source options
+      expect(find.byType(PopupMenuItem<String>), findsNWidgets(4));
+    });
+
+    testWidgets('shows all registered sources in popup',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(SourceDropdown));
+      await tester.pumpAndSettle();
+
+      // Each source should have its icon
+      for (final SearchSource source in searchSources) {
+        expect(find.byIcon(source.icon), findsAtLeast(1));
+      }
+    });
+
+    testWidgets('calls onChanged when different source selected',
+        (WidgetTester tester) async {
+      SearchSource? selectedSource;
+
+      await tester.pumpWidget(
+        buildWidget(
+          current: TmdbMoviesSource(),
+          onChanged: (SearchSource s) => selectedSource = s,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open popup
+      await tester.tap(find.byType(SourceDropdown));
+      await tester.pumpAndSettle();
+
+      // Select TV source (tap on tv icon in popup)
+      final Finder tvMenuItem = find.byWidgetPredicate(
+        (Widget w) =>
+            w is PopupMenuItem<String> && w.value == 'tv',
+      );
+      await tester.tap(tvMenuItem);
+      await tester.pumpAndSettle();
+
+      expect(selectedSource, isNotNull);
+      expect(selectedSource, isA<TmdbTvSource>());
+    });
+
+    testWidgets('does not call onChanged when same source selected',
+        (WidgetTester tester) async {
+      int callCount = 0;
+
+      await tester.pumpWidget(
+        buildWidget(
+          current: TmdbMoviesSource(),
+          onChanged: (_) => callCount++,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open popup
+      await tester.tap(find.byType(SourceDropdown));
+      await tester.pumpAndSettle();
+
+      // Select same source (movies)
+      final Finder moviesMenuItem = find.byWidgetPredicate(
+        (Widget w) =>
+            w is PopupMenuItem<String> && w.value == 'movies',
+      );
+      await tester.tap(moviesMenuItem);
+      await tester.pumpAndSettle();
+
+      expect(callCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
Replace 4-tab TabBarView with unified Browse/Search mode using SearchSource/SearchFilter abstractions. Add source dropdown, filter bar, BrowseGrid with in-collection markers, and consistent card sizes matching collection screen. Fix games losing data on add (missing upsertGame), genre filters not switching between sources (cacheKey differentiation).

New API methods: IgdbApi.browseGames(), IgdbApi.getGenres(), TmdbApi year-decade filtering. 50+ new tests, docs updated.