### PR TITLE
refactor: extract shared test helpers — mocks, builders, fallbacks, pumpApp

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,11 +127,18 @@ lib/core/database/
 - SQL-запросы в миграциях **нельзя** менять задним числом — только добавлять новые миграции
 - `database_service.dart` содержит **только** CRUD-операции и инициализацию — никаких CREATE TABLE / ALTER TABLE
 
-### Тесты (`test/`)
-- Зеркальная структура: `test/` повторяет `lib/`
-- Моки через mocktail: `class MockDio extends Mock implements Dio {}`
-- Группировка: `group('ClassName', () { group('methodName', () { ... }); });`
-- Widget тесты: `ProviderScope` с overrides для моков зависимостей
+### Tests (test/)
+- Mirror structure: test/ mirrors lib/
+- Shared helpers in test/helpers/:
+  - mocks.dart — all mock/fake classes (single source of truth)
+  - builders.dart — test data factories (createTestCollection, createTestStats, createTestCollectionItem, etc.)
+  - fallbacks.dart — registerAllFallbacks() for mocktail
+  - pump_app.dart — tester.pumpApp(widget, overrides: [...]) for widget tests
+  - test_helpers.dart — barrel export of all above
+- Mocks via mocktail, declared only in mocks.dart
+- Grouping: group('ClassName', () { group('methodName', () { ... }); });
+- Widget tests: use tester.pumpApp() instead of manual ProviderScope
+- Test behavior, not visuals — do not assert colors, text labels, icons, spacing. Tests should break only when logic breaks, not when design changes.
 
 ### Навигация
 ```dart
@@ -297,4 +304,5 @@ D-pad и кнопка A обрабатываются глобально в `Navi
 | `lib/shared/models/collection_item.dart` | Универсальный элемент коллекции |
 | `lib/shared/models/canvas_item.dart` | Элемент канваса (7 типов) |
 | `lib/shared/theme/app_theme.dart` | Централизованная тема (dark Material 3) |
+| `test/helpers/test_helpers.dart` | Shared mocks, builders, pumpApp for tests |
 | `analysis_options.yaml` | Строгие lint правила |

--- a/.claude/skills/full-coverage-tests/SKILL.md
+++ b/.claude/skills/full-coverage-tests/SKILL.md
@@ -1,128 +1,301 @@
 ---
 name: full-coverage-tests
-description: Creates unit tests with 100% code coverage. Use after writing any code or when requested by user.
+description: Creates unit tests with 100% code coverage using shared test helpers. Use after writing any code or when requested by user.
 ---
 
-# Creating Tests — Only Logic, No UI
+# Creating Tests with 100% Coverage
 
-## Scope
+## IMPORTANT: Shared Test Helpers
 
-**Тестируем ТОЛЬКО логику:**
-- Модели (fromJson, fromDb, toDb, copyWith, геттеры, операторы)
-- Сервисы и репозитории (CRUD, бизнес-логика, обработка ошибок)
-- Провайдеры Riverpod (state transitions, async logic)
-- API клиенты (запросы, парсинг, обработка ошибок)
-- Утилиты, хелперы, расширения
-- Миграции БД (структура данных, seed data)
+The project uses shared helpers in test/helpers/. Read this directory before writing any test.
 
-**НЕ тестируем:**
-- Наличие конкретных виджетов/кнопок/текстов в UI (find.text, find.byType для UI элементов)
-- Визуальное расположение элементов
-- Стили, цвета, размеры
-- Навигацию между экранами
-- Любые widget tests типа "должен показывать кнопку X" или "должен отображать текст Y"
+### Required Import
+
+One import replaces all mocks, builders, fallbacks, and pumpApp:
+
+  import '../../helpers/test_helpers.dart';
+
+Path depends on nesting depth:
+  test/core/api/          -> ../../helpers/test_helpers.dart
+  test/features/home/     -> ../../../helpers/test_helpers.dart
+  test/shared/models/     -> ../../helpers/test_helpers.dart
+
+### Forbidden
+
+- DO NOT declare mock classes inside test files if they exist in test/helpers/mocks.dart
+- DO NOT write registerFallbackValue() inline — use registerAllFallbacks() in setUpAll()
+- DO NOT construct Collection(...), CollectionStats(...) manually — use createTestCollection(), createTestStats() from builders.dart
+- DO NOT write ProviderScope + MaterialApp + localizationsDelegates manually — use tester.pumpApp()
+
+### When Local Declaration is OK
+
+- Mock/Fake is used only in this one file and does not exist in mocks.dart
+- Test data is unique to a specific test case
+- If you create a new mock — check if other tests need it too. If yes — add to mocks.dart
+
+---
+
+## What to Test vs What NOT to Test
+
+### DO TEST (logic and behavior):
+- Method returns correct value for given input
+- State changes after an action (status updated, item added/removed)
+- Error handling (exception thrown, error state set)
+- Async flows (loading -> data, loading -> error)
+- Navigation triggers (screen pushes on tap)
+- Conditional rendering (widget shown/hidden based on state)
+- Callbacks fire correctly (onTap called, onChanged called with value)
+- Data transformations (model parsing, JSON mapping, filtering, sorting)
+- Provider state transitions
+- Repository CRUD operations
+
+### DO NOT TEST (visual details):
+- Button labels and text content — "Save" vs "Submit" is cosmetic, not logic
+- Colors — AppColors.brand vs AppColors.error is a design decision
+- Font sizes, weights, styles — typography is not behavior
+- Icon types — Icons.add vs Icons.plus is cosmetic
+- Padding, margins, spacing — layout is not logic
+- Border radius, shadows, decorations — visual styling
+- Exact widget types for styling wrappers — dont assert find.byType(Container)
+- Localized string values — test that text IS displayed, not WHAT exact string
+
+### Why This Matters
+
+Visual tests are brittle. Every design tweak breaks them. A test like
+expect(find.text('Save'), findsOneWidget) breaks when you rename the button
+to "Submit" or translate to Russian — but nothing is actually broken.
+Tests should break only when behavior breaks.
+
+### Examples
+
+BAD — testing visual details:
+
+  test('save button has brand color', () {
+    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    expect(button.style?.backgroundColor, AppColors.brand);
+  });
+
+  test('title shows "My Collection"', () {
+    expect(find.text('My Collection'), findsOneWidget);
+  });
+
+  test('icon is Icons.folder', () {
+    expect(find.byIcon(Icons.folder), findsOneWidget);
+  });
+
+GOOD — testing behavior:
+
+  test('should save collection when save button is tapped', () async {
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    verify(() => mockRepo.save(any())).called(1);
+  });
+
+  test('should display collection name from data', () {
+    final collection = createTestCollection(name: 'RPG Games');
+    // ... setup ...
+    expect(find.text('RPG Games'), findsOneWidget);
+    // OK — testing that data flows to UI, not a static label
+  });
+
+  test('should navigate to detail on item tap', () async {
+    await tester.tap(find.byType(CollectionCard).first);
+    await tester.pumpAndSettle();
+    expect(find.byType(CollectionScreen), findsOneWidget);
+  });
+
+### Clarification: Data-Driven Text is OK
+
+Testing that dynamic data renders correctly IS behavior:
+
+  // OK — data flows from model to UI
+  expect(find.text('23 items'), findsOneWidget); // computed from stats.total
+  expect(find.text('RPG Games'), findsOneWidget); // from collection.name
+
+  // NOT OK — static UI labels
+  expect(find.text('Collections'), findsOneWidget); // screen title
+  expect(find.text('Add new'), findsOneWidget);     // button label
+  expect(find.text('No items yet'), findsOneWidget); // empty state message
+
+---
 
 ## Process
 
 ### 1. Code Analysis
-- Read all the code that needs test coverage
+- Read all code that needs test coverage
 - Identify all public methods and functions
 - Find all conditional branches (if/else/switch/try-catch)
 - Determine edge cases
+- Check which dependencies need mocking
 
-### 2. Test Structure
-```dart
-import 'package:flutter_test/flutter_test.dart';
+### 2. Check Helpers
+- Open test/helpers/mocks.dart — does the mock exist?
+- Open test/helpers/builders.dart — does the builder exist?
+- If something is missing and will be used in 2+ tests — add to helpers first
 
-void main() {
-  group('ClassName', () {
-    late ClassName sut; // System Under Test
+### 3. Test Structure
 
-    setUp(() {
-      sut = ClassName();
-    });
+  import 'package:flutter_test/flutter_test.dart';
+  import 'package:mocktail/mocktail.dart';
+  import 'package:xerabora/path/to/class.dart';
+  import '../../helpers/test_helpers.dart';
 
-    group('methodName', () {
-      test('should return X when Y', () {
-        // Arrange
-        final input = ...;
+  void main() {
+    group('ClassName', () {
+      late ClassName sut;
+      late MockDependency mockDep;
 
-        // Act
-        final result = sut.methodName(input);
+      setUpAll(() => registerAllFallbacks());
 
-        // Assert
-        expect(result, equals(expected));
+      setUp(() {
+        mockDep = MockDependency();
+        sut = ClassName(dependency: mockDep);
+      });
+
+      group('methodName', () {
+        test('should return X when Y', () {
+          // Arrange
+          when(() => mockDep.getData(any()))
+              .thenAnswer((_) async => createTestData());
+          // Act
+          final result = sut.methodName(input);
+          // Assert
+          expect(result, equals(expected));
+        });
       });
     });
-  });
-}
-```
+  }
 
-### 3. What to Cover (Checklist)
+### 4. Widget Tests
 
-#### For each function/method:
-- [ ] Happy path (successful scenario)
-- [ ] Empty input (null, [], '')
-- [ ] Boundary values (0, -1, maxInt)
-- [ ] Invalid input
-- [ ] All if/else branches
-- [ ] All switch cases
-- [ ] Exception handling (try-catch)
+  import 'package:flutter_test/flutter_test.dart';
+  import 'package:mocktail/mocktail.dart';
+  import 'package:xerabora/features/my_feature/screens/my_screen.dart';
+  import 'package:xerabora/data/repositories/collection_repository.dart';
+  import '../../../helpers/test_helpers.dart';
 
-#### For async code:
-- [ ] Successful execution
-- [ ] Timeout
-- [ ] Network/API error
-- [ ] Operation cancellation
+  void main() {
+    group('MyScreen', () {
+      late MockCollectionRepository mockRepo;
 
-#### For models:
-- [ ] fromJson — all fields, missing fields, null fields
-- [ ] fromDb — all fields, missing fields
-- [ ] toDb — round-trip (fromDb → toDb → fromDb)
-- [ ] copyWith — each field individually, no-change copy
-- [ ] Computed getters (displayName, urls, etc.)
-- [ ] equality / toString if overridden
+      setUpAll(() => registerAllFallbacks());
 
-#### For providers (Riverpod):
-- [ ] Initial state
-- [ ] State after method calls
-- [ ] Error states
-- [ ] Dependencies (mock ref.watch/ref.read)
+      setUp(() {
+        mockRepo = MockCollectionRepository();
+      });
 
-### 4. Mocks and Stubs
-```dart
-// Use mocktail for mocks
-import 'package:mocktail/mocktail.dart';
+      testWidgets('renders without errors', (WidgetTester tester) async {
+        when(() => mockRepo.getAll())
+            .thenAnswer((_) async => createTestCollections());
+        when(() => mockRepo.getStats(any()))
+            .thenAnswer((_) async => createTestStats());
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+        await tester.pumpApp(
+          const MyScreen(),
+          overrides: [
+            collectionRepositoryProvider.overrideWithValue(mockRepo),
+          ],
+        );
+        expect(tester.takeException(), isNull);
+      });
 
-// In tests
-final MockDatabaseService mockDb = MockDatabaseService();
-when(() => mockDb.getAllPlatforms()).thenAnswer((_) async => <Platform>[]);
-```
+      testWidgets('navigates to detail on tap', (WidgetTester tester) async {
+        // ... setup ...
+        await tester.pumpApp(const MyScreen(), overrides: [...]);
+        await tester.tap(find.byType(CollectionCard).first);
+        await tester.pumpAndSettle();
+        expect(find.byType(CollectionScreen), findsOneWidget);
+      });
+    });
+  }
 
-### 5. Coverage Verification
-```bash
-# Run tests with coverage
-flutter test --coverage
+### 5. Coverage Checklist
 
-# Generate HTML report (optional)
-genhtml coverage/lcov.info -o coverage/html
-```
+Per method:
+- Happy path
+- Empty input (null, [], '')
+- Boundary values (0, -1, maxInt)
+- Invalid input
+- All if/else branches
+- All switch cases
+- Exception handling (try-catch)
 
-### 6. Completion Criteria
-- All tests pass (`flutter test`)
-- All logic branches covered
-- Edge cases tested
-- No missed error handling paths
+Async code:
+- Successful execution
+- Timeout
+- Network/API error
+- Cancellation
 
-## Test Naming Convention
-```
-should [expected result] when [condition]
-```
+Widget tests:
+- Renders in each state (data, loading, error, empty)
+- Tap handlers trigger correct actions
+- Conditional widgets show/hide based on state
+- Lists render correct item count
+- Uses tester.pumpApp()
+- NO assertions on colors, labels, icons, spacing
+
+### 6. Available Builders
+
+Check builders.dart before creating test data:
+
+  createTestCollection(name: 'RPG Games', type: CollectionType.own)
+  createTestCollections(count: 5)
+  createTestStats(total: 10, completed: 7)
+  createTestItem(mediaType: MediaType.game, status: ItemStatus.completed)
+  createMovieJson(title: 'Inception', voteAverage: 8.8)
+  createTvShowJson(name: 'Breaking Bad', numberOfSeasons: 5)
+  createGameJson(name: 'Elden Ring', rating: 95.0)
+
+If you need a builder that doesnt exist — add to builders.dart, dont create locally.
+
+### 7. Available Mocks
+
+Check mocks.dart before declaring a mock:
+
+  MockDio, MockDatabase, MockDatabaseService, MockConfigService
+  MockTmdbApi, MockIgdbApi, MockSteamGridDbApi, MockVndbApi
+  MockImageCacheService, MockTraktZipImportService
+  MockCollectionRepository, MockCanvasRepository
+  MockGameRepository, MockWishlistRepository
+  MockCollectionItemsNotifier, MockWidgetRef, MockS
+  FakeCanvasItem, FakeCanvasConnection, FakeCanvasViewport, FakeGame
+
+### 8. Verification
+
+  powershell.exe -Command "cd D:\CODE\xerabora; flutter test"
+  powershell.exe -Command "cd D:\CODE\xerabora; flutter test --coverage"
+
+  # Check: no duplicate mocks outside helpers
+  grep -r "class Mock" test/ --include="*_test.dart"
+  # Result should be empty (all mocks live in helpers/mocks.dart)
+
+### 9. Completion Criteria
+
+- All tests pass (flutter test)
+- Line coverage >= 100%
+- Branch coverage >= 100%
+- No missed edge cases
+- No duplicate mock classes (all in test/helpers/mocks.dart)
+- No inline registerFallbackValue (use registerAllFallbacks())
+- No inline builders if equivalent exists in builders.dart
+- Widget tests use tester.pumpApp()
+- No visual assertions (colors, text labels, icons, spacing)
+
+## Test Naming
+
+  should [expected result] when [condition]
 
 Examples:
-- `should return empty list when no data exists`
-- `should throw exception when id is invalid`
-- `should parse all fields from valid JSON`
-- `should fallback to default when abbreviation is null`
+- should return empty list when no data exists
+- should throw exception when id is invalid
+- should navigate to detail when item is tapped
+- should call save when form is submitted
+
+## When Adding New Mocks/Builders
+
+When creating a new class and writing tests for it:
+
+1. Mock needed in 2+ test files? -> Add to test/helpers/mocks.dart
+2. Data factory needed in 2+ files? -> Add to test/helpers/builders.dart
+3. New fallback value? -> Add to registerAllFallbacks() in test/helpers/fallbacks.dart
+4. Mock/builder unique to one test? -> OK to declare locally

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:xerabora/app.dart';
 import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/core/services/update_service.dart';
@@ -14,11 +13,7 @@ import 'package:xerabora/features/splash/screens/splash_screen.dart';
 import 'package:xerabora/features/welcome/screens/welcome_screen.dart';
 import 'package:xerabora/shared/navigation/navigation_shell.dart';
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockDatabase extends Mock implements Database {}
+import 'helpers/test_helpers.dart';
 
 void main() {
   group('TonkatsuBoxApp', () {

--- a/test/core/api/igdb_api_games_test.dart
+++ b/test/core/api/igdb_api_games_test.dart
@@ -4,7 +4,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/api/igdb_api.dart';
 import 'package:xerabora/shared/models/game.dart';
 
-class MockDio extends Mock implements Dio {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late MockDio mockDio;

--- a/test/core/api/igdb_api_test.dart
+++ b/test/core/api/igdb_api_test.dart
@@ -5,7 +5,7 @@ import 'package:xerabora/core/api/igdb_api.dart';
 import 'package:xerabora/shared/models/game.dart';
 import 'package:xerabora/shared/models/platform.dart';
 
-class MockDio extends Mock implements Dio {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late IgdbApi sut;

--- a/test/core/api/steamgriddb_api_test.dart
+++ b/test/core/api/steamgriddb_api_test.dart
@@ -5,7 +5,7 @@ import 'package:xerabora/core/api/steamgriddb_api.dart';
 import 'package:xerabora/shared/models/steamgriddb_game.dart';
 import 'package:xerabora/shared/models/steamgriddb_image.dart';
 
-class MockDio extends Mock implements Dio {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late SteamGridDbApi sut;

--- a/test/core/api/tmdb_api_test.dart
+++ b/test/core/api/tmdb_api_test.dart
@@ -10,7 +10,7 @@ import 'package:xerabora/shared/models/tv_episode.dart';
 import 'package:xerabora/shared/models/tv_season.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 
-class MockDio extends Mock implements Dio {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late TmdbApi sut;

--- a/test/core/api/vndb_api_test.dart
+++ b/test/core/api/vndb_api_test.dart
@@ -6,7 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/api/vndb_api.dart';
 import 'package:xerabora/shared/models/visual_novel.dart';
 
-class MockDio extends Mock implements Dio {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late MockDio mockDio;

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -6,7 +6,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/services/export_service.dart';
 import 'package:xerabora/core/services/image_cache_service.dart';
 import 'package:xerabora/core/services/xcoll_file.dart';
-import 'package:xerabora/data/repositories/canvas_repository.dart';
 import 'package:xerabora/shared/models/canvas_connection.dart';
 import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
@@ -20,67 +19,13 @@ import 'package:xerabora/shared/models/platform.dart';
 import 'package:xerabora/shared/models/tv_episode.dart';
 import 'package:xerabora/shared/models/tv_season.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
-import 'package:xerabora/core/database/database_service.dart';
 
-class MockCanvasRepository extends Mock implements CanvasRepository {}
-
-class MockImageCacheService extends Mock implements ImageCacheService {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(ImageType.gameCover);
-    registerFallbackValue(Uint8List(0));
+    registerAllFallbacks();
   });
-
-  final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
-
-  Collection createTestCollection({
-    int id = 1,
-    String name = 'Test Collection',
-    String author = 'Test Author',
-    CollectionType type = CollectionType.own,
-  }) {
-    return Collection(
-      id: id,
-      name: name,
-      author: author,
-      type: type,
-      createdAt: testDate,
-    );
-  }
-
-  CollectionItem createTestItem({
-    int id = 1,
-    int collectionId = 1,
-    MediaType mediaType = MediaType.game,
-    int externalId = 100,
-    int? platformId = 18,
-    ItemStatus status = ItemStatus.notStarted,
-    String? authorComment,
-    int currentSeason = 0,
-    int currentEpisode = 0,
-    Game? game,
-    Movie? movie,
-    TvShow? tvShow,
-  }) {
-    return CollectionItem(
-      id: id,
-      collectionId: collectionId,
-      mediaType: mediaType,
-      externalId: externalId,
-      platformId: platformId,
-      status: status,
-      authorComment: authorComment,
-      currentSeason: currentSeason,
-      currentEpisode: currentEpisode,
-      addedAt: testDate,
-      game: game,
-      movie: movie,
-      tvShow: tvShow,
-    );
-  }
 
   group('ExportResult', () {
     test('ExportResult.success должен создать успешный результат', () {
@@ -147,21 +92,21 @@ void main() {
       test('должен экспортировать все типы медиа', () {
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             mediaType: MediaType.game,
             externalId: 100,
             platformId: 18,
             status: ItemStatus.completed,
             authorComment: 'Great game',
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.movie,
             externalId: 550,
             platformId: null,
             status: ItemStatus.notStarted,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 3,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -193,7 +138,7 @@ void main() {
 
       test('должен использовать toExport() для каждого элемента', () {
         final Collection collection = createTestCollection();
-        final CollectionItem item = createTestItem(
+        final CollectionItem item = createTestCollectionItem(
           mediaType: MediaType.game,
           externalId: 42,
           platformId: 6,
@@ -299,7 +244,7 @@ void main() {
       test('должен включить per-item canvas', () async {
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(id: 10, externalId: 100),
+          createTestCollectionItem(id: 10, externalId: 100),
         ];
 
         // Collection canvas — пустой
@@ -347,7 +292,7 @@ void main() {
       test('не должен включать _canvas если per-item canvas пуст', () async {
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(id: 10, externalId: 100),
+          createTestCollectionItem(id: 10, externalId: 100),
         ];
 
         when(() => mockCanvasRepo.getViewport(any()))
@@ -383,7 +328,7 @@ void main() {
         final Collection collection =
             createTestCollection(name: 'JSON Export');
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(externalId: 500, platformId: 20),
+          createTestCollectionItem(externalId: 500, platformId: 20),
         ];
 
         final String json = sut.exportToJson(collection, items);
@@ -422,7 +367,7 @@ void main() {
       test('должен сохранять все данные при round-trip', () {
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             externalId: 111,
             platformId: 22,
             authorComment: 'Fantastic game',
@@ -507,7 +452,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(externalId: 100),
+          createTestCollectionItem(externalId: 100),
         ];
 
         final XcollFile xcoll =
@@ -532,7 +477,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(externalId: 100),
+          createTestCollectionItem(externalId: 100),
         ];
 
         final XcollFile xcoll =
@@ -555,8 +500,8 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(id: 1, externalId: 100),
-          createTestItem(id: 2, externalId: 100),
+          createTestCollectionItem(id: 1, externalId: 100),
+          createTestCollectionItem(id: 2, externalId: 100),
         ];
 
         // Мокаем getGameCanvasItems для per-item canvas
@@ -603,18 +548,18 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 100,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.movie,
             externalId: 200,
             platformId: null,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 3,
             mediaType: MediaType.tvShow,
             externalId: 300,
@@ -641,7 +586,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(externalId: 100),
+          createTestCollectionItem(externalId: 100),
         ];
 
         final XcollFile xcoll =
@@ -668,7 +613,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.animation,
             externalId: 500,
@@ -704,7 +649,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.animation,
             externalId: 600,
@@ -842,7 +787,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(id: 10, externalId: 100),
+          createTestCollectionItem(id: 10, externalId: 100),
         ];
 
         final XcollFile xcoll =
@@ -1024,7 +969,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(id: 10, externalId: 100),
+          createTestCollectionItem(id: 10, externalId: 100),
         ];
 
         final XcollFile xcoll =
@@ -1046,14 +991,14 @@ void main() {
         final Collection collection =
             createTestCollection(name: 'Round Trip');
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             mediaType: MediaType.game,
             externalId: 42,
             platformId: 6,
             status: ItemStatus.completed,
             authorComment: 'Best game',
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1130,7 +1075,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
@@ -1168,7 +1113,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.movie,
             externalId: 550,
@@ -1206,7 +1151,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1239,13 +1184,13 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
             game: testGame,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.game,
             externalId: 42,
@@ -1274,7 +1219,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.animation,
             externalId: 999,
@@ -1309,7 +1254,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.animation,
             externalId: 888,
@@ -1339,7 +1284,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
@@ -1380,20 +1325,20 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
             game: testGame,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.movie,
             externalId: 550,
             platformId: null,
             movie: testMovie,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 3,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1467,7 +1412,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1505,7 +1450,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1543,7 +1488,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.animation,
             externalId: 999,
@@ -1575,7 +1520,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.animation,
             externalId: 888,
@@ -1601,7 +1546,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1635,14 +1580,14 @@ void main() {
         final Collection collection = createTestCollection();
         // Два элемента с одинаковым tvShow ID
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
             platformId: null,
             tvShow: testTvShow,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.animation,
             externalId: 1399,
@@ -1721,7 +1666,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1756,7 +1701,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
@@ -1794,14 +1739,14 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.tvShow,
             externalId: 1399,
             platformId: null,
             tvShow: testTvShow,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.animation,
             externalId: 1399,
@@ -1864,7 +1809,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
@@ -1897,7 +1842,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
@@ -1926,7 +1871,7 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
@@ -1968,13 +1913,13 @@ void main() {
 
         final Collection collection = createTestCollection();
         final List<CollectionItem> items = <CollectionItem>[
-          createTestItem(
+          createTestCollectionItem(
             id: 1,
             mediaType: MediaType.game,
             externalId: 42,
             game: game1,
           ),
-          createTestItem(
+          createTestCollectionItem(
             id: 2,
             mediaType: MediaType.game,
             externalId: 43,

--- a/test/core/services/gamepad_service_test.dart
+++ b/test/core/services/gamepad_service_test.dart
@@ -1,23 +1,10 @@
 // Тесты для GamepadService — маппинг, нормализация, дедзона, debounce.
 
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gamepads/gamepads.dart';
 import 'package:xerabora/core/services/gamepad_service.dart';
 
-/// Мок-источник событий для тестов.
-class MockGamepadEventSource implements GamepadEventSource {
-  final StreamController<GamepadEvent> controller =
-      StreamController<GamepadEvent>.broadcast();
-
-  @override
-  Stream<GamepadEvent> get events => controller.stream;
-
-  void emit(GamepadEvent event) => controller.add(event);
-
-  void dispose() => controller.close();
-}
+import '../../helpers/test_helpers.dart';
 
 /// Хелпер для создания GamepadEvent.
 GamepadEvent _event({

--- a/test/core/services/import_service_test.dart
+++ b/test/core/services/import_service_test.dart
@@ -4,14 +4,11 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/services/image_cache_service.dart';
 import 'package:xerabora/core/api/igdb_api.dart';
 import 'package:xerabora/core/api/tmdb_api.dart';
-import 'package:xerabora/core/database/database_service.dart';
-import 'package:xerabora/core/services/image_cache_service.dart';
 import 'package:xerabora/core/services/import_service.dart';
 import 'package:xerabora/core/services/xcoll_file.dart';
-import 'package:xerabora/data/repositories/canvas_repository.dart';
-import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/shared/models/canvas_connection.dart';
 import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
@@ -19,56 +16,13 @@ import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/game.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/movie.dart';
-import 'package:xerabora/shared/models/platform.dart';
-import 'package:xerabora/shared/models/tv_episode.dart';
-import 'package:xerabora/shared/models/tv_season.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockIgdbApi extends Mock implements IgdbApi {}
-
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockCanvasRepository extends Mock implements CanvasRepository {}
-
-class MockImageCacheService extends Mock implements ImageCacheService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
-  final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
-
   setUpAll(() {
-    registerFallbackValue(const Game(id: 0, name: 'fallback'));
-    registerFallbackValue(const Movie(tmdbId: 0, title: 'fallback'));
-    registerFallbackValue(const TvShow(tmdbId: 0, title: 'fallback'));
-    registerFallbackValue(const <Game>[]);
-    registerFallbackValue(const <Movie>[]);
-    registerFallbackValue(const <TvShow>[]);
-    registerFallbackValue(const <TvSeason>[]);
-    registerFallbackValue(const <TvEpisode>[]);
-    registerFallbackValue(const <Platform>[]);
-    registerFallbackValue(CollectionType.own);
-    registerFallbackValue(MediaType.game);
-    registerFallbackValue(const CanvasViewport(collectionId: 0));
-    registerFallbackValue(CanvasItem(
-      id: 0,
-      collectionId: 0,
-      itemType: CanvasItemType.game,
-      x: 0,
-      y: 0,
-      createdAt: DateTime.now(),
-    ));
-    registerFallbackValue(CanvasConnection(
-      id: 0,
-      collectionId: 0,
-      fromItemId: 0,
-      toItemId: 0,
-      createdAt: DateTime.now(),
-    ));
-    registerFallbackValue(Uint8List(0));
-    registerFallbackValue(ImageType.gameCover);
+    registerAllFallbacks();
   });
 
   group('ImportResult', () {

--- a/test/core/services/trakt_zip_import_service_test.dart
+++ b/test/core/services/trakt_zip_import_service_test.dart
@@ -5,11 +5,8 @@ import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/api/tmdb_api.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/core/services/import_service.dart';
 import 'package:xerabora/core/services/trakt_zip_import_service.dart';
-import 'package:xerabora/data/repositories/collection_repository.dart';
-import 'package:xerabora/data/repositories/wishlist_repository.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/item_status.dart';
@@ -18,17 +15,7 @@ import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 import 'package:xerabora/shared/models/wishlist_item.dart';
 
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
-
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockWishlistRepository extends Mock implements WishlistRepository {}
+import '../../helpers/test_helpers.dart';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -169,14 +156,8 @@ void main() {
   late Directory tempDir;
   late String zipPath;
 
-  final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
-
   setUpAll(() {
-    registerFallbackValue(const Movie(tmdbId: 0, title: 'fallback'));
-    registerFallbackValue(const TvShow(tmdbId: 0, title: 'fallback'));
-    registerFallbackValue(MediaType.game);
-    registerFallbackValue(ItemStatus.notStarted);
-    registerFallbackValue(CollectionType.own);
+    registerAllFallbacks();
   });
 
   setUp(() {
@@ -204,43 +185,6 @@ void main() {
   /// Записывает байты ZIP в тестовый файл.
   void writeZip(List<int> bytes) {
     File(zipPath).writeAsBytesSync(bytes);
-  }
-
-  /// Хелпер для создания тестовой коллекции.
-  Collection createTestCollection({
-    int id = 1,
-    String name = 'Test',
-    String author = 'testuser',
-  }) {
-    return Collection(
-      id: id,
-      name: name,
-      author: author,
-      type: CollectionType.own,
-      createdAt: testDate,
-    );
-  }
-
-  /// Хелпер для создания CollectionItem.
-  CollectionItem createTestItem({
-    int id = 1,
-    int collectionId = 1,
-    MediaType mediaType = MediaType.movie,
-    int externalId = 100,
-    ItemStatus status = ItemStatus.notStarted,
-    int? userRating,
-    DateTime? completedAt,
-  }) {
-    return CollectionItem(
-      id: id,
-      collectionId: collectionId,
-      mediaType: mediaType,
-      externalId: externalId,
-      status: status,
-      userRating: userRating,
-      completedAt: completedAt,
-      addedAt: testDate,
-    );
   }
 
   // =========================================================================
@@ -951,9 +895,10 @@ void main() {
             .thenAnswer((_) async => testMovie);
 
         // Фильм уже в коллекции, но без рейтинга
-        final CollectionItem existingItem = createTestItem(
+        final CollectionItem existingItem = createTestCollectionItem(
           id: 50,
           externalId: 300,
+          mediaType: MediaType.movie,
           status: ItemStatus.completed,
           userRating: null,
         );
@@ -989,9 +934,10 @@ void main() {
             .thenAnswer((_) async => testMovie);
 
         // Фильм уже в коллекции С рейтингом
-        final CollectionItem existingItem = createTestItem(
+        final CollectionItem existingItem = createTestCollectionItem(
           id: 50,
           externalId: 300,
+          mediaType: MediaType.movie,
           status: ItemStatus.completed,
           userRating: 7,
         );
@@ -1069,9 +1015,10 @@ void main() {
             .thenAnswer((_) async => testMovie);
 
         // Элемент уже planned
-        final CollectionItem existingPlanned = createTestItem(
+        final CollectionItem existingPlanned = createTestCollectionItem(
           id: 70,
           externalId: 100,
+          mediaType: MediaType.movie,
           status: ItemStatus.planned,
         );
         when(() => mockRepo.findItem(
@@ -1105,7 +1052,7 @@ void main() {
             .thenAnswer((_) async => testShow);
 
         // Элемент уже completed
-        final CollectionItem existingCompleted = createTestItem(
+        final CollectionItem existingCompleted = createTestCollectionItem(
           id: 80,
           externalId: 200,
           mediaType: MediaType.tvShow,
@@ -1150,9 +1097,10 @@ void main() {
             .thenAnswer((_) async => testMovie);
 
         // Элемент dropped
-        final CollectionItem existingDropped = createTestItem(
+        final CollectionItem existingDropped = createTestCollectionItem(
           id: 90,
           externalId: 100,
+          mediaType: MediaType.movie,
           status: ItemStatus.dropped,
         );
         when(() => mockRepo.findItem(
@@ -1185,9 +1133,10 @@ void main() {
             .thenAnswer((_) async => testMovie);
 
         // Элемент без completedAt
-        final CollectionItem existingItem = createTestItem(
+        final CollectionItem existingItem = createTestCollectionItem(
           id: 95,
           externalId: 100,
+          mediaType: MediaType.movie,
           status: ItemStatus.planned,
           completedAt: null,
         );
@@ -1349,9 +1298,10 @@ void main() {
             .thenAnswer((_) async => existingMovie);
 
         // Элемент уже в коллекции
-        final CollectionItem existing = createTestItem(
+        final CollectionItem existing = createTestCollectionItem(
           id: 55,
           externalId: 400,
+          mediaType: MediaType.movie,
           status: ItemStatus.completed,
         );
         when(() => mockRepo.findItem(
@@ -1852,9 +1802,10 @@ void main() {
             .thenAnswer((_) async => testMovie);
 
         // Элемент существует без рейтинга
-        final CollectionItem existingItem = createTestItem(
+        final CollectionItem existingItem = createTestCollectionItem(
           id: 50,
           externalId: 300,
+          mediaType: MediaType.movie,
           userRating: null,
         );
         when(() => mockRepo.findItem(
@@ -1897,9 +1848,10 @@ void main() {
 
         // Элемент уже имеет completedAt
         final DateTime existingCompletedAt = DateTime(2022, 1, 1);
-        final CollectionItem existingItem = createTestItem(
+        final CollectionItem existingItem = createTestCollectionItem(
           id: 96,
           externalId: 100,
+          mediaType: MediaType.movie,
           status: ItemStatus.planned,
           completedAt: existingCompletedAt,
         );

--- a/test/core/services/update_service_test.dart
+++ b/test/core/services/update_service_test.dart
@@ -6,7 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xerabora/core/services/update_service.dart';
 
-class MockDio extends Mock implements Dio {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -36,7 +36,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(Options());
+    registerAllFallbacks();
   });
 
   group('UpdateInfo', () {

--- a/test/data/repositories/canvas_repository_connections_test.dart
+++ b/test/data/repositories/canvas_repository_connections_test.dart
@@ -1,12 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/canvas_repository.dart';
 import 'package:xerabora/shared/models/canvas_connection.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
+  setUpAll(() {
+    registerAllFallbacks();
+  });
+
   group('CanvasRepository — Connections', () {
     late MockDatabaseService mockDb;
     late CanvasRepository repository;

--- a/test/data/repositories/canvas_repository_test.dart
+++ b/test/data/repositories/canvas_repository_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/canvas_repository.dart';
 import 'package:xerabora/shared/models/canvas_connection.dart';
 import 'package:xerabora/shared/models/canvas_item.dart';
@@ -13,9 +12,13 @@ import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 import 'package:xerabora/shared/models/visual_novel.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
+  setUpAll(() {
+    registerAllFallbacks();
+  });
+
   group('CanvasRepository', () {
     late MockDatabaseService mockDb;
     late CanvasRepository repository;

--- a/test/data/repositories/collection_repository_test.dart
+++ b/test/data/repositories/collection_repository_test.dart
@@ -1,17 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/shared/models/collection.dart';
-import 'package:xerabora/shared/models/item_status.dart';
-import 'package:xerabora/shared/models/media_type.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(MediaType.game);
-    registerFallbackValue(ItemStatus.notStarted);
+    registerAllFallbacks();
   });
 
   group('CollectionStats', () {
@@ -136,23 +132,6 @@ void main() {
   group('CollectionRepository', () {
     late MockDatabaseService mockDb;
     late CollectionRepository repository;
-
-    final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
-
-    Collection createTestCollection({
-      int id = 1,
-      String name = 'Test Collection',
-      String author = 'Test Author',
-      CollectionType type = CollectionType.own,
-    }) {
-      return Collection(
-        id: id,
-        name: name,
-        author: author,
-        type: type,
-        createdAt: testDate,
-      );
-    }
 
     setUp(() {
       mockDb = MockDatabaseService();

--- a/test/data/repositories/game_repository_test.dart
+++ b/test/data/repositories/game_repository_test.dart
@@ -1,16 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:xerabora/core/api/igdb_api.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/game_repository.dart';
 import 'package:xerabora/shared/models/game.dart';
 import 'package:xerabora/shared/models/platform.dart';
 
-class MockIgdbApi extends Mock implements IgdbApi {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class FakeGame extends Fake implements Game {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late MockIgdbApi mockApi;
@@ -18,10 +12,7 @@ void main() {
   late GameRepository repository;
 
   setUpAll(() {
-    registerFallbackValue(FakeGame());
-    registerFallbackValue(<Game>[]);
-    registerFallbackValue(<int>[]);
-    registerFallbackValue(<Platform>[]);
+    registerAllFallbacks();
   });
 
   setUp(() {

--- a/test/data/repositories/wishlist_repository_test.dart
+++ b/test/data/repositories/wishlist_repository_test.dart
@@ -1,11 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/wishlist_repository.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/wishlist_item.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late MockDatabaseService mockDb;
@@ -17,7 +16,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(MediaType.game);
+    registerAllFallbacks();
   });
 
   final WishlistItem testItem = WishlistItem(

--- a/test/features/collections/providers/canvas_provider_connections_test.dart
+++ b/test/features/collections/providers/canvas_provider_connections_test.dart
@@ -7,29 +7,11 @@ import 'package:xerabora/features/collections/providers/collections_provider.dar
 import 'package:xerabora/shared/models/canvas_connection.dart';
 import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
-import 'package:xerabora/shared/models/collection_item.dart';
 
-class MockCanvasRepository extends Mock implements CanvasRepository {}
-
-class MockCollectionItemsNotifier extends CollectionItemsNotifier {
-  @override
-  AsyncValue<List<CollectionItem>> build(int? arg) {
-    return const AsyncValue<List<CollectionItem>>.data(<CollectionItem>[]);
-  }
-}
-
-class FakeCanvasItem extends Fake implements CanvasItem {}
-
-class FakeCanvasViewport extends Fake implements CanvasViewport {}
-
-class FakeCanvasConnection extends Fake implements CanvasConnection {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
-  setUpAll(() {
-    registerFallbackValue(FakeCanvasItem());
-    registerFallbackValue(FakeCanvasViewport());
-    registerFallbackValue(FakeCanvasConnection());
-  });
+  setUpAll(registerAllFallbacks);
 
   group('CanvasState — connections', () {
     test('should create with empty connections by default', () {

--- a/test/features/collections/providers/canvas_provider_test.dart
+++ b/test/features/collections/providers/canvas_provider_test.dart
@@ -14,37 +14,10 @@ import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 
-// Моки
-class MockCanvasRepository extends Mock implements CanvasRepository {}
-
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockCollectionItemsNotifier extends CollectionItemsNotifier {
-  MockCollectionItemsNotifier(this._initialState);
-
-  final AsyncValue<List<CollectionItem>> _initialState;
-
-  @override
-  AsyncValue<List<CollectionItem>> build(int? arg) {
-    return _initialState;
-  }
-
-  void emitState(AsyncValue<List<CollectionItem>> newState) {
-    state = newState;
-  }
-}
-
-// Фейковые классы для registerFallbackValue
-class FakeCanvasItem extends Fake implements CanvasItem {}
-
-class FakeCanvasViewport extends Fake implements CanvasViewport {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
-  // Регистрация фейковых значений для mocktail
-  setUpAll(() {
-    registerFallbackValue(FakeCanvasItem());
-    registerFallbackValue(FakeCanvasViewport());
-  });
+  setUpAll(registerAllFallbacks);
 
   group('CanvasState', () {
     test('should create with default values', () {

--- a/test/features/collections/providers/collection_covers_provider_test.dart
+++ b/test/features/collections/providers/collection_covers_provider_test.dart
@@ -6,7 +6,7 @@ import 'package:xerabora/features/collections/providers/collection_covers_provid
 import 'package:xerabora/shared/models/cover_info.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockDatabaseService mockDb;

--- a/test/features/collections/providers/collections_provider_test.dart
+++ b/test/features/collections/providers/collections_provider_test.dart
@@ -12,8 +12,7 @@ import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 
-// Моки
-class MockCollectionRepository extends Mock implements CollectionRepository {}
+import '../../../helpers/test_helpers.dart';
 
 // Тестовые данные
 const int testCollectionId = 1;
@@ -43,11 +42,7 @@ void main() {
   late MockCollectionRepository mockRepository;
   late SharedPreferences sharedPrefs;
 
-  setUpAll(() {
-    registerFallbackValue(ItemStatus.notStarted);
-    registerFallbackValue(MediaType.game);
-    registerFallbackValue(DateTime(2024));
-  });
+  setUpAll(registerAllFallbacks);
 
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -13,17 +13,7 @@ import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/tv_episode.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 
-// Моки
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockCollectionItemsNotifier extends CollectionItemsNotifier {
-  @override
-  AsyncValue<List<CollectionItem>> build(int? arg) {
-    return const AsyncValue<List<CollectionItem>>.data(<CollectionItem>[]);
-  }
-}
+import '../../../helpers/test_helpers.dart';
 
 /// Mock CollectionItemsNotifier, который хранит заданный список items
 /// и записывает вызовы updateStatus для проверки.

--- a/test/features/collections/providers/steamgriddb_panel_provider_test.dart
+++ b/test/features/collections/providers/steamgriddb_panel_provider_test.dart
@@ -7,8 +7,7 @@ import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/shared/models/steamgriddb_game.dart';
 import 'package:xerabora/shared/models/steamgriddb_image.dart';
 
-// Моки
-class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
+import '../../../helpers/test_helpers.dart';
 
 const int testCollectionId = 10;
 

--- a/test/features/collections/screens/collection_screen_test.dart
+++ b/test/features/collections/screens/collection_screen_test.dart
@@ -21,9 +21,7 @@ import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 import 'package:xerabora/shared/widgets/media_poster_card.dart';
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockImageCacheService extends Mock implements ImageCacheService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   final DateTime testDate = DateTime(2024, 1, 15);
@@ -132,9 +130,7 @@ void main() {
   ];
 
   setUpAll(() {
-    registerFallbackValue(ImageType.gameCover);
-    registerFallbackValue(MediaType.game);
-    registerFallbackValue(ItemStatus.notStarted);
+    registerAllFallbacks();
   });
 
   setUp(() async {

--- a/test/features/collections/screens/home_screen_test.dart
+++ b/test/features/collections/screens/home_screen_test.dart
@@ -9,16 +9,14 @@ import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/collections/screens/home_screen.dart';
 import 'package:xerabora/features/collections/widgets/collection_card.dart';
-import 'package:xerabora/l10n/app_localizations.dart';
-import 'package:xerabora/shared/widgets/breadcrumb_scope.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/cover_info.dart';
+import 'package:xerabora/shared/widgets/breadcrumb_scope.dart';
 import 'package:xerabora/shared/widgets/shimmer_loading.dart';
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   group('HomeScreen', () {

--- a/test/features/collections/screens/item_detail_screen_test.dart
+++ b/test/features/collections/screens/item_detail_screen_test.dart
@@ -25,19 +25,17 @@ import 'package:xerabora/shared/widgets/media_detail_view.dart';
 import 'package:xerabora/shared/models/visual_novel.dart';
 import 'package:xerabora/shared/widgets/source_badge.dart';
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockTmdbApi extends Mock implements TmdbApi {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
-  final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
-
   late MockCollectionRepository mockRepo;
   late MockDatabaseService mockDb;
   late MockTmdbApi mockTmdbApi;
   late SharedPreferences prefs;
+
+  setUpAll(() {
+    registerAllFallbacks();
+  });
 
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
@@ -54,9 +52,6 @@ void main() {
         .thenAnswer((_) async => 0);
     when(() => mockTmdbApi.getTvSeasons(any()))
         .thenAnswer((_) async => <TvSeason>[]);
-
-    registerFallbackValue(ItemStatus.notStarted);
-    registerFallbackValue(MediaType.game);
   });
 
   Widget createTestWidget({

--- a/test/features/collections/widgets/canvas_image_item_test.dart
+++ b/test/features/collections/widgets/canvas_image_item_test.dart
@@ -1,4 +1,3 @@
-import 'package:xerabora/l10n/app_localizations.dart';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -7,16 +6,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/services/image_cache_service.dart';
 import 'package:xerabora/features/collections/widgets/canvas_image_item.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
 import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/widgets/cached_image.dart';
 
-class MockImageCacheService extends Mock implements ImageCacheService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockImageCacheService mockCacheService;
 
   setUpAll(() {
-    registerFallbackValue(ImageType.canvasImage);
+    registerAllFallbacks();
   });
 
   setUp(() {

--- a/test/features/collections/widgets/collection_card_test.dart
+++ b/test/features/collections/widgets/collection_card_test.dart
@@ -5,8 +5,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/collections/providers/collection_covers_provider.dart';
 import 'package:xerabora/features/collections/providers/collections_provider.dart';
@@ -15,10 +13,6 @@ import 'package:xerabora/l10n/app_localizations.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/cover_info.dart';
 import 'package:xerabora/shared/models/media_type.dart';
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockCollectionRepository extends Mock implements CollectionRepository {}
 
 // Тестовые данные
 

--- a/test/features/collections/widgets/recommendations_section_test.dart
+++ b/test/features/collections/widgets/recommendations_section_test.dart
@@ -17,9 +17,7 @@ import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 /// Pumps enough frames for async providers to resolve without waiting for
 /// CachedNetworkImage animations to settle (which never finish in tests).

--- a/test/features/home/providers/all_items_provider_test.dart
+++ b/test/features/home/providers/all_items_provider_test.dart
@@ -4,13 +4,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/collections/providers/collections_provider.dart';
 import 'package:xerabora/features/home/providers/all_items_provider.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/collection_sort_mode.dart';
@@ -19,11 +18,7 @@ import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/platform.dart' as model;
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockDatabase extends Mock implements Database {}
+import '../../../helpers/test_helpers.dart';
 
 /// Вспомогательная функция: прокачать event queue для async fire-and-forget.
 Future<void> _pump([int times = 5]) async {

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
@@ -22,11 +21,7 @@ import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/platform.dart' as model;
 import 'package:xerabora/shared/models/visual_novel.dart';
 
-class MockCollectionRepository extends Mock implements CollectionRepository {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockDatabase extends Mock implements Database {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockCollectionRepository mockRepo;

--- a/test/features/search/filters/anime_type_filter_test.dart
+++ b/test/features/search/filters/anime_type_filter_test.dart
@@ -1,13 +1,9 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/features/search/filters/anime_type_filter.dart';
 import 'package:xerabora/features/search/models/search_source.dart';
-import 'package:xerabora/l10n/app_localizations.dart';
 
-class MockWidgetRef extends Mock implements WidgetRef {}
-
-class MockS extends Mock implements S {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   group('AnimeTypeFilter', () {

--- a/test/features/search/filters/year_filter_test.dart
+++ b/test/features/search/filters/year_filter_test.dart
@@ -1,13 +1,8 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/features/search/filters/year_filter.dart';
 import 'package:xerabora/features/search/models/search_source.dart';
-import 'package:xerabora/l10n/app_localizations.dart';
 
-class MockWidgetRef extends Mock implements WidgetRef {}
-
-class MockS extends Mock implements S {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   group('YearFilter', () {

--- a/test/features/search/providers/genre_provider_test.dart
+++ b/test/features/search/providers/genre_provider_test.dart
@@ -8,7 +8,7 @@ import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/features/search/providers/genre_provider.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 class _FakeSettingsNotifier extends SettingsNotifier {
   _FakeSettingsNotifier(this._initialState);

--- a/test/features/search/providers/igdb_genre_provider_test.dart
+++ b/test/features/search/providers/igdb_genre_provider_test.dart
@@ -7,7 +7,7 @@ import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/features/search/filters/igdb_genre_filter.dart';
 import 'package:xerabora/features/search/providers/igdb_genre_provider.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockDatabaseService mockDb;

--- a/test/features/search/providers/vndb_tag_provider_test.dart
+++ b/test/features/search/providers/vndb_tag_provider_test.dart
@@ -7,7 +7,7 @@ import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/features/search/providers/vndb_tag_provider.dart';
 import 'package:xerabora/shared/models/visual_novel.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockDatabaseService mockDb;

--- a/test/features/settings/providers/settings_provider_flush_test.dart
+++ b/test/features/settings/providers/settings_provider_flush_test.dart
@@ -11,16 +11,7 @@ import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/core/services/config_service.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 
-// Моки
-class MockIgdbApi extends Mock implements IgdbApi {}
-
-class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
-
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockConfigService extends Mock implements ConfigService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockIgdbApi mockIgdbApi;

--- a/test/features/settings/providers/settings_provider_show_recommendations_test.dart
+++ b/test/features/settings/providers/settings_provider_show_recommendations_test.dart
@@ -10,14 +10,7 @@ import 'package:xerabora/core/api/tmdb_api.dart';
 import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 
-// Моки
-class MockIgdbApi extends Mock implements IgdbApi {}
-
-class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
-
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockIgdbApi mockIgdbApi;

--- a/test/features/settings/providers/settings_provider_test.dart
+++ b/test/features/settings/providers/settings_provider_test.dart
@@ -11,14 +11,7 @@ import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/shared/constants/api_defaults.dart';
 
-// Моки
-class MockIgdbApi extends Mock implements IgdbApi {}
-
-class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
-
-class MockTmdbApi extends Mock implements TmdbApi {}
-
-class MockDatabaseService extends Mock implements DatabaseService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockIgdbApi mockIgdbApi;

--- a/test/features/settings/screens/trakt_import_screen_test.dart
+++ b/test/features/settings/screens/trakt_import_screen_test.dart
@@ -4,7 +4,6 @@ import 'package:xerabora/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/services/trakt_zip_import_service.dart';
 import 'package:xerabora/features/collections/providers/collections_provider.dart';
 import 'package:xerabora/features/settings/screens/trakt_import_screen.dart';
@@ -12,8 +11,7 @@ import 'package:xerabora/features/settings/widgets/settings_section.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/widgets/breadcrumb_scope.dart';
 
-class MockTraktZipImportService extends Mock
-    implements TraktZipImportService {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockTraktZipImportService mockService;

--- a/test/features/splash/screens/splash_screen_test.dart
+++ b/test/features/splash/screens/splash_screen_test.dart
@@ -14,14 +14,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/features/splash/screens/splash_screen.dart';
 
-class MockDatabaseService extends Mock implements DatabaseService {}
-
-class MockDatabase extends Mock implements Database {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockDatabaseService mockDb;

--- a/test/features/wishlist/providers/wishlist_provider_test.dart
+++ b/test/features/wishlist/providers/wishlist_provider_test.dart
@@ -6,7 +6,7 @@ import 'package:xerabora/features/wishlist/providers/wishlist_provider.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/wishlist_item.dart';
 
-class MockWishlistRepository extends Mock implements WishlistRepository {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockWishlistRepository mockRepo;
@@ -16,7 +16,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(MediaType.game);
+    registerAllFallbacks();
   });
 
   ProviderContainer createContainer({

--- a/test/features/wishlist/screens/wishlist_screen_test.dart
+++ b/test/features/wishlist/screens/wishlist_screen_test.dart
@@ -9,7 +9,7 @@ import 'package:xerabora/shared/widgets/breadcrumb_scope.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/wishlist_item.dart';
 
-class MockWishlistRepository extends Mock implements WishlistRepository {}
+import '../../../helpers/test_helpers.dart';
 
 void main() {
   late MockWishlistRepository mockRepo;
@@ -19,7 +19,7 @@ void main() {
   });
 
   setUpAll(() {
-    registerFallbackValue(MediaType.game);
+    registerAllFallbacks();
   });
 
   final WishlistItem item1 = WishlistItem(

--- a/test/helpers/builders.dart
+++ b/test/helpers/builders.dart
@@ -1,0 +1,369 @@
+// Фабрики тестовых данных.
+//
+// Все параметры опциональны с разумными дефолтами. Это позволяет
+// в тестах указывать только релевантные поля.
+
+import 'package:xerabora/data/repositories/collection_repository.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/collection.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/platform.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+import 'package:xerabora/shared/models/visual_novel.dart';
+import 'package:xerabora/shared/models/wishlist_item.dart';
+
+/// Стандартная тестовая дата для единообразия.
+final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
+
+// ---------------------------------------------------------------------------
+// Collection
+// ---------------------------------------------------------------------------
+
+Collection createTestCollection({
+  int id = 1,
+  String name = 'Test Collection',
+  String author = 'Test Author',
+  CollectionType type = CollectionType.own,
+  DateTime? createdAt,
+  String? originalSnapshot,
+  String? forkedFromAuthor,
+  String? forkedFromName,
+}) {
+  return Collection(
+    id: id,
+    name: name,
+    author: author,
+    type: type,
+    createdAt: createdAt ?? testDate,
+    originalSnapshot: originalSnapshot,
+    forkedFromAuthor: forkedFromAuthor,
+    forkedFromName: forkedFromName,
+  );
+}
+
+/// Генерирует [count] коллекций с последовательными id и именами.
+List<Collection> createTestCollections({int count = 3}) {
+  return List<Collection>.generate(
+    count,
+    (int i) => createTestCollection(id: i + 1, name: 'Collection ${i + 1}'),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CollectionStats
+// ---------------------------------------------------------------------------
+
+CollectionStats createTestStats({
+  int total = 5,
+  int completed = 2,
+  int inProgress = 1,
+  int notStarted = 1,
+  int dropped = 0,
+  int planned = 1,
+  int gameCount = 0,
+  int movieCount = 0,
+  int tvShowCount = 0,
+  int animationCount = 0,
+  int visualNovelCount = 0,
+}) {
+  return CollectionStats(
+    total: total,
+    completed: completed,
+    inProgress: inProgress,
+    notStarted: notStarted,
+    dropped: dropped,
+    planned: planned,
+    gameCount: gameCount,
+    movieCount: movieCount,
+    tvShowCount: tvShowCount,
+    animationCount: animationCount,
+    visualNovelCount: visualNovelCount,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CollectionItem
+// ---------------------------------------------------------------------------
+
+CollectionItem createTestCollectionItem({
+  int id = 1,
+  int? collectionId = 1,
+  MediaType mediaType = MediaType.game,
+  int externalId = 100,
+  int? platformId,
+  ItemStatus status = ItemStatus.notStarted,
+  String? authorComment,
+  String? userComment,
+  int? userRating,
+  int currentSeason = 0,
+  int currentEpisode = 0,
+  int sortOrder = 0,
+  DateTime? addedAt,
+  DateTime? startedAt,
+  DateTime? completedAt,
+  DateTime? lastActivityAt,
+  Game? game,
+  Movie? movie,
+  TvShow? tvShow,
+  VisualNovel? visualNovel,
+  Platform? platform,
+}) {
+  return CollectionItem(
+    id: id,
+    collectionId: collectionId,
+    mediaType: mediaType,
+    externalId: externalId,
+    platformId: platformId,
+    status: status,
+    authorComment: authorComment,
+    userComment: userComment,
+    userRating: userRating,
+    currentSeason: currentSeason,
+    currentEpisode: currentEpisode,
+    sortOrder: sortOrder,
+    addedAt: addedAt ?? testDate,
+    startedAt: startedAt,
+    completedAt: completedAt,
+    lastActivityAt: lastActivityAt,
+    game: game,
+    movie: movie,
+    tvShow: tvShow,
+    visualNovel: visualNovel,
+    platform: platform,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Game
+// ---------------------------------------------------------------------------
+
+Game createTestGame({
+  int id = 100,
+  String name = 'Test Game',
+  String? summary,
+  String? coverUrl,
+  DateTime? releaseDate,
+  double? rating,
+  int? ratingCount,
+  List<String>? genres,
+  List<int>? platformIds,
+  String? externalUrl,
+}) {
+  return Game(
+    id: id,
+    name: name,
+    summary: summary,
+    coverUrl: coverUrl,
+    releaseDate: releaseDate,
+    rating: rating,
+    ratingCount: ratingCount,
+    genres: genres,
+    platformIds: platformIds,
+    externalUrl: externalUrl,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Movie
+// ---------------------------------------------------------------------------
+
+Movie createTestMovie({
+  int tmdbId = 550,
+  String title = 'Test Movie',
+  String? originalTitle,
+  String? posterUrl,
+  String? backdropUrl,
+  String? overview,
+  List<String>? genres,
+  int? releaseYear,
+  double? rating,
+  int? runtime,
+  String? externalUrl,
+}) {
+  return Movie(
+    tmdbId: tmdbId,
+    title: title,
+    originalTitle: originalTitle,
+    posterUrl: posterUrl,
+    backdropUrl: backdropUrl,
+    overview: overview,
+    genres: genres,
+    releaseYear: releaseYear,
+    rating: rating,
+    runtime: runtime,
+    externalUrl: externalUrl,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TvShow
+// ---------------------------------------------------------------------------
+
+TvShow createTestTvShow({
+  int tmdbId = 200,
+  String title = 'Test Show',
+  String? originalTitle,
+  String? posterUrl,
+  String? backdropUrl,
+  String? overview,
+  List<String>? genres,
+  int? firstAirYear,
+  int? totalSeasons,
+  int? totalEpisodes,
+  double? rating,
+  String? status,
+  String? externalUrl,
+}) {
+  return TvShow(
+    tmdbId: tmdbId,
+    title: title,
+    originalTitle: originalTitle,
+    posterUrl: posterUrl,
+    backdropUrl: backdropUrl,
+    overview: overview,
+    genres: genres,
+    firstAirYear: firstAirYear,
+    totalSeasons: totalSeasons,
+    totalEpisodes: totalEpisodes,
+    rating: rating,
+    status: status,
+    externalUrl: externalUrl,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// VisualNovel
+// ---------------------------------------------------------------------------
+
+VisualNovel createTestVisualNovel({
+  String id = 'v500',
+  String title = 'Test VN',
+  String? altTitle,
+  String? description,
+  String? imageUrl,
+  double? rating,
+  int? voteCount,
+  String? released,
+  int? lengthMinutes,
+  int? length,
+  List<String>? tags,
+  List<String>? developers,
+  List<String>? platforms,
+  String? externalUrl,
+}) {
+  return VisualNovel(
+    id: id,
+    title: title,
+    altTitle: altTitle,
+    description: description,
+    imageUrl: imageUrl,
+    rating: rating,
+    voteCount: voteCount,
+    released: released,
+    lengthMinutes: lengthMinutes,
+    length: length,
+    tags: tags,
+    developers: developers,
+    platforms: platforms,
+    externalUrl: externalUrl,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WishlistItem
+// ---------------------------------------------------------------------------
+
+WishlistItem createTestWishlistItem({
+  int id = 1,
+  String text = 'Chrono Trigger',
+  MediaType? mediaTypeHint,
+  String? note,
+  bool isResolved = false,
+  DateTime? createdAt,
+  DateTime? resolvedAt,
+}) {
+  return WishlistItem(
+    id: id,
+    text: text,
+    mediaTypeHint: mediaTypeHint,
+    note: note,
+    isResolved: isResolved,
+    createdAt: createdAt ?? testDate,
+    resolvedAt: resolvedAt,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CanvasItem
+// ---------------------------------------------------------------------------
+
+CanvasItem createTestCanvasItem({
+  int id = 1,
+  int collectionId = 1,
+  CanvasItemType itemType = CanvasItemType.game,
+  double x = 100.0,
+  double y = 100.0,
+  double? width = 160.0,
+  double? height = 220.0,
+  int? collectionItemId,
+  int? itemRefId = 100,
+  int zIndex = 0,
+  Map<String, dynamic>? data,
+  DateTime? createdAt,
+  Game? game,
+  Movie? movie,
+  TvShow? tvShow,
+  VisualNovel? visualNovel,
+}) {
+  return CanvasItem(
+    id: id,
+    collectionId: collectionId,
+    itemType: itemType,
+    x: x,
+    y: y,
+    width: width,
+    height: height,
+    collectionItemId: collectionItemId,
+    itemRefId: itemRefId,
+    zIndex: zIndex,
+    data: data,
+    createdAt: createdAt ?? testDate,
+    game: game,
+    movie: movie,
+    tvShow: tvShow,
+    visualNovel: visualNovel,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CanvasConnection
+// ---------------------------------------------------------------------------
+
+CanvasConnection createTestCanvasConnection({
+  int id = 1,
+  int collectionId = 1,
+  int? collectionItemId,
+  int fromItemId = 100,
+  int toItemId = 200,
+  String? label,
+  String color = '#FF0000',
+  ConnectionStyle style = ConnectionStyle.solid,
+  DateTime? createdAt,
+}) {
+  return CanvasConnection(
+    id: id,
+    collectionId: collectionId,
+    collectionItemId: collectionItemId,
+    fromItemId: fromItemId,
+    toItemId: toItemId,
+    label: label,
+    color: color,
+    style: style,
+    createdAt: createdAt ?? testDate,
+  );
+}

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -1,0 +1,58 @@
+// Централизованная регистрация fallback-значений для mocktail.
+//
+// Вызывать один раз в setUpAll() каждого тестового файла, который
+// использует any() / captureAny() для типов, требующих fallback.
+
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:xerabora/shared/models/canvas_viewport.dart';
+import 'package:xerabora/shared/models/collection.dart';
+import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/platform.dart';
+import 'package:xerabora/shared/models/tv_episode.dart';
+import 'package:xerabora/shared/models/tv_season.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+import 'package:xerabora/core/services/image_cache_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'mocks.dart';
+
+/// Регистрирует все fallback-значения, необходимые для mocktail.
+///
+/// Безопасно вызывать несколько раз — mocktail игнорирует повторные
+/// регистрации того же типа.
+void registerAllFallbacks() {
+  // Enums
+  registerFallbackValue(MediaType.game);
+  registerFallbackValue(ItemStatus.notStarted);
+  registerFallbackValue(CollectionType.own);
+  registerFallbackValue(ImageType.gameCover);
+
+  // Models
+  registerFallbackValue(const Game(id: 0, name: 'fallback'));
+  registerFallbackValue(const Movie(tmdbId: 0, title: 'fallback'));
+  registerFallbackValue(const TvShow(tmdbId: 0, title: 'fallback'));
+
+  // Canvas
+  registerFallbackValue(FakeCanvasItem());
+  registerFallbackValue(FakeCanvasConnection());
+  registerFallbackValue(const CanvasViewport(collectionId: 0));
+
+  // Collections
+  registerFallbackValue(const <Game>[]);
+  registerFallbackValue(const <Movie>[]);
+  registerFallbackValue(const <TvShow>[]);
+  registerFallbackValue(const <TvSeason>[]);
+  registerFallbackValue(const <TvEpisode>[]);
+  registerFallbackValue(const <Platform>[]);
+  registerFallbackValue(const <int>[]);
+
+  // Other
+  registerFallbackValue(Uint8List(0));
+  registerFallbackValue(DateTime(2024));
+  registerFallbackValue(Options());
+}

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -1,0 +1,122 @@
+// Единое хранилище mock-классов для всех тестов.
+//
+// Каждый mock объявляется ровно один раз. Тестовые файлы импортируют
+// `test_helpers.dart`, который реэкспортирует этот файл.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gamepads/gamepads.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:xerabora/core/api/igdb_api.dart';
+import 'package:xerabora/core/api/steamgriddb_api.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/core/api/vndb_api.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/core/services/config_service.dart';
+import 'package:xerabora/core/services/gamepad_service.dart';
+import 'package:xerabora/core/services/image_cache_service.dart';
+import 'package:xerabora/core/services/trakt_zip_import_service.dart';
+import 'package:xerabora/data/repositories/canvas_repository.dart';
+import 'package:xerabora/data/repositories/collection_repository.dart';
+import 'package:xerabora/data/repositories/game_repository.dart';
+import 'package:xerabora/data/repositories/wishlist_repository.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+import 'package:xerabora/shared/models/canvas_connection.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/canvas_viewport.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/game.dart';
+
+// ===== Core =====
+
+class MockDio extends Mock implements Dio {}
+
+class MockDatabase extends Mock implements Database {}
+
+class MockDatabaseService extends Mock implements DatabaseService {}
+
+class MockConfigService extends Mock implements ConfigService {}
+
+// ===== API =====
+
+class MockIgdbApi extends Mock implements IgdbApi {}
+
+class MockTmdbApi extends Mock implements TmdbApi {}
+
+class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
+
+class MockVndbApi extends Mock implements VndbApi {}
+
+// ===== Services =====
+
+class MockImageCacheService extends Mock implements ImageCacheService {}
+
+class MockTraktZipImportService extends Mock
+    implements TraktZipImportService {}
+
+// ===== Repositories =====
+
+class MockCollectionRepository extends Mock implements CollectionRepository {}
+
+class MockCanvasRepository extends Mock implements CanvasRepository {}
+
+class MockGameRepository extends Mock implements GameRepository {}
+
+class MockWishlistRepository extends Mock implements WishlistRepository {}
+
+// ===== Providers / Notifiers =====
+
+/// Мок [CollectionItemsNotifier] с настраиваемым начальным состоянием.
+///
+/// Если [initialState] не передан, возвращает пустой список.
+/// Метод [emitState] позволяет менять state в ходе теста.
+class MockCollectionItemsNotifier extends CollectionItemsNotifier {
+  MockCollectionItemsNotifier([this._initialState]);
+
+  final AsyncValue<List<CollectionItem>>? _initialState;
+
+  @override
+  AsyncValue<List<CollectionItem>> build(int? arg) {
+    return _initialState ??
+        const AsyncValue<List<CollectionItem>>.data(<CollectionItem>[]);
+  }
+
+  void emitState(AsyncValue<List<CollectionItem>> newState) {
+    state = newState;
+  }
+}
+
+class MockWidgetRef extends Mock implements WidgetRef {}
+
+// ===== Localization =====
+
+class MockS extends Mock implements S {}
+
+// ===== Gamepad =====
+
+/// Мок-источник событий геймпада с ручным контроллером.
+class MockGamepadEventSource implements GamepadEventSource {
+  final StreamController<GamepadEvent> controller =
+      StreamController<GamepadEvent>.broadcast();
+
+  @override
+  Stream<GamepadEvent> get events => controller.stream;
+
+  void emit(GamepadEvent event) => controller.add(event);
+
+  void dispose() => controller.close();
+}
+
+// ===== Fakes =====
+
+class FakeCanvasItem extends Fake implements CanvasItem {}
+
+class FakeCanvasConnection extends Fake implements CanvasConnection {}
+
+class FakeCanvasViewport extends Fake implements CanvasViewport {}
+
+class FakeGame extends Fake implements Game {}

--- a/test/helpers/pump_app.dart
+++ b/test/helpers/pump_app.dart
@@ -1,0 +1,76 @@
+// Extension для WidgetTester, упрощающий создание виджетов с
+// ProviderScope + MaterialApp + локализация.
+//
+// Использование:
+//   await tester.pumpApp(const MyScreen(), overrides: [...]);
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+import 'package:xerabora/shared/widgets/breadcrumb_scope.dart';
+
+/// Расширение [WidgetTester] для быстрого pump виджетов в тестовом окружении.
+extension PumpApp on WidgetTester {
+  /// Создаёт ProviderScope + MaterialApp с локализацией и делает pumpAndSettle.
+  ///
+  /// [widget] — тестируемый виджет (будет помещён в `home:`).
+  /// [overrides] — дополнительные Riverpod overrides.
+  /// [prefs] — SharedPreferences; если null, создаются пустые.
+  /// [breadcrumbLabel] — если указан, оборачивает виджет в BreadcrumbScope.
+  /// [wrapInScaffold] — если true, оборачивает виджет в Scaffold.body.
+  /// [mediaQuerySize] — если указан, оборачивает виджет в MediaQuery.
+  /// [settle] — если true (по умолчанию), вызывает pumpAndSettle.
+  Future<void> pumpApp(
+    Widget widget, {
+    List<Override> overrides = const <Override>[],
+    SharedPreferences? prefs,
+    String? breadcrumbLabel,
+    bool wrapInScaffold = false,
+    Size? mediaQuerySize,
+    bool settle = true,
+  }) async {
+    if (prefs == null) {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+    }
+
+    Widget child = widget;
+
+    if (wrapInScaffold) {
+      child = Scaffold(body: child);
+    }
+
+    if (breadcrumbLabel != null) {
+      child = BreadcrumbScope(label: breadcrumbLabel, child: child);
+    }
+
+    if (mediaQuerySize != null) {
+      child = MediaQuery(
+        data: MediaQueryData(size: mediaQuerySize),
+        child: child,
+      );
+    }
+
+    await pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          ...overrides,
+        ],
+        child: MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          locale: const Locale('en'),
+          home: child,
+        ),
+      ),
+    );
+
+    if (settle) {
+      await pumpAndSettle();
+    }
+  }
+}

--- a/test/helpers/test_helpers.dart
+++ b/test/helpers/test_helpers.dart
@@ -1,0 +1,9 @@
+// Barrel-файл. Один import для всех тестовых утилит.
+//
+// Использование:
+//   import '../../helpers/test_helpers.dart';
+
+export 'builders.dart';
+export 'fallbacks.dart';
+export 'mocks.dart';
+export 'pump_app.dart';

--- a/test/shared/gamepad/widgets/gamepad_listener_test.dart
+++ b/test/shared/gamepad/widgets/gamepad_listener_test.dart
@@ -6,8 +6,6 @@ import 'package:xerabora/l10n/app_localizations.dart';
 // поэтому подписка создаётся и тесты работают как прежде.
 // На Android/iOS подписка пропускается — геймпад не используется.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,18 +16,7 @@ import 'package:xerabora/shared/gamepad/gamepad_action.dart';
 import 'package:xerabora/shared/gamepad/gamepad_provider.dart';
 import 'package:xerabora/shared/gamepad/widgets/gamepad_listener.dart';
 
-/// Мок-источник событий.
-class MockGamepadEventSource implements GamepadEventSource {
-  final StreamController<GamepadEvent> controller =
-      StreamController<GamepadEvent>.broadcast();
-
-  @override
-  Stream<GamepadEvent> get events => controller.stream;
-
-  void emit(GamepadEvent event) => controller.add(event);
-
-  void dispose() => controller.close();
-}
+import '../../../helpers/test_helpers.dart';
 
 GamepadEvent _event({
   required String key,

--- a/test/shared/models/canvas_connection_test.dart
+++ b/test/shared/models/canvas_connection_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/shared/models/canvas_connection.dart';
 
+import '../../helpers/test_helpers.dart';
+
 void main() {
   group('ConnectionStyle', () {
     test('should have correct string values', () {
@@ -22,34 +24,15 @@ void main() {
   });
 
   group('CanvasConnection', () {
+    // Дата отличается от shared testDate — оставляем локально.
     final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
     final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
 
-    CanvasConnection createTestConnection({
-      int id = 1,
-      int collectionId = 10,
-      int? collectionItemId,
-      int fromItemId = 100,
-      int toItemId = 200,
-      String? label,
-      String color = '#FF0000',
-      ConnectionStyle style = ConnectionStyle.solid,
-    }) {
-      return CanvasConnection(
-        id: id,
-        collectionId: collectionId,
-        collectionItemId: collectionItemId,
-        fromItemId: fromItemId,
-        toItemId: toItemId,
-        label: label,
-        color: color,
-        style: style,
+    test('should create with required parameters', () {
+      final CanvasConnection conn = createTestCanvasConnection(
+        collectionId: 10,
         createdAt: testDate,
       );
-    }
-
-    test('should create with required parameters', () {
-      final CanvasConnection conn = createTestConnection();
       expect(conn.id, 1);
       expect(conn.collectionId, 10);
       expect(conn.fromItemId, 100);
@@ -74,8 +57,10 @@ void main() {
     });
 
     test('should create with collectionItemId', () {
-      final CanvasConnection conn = createTestConnection(
+      final CanvasConnection conn = createTestCanvasConnection(
+        collectionId: 10,
         collectionItemId: 42,
+        createdAt: testDate,
       );
       expect(conn.collectionItemId, 42);
     });
@@ -245,8 +230,10 @@ void main() {
 
     group('toDb', () {
       test('should convert all fields', () {
-        final CanvasConnection conn = createTestConnection(
+        final CanvasConnection conn = createTestCanvasConnection(
+          collectionId: 10,
           label: 'test',
+          createdAt: testDate,
         );
 
         final Map<String, dynamic> db = conn.toDb();
@@ -261,20 +248,29 @@ void main() {
       });
 
       test('should omit id when id is 0', () {
-        final CanvasConnection conn = createTestConnection(id: 0);
+        final CanvasConnection conn = createTestCanvasConnection(
+          id: 0,
+          collectionId: 10,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> db = conn.toDb();
         expect(db.containsKey('id'), isFalse);
       });
 
       test('should include null label', () {
-        final CanvasConnection conn = createTestConnection();
+        final CanvasConnection conn = createTestCanvasConnection(
+          collectionId: 10,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> db = conn.toDb();
         expect(db['label'], isNull);
       });
 
       test('should serialize collectionItemId to database map', () {
-        final CanvasConnection conn = createTestConnection(
+        final CanvasConnection conn = createTestCanvasConnection(
+          collectionId: 10,
           collectionItemId: 77,
+          createdAt: testDate,
         );
         final Map<String, dynamic> db = conn.toDb();
         expect(db['collection_item_id'], 77);
@@ -283,9 +279,11 @@ void main() {
 
     group('toExport', () {
       test('should convert all fields', () {
-        final CanvasConnection conn = createTestConnection(
+        final CanvasConnection conn = createTestCanvasConnection(
+          collectionId: 10,
           label: 'json test',
           style: ConnectionStyle.arrow,
+          createdAt: testDate,
         );
 
         final Map<String, dynamic> json = conn.toExport();
@@ -299,14 +297,19 @@ void main() {
       });
 
       test('should not contain collection_id', () {
-        final CanvasConnection conn = createTestConnection();
+        final CanvasConnection conn = createTestCanvasConnection(
+          collectionId: 10,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> json = conn.toExport();
         expect(json.containsKey('collection_id'), isFalse);
       });
 
       test('should include collectionItemId in export when set', () {
-        final CanvasConnection conn = createTestConnection(
+        final CanvasConnection conn = createTestCanvasConnection(
+          collectionId: 10,
           collectionItemId: 88,
+          createdAt: testDate,
         );
         final Map<String, dynamic> json = conn.toExport();
         expect(json['collection_item_id'], 88);
@@ -315,7 +318,10 @@ void main() {
 
     group('copyWith', () {
       test('should copy with changed fields', () {
-        final CanvasConnection original = createTestConnection();
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
+          createdAt: testDate,
+        );
         final CanvasConnection copy = original.copyWith(
           label: 'new label',
           color: '#00FF00',
@@ -332,8 +338,10 @@ void main() {
       });
 
       test('should clear label with clearLabel flag', () {
-        final CanvasConnection original = createTestConnection(
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
           label: 'will be cleared',
+          createdAt: testDate,
         );
         final CanvasConnection copy = original.copyWith(clearLabel: true);
 
@@ -341,8 +349,10 @@ void main() {
       });
 
       test('clearLabel should take precedence over label', () {
-        final CanvasConnection original = createTestConnection(
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
           label: 'old',
+          createdAt: testDate,
         );
         final CanvasConnection copy = original.copyWith(
           label: 'new',
@@ -353,9 +363,11 @@ void main() {
       });
 
       test('should keep original values when no changes', () {
-        final CanvasConnection original = createTestConnection(
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
           label: 'keep me',
           color: '#AABBCC',
+          createdAt: testDate,
         );
         final CanvasConnection copy = original.copyWith();
 
@@ -366,13 +378,19 @@ void main() {
       });
 
       test('should copy with changed id', () {
-        final CanvasConnection original = createTestConnection();
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
+          createdAt: testDate,
+        );
         final CanvasConnection copy = original.copyWith(id: 99);
         expect(copy.id, 99);
       });
 
       test('should copy with all fields changed', () {
-        final CanvasConnection original = createTestConnection();
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
+          createdAt: testDate,
+        );
         final DateTime newDate = DateTime(2025, 1, 1);
         final CanvasConnection copy = original.copyWith(
           id: 99,
@@ -395,8 +413,10 @@ void main() {
       });
 
       test('should copy with changed collectionItemId', () {
-        final CanvasConnection original = createTestConnection(
+        final CanvasConnection original = createTestCanvasConnection(
+          collectionId: 10,
           collectionItemId: 10,
+          createdAt: testDate,
         );
         final CanvasConnection copy = original.copyWith(
           collectionItemId: 99,
@@ -409,44 +429,76 @@ void main() {
 
     group('equality', () {
       test('should be equal when ids match', () {
-        final CanvasConnection a = createTestConnection(id: 1);
-        final CanvasConnection b = createTestConnection(
+        final CanvasConnection a = createTestCanvasConnection(
           id: 1,
+          collectionId: 10,
+          createdAt: testDate,
+        );
+        final CanvasConnection b = createTestCanvasConnection(
+          id: 1,
+          collectionId: 10,
           fromItemId: 999,
           color: '#FFFFFF',
+          createdAt: testDate,
         );
         expect(a, equals(b));
       });
 
       test('should not be equal when ids differ', () {
-        final CanvasConnection a = createTestConnection(id: 1);
-        final CanvasConnection b = createTestConnection(id: 2);
+        final CanvasConnection a = createTestCanvasConnection(
+          id: 1,
+          collectionId: 10,
+          createdAt: testDate,
+        );
+        final CanvasConnection b = createTestCanvasConnection(
+          id: 2,
+          collectionId: 10,
+          createdAt: testDate,
+        );
         expect(a, isNot(equals(b)));
       });
 
       test('should have same hashCode for equal ids', () {
-        final CanvasConnection a = createTestConnection(id: 5);
-        final CanvasConnection b = createTestConnection(id: 5);
+        final CanvasConnection a = createTestCanvasConnection(
+          id: 5,
+          collectionId: 10,
+          createdAt: testDate,
+        );
+        final CanvasConnection b = createTestCanvasConnection(
+          id: 5,
+          collectionId: 10,
+          createdAt: testDate,
+        );
         expect(a.hashCode, equals(b.hashCode));
       });
 
       test('should be equal to itself (identical)', () {
-        final CanvasConnection conn = createTestConnection(id: 1);
+        final CanvasConnection conn = createTestCanvasConnection(
+          id: 1,
+          collectionId: 10,
+          createdAt: testDate,
+        );
         expect(conn == conn, isTrue);
       });
 
       test('should not be equal to non-CanvasConnection object', () {
-        final CanvasConnection conn = createTestConnection(id: 1);
+        final CanvasConnection conn = createTestCanvasConnection(
+          id: 1,
+          collectionId: 10,
+          createdAt: testDate,
+        );
         expect(conn == Object(), isFalse);
       });
     });
 
     test('toString should contain key information', () {
-      final CanvasConnection conn = createTestConnection(
+      final CanvasConnection conn = createTestCanvasConnection(
         id: 7,
+        collectionId: 10,
         fromItemId: 10,
         toItemId: 20,
         style: ConnectionStyle.arrow,
+        createdAt: testDate,
       );
 
       final String str = conn.toString();

--- a/test/shared/models/canvas_item_test.dart
+++ b/test/shared/models/canvas_item_test.dart
@@ -7,6 +7,8 @@ import 'package:xerabora/shared/models/canvas_item.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/visual_novel.dart';
 
+import '../../helpers/test_helpers.dart';
+
 void main() {
   group('CanvasItemType', () {
     test('should have correct string values', () {
@@ -57,40 +59,16 @@ void main() {
   });
 
   group('CanvasItem', () {
+    // Дата отличается от shared testDate — оставляем локально.
     final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
     final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
 
-    CanvasItem createTestItem({
-      int id = 1,
-      int collectionId = 10,
-      int? collectionItemId,
-      CanvasItemType itemType = CanvasItemType.game,
-      int? itemRefId = 100,
-      double x = 50.0,
-      double y = 100.0,
-      double? width = 160.0,
-      double? height = 220.0,
-      int zIndex = 0,
-      Map<String, dynamic>? data,
-    }) {
-      return CanvasItem(
-        id: id,
-        collectionId: collectionId,
-        collectionItemId: collectionItemId,
-        itemType: itemType,
-        itemRefId: itemRefId,
-        x: x,
-        y: y,
-        width: width,
-        height: height,
-        zIndex: zIndex,
-        data: data,
+    test('should create with required parameters', () {
+      final CanvasItem item = createTestCanvasItem(
+        collectionId: 10,
+        x: 50.0,
         createdAt: testDate,
       );
-    }
-
-    test('should create with required parameters', () {
-      final CanvasItem item = createTestItem();
 
       expect(item.id, 1);
       expect(item.collectionId, 10);
@@ -107,10 +85,13 @@ void main() {
     });
 
     test('should create with data map', () {
-      final CanvasItem item = createTestItem(
+      final CanvasItem item = createTestCanvasItem(
+        collectionId: 10,
         itemType: CanvasItemType.text,
         itemRefId: null,
+        x: 50.0,
         data: <String, dynamic>{'content': 'Hello', 'fontSize': 16},
+        createdAt: testDate,
       );
 
       expect(item.data, isNotNull);
@@ -119,7 +100,12 @@ void main() {
     });
 
     test('should create with collectionItemId', () {
-      final CanvasItem item = createTestItem(collectionItemId: 42);
+      final CanvasItem item = createTestCanvasItem(
+        collectionId: 10,
+        collectionItemId: 42,
+        x: 50.0,
+        createdAt: testDate,
+      );
 
       expect(item.collectionItemId, 42);
       expect(item.id, 1);
@@ -271,7 +257,11 @@ void main() {
 
     group('toDb', () {
       test('should serialize game item to database map', () {
-        final CanvasItem item = createTestItem();
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> db = item.toDb();
 
         expect(db['id'], 1);
@@ -288,9 +278,12 @@ void main() {
       });
 
       test('should serialize data map as JSON string', () {
-        final CanvasItem item = createTestItem(
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
           itemType: CanvasItemType.text,
+          x: 50.0,
           data: <String, dynamic>{'content': 'Hello'},
+          createdAt: testDate,
         );
         final Map<String, dynamic> db = item.toDb();
 
@@ -301,21 +294,35 @@ void main() {
       });
 
       test('should omit id when id is 0 (new item)', () {
-        final CanvasItem item = createTestItem(id: 0);
+        final CanvasItem item = createTestCanvasItem(
+          id: 0,
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> db = item.toDb();
 
         expect(db.containsKey('id'), false);
       });
 
       test('should serialize collectionItemId to database map', () {
-        final CanvasItem item = createTestItem(collectionItemId: 42);
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
+          collectionItemId: 42,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> db = item.toDb();
 
         expect(db['collection_item_id'], 42);
       });
 
       test('should serialize null collectionItemId', () {
-        final CanvasItem item = createTestItem();
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> db = item.toDb();
 
         expect(db.containsKey('collection_item_id'), true);
@@ -325,7 +332,11 @@ void main() {
 
     group('toExport', () {
       test('should serialize for export', () {
-        final CanvasItem item = createTestItem();
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> jsonMap = item.toExport();
 
         expect(jsonMap['id'], 1);
@@ -341,8 +352,11 @@ void main() {
       });
 
       test('should include data map in export', () {
-        final CanvasItem item = createTestItem(
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
+          x: 50.0,
           data: <String, dynamic>{'content': 'Test'},
+          createdAt: testDate,
         );
         final Map<String, dynamic> jsonMap = item.toExport();
 
@@ -351,7 +365,12 @@ void main() {
       });
 
       test('should include collectionItemId in export', () {
-        final CanvasItem item = createTestItem(collectionItemId: 42);
+        final CanvasItem item = createTestCanvasItem(
+          collectionId: 10,
+          collectionItemId: 42,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final Map<String, dynamic> jsonMap = item.toExport();
 
         expect(jsonMap['collection_item_id'], 42);
@@ -431,7 +450,11 @@ void main() {
 
     group('copyWith', () {
       test('should create copy with changed fields', () {
-        final CanvasItem original = createTestItem();
+        final CanvasItem original = createTestCanvasItem(
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final CanvasItem copy = original.copyWith(
           x: 200.0,
           y: 300.0,
@@ -447,7 +470,11 @@ void main() {
       });
 
       test('should keep original values when not specified', () {
-        final CanvasItem original = createTestItem();
+        final CanvasItem original = createTestCanvasItem(
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final CanvasItem copy = original.copyWith();
 
         expect(copy.id, original.id);
@@ -457,7 +484,12 @@ void main() {
       });
 
       test('should copy with changed collectionItemId', () {
-        final CanvasItem original = createTestItem(collectionItemId: 10);
+        final CanvasItem original = createTestCanvasItem(
+          collectionId: 10,
+          collectionItemId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
         final CanvasItem copy = original.copyWith(collectionItemId: 99);
 
         expect(copy.collectionItemId, 99);
@@ -467,35 +499,69 @@ void main() {
 
     group('equality', () {
       test('should be equal when id matches', () {
-        final CanvasItem item1 = createTestItem(id: 1, x: 0);
-        final CanvasItem item2 = createTestItem(id: 1, x: 100);
+        final CanvasItem item1 = createTestCanvasItem(
+          id: 1,
+          collectionId: 10,
+          x: 0,
+          createdAt: testDate,
+        );
+        final CanvasItem item2 = createTestCanvasItem(
+          id: 1,
+          collectionId: 10,
+          x: 100,
+          createdAt: testDate,
+        );
 
         expect(item1, equals(item2));
         expect(item1.hashCode, item2.hashCode);
       });
 
       test('should be equal to identical object', () {
-        final CanvasItem item = createTestItem(id: 1);
+        final CanvasItem item = createTestCanvasItem(
+          id: 1,
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
 
         expect(item == item, true);
       });
 
       test('should not be equal when id differs', () {
-        final CanvasItem item1 = createTestItem(id: 1);
-        final CanvasItem item2 = createTestItem(id: 2);
+        final CanvasItem item1 = createTestCanvasItem(
+          id: 1,
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
+        final CanvasItem item2 = createTestCanvasItem(
+          id: 2,
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
 
         expect(item1, isNot(equals(item2)));
       });
 
       test('should not be equal to non-CanvasItem object', () {
-        final CanvasItem item = createTestItem(id: 1);
+        final CanvasItem item = createTestCanvasItem(
+          id: 1,
+          collectionId: 10,
+          x: 50.0,
+          createdAt: testDate,
+        );
 
         expect(item == Object(), false);
       });
     });
 
     test('toString should contain type and position', () {
-      final CanvasItem item = createTestItem();
+      final CanvasItem item = createTestCanvasItem(
+        collectionId: 10,
+        x: 50.0,
+        createdAt: testDate,
+      );
       final String str = item.toString();
 
       expect(str, contains('id: 1'));

--- a/test/shared/models/collection_test.dart
+++ b/test/shared/models/collection_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/shared/models/collection.dart';
 
+import '../../helpers/test_helpers.dart';
+
 void main() {
   group('CollectionType', () {
     test('должен иметь правильные строковые значения', () {
@@ -22,30 +24,7 @@ void main() {
   });
 
   group('Collection', () {
-    final DateTime testDate = DateTime(2024, 1, 15, 12, 0, 0);
     final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
-
-    Collection createTestCollection({
-      int id = 1,
-      String name = 'Test Collection',
-      String author = 'Test Author',
-      CollectionType type = CollectionType.own,
-      DateTime? createdAt,
-      String? originalSnapshot,
-      String? forkedFromAuthor,
-      String? forkedFromName,
-    }) {
-      return Collection(
-        id: id,
-        name: name,
-        author: author,
-        type: type,
-        createdAt: createdAt ?? testDate,
-        originalSnapshot: originalSnapshot,
-        forkedFromAuthor: forkedFromAuthor,
-        forkedFromName: forkedFromName,
-      );
-    }
 
     group('constructor', () {
       test('должен создавать экземпляр с обязательными полями', () {

--- a/test/shared/models/wishlist_item_test.dart
+++ b/test/shared/models/wishlist_item_test.dart
@@ -2,36 +2,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/wishlist_item.dart';
 
+import '../../helpers/test_helpers.dart';
+
 void main() {
   group('WishlistItem', () {
+    // Дата отличается от shared testDate — оставляем локально.
     final DateTime testDate = DateTime(2024, 6, 15, 12, 0, 0);
     final int testTimestamp = testDate.millisecondsSinceEpoch ~/ 1000;
     final DateTime resolvedDate = DateTime(2024, 6, 20, 18, 0, 0);
     final int resolvedTimestamp = resolvedDate.millisecondsSinceEpoch ~/ 1000;
 
-    WishlistItem createTestItem({
-      int id = 1,
-      String text = 'Chrono Trigger',
-      MediaType? mediaTypeHint,
-      String? note,
-      bool isResolved = false,
-      DateTime? createdAt,
-      DateTime? resolvedAt,
-    }) {
-      return WishlistItem(
-        id: id,
-        text: text,
-        mediaTypeHint: mediaTypeHint,
-        note: note,
-        isResolved: isResolved,
-        createdAt: createdAt ?? testDate,
-        resolvedAt: resolvedAt,
-      );
-    }
-
     group('constructor', () {
       test('должен создавать экземпляр с обязательными полями', () {
-        final WishlistItem item = createTestItem();
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,);
 
         expect(item.id, 1);
         expect(item.text, 'Chrono Trigger');
@@ -43,7 +26,7 @@ void main() {
       });
 
       test('должен создавать экземпляр со всеми полями', () {
-        final WishlistItem item = createTestItem(
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,
           mediaTypeHint: MediaType.game,
           note: 'SNES RPG, посоветовал друг',
           isResolved: true,
@@ -59,17 +42,17 @@ void main() {
 
     group('hasNote', () {
       test('должен возвращать false для null заметки', () {
-        final WishlistItem item = createTestItem();
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,);
         expect(item.hasNote, false);
       });
 
       test('должен возвращать false для пустой заметки', () {
-        final WishlistItem item = createTestItem(note: '');
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate, note: '');
         expect(item.hasNote, false);
       });
 
       test('должен возвращать true для непустой заметки', () {
-        final WishlistItem item = createTestItem(note: 'Some note');
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate, note: 'Some note');
         expect(item.hasNote, true);
       });
     });
@@ -144,7 +127,7 @@ void main() {
 
     group('toDb', () {
       test('должен возвращать корректную Map для БД', () {
-        final WishlistItem item = createTestItem();
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,);
         final Map<String, dynamic> db = item.toDb();
 
         expect(db['id'], 1);
@@ -157,7 +140,7 @@ void main() {
       });
 
       test('должен включать все поля', () {
-        final WishlistItem item = createTestItem(
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,
           mediaTypeHint: MediaType.tvShow,
           note: 'Заметка',
           isResolved: true,
@@ -174,7 +157,7 @@ void main() {
 
     group('fromDb → toDb roundtrip', () {
       test('должен быть обратимым для минимального элемента', () {
-        final WishlistItem original = createTestItem();
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate,);
         final Map<String, dynamic> db = original.toDb();
         final WishlistItem restored = WishlistItem.fromDb(db);
 
@@ -187,7 +170,7 @@ void main() {
       });
 
       test('должен быть обратимым для полного элемента', () {
-        final WishlistItem original = createTestItem(
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate,
           mediaTypeHint: MediaType.animation,
           note: 'Аниме',
           isResolved: true,
@@ -210,7 +193,7 @@ void main() {
 
     group('copyWith', () {
       test('должен создавать копию с изменённым текстом', () {
-        final WishlistItem original = createTestItem();
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate,);
         final WishlistItem copy = original.copyWith(text: 'New Title');
 
         expect(copy.text, 'New Title');
@@ -219,7 +202,7 @@ void main() {
       });
 
       test('должен создавать копию с изменённым mediaTypeHint', () {
-        final WishlistItem original = createTestItem();
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate,);
         final WishlistItem copy =
             original.copyWith(mediaTypeHint: MediaType.movie);
 
@@ -229,7 +212,7 @@ void main() {
 
       test('должен очищать mediaTypeHint через clearMediaTypeHint', () {
         final WishlistItem original =
-            createTestItem(mediaTypeHint: MediaType.game);
+            createTestWishlistItem(createdAt: testDate, mediaTypeHint: MediaType.game);
         final WishlistItem copy =
             original.copyWith(clearMediaTypeHint: true);
 
@@ -237,7 +220,7 @@ void main() {
       });
 
       test('должен очищать note через clearNote', () {
-        final WishlistItem original = createTestItem(note: 'Заметка');
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate, note: 'Заметка');
         final WishlistItem copy = original.copyWith(clearNote: true);
 
         expect(copy.note, null);
@@ -245,7 +228,7 @@ void main() {
 
       test('должен очищать resolvedAt через clearResolvedAt', () {
         final WishlistItem original =
-            createTestItem(resolvedAt: resolvedDate);
+            createTestWishlistItem(createdAt: testDate, resolvedAt: resolvedDate);
         final WishlistItem copy =
             original.copyWith(clearResolvedAt: true);
 
@@ -253,7 +236,7 @@ void main() {
       });
 
       test('должен создавать копию со всеми изменёнными полями', () {
-        final WishlistItem original = createTestItem();
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate,);
         final DateTime newDate = DateTime(2025, 1, 1);
         final WishlistItem copy = original.copyWith(
           id: 99,
@@ -275,7 +258,7 @@ void main() {
       });
 
       test('должен сохранять все поля при пустом copyWith', () {
-        final WishlistItem original = createTestItem(
+        final WishlistItem original = createTestWishlistItem(createdAt: testDate,
           mediaTypeHint: MediaType.game,
           note: 'Заметка',
           isResolved: true,
@@ -294,27 +277,27 @@ void main() {
 
     group('equality', () {
       test('должен быть равен при одинаковом id', () {
-        final WishlistItem a = createTestItem(id: 1, text: 'A');
-        final WishlistItem b = createTestItem(id: 1, text: 'B');
+        final WishlistItem a = createTestWishlistItem(createdAt: testDate, id: 1, text: 'A');
+        final WishlistItem b = createTestWishlistItem(createdAt: testDate, id: 1, text: 'B');
 
         expect(a == b, true);
         expect(a.hashCode, b.hashCode);
       });
 
       test('должен быть не равен при разных id', () {
-        final WishlistItem a = createTestItem(id: 1);
-        final WishlistItem b = createTestItem(id: 2);
+        final WishlistItem a = createTestWishlistItem(createdAt: testDate, id: 1);
+        final WishlistItem b = createTestWishlistItem(createdAt: testDate, id: 2);
 
         expect(a == b, false);
       });
 
       test('должен быть равен самому себе', () {
-        final WishlistItem item = createTestItem();
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,);
         expect(item == item, true);
       });
 
       test('должен быть не равен объекту другого типа', () {
-        final WishlistItem item = createTestItem();
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate,);
         // ignore: unrelated_type_equality_checks
         expect(item == 'string', false);
       });
@@ -322,7 +305,7 @@ void main() {
 
     group('toString', () {
       test('должен возвращать корректную строку', () {
-        final WishlistItem item = createTestItem(id: 5, text: 'Test Game');
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate, id: 5, text: 'Test Game');
 
         expect(
           item.toString(),
@@ -331,7 +314,7 @@ void main() {
       });
 
       test('должен показывать resolved статус', () {
-        final WishlistItem item = createTestItem(isResolved: true);
+        final WishlistItem item = createTestWishlistItem(createdAt: testDate, isResolved: true);
 
         expect(item.toString(), contains('resolved: true'));
       });

--- a/test/shared/widgets/cached_image_test.dart
+++ b/test/shared/widgets/cached_image_test.dart
@@ -11,13 +11,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:xerabora/core/services/image_cache_service.dart';
 import 'package:xerabora/shared/widgets/cached_image.dart';
 
-class MockImageCacheService extends Mock implements ImageCacheService {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late MockImageCacheService mockCacheService;
 
   setUpAll(() {
-    registerFallbackValue(ImageType.gameCover);
+    registerAllFallbacks();
   });
 
   setUp(() {


### PR DESCRIPTION
Eliminate massive duplication across 155 test files (67k LOC, 3837 tests):

- Create test/helpers/ with 5 files: mocks.dart (22 mock/fake classes), builders.dart (12 test data factories), fallbacks.dart (registerAllFallbacks), pump_app.dart (pumpApp extension for WidgetTester), test_helpers.dart (barrel)
- Migrate ~50 test files to use shared helpers instead of inline declarations
- Remove 103 duplicate mock/fake class declarations (now 0 outside helpers/)
- Remove 47 inline registerFallbackValue calls (now 0 outside helpers/)
- Consolidate 6 duplicate createTestCollection definitions into 1
- Update full-coverage-tests skill with shared helpers usage rules
- Update CLAUDE.md tests section with new helpers documentation

All 3837 tests pass. Zero duplicate mocks outside test/helpers/.