### PR TITLE
fix: replace silent catches with logging and descriptive comments

### DIFF
--- a/lib/features/collections/providers/canvas_provider.dart
+++ b/lib/features/collections/providers/canvas_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../data/repositories/collection_repository.dart';
@@ -168,6 +169,8 @@ final NotifierProviderFamily<CanvasNotifier, CanvasState, int?>
 /// Notifier для управления состоянием канваса.
 class CanvasNotifier extends FamilyNotifier<CanvasState, int?>
     implements BaseCanvasController {
+  static final Logger _log = Logger('CanvasNotifier');
+
   late CanvasRepository _repository;
   late int? _collectionId;
   Timer? _viewportSaveTimer;
@@ -287,16 +290,16 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int?>
     final int collectionId = _collectionId!;
     try {
       await _syncCanvasWithItems();
-    } catch (_) {
-      // Sync может упасть, но reload всё равно нужен
+    } catch (e) {
+      _log.warning('Canvas sync failed, proceeding to reload', e);
     }
     try {
       // Перезагружаем элементы канваса даже если sync упал
       final List<CanvasItem> items =
           await _repository.getItemsWithData(collectionId);
       state = state.copyWith(items: items);
-    } catch (_) {
-      // Ошибка перезагрузки — оставляем текущий state
+    } catch (e) {
+      _log.warning('Canvas reload failed, keeping current state', e);
     } finally {
       _isSyncing = false;
     }

--- a/lib/features/collections/providers/episode_tracker_provider.dart
+++ b/lib/features/collections/providers/episode_tracker_provider.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
 
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
@@ -97,6 +98,8 @@ final NotifierProviderFamily<EpisodeTrackerNotifier, EpisodeTrackerState,
 /// Нотификатор для управления просмотренными эпизодами.
 class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
     ({int? collectionId, int showId})> {
+  static final Logger _log = Logger('EpisodeTrackerNotifier');
+
   late DatabaseService _db;
   late TmdbApi _tmdbApi;
   late int? _collectionId;
@@ -331,8 +334,8 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
           _cachedTotalEpisodes = totalInShow;
           _cachedTotalSeasons = totalSeasons;
         }
-      } on Exception catch (_) {
-        // API недоступен — используем имеющиеся данные
+      } on Exception catch (e) {
+        _log.warning('TMDB API unavailable, using cached episode data', e);
       }
     }
 

--- a/lib/features/collections/widgets/episode_tracker_section.dart
+++ b/lib/features/collections/widgets/episode_tracker_section.dart
@@ -147,7 +147,8 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
           await db.upsertTvSeasons(seasons);
         }
       } on Exception catch (_) {
-        // Если API недоступен — покажем пустой список
+        // TMDB API unavailable — show empty season list, not critical.
+        // User can retry via pull-to-refresh.
       }
     }
 
@@ -195,6 +196,7 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
         });
       }
     } on Exception catch (_) {
+      // Season refresh failed (network/API error) — stop spinner, keep existing data.
       if (mounted) {
         setState(() => _refreshing = false);
       }

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -160,7 +160,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         }
       }
     } catch (_) {
-      // Не критично
+      // Episode pre-cache failed (network/API error) — not critical,
+      // episodes will be fetched on demand when user opens the show.
     }
   }
 

--- a/lib/features/settings/screens/demo_collections_screen.dart
+++ b/lib/features/settings/screens/demo_collections_screen.dart
@@ -647,7 +647,8 @@ class _DemoCollectionsScreenState
         return base64Encode(response.data!);
       }
     } catch (_) {
-      // Skip failed images silently.
+      // Image download failed — skip this cover, demo collection
+      // will work without it. Not worth blocking the whole export.
     }
     return null;
   }


### PR DESCRIPTION
Add Logger to CanvasNotifier and EpisodeTrackerNotifier for 3 catch blocks. Improve comments on 4 intentionally-ignored catches in widgets.