### PR TITLE
feat: add structured logging with package:logging to core layer

### DIFF
--- a/.claude/skills/dart-tonkatsu/SKILL.md
+++ b/.claude/skills/dart-tonkatsu/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: dart-tonkatsu
+description: Dart/Flutter coding standards for Tonkatsu Box. Use this skill for ANY code changes in the Tonkatsu Box project — writing new features, fixing bugs, refactoring, creating new files, editing existing code. Trigger whenever working with .dart files in a Flutter project that has Riverpod, sqflite, and strict analysis_options. Also trigger when discussing code style, architecture decisions, or reviewing code in this project.
+---
+
+# Tonkatsu Box — Код-стандарт
+
+Обязательные правила для всего кода в проекте Tonkatsu Box. Этот документ — источник истины; `analysis_options.yaml` обеспечивает автоматическую проверку, но не покрывает все соглашения.
+
+## Анализатор
+
+Проект использует максимально строгие настройки. Код не должен генерировать ни одного warning/info:
+
+- `strict-casts: true` — нет неявных приведений
+- `strict-inference: true` — нет неявного вывода типов
+- `strict-raw-types: true` — нет raw-дженериков
+- `always_specify_types: true` — все типы явно
+- `avoid_print: true` — print запрещён, использовать `_log`
+- `require_trailing_commas: true` — завершающие запятые
+- `prefer_single_quotes: true` — одинарные кавычки
+
+## Структура проекта
+
+```
+lib/
+├── main.dart                 # Точка входа
+├── app.dart                  # Корневой виджет
+├── core/                     # Ядро (не зависит от features)
+│   ├── api/                  #   API-клиенты (Dio)
+│   ├── database/             #   DatabaseService, schema, миграции
+│   │   └── migrations/       #     Отдельные файлы миграций
+│   ├── logging/              #   AppLogger
+│   └── services/             #   Export, Import, ImageCache, Config
+├── data/                     # Репозитории (мост core ↔ features)
+│   └── repositories/
+├── features/                 # Фичи (экраны, провайдеры, виджеты)
+│   ├── collections/
+│   ├── home/
+│   ├── search/
+│   ├── settings/
+│   ├── splash/
+│   ├── welcome/
+│   └── wishlist/
+├── l10n/                     # Локализация (ARB, gen_l10n)
+└── shared/                   # Общие модели, виджеты, тема
+├── constants/
+├── extensions/
+├── gamepad/
+├── models/
+├── navigation/
+├── theme/
+└── widgets/
+```
+
+Направление зависимостей: `features → data → core → shared`. Фичи не импортируют друг друга (кроме навигации).
+
+## Именование файлов и классов
+
+- Файлы: `snake_case.dart`
+- Классы: `PascalCase`
+- Перечисления: `PascalCase`, значения `camelCase`
+- Провайдеры: `camelCaseProvider` (суффикс `Provider`)
+- Приватные поля: `_camelCase`
+- Константы: `camelCase` (Dart-стиль, не UPPER_SNAKE)
+
+## State Management (Riverpod)
+
+Паттерн провайдеров:
+
+```dart
+// Простой провайдер — глобальный final
+final Provider<SomeApi> someApiProvider = Provider<SomeApi>((Ref ref) {
+  return SomeApi();
+});
+
+// AsyncNotifier — для состояния с загрузкой
+final AsyncNotifierProvider<SomeNotifier, List<Item>>
+    someProvider =
+    AsyncNotifierProvider<SomeNotifier, List<Item>>(
+  SomeNotifier.new,
+);
+
+class SomeNotifier extends AsyncNotifier<List<Item>> {
+  late SomeRepository _repository;
+
+  @override
+  Future<List<Item>> build() async {
+    _repository = ref.watch(someRepositoryProvider);
+    return _repository.getAll();
+  }
+}
+```
+
+- Типы провайдеров указываются **явно** в объявлении
+- `ref.watch()` — в `build()`, `ref.read()` — в методах-действиях
+
+## Модели данных
+
+Модели — immutable классы с фабричными конструкторами:
+
+```dart
+class Game {
+  const Game({
+    required this.id,
+    required this.name,
+    this.summary,
+  });
+
+  factory Game.fromJson(Map<String, dynamic> json) { ... }
+  factory Game.fromDb(Map<String, dynamic> row) { ... }
+
+  final int id;
+  final String name;
+  final String? summary;
+
+  Map<String, dynamic> toDb() { ... }
+  Map<String, dynamic> toJson() { ... }
+  Game copyWith({...}) { ... }
+}
+```
+
+Порядок в классе модели:
+1. `const` конструктор
+2. Фабричные конструкторы (`fromJson`, `fromDb`)
+3. Поля (`final`)
+4. Геттеры/computed-свойства
+5. Методы (`toDb`, `toJson`, `copyWith`)
+
+## Логирование
+
+### Правила
+
+- `print()` и `debugPrint()` — **запрещены** (`avoid_print: true`)
+- Для логирования использовать `package:logging`
+- Инициализация: `AppLogger.init()` в `main()` до `runApp()`
+- Логи выводятся через `dart:developer` `log()` (видны в Flutter DevTools)
+
+### Уровни логирования
+
+| Уровень | Когда использовать | Пример |
+|---------|-------------------|--------|
+| `_log.fine()` | Детали для отладки, обычно шумно | `_log.fine('Loaded 42 platforms')` |
+| `_log.info()` | Важные события жизненного цикла | `_log.info('Database upgraded to v23')` |
+| `_log.warning()` | Ошибки, которые не ломают приложение | `_log.warning('Failed to load genre map', e)` |
+| `_log.severe()` | Критические ошибки | `_log.severe('Database creation failed', e, stackTrace)` |
+
+### Размещение логгера
+
+Статическое поле `_log` размещается **первым** в теле класса:
+
+```dart
+class IgdbApi {
+  static final Logger _log = Logger('IgdbApi');
+
+  // ... остальные поля и методы
+}
+```
+
+Имя логгера = имя класса.
+
+### Правило catch-блоков
+
+**Запрещено** писать `catch (_)` без логирования (кроме осознанных ситуаций вроде repair-миграции v16). Каждый catch должен либо:
+- логировать ошибку: `_log.warning('описание', e)`
+- пробрасывать её дальше: `rethrow`
+- иметь комментарий, почему ошибка намеренно игнорируется
+
+```dart
+// ✅ Правильно
+} catch (e) {
+  _log.warning('Failed to download image: $imageId', e);
+  return false;
+}
+
+// ✅ Правильно — осознанное игнорирование с комментарием
+} on DatabaseException catch (_) {
+  // Колонка уже существует — repair-миграция, безопасно игнорировать.
+}
+
+// ❌ Запрещено — молчаливый catch
+} catch (_) {
+  return false;
+}
+```
+
+### Где добавлять логгер
+
+Логгер **обязателен** в:
+- Всех классах в `lib/core/` (API, Database, Services)
+- Всех репозиториях в `lib/data/repositories/`
+- Всех Notifier/AsyncNotifier в `lib/features/*/providers/`
+
+Логгер **не нужен** в:
+- Моделях (`lib/shared/models/`)
+- Статических утилитах без side-effects
+- Виджетах (кроме debug-экранов)
+
+## Миграции БД
+
+Каждая миграция — отдельный файл в `lib/core/database/migrations/`:
+
+```dart
+class MigrationV24 extends Migration {
+  @override
+  int get version => 24;
+
+  @override
+  String get description => 'Brief description in English';
+
+  @override
+  Future<void> migrate(Database db) async {
+    // SQL-операции
+  }
+}
+```
+
+Процедура добавления:
+1. Создать `migration_v24.dart`
+2. Добавить `MigrationV24()` в `MigrationRegistry.all`
+3. Обновить `version: 24` в `_initDatabase()`
+4. Если нужна новая таблица — добавить метод в `DatabaseSchema` и вызвать из `createAll()`
+
+## Документация
+
+- Doc-комментарии (`///`) — на русском
+- На всех публичных классах и методах
+- На приватных методах, если логика неочевидна
+- Inline-комментарии (`//`) — по ситуации, русский или английский
+
+```dart
+/// Сервис для работы с SQLite базой данных.
+///
+/// Управляет инициализацией базы данных и CRUD операциями.
+class DatabaseService {
+```
+
+## Импорты
+
+Порядок групп (разделённых пустой строкой):
+1. `dart:` стандартная библиотека
+2. `package:` внешние пакеты
+3. Относительные импорты проекта
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import '../../shared/models/game.dart';
+import '../../shared/models/platform.dart';
+```
+
+## Тестирование
+
+- Тесты зеркалят структуру `lib/` → `test/`
+- Используется `mocktail` для моков
+- In-memory SQLite (`sqflite_common_ffi`, `inMemoryDatabasePath`) для тестов БД
+- Тест-файлы: `*_test.dart`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 ## [Unreleased]
 
 ### Added
+- `AppLogger` utility (`lib/core/logging/app_logger.dart`) — centralized logging via `package:logging` and `dart:developer`. Initialized once in `main()` before `runApp()`, logs visible in Flutter DevTools Logging tab
+- `static final Logger _log` field in 11 core classes: `IgdbApi`, `TmdbApi`, `SteamGridDbApi`, `VndbApi`, `DatabaseService`, `ImageCacheService`, `ImportService`, `ExportService`, `TraktZipImportService`, `ConfigService`, `UpdateService`
+- Logging in `DatabaseService._onCreate()` and `_onUpgrade()` — schema creation and migration progress messages
+- `dart-tonkatsu` coding standards skill (`.claude/skills/dart-tonkatsu/SKILL.md`) — project-wide Dart/Flutter conventions including logging rules, catch-block policy, import ordering, model structure
 - iOS folder-style `CollectionCard` widget (`collection_card.dart`) — 3+3 mosaic grid (3 posters top row, 2 posters + "+N" counter bottom row), hover dimming effect with `AnimationController`, rounded corners (16px outer, 8px cells), internal padding 14px
 - `UncategorizedCard` widget for uncategorized items with inbox icon
 - `CoverInfo` model (`cover_info.dart`) — lightweight cover data (externalId, mediaType, platformId, thumbnailUrl) for collection card mosaics
@@ -20,6 +24,10 @@
 - Tests: `collection_card_test.dart` (22 tests), `collection_covers_provider_test.dart` (4 tests), `collection_filter_bar_test.dart`, `collection_item_tile_test.dart`, `collection_items_view_test.dart`, `collection_canvas_layout_test.dart`, `collection_actions_test.dart`, `cover_info_test.dart`
 
 ### Changed
+- Replaced 5 silent `catch (_)` blocks with `catch (e)` + `_log.warning(...)` in `TmdbApi` (genre map loading), `ImageCacheService` (save bytes, download), `ImportService` (base64 restore), `ExportService` (export failure)
+- Replaced `debugPrint()` with `_log.warning()` in `ImportService` (VNDB fetch error)
+- Replaced `print()` with `_log.fine()` in `GamepadDebugScreen` (raw gamepad events)
+- Replaced `import 'package:flutter/foundation.dart'` with `import 'dart:typed_data'` in `ImportService` (only `Uint8List` was needed)
 - `HomeScreen` — replaced category-grouped layout with single `GridView.builder` using `SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: 273, childAspectRatio: 1)`. All collections rendered as `CollectionCard` widgets
 - `CollectionScreen` — major refactoring: extracted filter bar, items view, canvas layout, and action helpers into separate widgets. Reduced from ~1800 lines to ~500 lines
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,6 +26,7 @@ graph TB
     subgraph core ["🔧 Core"]
         api["API<br/><small>igdb_api, tmdb_api,<br/>steamgriddb_api, vndb_api</small>"]
         database["Database<br/><small>database_service<br/>SQLite, 16 таблиц</small>"]
+        logging["Logging<br/><small>AppLogger<br/>package:logging</small>"]
         services["Services<br/><small>export, import,<br/>image_cache, config</small>"]
     end
 
@@ -72,7 +73,7 @@ graph TB
 lib/
 ├── main.dart                 # Точка входа
 ├── app.dart                  # Корневой виджет
-├── core/                     # Ядро (API, БД)
+├── core/                     # Ядро (API, БД, Logging)
 ├── data/                     # Репозитории
 ├── features/                 # Фичи (экраны, виджеты)
 ├── l10n/                     # Локализация (ARB файлы, gen_l10n)
@@ -87,7 +88,7 @@ lib/
 
 | Файл | Назначение |
 |------|------------|
-| `lib/main.dart` | Инициализация Flutter, SQLite, SharedPreferences. Запуск приложения через `ProviderScope` |
+| `lib/main.dart` | Инициализация Flutter, `AppLogger.init()`, SQLite, SharedPreferences. Запуск приложения через `ProviderScope` |
 | `lib/app.dart` | Корневой виджет `TonkatsuBoxApp`. Настройка темы (Material 3), локализация (`locale`, `localizationsDelegates`), роутинг на основе состояния API |
 | `l10n.yaml` | Конфигурация Flutter `gen_l10n`: `arb-dir: lib/l10n`, output class `S`, `nullable-getter: false` |
 | `lib/l10n/app_en.arb` | Английские строки (521 ключ) — шаблон для генерации |
@@ -109,6 +110,7 @@ lib/
 | `lib/shared/constants/platform_features.dart` | **Флаги платформы**. `kCanvasEnabled` (true на всех платформах), `kVgMapsEnabled` (только Windows), `kScreenshotEnabled` (только Windows). VGMaps скрыт на не-Windows платформах |
 | `lib/shared/constants/api_defaults.dart` | **Встроенные API ключи**. `ApiDefaults` — `abstract final class` с `String.fromEnvironment` для TMDB и SteamGridDB ключей, инжектируемых при сборке через `--dart-define`. Геттеры `hasTmdbKey`, `hasSteamGridDbKey`. Используется в `SettingsNotifier._loadFromPrefs()` как fallback: user key → built-in → null |
 | `lib/core/database/database_service.dart` | **SQLite сервис**. Создание таблиц, миграции (версия 19), CRUD для всех сущностей. Использует `databaseFactory.openDatabase()` — кроссплатформенный вызов (FFI на desktop, нативный плагин на Android). Таблицы: `platforms`, `games`, `collections`, `collection_items`, `canvas_items`, `canvas_viewport`, `canvas_connections`, `game_canvas_viewport`, `movies_cache`, `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache`, `watched_episodes`, `tmdb_genres`, `wishlist`. Миграция v14: `UPDATE collection_items SET status='in_progress' WHERE status='playing'`. Методы кэша жанров: `cacheTmdbGenres()`, `getTmdbGenreMap()`. Авторезолвинг числовых genre_ids при загрузке коллекций: `_resolveGenresIfNeeded<T>()`. `updateItemStatus` автоматически устанавливает даты активности при смене статуса. `updateItemActivityDates` для ручного обновления дат. Методы per-item canvas: `getGameCanvasItems`, `getGameCanvasConnections`, `getGameCanvasViewport`, `upsertGameCanvasViewport`. Методы эпизодов: `getEpisodesByShowAndSeason`, `upsertEpisodes`, `clearEpisodesByShow`, `getWatchedEpisodes` (возвращает `Map<(int, int), DateTime?>` с датами просмотра), `markEpisodeWatched`, `markEpisodeUnwatched`, `getWatchedEpisodeCount`, `markSeasonWatched`, `unmarkSeasonWatched`. Изоляция данных: коллекционные методы фильтруют `collection_item_id IS NULL`. Метод `clearAllData()` — очистка всех 16 таблиц в транзакции. Метод `updateItemCollectionId()` — обновление `collection_id` и `sort_order` элемента (для Move to Collection). Миграция v18: UNIQUE индексы расширены на `COALESCE(platform_id, -1)` для мультиплатформенных игр. Метод `getUniquePlatformIds()` — уникальные ID платформ из игровых элементов. Метод `deleteCanvasItemByCollectionItemId()` — удаление канвас-элемента по ID элемента коллекции. Метод `findCollectionItem()` — поиск элемента по (collectionId, mediaType, externalId) для конфликт-резолюции при импорте. Миграция v19: таблица `wishlist`. Методы wishlist: `addWishlistItem()`, `getWishlistItems()`, `getWishlistItemCount()`, `updateWishlistItem()`, `resolveWishlistItem()`, `unresolveWishlistItem()`, `deleteWishlistItem()`, `clearResolvedWishlistItems()` |
+| `lib/core/logging/app_logger.dart` | **Утилита логирования**. `abstract final class AppLogger` — инициализация `package:logging` с выводом через `dart:developer`. Вызывается один раз в `main()`. Все core-классы используют `static final Logger _log = Logger('ClassName')` |
 | `lib/core/services/config_service.dart` | **Сервис конфигурации**. Экспорт/импорт 8 ключей SharedPreferences в JSON файл. Класс `ConfigResult` (success/failure/cancelled). Методы: `collectSettings()`, `applySettings()`, `exportToFile()`, `importFromFile()` |
 | `lib/core/services/image_cache_service.dart` | **Сервис кэширования изображений**. Enum `ImageType` (platformLogo, gameCover, moviePoster, tvShowPoster, canvasImage). Локальное хранение изображений в папках по типу. SharedPreferences для enable/disable и custom path. Валидация magic bytes (JPEG/PNG/WebP) при скачивании и при чтении из кэша. Безопасное удаление файлов (`_tryDelete`) при Windows file lock. Методы: `getImageUri()` (cache-first с fallback на remoteUrl + magic bytes проверка), `downloadImage()` (+ валидация), `downloadImages()`, `readImageBytes()`, `saveImageBytes()`, `clearCache()`, `getCacheSize()`, `getCachedCount()`. Провайдер `imageCacheServiceProvider` |
 | `lib/core/services/xcoll_file.dart` | **Модель файла экспорта/импорта**. Формат v2 (.xcoll/.xcollx, items + canvas + images). Классы: `XcollFile`, `ExportFormat` (light/full), `ExportCanvas`. Файлы v1 выбрасывают `FormatException` |

--- a/lib/core/api/igdb_api.dart
+++ b/lib/core/api/igdb_api.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../shared/models/game.dart';
 import '../../shared/models/platform.dart';
@@ -64,6 +65,9 @@ class IgdbApiException implements Exception {
 class IgdbApi {
   /// Создаёт экземпляр [IgdbApi].
   IgdbApi({Dio? dio}) : _dio = dio ?? Dio();
+
+  // ignore: unused_field
+  static final Logger _log = Logger('IgdbApi');
 
   static const String _twitchAuthUrl = 'https://id.twitch.tv/oauth2/token';
   static const String _igdbBaseUrl = 'https://api.igdb.com/v4';

--- a/lib/core/api/steamgriddb_api.dart
+++ b/lib/core/api/steamgriddb_api.dart
@@ -2,6 +2,7 @@
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../shared/models/steamgriddb_game.dart';
 import '../../shared/models/steamgriddb_image.dart';
@@ -35,6 +36,9 @@ class SteamGridDbApiException implements Exception {
 class SteamGridDbApi {
   /// Создаёт экземпляр [SteamGridDbApi].
   SteamGridDbApi({Dio? dio}) : _dio = dio ?? Dio();
+
+  // ignore: unused_field
+  static final Logger _log = Logger('SteamGridDbApi');
 
   static const String _baseUrl = 'https://www.steamgriddb.com/api/v2';
 

--- a/lib/core/api/tmdb_api.dart
+++ b/lib/core/api/tmdb_api.dart
@@ -3,6 +3,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../shared/models/movie.dart';
 import '../../shared/models/tmdb_review.dart';
@@ -113,6 +114,8 @@ class TmdbApi {
   TmdbApi({Dio? dio, String language = 'ru-RU'})
       : _dio = dio ?? Dio(),
         _language = language;
+
+  static final Logger _log = Logger('TmdbApi');
 
   static const String _baseUrl = 'https://api.themoviedb.org/3';
 
@@ -1049,7 +1052,8 @@ class TmdbApi {
       _movieGenreMap = <int, String>{
         for (final TmdbGenre g in genres) g.id: g.name,
       };
-    } catch (_) {
+    } catch (e) {
+      _log.warning('Failed to load movie genre map', e);
       _movieGenreMap = <int, String>{};
     }
     return _movieGenreMap!;
@@ -1063,7 +1067,8 @@ class TmdbApi {
       _tvGenreMap = <int, String>{
         for (final TmdbGenre g in genres) g.id: g.name,
       };
-    } catch (_) {
+    } catch (e) {
+      _log.warning('Failed to load TV genre map', e);
       _tvGenreMap = <int, String>{};
     }
     return _tvGenreMap!;

--- a/lib/core/api/vndb_api.dart
+++ b/lib/core/api/vndb_api.dart
@@ -2,6 +2,7 @@
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../shared/models/visual_novel.dart';
 
@@ -32,6 +33,9 @@ class VndbApiException implements Exception {
 class VndbApi {
   /// Создаёт экземпляр [VndbApi].
   VndbApi({Dio? dio}) : _dio = dio ?? Dio();
+
+  // ignore: unused_field
+  static final Logger _log = Logger('VndbApi');
 
   static const String _baseUrl = 'https://api.vndb.org/kana';
 

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -33,6 +34,8 @@ final Provider<DatabaseService> databaseServiceProvider =
 ///
 /// Управляет инициализацией базы данных и CRUD операциями для платформ.
 class DatabaseService {
+  static final Logger _log = Logger('DatabaseService');
+
   Database? _database;
 
   /// Возвращает экземпляр базы данных, инициализируя при необходимости.
@@ -70,13 +73,17 @@ class DatabaseService {
   }
 
   Future<void> _onCreate(Database db, int version) async {
+    _log.info('Creating database schema v$version');
     await DatabaseSchema.createAll(db);
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    _log.info('Upgrading database from v$oldVersion to v$newVersion');
     for (final Migration migration in MigrationRegistry.pending(oldVersion)) {
+      _log.fine('Running migration v${migration.version}: ${migration.description}');
       await migration.migrate(db);
     }
+    _log.info('Database upgrade complete');
   }
 
   // ==================== IGDB Genres ====================

--- a/lib/core/logging/app_logger.dart
+++ b/lib/core/logging/app_logger.dart
@@ -1,0 +1,27 @@
+import 'dart:developer' as developer;
+
+import 'package:logging/logging.dart';
+
+/// Настройка логирования для приложения.
+///
+/// Вызывается один раз в `main()` до `runApp()`.
+/// Выводит логи через `dart:developer` — видны в консоли `flutter run`
+/// и во вкладке Logging в Flutter DevTools.
+abstract final class AppLogger {
+  /// Инициализирует корневой логгер.
+  static void init() {
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen(_onLogRecord);
+  }
+
+  static void _onLogRecord(LogRecord record) {
+    developer.log(
+      record.message,
+      time: record.time,
+      level: record.level.value,
+      name: record.loggerName,
+      error: record.error,
+      stackTrace: record.stackTrace,
+    );
+  }
+}

--- a/lib/core/services/config_service.dart
+++ b/lib/core/services/config_service.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../features/settings/providers/settings_provider.dart';
@@ -69,6 +70,9 @@ class ConfigResult {
 class ConfigService {
   /// Создаёт экземпляр [ConfigService].
   ConfigService({required SharedPreferences prefs}) : _prefs = prefs;
+
+  // ignore: unused_field
+  static final Logger _log = Logger('ConfigService');
 
   final SharedPreferences _prefs;
 

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../data/repositories/canvas_repository.dart';
 import '../../shared/models/canvas_connection.dart';
@@ -83,6 +84,8 @@ class ExportService {
   })  : _canvasRepository = canvasRepository,
         _imageCacheService = imageCacheService,
         _database = database;
+
+  static final Logger _log = Logger('ExportService');
 
   final CanvasRepository? _canvasRepository;
   final ImageCacheService? _imageCacheService;
@@ -517,6 +520,7 @@ class ExportService {
     } on FileSystemException catch (e) {
       return ExportResult.failure('Failed to save file: ${e.message}');
     } catch (e) {
+      _log.warning('Export failed', e);
       return ExportResult.failure('Export failed: $e');
     }
   }

--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -51,6 +52,7 @@ final Provider<ImageCacheService> imageCacheServiceProvider =
 /// При включённом кэшировании изображения сохраняются локально
 /// и используются в оффлайн режиме.
 class ImageCacheService {
+  static final Logger _log = Logger('ImageCacheService');
   final Dio _dio = Dio();
 
   /// Возвращает базовый путь к директории кэша.
@@ -136,7 +138,8 @@ class ImageCacheService {
       }
       await file.writeAsBytes(bytes);
       return true;
-    } catch (_) {
+    } catch (e) {
+      _log.warning('Failed to save image bytes: $imageId', e);
       return false;
     }
   }
@@ -289,6 +292,7 @@ class ImageCacheService {
 
       return true;
     } catch (e) {
+      _log.warning('Failed to download image: $imageId', e);
       // Удаляем невалидный/частичный файл при ошибке
       final String localPath = await getLocalImagePath(type, imageId);
       final File partial = File(localPath);

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../data/repositories/canvas_repository.dart';
 import '../../data/repositories/collection_repository.dart';
@@ -187,6 +188,8 @@ class ImportService {
   final DatabaseService _database;
   final CanvasRepository? _canvasRepository;
   final ImageCacheService? _imageCacheService;
+
+  static final Logger _log = Logger('ImportService');
 
   /// Допустимые расширения для импорта коллекций.
   static const List<String> _allowedExtensions = <String>[
@@ -721,7 +724,7 @@ class ImportService {
       try {
         visualNovels = await vndbApi.getVnByIds(vnIds);
       } on VndbApiException catch (e) {
-        debugPrint('Failed to fetch visual novels: ${e.message}');
+        _log.warning('Failed to fetch visual novels: ${e.message}');
       }
       onProgress?.call(ImportProgress(
         stage: ImportStage.fetchingVisualNovels,
@@ -817,8 +820,8 @@ class ImportService {
         final bool success =
             await cache.saveImageBytes(imageType, imageId, bytes);
         if (success) restored++;
-      } catch (_) {
-        // Пропускаем невалидный base64
+      } catch (e) {
+        _log.warning('Failed to restore image from base64: $imageId', e);
       }
     }
 

--- a/lib/core/services/trakt_zip_import_service.dart
+++ b/lib/core/services/trakt_zip_import_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../data/repositories/collection_repository.dart';
 import '../../data/repositories/wishlist_repository.dart';
@@ -280,6 +281,9 @@ class TraktZipImportService {
         _repository = repository,
         _database = database,
         _wishlistRepository = wishlistRepository;
+
+  // ignore: unused_field
+  static final Logger _log = Logger('TraktZipImportService');
 
   final TmdbApi _tmdbApi;
   final CollectionRepository _repository;

--- a/lib/core/services/update_service.dart
+++ b/lib/core/services/update_service.dart
@@ -2,6 +2,7 @@
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -47,6 +48,9 @@ class UpdateService {
   })  : _prefs = prefs,
         _dio = dio,
         _currentVersionOverride = currentVersionOverride;
+
+  // ignore: unused_field
+  static final Logger _log = Logger('UpdateService');
 
   final SharedPreferences _prefs;
   final Dio _dio;

--- a/lib/features/settings/screens/gamepad_debug_screen.dart
+++ b/lib/features/settings/screens/gamepad_debug_screen.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gamepads/gamepads.dart';
+import 'package:logging/logging.dart';
 
 import '../../../core/services/gamepad_service.dart';
 import '../../../l10n/app_localizations.dart';
@@ -34,6 +35,8 @@ class GamepadDebugScreen extends ConsumerStatefulWidget {
 }
 
 class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
+  static final Logger _log = Logger('GamepadDebugScreen');
+
   final List<_EventEntry> _rawEvents = <_EventEntry>[];
   final List<_EventEntry> _serviceEvents = <_EventEntry>[];
   final ScrollController _rawScrollController = ScrollController();
@@ -47,8 +50,7 @@ class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
     final GamepadService service = ref.read(gamepadServiceProvider);
 
     _rawSub = service.rawEvents.listen((GamepadEvent event) {
-      // ignore: avoid_print
-      print('[GAMEPAD] key=${event.key}  type=${event.type}  '
+      _log.fine('key=${event.key}  type=${event.type}  '
           'value=${event.value.toStringAsFixed(3)}');
       setState(() {
         _rawEvents.insert(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,11 +6,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'app.dart';
+import 'core/logging/app_logger.dart';
 import 'features/settings/providers/settings_provider.dart';
 
 /// Точка входа в приложение.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  AppLogger.init();
 
   // Инициализация SQLite FFI для Windows/Linux/macOS
   if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -422,7 +422,7 @@ packages:
     source: hosted
     version: "6.1.0"
   logging:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,9 @@ dependencies:
   # Gamepad
   gamepads: ^0.1.9
 
+  # Logging
+  logging: ^1.3.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Add AppLogger utility with dart:developer output, visible in Flutter DevTools. Add Logger fields to 11 core classes, replace silent catch blocks with _log.warning, replace print/debugPrint with _log calls. Add dart-tonkatsu coding standards skill.