### PR TITLE
feat(anime): add AniList anime as new media type with full integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## [Unreleased]
 
+### Added
+- **Anime (AniList) as new media type** — `MediaType.anime` for Japanese anime with full AniList metadata: episodes, duration, format (TV/OVA/Movie/ONA/Special), source material (Original/Manga/Light Novel), studios, season, banner image for backdrop. New `anime_cache` table (DB migration v33), `AnimeDao`, `ImageType.animeCover`, `AppColors.animeAccent` (pink). AniList GraphQL queries extended with `duration`, `source`, `bannerImage`, `nextAiringEpisode`. Full integration: search (browse + filters), add to collection, detail card with chips, canvas, export/import, backup. `AniListAnimeSource` activated in search sources. Anime filter chip added to collection filter bar and Home/All Items screen. 5 localization keys EN+RU (`anime_dao.dart`, `migration_v33.dart`, `anime_progress_section.dart`, `anilist_anime_source.dart`, + ~35 files updated)
+- **Anime episode progress tracker** — `AnimeProgressSection` with progress bar, "+1 episode" button, manual edit dialog, "Mark as completed" button, and next airing episode info for ongoing anime. Auto-status: +1 from zero → inProgress, mark completed → completed, reset to 0 → notStarted, dropped untouched. Uses existing `currentEpisode` field (no migration needed) (`anime_progress_section.dart`, `collections_provider.dart`)
+- **CopyableText shared widget** — extracted from `ScreenAppBar._CopyableTitle` into reusable `CopyableText` widget. Accepts any child widget + text to copy. Now used in both `ScreenAppBar` and `ItemDetailsSheet` title. Tap to copy, hover shows copy/check icon (`copyable_text.dart`, `screen_app_bar.dart`, `item_details_sheet.dart`)
+- **MediaProgressRow shared widget** — extracted progress row (label + value + progress bar + increment button) from `MangaProgressSection` into reusable `MediaProgressRow`. Now shared between manga and anime progress sections, eliminating code duplication (`media_progress_row.dart`, `manga_progress_section.dart`, `anime_progress_section.dart`)
+
 ## [0.25.1] - 2026-04-10
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ graph TB
     end
 
     subgraph shared ["🧩 Shared"]
-        models["Models<br/><small>26 моделей:<br/>Game, Movie, TvShow,<br/>VisualNovel, Manga, CustomMedia,<br/>Collection, CanvasItem, WishlistItem,<br/>RaGameProgress, RaUserProfile...</small>"]
+        models["Models<br/><small>27 моделей:<br/>Game, Movie, TvShow, Anime,<br/>VisualNovel, Manga, CustomMedia,<br/>Collection, CanvasItem, WishlistItem,<br/>RaGameProgress, RaUserProfile...</small>"]
         widgets["Widgets<br/><small>CachedImage, MediaPosterCard,<br/>ScreenAppBar, StarRatingBar...</small>"]
         theme["Theme<br/><small>AppColors, AppTypography,<br/>AppSpacing, AppTheme</small>"]
         navigation["Navigation<br/><small>NavigationShell<br/>Rail / BottomBar</small>"]
@@ -121,6 +121,7 @@ lib/
 | `lib/core/database/dao/tv_show_dao.dart` | **DAO сериалов**. CRUD для `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache`, `watched_episodes`. Методы для шоу, сезонов, эпизодов и отслеживания просмотра. Batch upsert через транзакции |
 | `lib/core/database/dao/visual_novel_dao.dart` | **DAO визуальных новелл**. CRUD для `visual_novels_cache`, `vndb_tags`. Методы: `upsertVisualNovel()`, `upsertVisualNovels()`, `getVisualNovel()`, `getVisualNovelsByNumericIds()`, `getVndbTags()` |
 | `lib/core/database/dao/manga_dao.dart` | **DAO манги**. CRUD для `manga_cache`. Методы: `upsertManga()`, `upsertMangas()`, `getManga()`, `getMangaByIds()` |
+| `lib/core/database/dao/anime_dao.dart` | **DAO аниме**. CRUD для `anime_cache`. Методы: `upsertAnime()`, `upsertAnimes()`, `getAnime()`, `getAnimeByIds()`. Провайдер: `animeDaoProvider` |
 | `lib/core/database/dao/collection_dao.dart` | **DAO коллекций**. CRUD для `collections`, `collection_items`. Методы: `getCollections()`, `insertCollection()`, `getCollectionItemsWithData()`, `addItemToCollection()`, `updateItemStatus()`, `reorderItems()` (batch), `getCollectionStats()`, `findCollectionItem()` и др. Авторезолвинг жанров через `_resolveGenresIfNeeded<T>()` |
 | `lib/core/database/dao/canvas_dao.dart` | **DAO канваса**. CRUD для `canvas_items`, `canvas_viewport`, `canvas_connections`, `game_canvas_viewport`. Методы: `getCanvasItems()`, `insertCanvasItem()`, `updateCanvasItem()`, `deleteCanvasItem()`, `insertCanvasItemsBatch()`, `deleteCanvasItemsBatch()`, `getCanvasConnections()`, viewport операции. Batch методы используют `Transaction` + `Batch` для массовых INSERT/DELETE |
 | `lib/core/database/dao/custom_media_dao.dart` | **DAO кастомных элементов**. CRUD для `custom_items`. Методы: `create()`, `update()`, `getById()`, `getByIds()`, `delete()`, `deleteByIds()` |
@@ -426,6 +427,8 @@ lib/
 | Файл | Назначение |
 |------|------------|
 | `lib/shared/widgets/api_error_display.dart` | **ApiErrorDisplay**. Виджет ошибки API: иконка error_outline + сообщение + кнопка "Скопировать детали" (копирует debug info в clipboard через `Clipboard.setData`). Кнопка показывается только при наличии `detail`. Snackbar подтверждение через `showSnack()` |
+| `lib/shared/widgets/copyable_text.dart` | **CopyableText**. Обёртка для текста с копированием по нажатию. Hover показывает иконку copy, нажатие → check + копирование. Принимает `child` Widget и `text` String. Используется в `ScreenAppBar` и `ItemDetailsSheet` |
+| `lib/shared/widgets/media_progress_row.dart` | **MediaProgressRow**. Строка прогресса: label + текущее/общее + прогресс-бар + кнопка "+1". Переиспользуется в `MangaProgressSection` (главы, тома) и `AnimeProgressSection` (эпизоды) |
 | `lib/shared/widgets/section_header.dart` | **SectionHeader**. Заголовок секции с опциональной кнопкой действия справа |
 | `lib/shared/widgets/cached_image.dart` | **Виджет кэшированного изображения**. ConsumerStatefulWidget с FutureBuilder. Логика: cache disabled -> Image.network, cache enabled + file -> Image.file (с sync guard: existsSync + lengthSync > 0), cache enabled + no file -> Image.network + фоновый download через addPostFrameCallback. Corrupt/empty файлы удаляются и перекачиваются (`_deleteAndRedownload` с флагом `_corruptHandled`). Параметры: imageType, imageId, remoteUrl, memCacheWidth/Height, autoDownload, placeholder, errorWidget |
 | `lib/shared/widgets/dual_rating_badge.dart` | **Двойной рейтинг**. Формат `* 8 / 7.5` (userRating / apiRating). Режимы: badge (затемнённый фон 0xCC000000, белый текст), compact (уменьшенные размеры), inline (без фона, для list-карточек). Геттеры `hasRating`, `formattedRating`. Если нет ни одного рейтинга — `SizedBox.shrink()` |

--- a/lib/core/api/anilist_api.dart
+++ b/lib/core/api/anilist_api.dart
@@ -177,8 +177,11 @@ query ($page: Int, $perPage: Int, $search: String, $genre: String,
       seasonYear
       startDate { year month day }
       episodes
+      duration
       format
+      source
       studios(isMain: true) { nodes { name } }
+      nextAiringEpisode { airingAt episode }
     }
   }
 }
@@ -191,6 +194,7 @@ query ($id: Int) {
     id
     title { romaji english native }
     coverImage { large medium }
+    bannerImage
     description(asHtml: false)
     genres
     averageScore
@@ -201,8 +205,11 @@ query ($id: Int) {
     seasonYear
     startDate { year month day }
     episodes
+    duration
     format
+    source
     studios(isMain: true) { nodes { name } }
+    nextAiringEpisode { airingAt episode }
   }
 }
 ''';
@@ -226,8 +233,11 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
       seasonYear
       startDate { year month day }
       episodes
+      duration
       format
+      source
       studios(isMain: true) { nodes { name } }
+      nextAiringEpisode { airingAt episode }
     }
   }
 }

--- a/lib/core/database/dao/anime_dao.dart
+++ b/lib/core/database/dao/anime_dao.dart
@@ -1,0 +1,64 @@
+// DAO для работы с аниме из AniList.
+
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../../../shared/models/anime.dart';
+
+/// DAO для таблицы `anime_cache`.
+class AnimeDao {
+  /// Создаёт DAO с функцией получения базы данных.
+  const AnimeDao(this._getDatabase);
+
+  final Future<Database> Function() _getDatabase;
+
+  /// Сохраняет или обновляет аниме в кэше.
+  Future<void> upsertAnime(Anime anime) async {
+    final Database db = await _getDatabase();
+    await db.insert(
+      'anime_cache',
+      anime.toDb(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  /// Сохраняет или обновляет список аниме.
+  Future<void> upsertAnimes(List<Anime> animes) async {
+    if (animes.isEmpty) return;
+    final Database db = await _getDatabase();
+    final Batch batch = db.batch();
+    for (final Anime anime in animes) {
+      batch.insert(
+        'anime_cache',
+        anime.toDb(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  /// Получает аниме по AniList ID.
+  Future<Anime?> getAnime(int id) async {
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> rows = await db.query(
+      'anime_cache',
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return Anime.fromDb(rows.first);
+  }
+
+  /// Получает аниме по списку ID.
+  Future<List<Anime>> getAnimeByIds(List<int> ids) async {
+    if (ids.isEmpty) return <Anime>[];
+    final Database db = await _getDatabase();
+    final String placeholders =
+        List<String>.filled(ids.length, '?').join(',');
+    final List<Map<String, dynamic>> rows = await db.rawQuery(
+      'SELECT * FROM anime_cache WHERE id IN ($placeholders)',
+      ids,
+    );
+    return rows.map(Anime.fromDb).toList();
+  }
+}

--- a/lib/core/database/dao/collection_dao.dart
+++ b/lib/core/database/dao/collection_dao.dart
@@ -2,6 +2,7 @@
 
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+import '../../../shared/models/anime.dart';
 import '../../../shared/models/collected_item_info.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
@@ -15,6 +16,7 @@ import '../../../shared/models/manga.dart';
 import '../../../shared/models/tv_show.dart';
 import '../../../shared/models/custom_media.dart';
 import '../../../shared/models/visual_novel.dart';
+import 'anime_dao.dart';
 import 'custom_media_dao.dart';
 import 'game_dao.dart';
 import 'manga_dao.dart';
@@ -31,12 +33,14 @@ class CollectionDao {
     required MovieDao movieDao,
     required TvShowDao tvShowDao,
     required VisualNovelDao visualNovelDao,
+    required AnimeDao animeDao,
     required MangaDao mangaDao,
     required CustomMediaDao customMediaDao,
   })  : _gameDao = gameDao,
         _movieDao = movieDao,
         _tvShowDao = tvShowDao,
         _visualNovelDao = visualNovelDao,
+        _animeDao = animeDao,
         _mangaDao = mangaDao,
         _customMediaDao = customMediaDao;
 
@@ -45,6 +49,7 @@ class CollectionDao {
   final MovieDao _movieDao;
   final TvShowDao _tvShowDao;
   final VisualNovelDao _visualNovelDao;
+  final AnimeDao _animeDao;
   final MangaDao _mangaDao;
   final CustomMediaDao _customMediaDao;
 
@@ -675,6 +680,7 @@ class CollectionDao {
       'animationCount': 0,
       'visualNovelCount': 0,
       'mangaCount': 0,
+      'animeCount': 0,
       'customCount': 0,
     };
 
@@ -699,6 +705,8 @@ class CollectionDao {
               (stats['visualNovelCount'] ?? 0) + count;
         case 'manga':
           stats['mangaCount'] = (stats['mangaCount'] ?? 0) + count;
+        case 'anime':
+          stats['animeCount'] = (stats['animeCount'] ?? 0) + count;
         case 'custom':
           stats['customCount'] = (stats['customCount'] ?? 0) + count;
       }
@@ -819,6 +827,7 @@ class CollectionDao {
                    ELSE m2.poster_url END
             WHEN 'visual_novel' THEN vn.image_url
             WHEN 'manga' THEN mc.cover_url
+            WHEN 'anime' THEN ac.cover_url
           END AS thumbnail_url
         FROM collection_items ci
         LEFT JOIN games g
@@ -837,6 +846,8 @@ class CollectionDao {
           ON ci.media_type = 'visual_novel' AND ci.external_id = vn.numeric_id
         LEFT JOIN manga_cache mc
           ON ci.media_type = 'manga' AND ci.external_id = mc.id
+        LEFT JOIN anime_cache ac
+          ON ci.media_type = 'anime' AND ci.external_id = ac.id
         WHERE $whereClause
       )
       WHERE thumbnail_url IS NOT NULL
@@ -864,6 +875,7 @@ class CollectionDao {
     final List<int> movieIds = <int>[];
     final List<int> tvShowIds = <int>[];
     final List<int> vnIds = <int>[];
+    final List<int> animeIds = <int>[];
     final List<int> mangaIds = <int>[];
     final List<int> customIds = <int>[];
     final Set<int> platformIds = <int>{};
@@ -887,6 +899,8 @@ class CollectionDao {
           }
         case MediaType.visualNovel:
           vnIds.add(item.externalId);
+        case MediaType.anime:
+          animeIds.add(item.externalId);
         case MediaType.manga:
           mangaIds.add(item.externalId);
         case MediaType.custom:
@@ -911,6 +925,9 @@ class CollectionDao {
       mangaIds.isNotEmpty
           ? _mangaDao.getMangaByIds(mangaIds)
           : Future<List<Manga>>.value(<Manga>[]),
+      animeIds.isNotEmpty
+          ? _animeDao.getAnimeByIds(animeIds)
+          : Future<List<Anime>>.value(<Anime>[]),
       customIds.isNotEmpty
           ? _customMediaDao.getByIds(customIds)
           : Future<List<CustomMedia>>.value(<CustomMedia>[]),
@@ -924,8 +941,9 @@ class CollectionDao {
     final List<TvShow> tvShows = results[2] as List<TvShow>;
     final List<VisualNovel> visualNovels = results[3] as List<VisualNovel>;
     final List<Manga> mangas = results[4] as List<Manga>;
-    final List<CustomMedia> customMediaList = results[5] as List<CustomMedia>;
-    final List<Platform> platforms = results[6] as List<Platform>;
+    final List<Anime> animes = results[5] as List<Anime>;
+    final List<CustomMedia> customMediaList = results[6] as List<CustomMedia>;
+    final List<Platform> platforms = results[7] as List<Platform>;
 
     final Map<int, Platform> platformsMap = <int, Platform>{
       for (final Platform p in platforms) p.id: p,
@@ -961,6 +979,9 @@ class CollectionDao {
     final Map<int, Manga> mangaMap = <int, Manga>{
       for (final Manga m in mangas) m.id: m,
     };
+    final Map<int, Anime> animeMap = <int, Anime>{
+      for (final Anime a in animes) a.id: a,
+    };
     final Map<int, CustomMedia> customMap = <int, CustomMedia>{
       for (final CustomMedia c in customMediaList) c.id: c,
     };
@@ -986,6 +1007,8 @@ class CollectionDao {
           return item.copyWith(movie: moviesMap[item.externalId]);
         case MediaType.visualNovel:
           return item.copyWith(visualNovel: vnMap[item.externalId]);
+        case MediaType.anime:
+          return item.copyWith(anime: animeMap[item.externalId]);
         case MediaType.manga:
           return item.copyWith(manga: mangaMap[item.externalId]);
         case MediaType.custom:

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -21,12 +21,14 @@ import '../../shared/models/platform.dart';
 import '../../shared/models/tv_episode.dart';
 import '../../shared/models/tv_season.dart';
 import '../../shared/models/tv_show.dart';
+import '../../shared/models/anime.dart';
 import '../../shared/models/manga.dart';
 import '../../shared/models/visual_novel.dart';
 import '../../shared/models/wishlist_item.dart';
 import 'dao/canvas_dao.dart';
 import 'dao/collection_dao.dart';
 import 'dao/custom_media_dao.dart';
+import 'dao/anime_dao.dart';
 import 'dao/game_dao.dart';
 import 'dao/movie_dao.dart';
 import 'dao/tag_dao.dart';
@@ -71,6 +73,11 @@ final Provider<VisualNovelDao> visualNovelDaoProvider =
 /// Провайдер для [MangaDao].
 final Provider<MangaDao> mangaDaoProvider = Provider<MangaDao>((Ref ref) {
   return ref.watch(databaseServiceProvider).mangaDao;
+});
+
+/// Провайдер для [AnimeDao].
+final Provider<AnimeDao> animeDaoProvider = Provider<AnimeDao>((Ref ref) {
+  return ref.watch(databaseServiceProvider).animeDao;
 });
 
 /// Провайдер для [CollectionDao].
@@ -145,6 +152,9 @@ class DatabaseService {
   /// DAO для работы с мангой.
   late final MangaDao mangaDao = MangaDao(() => database);
 
+  /// DAO для работы с аниме.
+  late final AnimeDao animeDao = AnimeDao(() => database);
+
   /// DAO для работы с кастомными элементами.
   late final CustomMediaDao customMediaDao = CustomMediaDao(() => database);
 
@@ -155,6 +165,7 @@ class DatabaseService {
     movieDao: movieDao,
     tvShowDao: tvShowDao,
     visualNovelDao: visualNovelDao,
+    animeDao: animeDao,
     mangaDao: mangaDao,
     customMediaDao: customMediaDao,
   );
@@ -216,7 +227,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 32,
+        version: 33,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {
@@ -931,6 +942,7 @@ class DatabaseService {
       await txn.delete('games');
       await txn.delete('visual_novels_cache');
       await txn.delete('manga_cache');
+      await txn.delete('anime_cache');
       // Статические справочники (platforms, tmdb_genres, igdb_genres, vndb_tags)
       // не очищаются — они заполнены миграцией v24 и не являются пользовательскими.
       // Wishlist
@@ -976,6 +988,22 @@ class DatabaseService {
   /// Получает манги по списку ID.
   Future<List<Manga>> getMangaByIds(List<int> ids) =>
       mangaDao.getMangaByIds(ids);
+
+  // ==================== Anime (delegates to AnimeDao) ====================
+
+  /// Сохраняет или обновляет аниме в кэше.
+  Future<void> upsertAnime(Anime anime) => animeDao.upsertAnime(anime);
+
+  /// Сохраняет или обновляет список аниме.
+  Future<void> upsertAnimes(List<Anime> animes) =>
+      animeDao.upsertAnimes(animes);
+
+  /// Получает аниме по AniList ID.
+  Future<Anime?> getAnime(int id) => animeDao.getAnime(id);
+
+  /// Получает аниме по списку ID.
+  Future<List<Anime>> getAnimeByIds(List<int> ids) =>
+      animeDao.getAnimeByIds(ids);
 
   // ==================== Collection Covers (delegates to CollectionDao) ====================
 

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -31,6 +31,7 @@ import 'migration_v29.dart';
 import 'migration_v30.dart';
 import 'migration_v31.dart';
 import 'migration_v32.dart';
+import 'migration_v33.dart';
 
 /// Реестр всех миграций базы данных.
 ///
@@ -70,6 +71,7 @@ abstract final class MigrationRegistry {
     MigrationV30(),
     MigrationV31(),
     MigrationV32(),
+    MigrationV33(),
   ];
 
   /// Возвращает миграции, ожидающие выполнения для данной версии.

--- a/lib/core/database/migrations/migration_v33.dart
+++ b/lib/core/database/migrations/migration_v33.dart
@@ -1,0 +1,19 @@
+// Миграция v33: создание таблицы anime_cache.
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../schema.dart';
+import 'migration.dart';
+
+/// Миграция v33: добавляет таблицу кэша аниме из AniList.
+class MigrationV33 extends Migration {
+  @override
+  int get version => 33;
+
+  @override
+  String get description => 'Add anime_cache table';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await DatabaseSchema.createAnimeCacheTable(db);
+  }
+}

--- a/lib/core/database/schema.dart
+++ b/lib/core/database/schema.dart
@@ -32,6 +32,7 @@ abstract final class DatabaseSchema {
     await createTrackerProfilesTable(db);
     await createTrackerGameDataTable(db);
     await createTrackerAchievementsTable(db);
+    await createAnimeCacheTable(db);
   }
 
   /// Таблица платформ (IGDB).
@@ -425,6 +426,41 @@ abstract final class DatabaseSchema {
         authors TEXT,
         external_url TEXT,
         banner_url TEXT,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+  }
+
+  /// Таблица кэша аниме (AniList).
+  static Future<void> createAnimeCacheTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS anime_cache (
+        id INTEGER PRIMARY KEY,
+        title TEXT NOT NULL,
+        title_english TEXT,
+        title_native TEXT,
+        description TEXT,
+        cover_url TEXT,
+        cover_url_medium TEXT,
+        banner_url TEXT,
+        average_score INTEGER,
+        mean_score INTEGER,
+        popularity INTEGER,
+        status TEXT,
+        season TEXT,
+        season_year INTEGER,
+        start_year INTEGER,
+        start_month INTEGER,
+        start_day INTEGER,
+        episodes INTEGER,
+        duration INTEGER,
+        format TEXT,
+        source TEXT,
+        genres TEXT,
+        studios TEXT,
+        next_airing_episode INTEGER,
+        next_airing_at INTEGER,
+        external_url TEXT,
         updated_at INTEGER NOT NULL
       )
     ''');

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -382,6 +382,8 @@ class ExportService {
     final Map<int, Map<String, dynamic>> vns = <int, Map<String, dynamic>>{};
     final Map<int, Map<String, dynamic>> mangas =
         <int, Map<String, dynamic>>{};
+    final Map<int, Map<String, dynamic>> animes =
+        <int, Map<String, dynamic>>{};
     final Map<int, Map<String, dynamic>> customItems =
         <int, Map<String, dynamic>>{};
     final Set<int> tvShowIds = <int>{};
@@ -436,6 +438,10 @@ class ExportService {
           if (item.manga != null && !mangas.containsKey(item.externalId)) {
             mangas[item.externalId] = item.manga!.toExport();
           }
+        case MediaType.anime:
+          if (item.anime != null && !animes.containsKey(item.externalId)) {
+            animes[item.externalId] = item.anime!.toExport();
+          }
         case MediaType.custom:
           if (item.customMedia != null &&
               !customItems.containsKey(item.externalId)) {
@@ -481,6 +487,7 @@ class ExportService {
         tvShows.isEmpty &&
         vns.isEmpty &&
         mangas.isEmpty &&
+        animes.isEmpty &&
         allSeasons.isEmpty &&
         allEpisodes.isEmpty &&
         allPlatforms.isEmpty) {
@@ -496,6 +503,7 @@ class ExportService {
       if (allPlatforms.isNotEmpty) 'platforms': allPlatforms,
       if (vns.isNotEmpty) 'visual_novels': vns.values.toList(),
       if (mangas.isNotEmpty) 'mangas': mangas.values.toList(),
+      if (animes.isNotEmpty) 'animes': animes.values.toList(),
       if (customItems.isNotEmpty)
         'custom_items': customItems.values.toList(),
     };

--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -37,6 +37,9 @@ enum ImageType {
   /// Обложки визуальных новелл.
   vnCover('vn_covers'),
 
+  /// Обложки аниме.
+  animeCover('anime_covers'),
+
   /// Обложки кастомных элементов.
   customCover('custom_covers');
 

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -25,6 +25,7 @@ import '../../shared/models/platform.dart' as model;
 import '../../shared/models/tv_episode.dart';
 import '../../shared/models/tv_season.dart';
 import '../../shared/models/tv_show.dart';
+import '../../shared/models/anime.dart';
 import '../../shared/models/manga.dart';
 import '../../shared/models/tracker_game_data.dart';
 import '../../shared/models/visual_novel.dart';
@@ -155,6 +156,9 @@ enum ImportStage {
 
   /// Загрузка данных манги из AniList.
   fetchingManga('Fetching manga data...'),
+
+  /// Загрузка данных аниме из AniList.
+  fetchingAnime('Fetching anime data...'),
 
   /// Кэширование медиа-данных.
   cachingMedia('Caching media...'),
@@ -664,6 +668,8 @@ class ImportService {
         media['visual_novels'] as List<dynamic>? ?? <dynamic>[];
     final List<dynamic> rawMangas =
         media['mangas'] as List<dynamic>? ?? <dynamic>[];
+    final List<dynamic> rawAnimes =
+        media['animes'] as List<dynamic>? ?? <dynamic>[];
     final List<dynamic> rawCustom =
         media['custom_items'] as List<dynamic>? ?? <dynamic>[];
 
@@ -675,6 +681,7 @@ class ImportService {
         rawPlatforms.length +
         rawVisualNovels.length +
         rawMangas.length +
+        rawAnimes.length +
         rawCustom.length;
     final int cachedAt = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     int current = 0;
@@ -830,6 +837,24 @@ class ImportService {
       await _database.upsertMangas(mangas);
     }
 
+    // Восстановление аниме
+    if (rawAnimes.isNotEmpty) {
+      final List<Anime> animes = <Anime>[];
+      for (final dynamic raw in rawAnimes) {
+        final Map<String, dynamic> row =
+            Map<String, dynamic>.from(raw as Map<String, dynamic>);
+        row['updated_at'] = cachedAt;
+        animes.add(Anime.fromDb(row));
+        current++;
+        onProgress?.call(ImportProgress(
+          stage: ImportStage.restoringMedia,
+          current: current,
+          total: total,
+        ));
+      }
+      await _database.upsertAnimes(animes);
+    }
+
     // Восстановление кастомных элементов
     if (rawCustom.isNotEmpty) {
       final List<CustomMedia> customItems = <CustomMedia>[];
@@ -865,6 +890,7 @@ class ImportService {
     final List<Map<String, dynamic>> tvShowItems = <Map<String, dynamic>>[];
     final List<Map<String, dynamic>> vnItems = <Map<String, dynamic>>[];
     final List<Map<String, dynamic>> mangaItems = <Map<String, dynamic>>[];
+    final List<Map<String, dynamic>> animeItems = <Map<String, dynamic>>[];
 
     for (final Map<String, dynamic> item in items) {
       final String mediaType = item['media_type'] as String;
@@ -886,6 +912,8 @@ class ImportService {
           vnItems.add(item);
         case 'manga':
           mangaItems.add(item);
+        case 'anime':
+          animeItems.add(item);
       }
     }
 
@@ -1026,12 +1054,41 @@ class ImportService {
       ));
     }
 
+    // Загрузка аниме из AniList
+    final List<int> animeIds = animeItems
+        .where((Map<String, dynamic> i) => i['external_id'] != null)
+        .map((Map<String, dynamic> i) => i['external_id'] as int)
+        .toList();
+    List<Anime> animes = <Anime>[];
+
+    if (animeIds.isNotEmpty && _aniListApi != null) {
+      final AniListApi aniListApi = _aniListApi;
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.fetchingAnime,
+        current: 0,
+        total: animeIds.length,
+        message: 'Fetching ${animeIds.length} anime from AniList...',
+      ));
+
+      try {
+        animes = await aniListApi.getAnimeByIds(animeIds);
+      } on AniListApiException catch (e) {
+        _log.warning('Failed to fetch anime: ${e.message}');
+      }
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.fetchingAnime,
+        current: animeIds.length,
+        total: animeIds.length,
+      ));
+    }
+
     // Кэширование медиа-данных
     final int totalMedia = games.length +
         movies.length +
         tvShows.length +
         visualNovels.length +
-        mangas.length;
+        mangas.length +
+        animes.length;
     onProgress?.call(ImportProgress(
       stage: ImportStage.cachingMedia,
       current: 0,
@@ -1082,6 +1139,16 @@ class ImportService {
     if (mangas.isNotEmpty) {
       await _database.upsertMangas(mangas);
       cachedCount += mangas.length;
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.cachingMedia,
+        current: cachedCount,
+        total: totalMedia,
+      ));
+    }
+
+    if (animes.isNotEmpty) {
+      await _database.upsertAnimes(animes);
+      cachedCount += animes.length;
       onProgress?.call(ImportProgress(
         stage: ImportStage.cachingMedia,
         current: cachedCount,

--- a/lib/core/services/text_export_service.dart
+++ b/lib/core/services/text_export_service.dart
@@ -160,6 +160,8 @@ class TextExportService {
         return 'Visual Novel';
       case MediaType.manga:
         return 'Manga';
+      case MediaType.anime:
+        return 'Anime';
       case MediaType.custom:
         return 'Custom';
     }

--- a/lib/data/repositories/canvas_repository.dart
+++ b/lib/data/repositories/canvas_repository.dart
@@ -11,6 +11,7 @@ import '../../shared/models/custom_media.dart';
 import '../../shared/models/game.dart';
 import '../../shared/models/movie.dart';
 import '../../shared/models/tv_show.dart';
+import '../../shared/models/anime.dart';
 import '../../shared/models/manga.dart';
 import '../../shared/models/visual_novel.dart';
 
@@ -233,6 +234,12 @@ class CanvasRepository {
         .map((CanvasItem item) => item.itemRefId!)
         .toList();
 
+    final List<int> animeIds = items
+        .where((CanvasItem item) =>
+            item.itemType == CanvasItemType.anime && item.itemRefId != null)
+        .map((CanvasItem item) => item.itemRefId!)
+        .toList();
+
     final List<int> customIds = items
         .where((CanvasItem item) =>
             item.itemType == CanvasItemType.custom && item.itemRefId != null)
@@ -245,6 +252,7 @@ class CanvasRepository {
         tvShowTmdbIds.isEmpty &&
         vnIds.isEmpty &&
         mangaIds.isEmpty &&
+        animeIds.isEmpty &&
         customIds.isEmpty) {
       return items;
     }
@@ -266,6 +274,9 @@ class CanvasRepository {
       mangaIds.isNotEmpty
           ? _db.getMangaByIds(mangaIds)
           : Future<List<Manga>>.value(<Manga>[]),
+      animeIds.isNotEmpty
+          ? _db.animeDao.getAnimeByIds(animeIds)
+          : Future<List<Anime>>.value(<Anime>[]),
       customIds.isNotEmpty
           ? _db.customMediaDao.getByIds(customIds)
           : Future<List<CustomMedia>>.value(<CustomMedia>[]),
@@ -287,8 +298,11 @@ class CanvasRepository {
     final Map<int, Manga> mangaMap = <int, Manga>{
       for (final Manga m in results[4] as List<Manga>) m.id: m,
     };
+    final Map<int, Anime> animeMap = <int, Anime>{
+      for (final Anime a in results[5] as List<Anime>) a.id: a,
+    };
     final Map<int, CustomMedia> customMap = <int, CustomMedia>{
-      for (final CustomMedia c in results[5] as List<CustomMedia>) c.id: c,
+      for (final CustomMedia c in results[6] as List<CustomMedia>) c.id: c,
     };
 
     return items.map((CanvasItem item) {
@@ -311,6 +325,8 @@ class CanvasRepository {
           return item.copyWith(visualNovel: vnMap[item.itemRefId]);
         case CanvasItemType.manga:
           return item.copyWith(manga: mangaMap[item.itemRefId]);
+        case CanvasItemType.anime:
+          return item.copyWith(anime: animeMap[item.itemRefId]);
         case CanvasItemType.custom:
           return item.copyWith(customMedia: customMap[item.itemRefId]);
         case CanvasItemType.text:

--- a/lib/data/repositories/collection_repository.dart
+++ b/lib/data/repositories/collection_repository.dart
@@ -30,6 +30,7 @@ class CollectionStats {
     this.animationCount = 0,
     this.visualNovelCount = 0,
     this.mangaCount = 0,
+    this.animeCount = 0,
     this.customCount = 0,
   });
 
@@ -68,6 +69,9 @@ class CollectionStats {
 
   /// Количество манги.
   final int mangaCount;
+
+  /// Количество аниме.
+  final int animeCount;
 
   /// Количество кастомных элементов.
   final int customCount;
@@ -310,6 +314,7 @@ class CollectionRepository {
       animationCount: raw['animationCount'] ?? 0,
       visualNovelCount: raw['visualNovelCount'] ?? 0,
       mangaCount: raw['mangaCount'] ?? 0,
+      animeCount: raw['animeCount'] ?? 0,
       customCount: raw['customCount'] ?? 0,
     );
   }

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -722,6 +722,8 @@ class CollectionItemsNotifier
         ref.invalidate(collectedVisualNovelIdsProvider);
       case MediaType.manga:
         ref.invalidate(collectedMangaIdsProvider);
+      case MediaType.anime:
+        ref.invalidate(collectedAnimeIdsProvider);
       case MediaType.custom:
         break; // Кастомные элементы не имеют collected IDs провайдера
     }
@@ -885,8 +887,9 @@ class CollectionItemsNotifier
         }).toList(),
       );
 
-      // Авто-статус для манги
+      // Авто-статус для манги и аниме
       await _autoUpdateMangaStatus(id, currentEpisode, currentSeason);
+      await _autoUpdateAnimeStatus(id, currentEpisode);
     }
   }
 
@@ -928,6 +931,45 @@ class CollectionItemsNotifier
 
     if (targetStatus != null) {
       await updateStatus(id, targetStatus, MediaType.manga);
+    }
+  }
+
+  /// Автоматически обновляет статус аниме на основе прогресса просмотра.
+  Future<void> _autoUpdateAnimeStatus(
+    int id,
+    int? newEpisodeValue,
+  ) async {
+    final CollectionItem? item =
+        state.valueOrNull?.where((CollectionItem i) => i.id == id).firstOrNull;
+    if (item == null ||
+        item.mediaType != MediaType.anime ||
+        item.status == ItemStatus.dropped) {
+      return;
+    }
+
+    final int newEpisode = newEpisodeValue ?? item.currentEpisode;
+    final int? totalEpisodes = item.anime?.episodes;
+
+    ItemStatus? targetStatus;
+
+    if (newEpisode == 0) {
+      if (item.status == ItemStatus.inProgress ||
+          item.status == ItemStatus.completed) {
+        targetStatus = ItemStatus.notStarted;
+      }
+    } else if (totalEpisodes != null && newEpisode >= totalEpisodes) {
+      if (item.status != ItemStatus.completed) {
+        targetStatus = ItemStatus.completed;
+      }
+    } else if (item.status == ItemStatus.notStarted ||
+        item.status == ItemStatus.planned) {
+      targetStatus = ItemStatus.inProgress;
+    } else if (item.status == ItemStatus.completed) {
+      targetStatus = ItemStatus.inProgress;
+    }
+
+    if (targetStatus != null) {
+      await updateStatus(id, targetStatus, MediaType.anime);
     }
   }
 
@@ -1054,6 +1096,16 @@ final FutureProvider<Map<int, List<CollectedItemInfo>>>
     FutureProvider<Map<int, List<CollectedItemInfo>>>((Ref ref) async {
   final DatabaseService db = ref.watch(databaseServiceProvider);
   return db.getCollectedItemInfos(MediaType.manga);
+});
+
+/// Провайдер для информации о нахождении аниме в коллекциях.
+///
+/// Возвращает `Map` anilist_id -> список записей в коллекциях.
+final FutureProvider<Map<int, List<CollectedItemInfo>>>
+    collectedAnimeIdsProvider =
+    FutureProvider<Map<int, List<CollectedItemInfo>>>((Ref ref) async {
+  final DatabaseService db = ref.watch(databaseServiceProvider);
+  return db.getCollectedItemInfos(MediaType.anime);
 });
 
 /// Провайдер для количества uncategorized элементов.

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -15,6 +15,7 @@ import '../../../shared/widgets/collection_picker_dialog.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/widgets/screen_app_bar.dart';
 import '../../../core/database/database_service.dart';
+import '../../../shared/models/anime.dart';
 import '../../../shared/models/collected_item_info.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../shared/models/collection.dart';
@@ -38,6 +39,7 @@ import '../providers/vgmaps_panel_provider.dart';
 import '../widgets/canvas_view.dart';
 import '../widgets/episode_tracker_section.dart';
 import '../widgets/item_tags_section.dart';
+import '../widgets/anime_progress_section.dart';
 import '../widgets/manga_progress_section.dart';
 import '../providers/tracker_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -70,10 +72,12 @@ class _MediaConfig {
     required this.description,
     required this.hasEpisodeTracker,
     required this.hasMangaProgress,
+    required this.hasAnimeProgress,
     this.externalUrl,
     this.backdropUrl,
     this.tvShow,
     this.manga,
+    this.anime,
   });
 
   final String? coverUrl;
@@ -88,10 +92,12 @@ class _MediaConfig {
   final String? description;
   final bool hasEpisodeTracker;
   final bool hasMangaProgress;
+  final bool hasAnimeProgress;
   final String? externalUrl;
   final String? backdropUrl;
   final TvShow? tvShow;
   final Manga? manga;
+  final Anime? anime;
 }
 
 /// Единый экран детального просмотра элемента коллекции.
@@ -597,6 +603,14 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
             currentVolume: item.currentSeason,
             accentColor: config.accentColor,
           ),
+        if (config.hasAnimeProgress && widget.collectionId != null)
+          AnimeProgressSection(
+            itemId: item.id,
+            collectionId: widget.collectionId,
+            anime: config.anime,
+            currentEpisode: item.currentEpisode,
+            accentColor: config.accentColor,
+          ),
       ],
       recommendationSections: <Widget>[
         if (showRecs)
@@ -645,6 +659,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
       MediaType.tvShow => item.tvShow?.externalUrl,
       MediaType.visualNovel => item.visualNovel?.externalUrl,
       MediaType.manga => item.manga?.externalUrl,
+      MediaType.anime => item.anime?.externalUrl,
       MediaType.custom => item.customMedia?.externalUrl,
     };
 
@@ -665,13 +680,16 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
           (item.mediaType == MediaType.animation &&
               item.platformId == AnimationSource.tvShow),
       hasMangaProgress: item.mediaType == MediaType.manga,
+      hasAnimeProgress: item.mediaType == MediaType.anime,
       externalUrl: externalUrl,
       backdropUrl: item.game?.artworkUrl
           ?? item.movie?.backdropUrl
           ?? item.tvShow?.backdropUrl
-          ?? item.manga?.bannerUrl,
+          ?? item.manga?.bannerUrl
+          ?? item.anime?.bannerUrl,
       tvShow: item.tvShow,
       manga: item.manga,
+      anime: item.anime,
     );
   }
 
@@ -686,6 +704,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
           : l.animatedMovie,
       MediaType.visualNovel => l.mediaTypeVisualNovel,
       MediaType.manga => l.mediaTypeManga,
+      MediaType.anime => l.mediaTypeAnime,
       MediaType.custom => item.customMedia?.platformName ?? l.mediaTypeCustom,
     };
   }
@@ -759,6 +778,44 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
         chips.add(MediaDetailChip(
           icon: Icons.person_outline,
           text: m.authorsString!,
+        ));
+      }
+    }
+    // Anime-специфичные чипы: format, episodes, duration, studios, season, source
+    if (item.mediaType == MediaType.anime && item.anime != null) {
+      final Anime a = item.anime!;
+      if (a.formatLabel != null) {
+        chips.add(MediaDetailChip(
+          icon: Icons.category_outlined,
+          text: a.formatLabel!,
+        ));
+      }
+      chips.add(MediaDetailChip(
+        icon: Icons.playlist_play,
+        text: a.episodesString,
+      ));
+      if (a.durationString != null) {
+        chips.add(MediaDetailChip(
+          icon: Icons.schedule_outlined,
+          text: a.durationString!,
+        ));
+      }
+      if (a.studiosString != null) {
+        chips.add(MediaDetailChip(
+          icon: Icons.business,
+          text: a.studiosString!,
+        ));
+      }
+      if (a.seasonLabel != null) {
+        chips.add(MediaDetailChip(
+          icon: Icons.date_range,
+          text: a.seasonLabel!,
+        ));
+      }
+      if (a.sourceLabel != null) {
+        chips.add(MediaDetailChip(
+          icon: Icons.source,
+          text: a.sourceLabel!,
         ));
       }
     }
@@ -884,6 +941,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
       MediaType.animation => l.animationNotFound,
       MediaType.visualNovel => l.visualNovelNotFound,
       MediaType.manga => l.mangaNotFound,
+      MediaType.anime => l.mediaTypeAnime,
       MediaType.custom => l.unknownCustom,
       null => l.gameNotFound,
     };

--- a/lib/features/collections/widgets/anime_progress_section.dart
+++ b/lib/features/collections/widgets/anime_progress_section.dart
@@ -1,0 +1,177 @@
+// Секция прогресса просмотра аниме — эпизоды.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/anime.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/media_progress_row.dart';
+import '../providers/collections_provider.dart';
+
+/// Секция прогресса просмотра аниме с прогресс-баром и кнопками.
+///
+/// Использует `currentEpisode` для просмотренных эпизодов.
+/// `currentSeason` не используется (у AniList аниме нет деления на сезоны).
+class AnimeProgressSection extends ConsumerWidget {
+  /// Создаёт [AnimeProgressSection].
+  const AnimeProgressSection({
+    required this.itemId,
+    required this.collectionId,
+    required this.anime,
+    required this.currentEpisode,
+    required this.accentColor,
+    super.key,
+  });
+
+  /// ID элемента коллекции.
+  final int itemId;
+
+  /// ID коллекции.
+  final int? collectionId;
+
+  /// Данные аниме.
+  final Anime? anime;
+
+  /// Текущий просмотренный эпизод (из `collection_items.current_episode`).
+  final int currentEpisode;
+
+  /// Акцентный цвет.
+  final Color accentColor;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final S l = S.of(context);
+    final int? totalEpisodes = anime?.episodes;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        // Заголовок
+        Row(
+          children: <Widget>[
+            Icon(Icons.play_circle_outline, size: 20, color: accentColor),
+            const SizedBox(width: AppSpacing.sm),
+            Text(
+              l.animeProgress,
+              style: AppTypography.h3.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+
+        // Episodes progress
+        MediaProgressRow(
+          label: l.animeEpisodes,
+          current: currentEpisode,
+          total: totalEpisodes,
+          accentColor: accentColor,
+          onIncrement: () => _incrementEpisode(ref, totalEpisodes),
+          onEdit: () => _editProgress(context, ref, totalEpisodes),
+        ),
+
+        // Next airing episode info
+        if (anime != null && anime!.hasNextAiring) ...<Widget>[
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            children: <Widget>[
+              Icon(Icons.schedule, size: 14, color: accentColor),
+              const SizedBox(width: 4),
+              Text(
+                l.animeNextEpisode(anime!.nextAiringEpisode!),
+                style: AppTypography.caption.copyWith(
+                  color: accentColor,
+                ),
+              ),
+            ],
+          ),
+        ],
+
+        // Mark as completed
+        if (totalEpisodes != null &&
+            currentEpisode < totalEpisodes) ...<Widget>[
+          const SizedBox(height: AppSpacing.md),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: () => _markCompleted(ref),
+              icon: const Icon(Icons.check_circle_outline, size: 18),
+              label: Text(l.animeMarkCompleted),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: accentColor,
+                side: BorderSide(color: accentColor.withValues(alpha: 0.5)),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  void _incrementEpisode(WidgetRef ref, int? total) {
+    final int next = currentEpisode + 1;
+    if (total != null && next > total) return;
+    ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .updateProgress(itemId, currentEpisode: next);
+  }
+
+  void _markCompleted(WidgetRef ref) {
+    ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .updateProgress(
+          itemId,
+          currentEpisode: anime?.episodes ?? currentEpisode,
+        );
+  }
+
+  Future<void> _editProgress(
+    BuildContext context,
+    WidgetRef ref,
+    int? total,
+  ) async {
+    final TextEditingController controller = TextEditingController(
+        text: currentEpisode > 0 ? currentEpisode.toString() : '');
+    final S l = S.of(context);
+
+    final String? result = await showDialog<String>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(l.animeEpisodes),
+        content: TextField(
+          controller: controller,
+          keyboardType: TextInputType.number,
+          autofocus: true,
+          decoration: InputDecoration(
+            hintText: total != null ? '0–$total' : '0+',
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(l.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: Text(l.save),
+          ),
+        ],
+      ),
+    );
+
+    if (result != null) {
+      final int? value = int.tryParse(result);
+      if (value != null && value >= 0) {
+        final int clamped =
+            total != null && value > total ? total : value;
+        ref
+            .read(collectionItemsNotifierProvider(collectionId).notifier)
+            .updateProgress(itemId, currentEpisode: clamped);
+      }
+    }
+    controller.dispose();
+  }
+}

--- a/lib/features/collections/widgets/canvas_view.dart
+++ b/lib/features/collections/widgets/canvas_view.dart
@@ -331,6 +331,7 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
       case CanvasItemType.animation:
       case CanvasItemType.visualNovel:
       case CanvasItemType.manga:
+      case CanvasItemType.anime:
       case CanvasItemType.custom:
         break; // Медиа-элементы не редактируются через контекстное меню
     }
@@ -834,6 +835,7 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
       case CanvasItemType.animation:
       case CanvasItemType.visualNovel:
       case CanvasItemType.manga:
+      case CanvasItemType.anime:
       case CanvasItemType.custom:
         child = _buildMediaCard(item);
       case CanvasItemType.text:
@@ -986,6 +988,7 @@ class _DraggableCanvasItemState extends ConsumerState<_DraggableCanvasItem> {
       CanvasItemType.animation => CanvasRepository.defaultCardWidth,
       CanvasItemType.visualNovel => CanvasRepository.defaultCardWidth,
       CanvasItemType.manga => CanvasRepository.defaultCardWidth,
+      CanvasItemType.anime => CanvasRepository.defaultCardWidth,
       CanvasItemType.custom => CanvasRepository.defaultCardWidth,
       CanvasItemType.text => 200,
       CanvasItemType.image => 200,
@@ -1002,6 +1005,7 @@ class _DraggableCanvasItemState extends ConsumerState<_DraggableCanvasItem> {
       CanvasItemType.animation => CanvasRepository.defaultCardHeight,
       CanvasItemType.visualNovel => CanvasRepository.defaultCardHeight,
       CanvasItemType.manga => CanvasRepository.defaultCardHeight,
+      CanvasItemType.anime => CanvasRepository.defaultCardHeight,
       CanvasItemType.custom => CanvasRepository.defaultCardHeight,
       CanvasItemType.text => 100,
       CanvasItemType.image => 200,

--- a/lib/features/collections/widgets/collection_card.dart
+++ b/lib/features/collections/widgets/collection_card.dart
@@ -388,6 +388,8 @@ class _CoverImage extends StatelessWidget {
         return ImageType.vnCover;
       case MediaType.manga:
         return ImageType.mangaCover;
+      case MediaType.anime:
+        return ImageType.animeCover;
       case MediaType.custom:
         return ImageType.customCover;
     }

--- a/lib/features/collections/widgets/collection_filter_bar.dart
+++ b/lib/features/collections/widgets/collection_filter_bar.dart
@@ -1016,6 +1016,7 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
       _TypeEntry(MediaType.animation, l.collectionFilterAnimation, stats?.animationCount),
       _TypeEntry(MediaType.visualNovel, l.collectionFilterVisualNovels, stats?.visualNovelCount),
       _TypeEntry(MediaType.manga, l.collectionFilterManga, stats?.mangaCount),
+      _TypeEntry(MediaType.anime, l.mediaTypeAnime, stats?.animeCount),
       _TypeEntry(MediaType.custom, l.collectionFilterCustom, stats?.customCount),
     ];
   }

--- a/lib/features/collections/widgets/manga_progress_section.dart
+++ b/lib/features/collections/widgets/manga_progress_section.dart
@@ -5,9 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/manga.dart';
-import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/media_progress_row.dart';
 import '../providers/collections_provider.dart';
 
 /// Секция прогресса чтения манги с прогресс-барами и кнопками.
@@ -69,7 +69,7 @@ class MangaProgressSection extends ConsumerWidget {
         const SizedBox(height: AppSpacing.md),
 
         // Chapters progress
-        _ProgressRow(
+        MediaProgressRow(
           label: l.mangaChapters,
           current: currentChapter,
           total: totalChapters,
@@ -81,7 +81,7 @@ class MangaProgressSection extends ConsumerWidget {
         const SizedBox(height: AppSpacing.sm),
 
         // Volumes progress
-        _ProgressRow(
+        MediaProgressRow(
           label: l.mangaVolumes,
           current: currentVolume,
           total: totalVolumes,
@@ -195,89 +195,3 @@ class MangaProgressSection extends ConsumerWidget {
   }
 }
 
-/// Строка прогресса с меткой, значением, прогресс-баром и кнопками.
-class _ProgressRow extends StatelessWidget {
-  const _ProgressRow({
-    required this.label,
-    required this.current,
-    required this.total,
-    required this.accentColor,
-    required this.onIncrement,
-    required this.onEdit,
-  });
-
-  final String label;
-  final int current;
-  final int? total;
-  final Color accentColor;
-  final VoidCallback onIncrement;
-  final VoidCallback onEdit;
-
-  @override
-  Widget build(BuildContext context) {
-    final String progressText =
-        total != null ? '$current / $total' : '$current';
-    final double? progressValue =
-        total != null && total! > 0 ? current / total! : null;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Row(
-          children: <Widget>[
-            Text(
-              label,
-              style: AppTypography.bodySmall.copyWith(
-                color: AppColors.textSecondary,
-              ),
-            ),
-            const Spacer(),
-            InkWell(
-              onTap: onEdit,
-              borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSpacing.xs,
-                  vertical: 2,
-                ),
-                child: Text(
-                  progressText,
-                  style: AppTypography.bodySmall.copyWith(
-                    color: AppColors.textPrimary,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: AppSpacing.xs),
-            SizedBox(
-              width: 28,
-              height: 28,
-              child: IconButton(
-                onPressed: onIncrement,
-                icon: const Icon(Icons.add, size: 16),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(),
-                style: IconButton.styleFrom(
-                  foregroundColor: accentColor,
-                ),
-              ),
-            ),
-          ],
-        ),
-        if (progressValue != null) ...<Widget>[
-          const SizedBox(height: 4),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
-            child: LinearProgressIndicator(
-              value: progressValue.clamp(0.0, 1.0),
-              minHeight: 4,
-              backgroundColor: AppColors.surfaceLight,
-              valueColor: AlwaysStoppedAnimation<Color>(accentColor),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-}

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -154,6 +154,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
             _buildMediaChip(MediaType.visualNovel, l.allItemsVisualNovels, counts[MediaType.visualNovel]),
             const SizedBox(width: AppSpacing.xs),
             _buildMediaChip(MediaType.manga, l.allItemsManga, counts[MediaType.manga]),
+            const SizedBox(width: AppSpacing.xs),
+            _buildMediaChip(MediaType.anime, l.mediaTypeAnime, counts[MediaType.anime]),
             _buildMediaChip(MediaType.custom, l.allItemsCustom, counts[MediaType.custom]),
 
             const SizedBox(width: AppSpacing.md),
@@ -697,6 +699,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         return item.visualNovel?.releaseYear;
       case MediaType.manga:
         return item.manga?.releaseYear;
+      case MediaType.anime:
+        return item.anime?.releaseYear;
       case MediaType.custom:
         return item.customMedia?.year;
     }
@@ -719,6 +723,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         return ImageType.vnCover;
       case MediaType.manga:
         return ImageType.mangaCover;
+      case MediaType.anime:
+        return ImageType.animeCover;
       case MediaType.custom:
         return ImageType.customCover;
     }

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -20,6 +20,7 @@ import '../../../shared/models/platform.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
+import '../../../shared/models/anime.dart';
 import '../../../shared/models/manga.dart';
 import '../../../shared/models/visual_novel.dart';
 import '../../../shared/theme/app_colors.dart';
@@ -299,6 +300,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         collected = await ref.read(collectedVisualNovelIdsProvider.future);
       case MediaType.manga:
         collected = await ref.read(collectedMangaIdsProvider.future);
+      case MediaType.anime:
+        collected = await ref.read(collectedAnimeIdsProvider.future);
       case MediaType.custom:
         return <CollectedItemInfo>[]; // Кастомные элементы не ищутся через API
     }
@@ -330,6 +333,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       _onVisualNovelTap(item);
     } else if (item is Manga) {
       _onMangaTap(item);
+    } else if (item is Anime) {
+      _onAnimeTap(item);
     }
   }
 
@@ -1211,6 +1216,121 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       builder: (BuildContext context) => ItemDetailsSheet.manga(
         manga,
         onAddToCollection: () => _addMangaToAnyCollection(manga),
+      ),
+    );
+  }
+
+  // ==================== Anime actions ====================
+
+  void _onAnimeTap(Anime anime) {
+    if (widget.collectionId != null) {
+      _addAnimeToCollection(anime);
+    } else {
+      _showAnimeDetails(anime);
+    }
+  }
+
+  Future<void> _addAnimeToCollection(Anime anime) async {
+    final String title = anime.title;
+
+    await ref.read(databaseServiceProvider).upsertAnime(anime);
+
+    final bool success = await ref
+        .read(
+            collectionItemsNotifierProvider(widget.collectionId).notifier)
+        .addItem(
+          mediaType: MediaType.anime,
+          externalId: anime.id,
+        );
+
+    if (mounted) {
+      final S l = S.of(context);
+      if (success) {
+        _cacheImage(
+          ImageType.animeCover,
+          anime.id.toString(),
+          anime.coverUrl,
+        );
+        context.showSnack(
+          l.searchAddedToCollection(title),
+          type: SnackType.success,
+        );
+      } else {
+        context.showSnack(
+          l.searchAlreadyInCollection(title),
+          type: SnackType.info,
+        );
+      }
+    }
+  }
+
+  Future<void> _addAnimeToAnyCollection(Anime anime) async {
+    final String title = anime.title;
+
+    final Map<int, List<CollectedItemInfo>> collectedAnime =
+        await ref.read(collectedAnimeIdsProvider.future);
+    final List<CollectedItemInfo> infos =
+        collectedAnime[anime.id] ?? <CollectedItemInfo>[];
+    final Set<int?> alreadyIn =
+        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
+
+    if (!mounted) return;
+    final S l = S.of(context);
+    final CollectionChoice? choice = await showCollectionPickerDialog(
+      context: context,
+      ref: ref,
+      title: l.searchAddToCollection,
+      alreadyInCollectionIds: alreadyIn,
+    );
+    if (choice == null || !mounted) return;
+
+    final int? collectionId;
+    final String collectionName;
+    switch (choice) {
+      case ChosenCollection(:final Collection collection):
+        collectionId = collection.id;
+        collectionName = collection.name;
+      case WithoutCollection():
+        collectionId = null;
+        collectionName = l.collectionsUncategorized;
+    }
+
+    await ref.read(databaseServiceProvider).upsertAnime(anime);
+
+    final bool success = await ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .addItem(
+          mediaType: MediaType.anime,
+          externalId: anime.id,
+        );
+
+    if (mounted) {
+      if (success) {
+        _cacheImage(
+          ImageType.animeCover,
+          anime.id.toString(),
+          anime.coverUrl,
+        );
+        context.showSnack(
+          l.searchAddedToNamed(title, collectionName),
+          type: SnackType.success,
+        );
+      } else {
+        context.showSnack(
+          l.searchAlreadyInNamed(title, collectionName),
+          type: SnackType.info,
+        );
+      }
+    }
+  }
+
+  void _showAnimeDetails(Anime anime) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext context) => ItemDetailsSheet.anime(
+        anime,
+        onAddToCollection: () => _addAnimeToAnyCollection(anime),
       ),
     );
   }

--- a/lib/features/search/sources/anilist_anime_source.dart
+++ b/lib/features/search/sources/anilist_anime_source.dart
@@ -83,7 +83,7 @@ class AniListAnimeSource extends SearchSource {
 
       return BrowseResult(
         items: animes,
-        mediaType: MediaType.animation,
+        mediaType: MediaType.anime,
         hasMore: hasMore,
         totalPages: totalPages,
         currentPage: page,

--- a/lib/features/search/sources/search_sources.dart
+++ b/lib/features/search/sources/search_sources.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../models/search_source.dart';
+import 'anilist_anime_source.dart';
 import 'anilist_manga_source.dart';
 import 'igdb_games_source.dart';
 import 'tmdb_anime_source.dart';
@@ -23,9 +24,7 @@ final List<SearchSource> searchSources = List<SearchSource>.unmodifiable(
     // IGDB
     IgdbGamesSource(),
     // AniList
-    // TODO: AniListAnimeSource() — раскомментировать после добавления
-    // таблицы anime_cache, AnimeDao, DetailsSheet, browse_grid, search_screen.
-    // См. dev/unwork/anime_metadata.md
+    AniListAnimeSource(),
     AniListMangaSource(),
     // VNDB
     VndbSource(),

--- a/lib/features/search/widgets/browse_grid.dart
+++ b/lib/features/search/widgets/browse_grid.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/image_cache_service.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/anime.dart';
 import '../../../shared/models/game.dart';
 import '../../../shared/models/manga.dart';
 import '../../../shared/models/media_type.dart';
@@ -31,6 +32,7 @@ final FutureProvider<
           Set<int> gameIds,
           Set<int> vnIds,
           Set<int> mangaIds,
+          Set<int> animeIds,
         })>
     _collectedIdsProvider = FutureProvider<
         ({
@@ -38,6 +40,7 @@ final FutureProvider<
           Set<int> gameIds,
           Set<int> vnIds,
           Set<int> mangaIds,
+          Set<int> animeIds,
         })>((Ref ref) async {
   final Map<int, List<CollectedItemInfo>> movies =
       await ref.watch(collectedMovieIdsProvider.future);
@@ -51,11 +54,14 @@ final FutureProvider<
       await ref.watch(collectedVisualNovelIdsProvider.future);
   final Map<int, List<CollectedItemInfo>> mangas =
       await ref.watch(collectedMangaIdsProvider.future);
+  final Map<int, List<CollectedItemInfo>> animes =
+      await ref.watch(collectedAnimeIdsProvider.future);
   return (
     tmdbIds: <int>{...movies.keys, ...tvShows.keys, ...animations.keys},
     gameIds: games.keys.toSet(),
     vnIds: visualNovels.keys.toSet(),
     mangaIds: mangas.keys.toSet(),
+    animeIds: animes.keys.toSet(),
   );
 });
 
@@ -213,6 +219,7 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
               Set<int> gameIds,
               Set<int> vnIds,
               Set<int> mangaIds,
+              Set<int> animeIds,
             })> collectedIds =
         ref.watch(_collectedIdsProvider);
     final Set<int> tmdbIds =
@@ -223,6 +230,8 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         collectedIds.valueOrNull?.vnIds ?? const <int>{};
     final Set<int> mangaIds =
         collectedIds.valueOrNull?.mangaIds ?? const <int>{};
+    final Set<int> animeIds =
+        collectedIds.valueOrNull?.animeIds ?? const <int>{};
 
     // Применяем клиентский фильтр по названию
     final List<Object> displayItems;
@@ -260,7 +269,7 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         final Object item = displayItems[index];
         return _buildCard(
             item, state.source.id, tmdbIds, gameIds, vnIds, mangaIds,
-            variant);
+            animeIds, variant);
       },
     );
   }
@@ -272,6 +281,7 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
     Set<int> gameIds,
     Set<int> vnIds,
     Set<int> mangaIds,
+    Set<int> animeIds,
     CardVariant variant,
   ) {
     VoidCallback? openCallback(int externalId, MediaType mediaType, bool inCollection) {
@@ -373,6 +383,24 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
       );
     }
 
+    if (item is Anime) {
+      final bool inColl = animeIds.contains(item.id);
+      return MediaPosterCard(
+        variant: variant,
+        title: item.title,
+        imageUrl: item.coverUrl ?? '',
+        cacheImageType: ImageType.animeCover,
+        cacheImageId: item.id.toString(),
+        apiRating: item.rating10,
+        year: item.releaseYear,
+
+        mediaType: MediaType.anime,
+        isInCollection: inColl,
+        onTap: () => widget.onItemTap(item, MediaType.anime),
+        onOpenInCollection: openCallback(item.id, MediaType.anime, inColl),
+      );
+    }
+
     return const SizedBox.shrink();
   }
 
@@ -397,6 +425,7 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
     if (item is TvShow) return item.title;
     if (item is VisualNovel) return item.title;
     if (item is Manga) return item.title;
+    if (item is Anime) return item.title;
     return '';
   }
 

--- a/lib/features/search/widgets/item_details_sheet.dart
+++ b/lib/features/search/widgets/item_details_sheet.dart
@@ -4,9 +4,12 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../shared/widgets/copyable_text.dart';
+
 import '../../../core/services/image_cache_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/game.dart';
+import '../../../shared/models/anime.dart';
 import '../../../shared/models/manga.dart';
 import '../../../shared/models/movie.dart';
 import '../../../shared/models/tv_show.dart';
@@ -150,6 +153,39 @@ class ItemDetailsSheet extends StatelessWidget {
       externalUrl: manga.externalUrl,
       dataSource: DataSource.anilist,
       backdropUrl: manga.bannerUrl,
+      coverHeight: 142,
+      onAddToCollection: onAddToCollection,
+    );
+  }
+
+  /// Создаёт sheet для аниме.
+  factory ItemDetailsSheet.anime(
+    Anime anime, {
+    required VoidCallback onAddToCollection,
+  }) {
+    return ItemDetailsSheet(
+      title: anime.title,
+      icon: Icons.play_circle_outline,
+      overview: anime.description,
+      year: anime.releaseYear,
+      rating: anime.formattedRating,
+      genres: anime.genres,
+      maxGenres: _defaultMaxChips,
+      subtitle: anime.titleEnglish != anime.title ? anime.titleEnglish : null,
+      infoChips: <(IconData, String)>[
+        if (anime.studiosString != null)
+          (Icons.business, anime.studiosString!),
+        (Icons.play_circle_outline, anime.episodesString),
+        if (anime.durationString != null)
+          (Icons.timer_outlined, anime.durationString!),
+      ],
+      extraInfo: anime.formatLabel,
+      posterUrl: anime.coverUrl,
+      cacheImageType: ImageType.animeCover,
+      cacheImageId: anime.id.toString(),
+      externalUrl: anime.externalUrl,
+      dataSource: DataSource.anilist,
+      backdropUrl: anime.bannerUrl,
       coverHeight: 142,
       onAddToCollection: onAddToCollection,
     );
@@ -428,23 +464,27 @@ class ItemDetailsSheet extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    // Название + год
-                    Text.rich(
-                      TextSpan(children: <InlineSpan>[
-                        TextSpan(
-                          text: title,
-                          style: AppTypography.h2.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        if (year != null)
+                    // Название + год (нажатие копирует название)
+                    CopyableText(
+                      text: title,
+                      iconSize: 16,
+                      child: Text.rich(
+                        TextSpan(children: <InlineSpan>[
                           TextSpan(
-                            text: '  $year',
-                            style: AppTypography.bodySmall.copyWith(
-                              color: AppColors.textTertiary,
+                            text: title,
+                            style: AppTypography.h2.copyWith(
+                              fontWeight: FontWeight.bold,
                             ),
                           ),
-                      ]),
+                          if (year != null)
+                            TextSpan(
+                              text: '  $year',
+                              style: AppTypography.bodySmall.copyWith(
+                                color: AppColors.textTertiary,
+                              ),
+                            ),
+                        ]),
+                      ),
                     ),
                     // Подзаголовок (alt title)
                     if (subtitle != null) ...<Widget>[

--- a/lib/features/wishlist/screens/wishlist_screen.dart
+++ b/lib/features/wishlist/screens/wishlist_screen.dart
@@ -247,6 +247,7 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
       MediaType.animation => 'anime',
       MediaType.visualNovel => 'visual_novels',
       MediaType.manga => 'manga',
+      MediaType.anime => 'anilist_anime',
       MediaType.custom => null,
       null => null,
     };

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -24,6 +24,7 @@
   "mediaTypeAnimation": "Animation",
   "mediaTypeVisualNovel": "Visual Novel",
   "mediaTypeManga": "Manga",
+  "mediaTypeAnime": "Anime",
   "mediaTypeCustom": "Custom",
 
   "sortManualDisplay": "Manual",
@@ -542,6 +543,15 @@
   "mangaChapters": "Chapters",
   "mangaVolumes": "Volumes",
   "mangaMarkCompleted": "Mark as completed",
+  "animeProgress": "Watch Progress",
+  "animeEpisodes": "Episodes",
+  "animeMarkCompleted": "Mark as completed",
+  "animeNextEpisode": "Ep {episode} airing soon",
+  "@animeNextEpisode": {
+    "placeholders": {
+      "episode": {"type": "int"}
+    }
+  },
   "animatedMovie": "Animated Movie",
   "animatedSeries": "Animated Series",
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -217,6 +217,12 @@ abstract class S {
   /// **'Manga'**
   String get mediaTypeManga;
 
+  /// No description provided for @mediaTypeAnime.
+  ///
+  /// In en, this message translates to:
+  /// **'Anime'**
+  String get mediaTypeAnime;
+
   /// No description provided for @mediaTypeCustom.
   ///
   /// In en, this message translates to:
@@ -2382,6 +2388,30 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Mark as completed'**
   String get mangaMarkCompleted;
+
+  /// No description provided for @animeProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'Watch Progress'**
+  String get animeProgress;
+
+  /// No description provided for @animeEpisodes.
+  ///
+  /// In en, this message translates to:
+  /// **'Episodes'**
+  String get animeEpisodes;
+
+  /// No description provided for @animeMarkCompleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark as completed'**
+  String get animeMarkCompleted;
+
+  /// No description provided for @animeNextEpisode.
+  ///
+  /// In en, this message translates to:
+  /// **'Ep {episode} airing soon'**
+  String animeNextEpisode(int episode);
 
   /// No description provided for @animatedMovie.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -69,6 +69,9 @@ class SEn extends S {
   String get mediaTypeManga => 'Manga';
 
   @override
+  String get mediaTypeAnime => 'Anime';
+
+  @override
   String get mediaTypeCustom => 'Custom';
 
   @override
@@ -1256,6 +1259,20 @@ class SEn extends S {
 
   @override
   String get mangaMarkCompleted => 'Mark as completed';
+
+  @override
+  String get animeProgress => 'Watch Progress';
+
+  @override
+  String get animeEpisodes => 'Episodes';
+
+  @override
+  String get animeMarkCompleted => 'Mark as completed';
+
+  @override
+  String animeNextEpisode(int episode) {
+    return 'Ep $episode airing soon';
+  }
 
   @override
   String get animatedMovie => 'Animated Movie';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -69,6 +69,9 @@ class SRu extends S {
   String get mediaTypeManga => 'Манга';
 
   @override
+  String get mediaTypeAnime => 'Аниме';
+
+  @override
   String get mediaTypeCustom => 'Своё';
 
   @override
@@ -1267,6 +1270,20 @@ class SRu extends S {
 
   @override
   String get mangaMarkCompleted => 'Отметить как прочитано';
+
+  @override
+  String get animeProgress => 'Прогресс просмотра';
+
+  @override
+  String get animeEpisodes => 'Эпизоды';
+
+  @override
+  String get animeMarkCompleted => 'Отметить как просмотрено';
+
+  @override
+  String animeNextEpisode(int episode) {
+    return 'Эп. $episode скоро выйдет';
+  }
 
   @override
   String get animatedMovie => 'Мультфильм';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -24,6 +24,7 @@
   "mediaTypeAnimation": "Анимация",
   "mediaTypeVisualNovel": "Визуальная новелла",
   "mediaTypeManga": "Манга",
+  "mediaTypeAnime": "Аниме",
   "mediaTypeCustom": "Своё",
 
   "sortManualDisplay": "Вручную",
@@ -463,6 +464,10 @@
   "mangaChapters": "Главы",
   "mangaVolumes": "Тома",
   "mangaMarkCompleted": "Отметить как прочитано",
+  "animeProgress": "Прогресс просмотра",
+  "animeEpisodes": "Эпизоды",
+  "animeMarkCompleted": "Отметить как просмотрено",
+  "animeNextEpisode": "Эп. {episode} скоро выйдет",
   "animatedMovie": "Мультфильм",
   "animatedSeries": "Мультсериал",
 

--- a/lib/shared/constants/media_type_theme.dart
+++ b/lib/shared/constants/media_type_theme.dart
@@ -28,6 +28,9 @@ abstract final class MediaTypeTheme {
   /// Цвет для манги.
   static const Color mangaColor = AppColors.mangaAccent;
 
+  /// Цвет для аниме.
+  static const Color animeColor = AppColors.animeAccent;
+
   /// Цвет для кастомных элементов.
   static const Color customColor = AppColors.customAccent;
 
@@ -39,6 +42,7 @@ abstract final class MediaTypeTheme {
         MediaType.animation => Icons.animation,
         MediaType.visualNovel => Icons.menu_book,
         MediaType.manga => Icons.auto_stories,
+        MediaType.anime => Icons.play_circle_outline,
         MediaType.custom => Icons.dashboard_customize,
       };
 
@@ -50,6 +54,7 @@ abstract final class MediaTypeTheme {
         MediaType.animation => animationColor,
         MediaType.visualNovel => visualNovelColor,
         MediaType.manga => mangaColor,
+        MediaType.anime => animeColor,
         MediaType.custom => customColor,
       };
 }

--- a/lib/shared/models/anime.dart
+++ b/lib/shared/models/anime.dart
@@ -25,9 +25,14 @@ class Anime {
     this.startMonth,
     this.startDay,
     this.episodes,
+    this.duration,
     this.format,
+    this.source,
     this.genres,
     this.studios,
+    this.bannerUrl,
+    this.nextAiringEpisode,
+    this.nextAiringAt,
     this.externalUrl,
     this.updatedAt,
   });
@@ -94,9 +99,18 @@ class Anime {
       startMonth: dateMap?['month'] as int?,
       startDay: dateMap?['day'] as int?,
       episodes: json['episodes'] as int?,
+      duration: json['duration'] as int?,
       format: json['format'] as String?,
+      source: json['source'] as String?,
       genres: genresList?.map((dynamic g) => g as String).toList(),
       studios: studios,
+      bannerUrl: json['bannerImage'] as String?,
+      nextAiringEpisode:
+          (json['nextAiringEpisode'] as Map<String, dynamic>?)?['episode']
+              as int?,
+      nextAiringAt:
+          (json['nextAiringEpisode'] as Map<String, dynamic>?)?['airingAt']
+              as int?,
       externalUrl: 'https://anilist.co/anime/$id',
       updatedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
@@ -144,9 +158,14 @@ class Anime {
       startMonth: row['start_month'] as int?,
       startDay: row['start_day'] as int?,
       episodes: row['episodes'] as int?,
+      duration: row['duration'] as int?,
       format: row['format'] as String?,
+      source: row['source'] as String?,
       genres: genres,
       studios: studios,
+      bannerUrl: row['banner_url'] as String?,
+      nextAiringEpisode: row['next_airing_episode'] as int?,
+      nextAiringAt: row['next_airing_at'] as int?,
       externalUrl: row['external_url'] as String?,
       updatedAt: row['updated_at'] as int?,
     );
@@ -203,14 +222,29 @@ class Anime {
   /// Количество эпизодов (null если ongoing/неизвестно).
   final int? episodes;
 
+  /// Длительность эпизода в минутах.
+  final int? duration;
+
   /// Формат: TV, TV_SHORT, MOVIE, SPECIAL, OVA, ONA, MUSIC.
   final String? format;
+
+  /// Исходный материал: ORIGINAL, MANGA, LIGHT_NOVEL, VISUAL_NOVEL, VIDEO_GAME.
+  final String? source;
 
   /// Список жанров.
   final List<String>? genres;
 
   /// Список студий.
   final List<String>? studios;
+
+  /// URL баннера (для backdrop).
+  final String? bannerUrl;
+
+  /// Номер следующего выходящего эпизода (для ongoing).
+  final int? nextAiringEpisode;
+
+  /// Unix timestamp выхода следующего эпизода.
+  final int? nextAiringAt;
 
   /// URL страницы на AniList.
   final String? externalUrl;
@@ -276,6 +310,25 @@ class Anime {
   String get episodesString =>
       episodes != null ? '$episodes ep' : '? ep';
 
+  /// Длительность эпизода: "24 min/ep".
+  String? get durationString =>
+      duration != null ? '$duration min/ep' : null;
+
+  /// Человекочитаемый исходный материал.
+  String? get sourceLabel => switch (source) {
+        'ORIGINAL' => 'Original',
+        'MANGA' => 'Based on Manga',
+        'LIGHT_NOVEL' => 'Based on Light Novel',
+        'VISUAL_NOVEL' => 'Based on Visual Novel',
+        'VIDEO_GAME' => 'Based on Video Game',
+        'OTHER' => 'Other',
+        _ => source,
+      };
+
+  /// Есть ли информация о следующем эпизоде.
+  bool get hasNextAiring =>
+      nextAiringEpisode != null && nextAiringAt != null;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -308,9 +361,14 @@ class Anime {
       'start_month': startMonth,
       'start_day': startDay,
       'episodes': episodes,
+      'duration': duration,
       'format': format,
+      'source': source,
       'genres': genres != null ? jsonEncode(genres) : null,
       'studios': studios != null ? jsonEncode(studios) : null,
+      'banner_url': bannerUrl,
+      'next_airing_episode': nextAiringEpisode,
+      'next_airing_at': nextAiringAt,
       'external_url': externalUrl,
       'updated_at':
           updatedAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
@@ -343,9 +401,14 @@ class Anime {
     int? startMonth,
     int? startDay,
     int? episodes,
+    int? duration,
     String? format,
+    String? source,
     List<String>? genres,
     List<String>? studios,
+    String? bannerUrl,
+    int? nextAiringEpisode,
+    int? nextAiringAt,
     String? externalUrl,
     int? updatedAt,
   }) {
@@ -367,9 +430,14 @@ class Anime {
       startMonth: startMonth ?? this.startMonth,
       startDay: startDay ?? this.startDay,
       episodes: episodes ?? this.episodes,
+      duration: duration ?? this.duration,
       format: format ?? this.format,
+      source: source ?? this.source,
       genres: genres ?? this.genres,
       studios: studios ?? this.studios,
+      bannerUrl: bannerUrl ?? this.bannerUrl,
+      nextAiringEpisode: nextAiringEpisode ?? this.nextAiringEpisode,
+      nextAiringAt: nextAiringAt ?? this.nextAiringAt,
       externalUrl: externalUrl ?? this.externalUrl,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/lib/shared/models/canvas_item.dart
+++ b/lib/shared/models/canvas_item.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 
 import '../../core/services/image_cache_service.dart';
+import 'anime.dart';
 import 'custom_media.dart';
 import 'exportable.dart';
 import 'game.dart';
@@ -31,6 +32,9 @@ enum CanvasItemType {
 
   /// Карточка манги.
   manga('manga'),
+
+  /// Карточка аниме.
+  anime('anime'),
 
   /// Карточка кастомного элемента.
   custom('custom'),
@@ -72,6 +76,8 @@ enum CanvasItemType {
         return CanvasItemType.visualNovel;
       case MediaType.manga:
         return CanvasItemType.manga;
+      case MediaType.anime:
+        return CanvasItemType.anime;
       case MediaType.custom:
         return CanvasItemType.custom;
     }
@@ -85,6 +91,7 @@ enum CanvasItemType {
       this == animation ||
       this == visualNovel ||
       this == manga ||
+      this == anime ||
       this == custom;
 }
 
@@ -111,6 +118,7 @@ class CanvasItem with Exportable {
     this.movie,
     this.tvShow,
     this.visualNovel,
+    this.anime,
     this.manga,
     this.customMedia,
   });
@@ -215,6 +223,9 @@ class CanvasItem with Exportable {
   /// Данные визуальной новеллы (joined, не сохраняются в БД).
   final VisualNovel? visualNovel;
 
+  /// Данные аниме (joined, не сохраняются в БД).
+  final Anime? anime;
+
   /// Данные манги (joined, не сохраняются в БД).
   final Manga? manga;
 
@@ -232,6 +243,7 @@ class CanvasItem with Exportable {
       CanvasItemType.animation => movie?.title ?? tvShow?.title,
       CanvasItemType.visualNovel => visualNovel?.title,
       CanvasItemType.manga => manga?.title,
+      CanvasItemType.anime => anime?.title,
       CanvasItemType.custom => customMedia?.title,
       _ => null,
     };
@@ -248,6 +260,7 @@ class CanvasItem with Exportable {
           : movie?.posterThumbUrl,
       CanvasItemType.visualNovel => visualNovel?.imageUrl,
       CanvasItemType.manga => manga?.coverUrl,
+      CanvasItemType.anime => anime?.coverUrl,
       CanvasItemType.custom => customMedia?.coverUrl,
       _ => null,
     };
@@ -264,6 +277,7 @@ class CanvasItem with Exportable {
           : ImageType.moviePoster,
       CanvasItemType.visualNovel => ImageType.vnCover,
       CanvasItemType.manga => ImageType.mangaCover,
+      CanvasItemType.anime => ImageType.animeCover,
       CanvasItemType.custom => ImageType.customCover,
       _ => ImageType.gameCover,
     };
@@ -281,6 +295,7 @@ class CanvasItem with Exportable {
       CanvasItemType.visualNovel =>
         (itemRefId ?? 0).toString(),
       CanvasItemType.manga => (manga?.id ?? 0).toString(),
+      CanvasItemType.anime => (anime?.id ?? 0).toString(),
       CanvasItemType.custom => (customMedia?.id ?? 0).toString(),
       _ => '0',
     };
@@ -295,6 +310,7 @@ class CanvasItem with Exportable {
       CanvasItemType.animation => Icons.animation,
       CanvasItemType.visualNovel => Icons.menu_book,
       CanvasItemType.manga => Icons.auto_stories,
+      CanvasItemType.anime => Icons.play_circle_outline,
       CanvasItemType.custom => switch (customMedia?.displayType) {
         MediaType.game => Icons.videogame_asset,
         MediaType.movie => Icons.movie_outlined,
@@ -302,6 +318,7 @@ class CanvasItem with Exportable {
         MediaType.animation => Icons.animation,
         MediaType.visualNovel => Icons.menu_book,
         MediaType.manga => Icons.auto_stories,
+        MediaType.anime => Icons.play_circle_outline,
         _ => Icons.dashboard_customize,
       },
       _ => Icons.note,
@@ -317,6 +334,7 @@ class CanvasItem with Exportable {
       CanvasItemType.animation => MediaType.animation,
       CanvasItemType.visualNovel => MediaType.visualNovel,
       CanvasItemType.manga => MediaType.manga,
+      CanvasItemType.anime => MediaType.anime,
       CanvasItemType.custom => customMedia?.displayType ?? MediaType.custom,
       _ => null,
     };
@@ -386,6 +404,7 @@ class CanvasItem with Exportable {
     Movie? movie,
     TvShow? tvShow,
     VisualNovel? visualNovel,
+    Anime? anime,
     Manga? manga,
     CustomMedia? customMedia,
   }) {
@@ -406,6 +425,7 @@ class CanvasItem with Exportable {
       movie: movie ?? this.movie,
       tvShow: tvShow ?? this.tvShow,
       visualNovel: visualNovel ?? this.visualNovel,
+      anime: anime ?? this.anime,
       manga: manga ?? this.manga,
       customMedia: customMedia ?? this.customMedia,
     );

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -11,6 +11,7 @@ import 'item_status.dart';
 import 'media_type.dart';
 import 'movie.dart';
 import 'platform.dart';
+import 'anime.dart';
 import 'manga.dart';
 import 'tv_show.dart';
 import 'visual_novel.dart';
@@ -42,6 +43,7 @@ class CollectionItem with Exportable {
     this.movie,
     this.tvShow,
     this.visualNovel,
+    this.anime,
     this.manga,
     this.customMedia,
     this.platform,
@@ -59,6 +61,7 @@ class CollectionItem with Exportable {
     Movie? movie,
     TvShow? tvShow,
     VisualNovel? visualNovel,
+    Anime? anime,
     Manga? manga,
     CustomMedia? customMedia,
     Platform? platform,
@@ -99,6 +102,7 @@ class CollectionItem with Exportable {
       movie: movie,
       tvShow: tvShow,
       visualNovel: visualNovel,
+      anime: anime,
       manga: manga,
       customMedia: customMedia,
       platform: platform,
@@ -215,6 +219,9 @@ class CollectionItem with Exportable {
 
   /// Данные визуальной новеллы (joined).
   final VisualNovel? visualNovel;
+
+  /// Данные аниме (joined).
+  final Anime? anime;
 
   /// Данные манги (joined).
   final Manga? manga;
@@ -388,6 +395,25 @@ class CollectionItem with Exportable {
           imageType: ImageType.mangaCover,
           placeholderIcon: Icons.auto_stories,
         );
+      case MediaType.anime:
+        return (
+          name: anime?.title,
+          coverUrl: anime?.coverUrl,
+          thumbUrl: anime?.coverUrlMedium ?? anime?.coverUrl,
+          description: anime?.description,
+          rating: anime?.rating10,
+          formattedRating: anime?.formattedRating,
+          releaseYear: anime?.releaseYear,
+          runtime: null,
+          totalSeasons: null,
+          totalEpisodes: anime?.episodes,
+          genresString: anime?.genresString,
+          genres: anime?.genres,
+          mediaStatus: anime?.statusLabel,
+          source: DataSource.anilist,
+          imageType: ImageType.animeCover,
+          placeholderIcon: Icons.play_circle_outline,
+        );
       case MediaType.custom:
         final MediaType displayType =
             customMedia?.displayType ?? MediaType.custom;
@@ -423,6 +449,7 @@ class CollectionItem with Exportable {
       MediaType.animation => 'Unknown Animation',
       MediaType.visualNovel => 'Unknown Visual Novel',
       MediaType.manga => 'Unknown Manga',
+      MediaType.anime => 'Unknown Anime',
       MediaType.custom => 'Unknown Custom Item',
     };
     return _resolvedMedia.name ?? fallback;
@@ -445,6 +472,7 @@ class CollectionItem with Exportable {
         MediaType.animation => Icons.animation,
         MediaType.visualNovel => Icons.menu_book,
         MediaType.manga => Icons.auto_stories,
+        MediaType.anime => Icons.play_circle_outline,
         MediaType.custom => Icons.dashboard_customize,
       };
 
@@ -622,6 +650,7 @@ class CollectionItem with Exportable {
     Movie? movie,
     TvShow? tvShow,
     VisualNovel? visualNovel,
+    Anime? anime,
     Manga? manga,
     CustomMedia? customMedia,
     Platform? platform,
@@ -651,6 +680,7 @@ class CollectionItem with Exportable {
       movie: movie ?? this.movie,
       tvShow: tvShow ?? this.tvShow,
       visualNovel: visualNovel ?? this.visualNovel,
+      anime: anime ?? this.anime,
       manga: manga ?? this.manga,
       customMedia: customMedia ?? this.customMedia,
       platform: platform ?? this.platform,

--- a/lib/shared/models/cover_info.dart
+++ b/lib/shared/models/cover_info.dart
@@ -56,6 +56,7 @@ class CoverInfo {
       case MediaType.game:
       case MediaType.visualNovel:
       case MediaType.manga:
+      case MediaType.anime:
       case MediaType.custom:
         return url;
     }

--- a/lib/shared/models/media_type.dart
+++ b/lib/shared/models/media_type.dart
@@ -13,7 +13,10 @@ enum MediaType {
   /// Сериал (TMDB).
   tvShow('tv_show'),
 
-  /// Анимация (TMDB) — анимационные фильмы и сериалы.
+  /// Анимация (TMDB) — анимационные фильмы и сериалы (Pixar, Disney и т.д.).
+  ///
+  /// Использует модели [Movie]/[TvShow] с [AnimationSource] platformId.
+  /// Не путать с [anime] — японское аниме из AniList.
   animation('animation'),
 
   /// Визуальная новелла (VNDB).
@@ -21,6 +24,12 @@ enum MediaType {
 
   /// Манга (AniList).
   manga('manga'),
+
+  /// Аниме (AniList) — японское аниме с полной метадатой.
+  ///
+  /// Использует собственную модель [Anime] с данными из AniList API.
+  /// Не путать с [animation] — TMDB анимация (мультфильмы).
+  anime('anime'),
 
   /// Кастомный элемент (созданный пользователем).
   custom('custom');
@@ -57,6 +66,8 @@ enum MediaType {
         return 'Visual Novel';
       case MediaType.manga:
         return 'Manga';
+      case MediaType.anime:
+        return 'Anime';
       case MediaType.custom:
         return 'Custom';
     }
@@ -77,6 +88,8 @@ enum MediaType {
         return l.mediaTypeVisualNovel;
       case MediaType.manga:
         return l.mediaTypeManga;
+      case MediaType.anime:
+        return l.mediaTypeAnime;
       case MediaType.custom:
         return l.mediaTypeCustom;
     }

--- a/lib/shared/theme/app_colors.dart
+++ b/lib/shared/theme/app_colors.dart
@@ -63,6 +63,9 @@ abstract final class AppColors {
   /// Акцентный цвет для манги (голубой AniList).
   static const Color mangaAccent = Color(0xFF3DB4F2);
 
+  /// Акцентный цвет для аниме (розовый AniList).
+  static const Color animeAccent = Color(0xFFE85D75);
+
   /// Акцентный цвет для кастомных элементов (бирюзовый).
   static const Color customAccent = Color(0xFF26A69A);
 

--- a/lib/shared/widgets/copyable_text.dart
+++ b/lib/shared/widgets/copyable_text.dart
@@ -1,0 +1,76 @@
+// Текст с копированием по нажатию.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../theme/app_colors.dart';
+
+/// Текст, который копируется в буфер обмена при нажатии.
+///
+/// При hover показывает иконку копирования, при нажатии — галочку.
+/// Переиспользуется в [ScreenAppBar] и [ItemDetailsSheet].
+class CopyableText extends StatefulWidget {
+  /// Создаёт [CopyableText].
+  const CopyableText({
+    required this.text,
+    required this.child,
+    this.iconSize = 14,
+    super.key,
+  });
+
+  /// Текст для копирования.
+  final String text;
+
+  /// Виджет-содержимое (обычно Text или Text.rich).
+  final Widget child;
+
+  /// Размер иконки copy/check.
+  final double iconSize;
+
+  @override
+  State<CopyableText> createState() => _CopyableTextState();
+}
+
+class _CopyableTextState extends State<CopyableText> {
+  bool _hovering = false;
+  bool _copied = false;
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: widget.text));
+    setState(() => _copied = true);
+    Future<void>.delayed(const Duration(seconds: 1), () {
+      if (mounted) setState(() => _copied = false);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovering = true),
+      onExit: (_) => setState(() {
+        _hovering = false;
+        _copied = false;
+      }),
+      child: GestureDetector(
+        onTap: _copy,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Flexible(child: widget.child),
+            if (_hovering) ...<Widget>[
+              const SizedBox(width: 4),
+              Icon(
+                _copied ? Icons.check : Icons.copy,
+                size: widget.iconSize,
+                color: _copied
+                    ? AppColors.success
+                    : AppColors.textTertiary,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/media_progress_row.dart
+++ b/lib/shared/widgets/media_progress_row.dart
@@ -1,0 +1,109 @@
+// Строка прогресса с меткой, значением, прогресс-баром и кнопками.
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_spacing.dart';
+import '../theme/app_typography.dart';
+
+/// Строка прогресса для трекинга (эпизоды, главы, тома).
+///
+/// Переиспользуется в [MangaProgressSection] и [AnimeProgressSection].
+class MediaProgressRow extends StatelessWidget {
+  /// Создаёт [MediaProgressRow].
+  const MediaProgressRow({
+    required this.label,
+    required this.current,
+    required this.total,
+    required this.accentColor,
+    required this.onIncrement,
+    required this.onEdit,
+    super.key,
+  });
+
+  /// Метка (например "Chapters", "Episodes").
+  final String label;
+
+  /// Текущее значение.
+  final int current;
+
+  /// Общее количество (null если неизвестно).
+  final int? total;
+
+  /// Акцентный цвет прогресс-бара и кнопки.
+  final Color accentColor;
+
+  /// Callback при нажатии "+1".
+  final VoidCallback onIncrement;
+
+  /// Callback при нажатии на значение (редактирование).
+  final VoidCallback onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    final String progressText =
+        total != null ? '$current / $total' : '$current';
+    final double? progressValue =
+        total != null && total! > 0 ? current / total! : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Text(
+              label,
+              style: AppTypography.bodySmall.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+            const Spacer(),
+            InkWell(
+              onTap: onEdit,
+              borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.xs,
+                  vertical: 2,
+                ),
+                child: Text(
+                  progressText,
+                  style: AppTypography.bodySmall.copyWith(
+                    color: AppColors.textPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+            SizedBox(
+              width: 28,
+              height: 28,
+              child: IconButton(
+                onPressed: onIncrement,
+                icon: const Icon(Icons.add, size: 16),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                style: IconButton.styleFrom(
+                  foregroundColor: accentColor,
+                ),
+              ),
+            ),
+          ],
+        ),
+        if (progressValue != null) ...<Widget>[
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
+            child: LinearProgressIndicator(
+              value: progressValue.clamp(0.0, 1.0),
+              minHeight: 4,
+              backgroundColor: AppColors.surfaceLight,
+              valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/shared/widgets/screen_app_bar.dart
+++ b/lib/shared/widgets/screen_app_bar.dart
@@ -1,10 +1,10 @@
 // Единый AppBar для всех экранов приложения.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
+import 'copyable_text.dart';
 
 /// Высота toolbar для [ScreenAppBar].
 const double kScreenAppBarHeight = 44;
@@ -84,7 +84,18 @@ class ScreenAppBar extends StatelessWidget implements PreferredSizeWidget {
                 padding: EdgeInsets.only(
                   left: !canPop ? 16 : 0,
                 ),
-                child: _CopyableTitle(title: title!),
+                child: CopyableText(
+                  text: title!,
+                  child: Text(
+                    title!,
+                    style: AppTypography.body.copyWith(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.textSecondary,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
               )
             : null,
         actions: actions,
@@ -94,65 +105,3 @@ class ScreenAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-class _CopyableTitle extends StatefulWidget {
-  const _CopyableTitle({required this.title});
-
-  final String title;
-
-  @override
-  State<_CopyableTitle> createState() => _CopyableTitleState();
-}
-
-class _CopyableTitleState extends State<_CopyableTitle> {
-  bool _hovering = false;
-  bool _copied = false;
-
-  void _copy() {
-    Clipboard.setData(ClipboardData(text: widget.title));
-    setState(() => _copied = true);
-    Future<void>.delayed(const Duration(seconds: 1), () {
-      if (mounted) setState(() => _copied = false);
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hovering = true),
-      onExit: (_) => setState(() {
-        _hovering = false;
-        _copied = false;
-      }),
-      child: GestureDetector(
-        onTap: _copy,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Flexible(
-              child: Text(
-                widget.title,
-                style: AppTypography.body.copyWith(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.textSecondary,
-                ),
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            if (_hovering) ...<Widget>[
-              const SizedBox(width: 4),
-              Icon(
-                _copied ? Icons.check : Icons.copy,
-                size: 14,
-                color: _copied
-                    ? AppColors.statusCompleted
-                    : AppColors.textTertiary,
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/test/core/database/dao/collection_dao_test.dart
+++ b/test/core/database/dao/collection_dao_test.dart
@@ -53,6 +53,7 @@ void main() {
   late MockTvShowDao mockTvShowDao;
   late MockVisualNovelDao mockVisualNovelDao;
   late MockMangaDao mockMangaDao;
+  late MockAnimeDao mockAnimeDao;
   late MockCustomMediaDao mockCustomMediaDao;
   late CollectionDao dao;
 
@@ -64,6 +65,7 @@ void main() {
     mockTvShowDao = MockTvShowDao();
     mockVisualNovelDao = MockVisualNovelDao();
     mockMangaDao = MockMangaDao();
+    mockAnimeDao = MockAnimeDao();
     mockCustomMediaDao = MockCustomMediaDao();
     dao = CollectionDao(
       () async => mockDb,
@@ -71,6 +73,7 @@ void main() {
       movieDao: mockMovieDao,
       tvShowDao: mockTvShowDao,
       visualNovelDao: mockVisualNovelDao,
+      animeDao: mockAnimeDao,
       mangaDao: mockMangaDao,
       customMediaDao: mockCustomMediaDao,
     );

--- a/test/features/search/sources/search_sources_grouping_test.dart
+++ b/test/features/search/sources/search_sources_grouping_test.dart
@@ -36,11 +36,12 @@ void main() {
       expect(igdb.sources.first.id, 'games');
     });
 
-    test('anilist group has 1 source', () {
+    test('anilist group has 2 sources', () {
       final SourceGroupEntry anilist = groupedSearchSources
           .firstWhere((SourceGroupEntry g) => g.groupId == 'anilist');
-      expect(anilist.sources.length, 1);
-      expect(anilist.sources.first.id, 'manga');
+      expect(anilist.sources.length, 2);
+      expect(anilist.sources[0].id, 'anilist_anime');
+      expect(anilist.sources[1].id, 'manga');
     });
 
     test('vndb group has 1 source', () {

--- a/test/features/search/sources/search_sources_test.dart
+++ b/test/features/search/sources/search_sources_test.dart
@@ -5,13 +5,14 @@ import 'package:xerabora/features/search/sources/search_sources.dart';
 import 'package:xerabora/features/search/sources/tmdb_anime_source.dart';
 import 'package:xerabora/features/search/sources/tmdb_movies_source.dart';
 import 'package:xerabora/features/search/sources/tmdb_tv_source.dart';
+import 'package:xerabora/features/search/sources/anilist_anime_source.dart';
 import 'package:xerabora/features/search/sources/anilist_manga_source.dart';
 import 'package:xerabora/features/search/sources/vndb_source.dart';
 
 void main() {
   group('searchSources', () {
-    test('contains 6 sources', () {
-      expect(searchSources, hasLength(6));
+    test('contains 7 sources', () {
+      expect(searchSources, hasLength(7));
     });
 
     test('first source is TmdbMoviesSource', () {
@@ -30,12 +31,16 @@ void main() {
       expect(searchSources[3], isA<IgdbGamesSource>());
     });
 
-    test('fifth source is AniListMangaSource', () {
-      expect(searchSources[4], isA<AniListMangaSource>());
+    test('fifth source is AniListAnimeSource', () {
+      expect(searchSources[4], isA<AniListAnimeSource>());
     });
 
-    test('sixth source is VndbSource', () {
-      expect(searchSources[5], isA<VndbSource>());
+    test('sixth source is AniListMangaSource', () {
+      expect(searchSources[5], isA<AniListMangaSource>());
+    });
+
+    test('seventh source is VndbSource', () {
+      expect(searchSources[6], isA<VndbSource>());
     });
 
     test('all sources have unique ids', () {
@@ -52,6 +57,7 @@ void main() {
         'tv',
         'anime',
         'games',
+        'anilist_anime',
         'manga',
         'visual_novels',
       ]);

--- a/test/features/search/widgets/browse_grid_test.dart
+++ b/test/features/search/widgets/browse_grid_test.dart
@@ -43,6 +43,9 @@ void main() {
       collectedMangaIdsProvider.overrideWith(
         (Ref ref) async => const <int, List<CollectedItemInfo>>{},
       ),
+      collectedAnimeIdsProvider.overrideWith(
+        (Ref ref) async => const <int, List<CollectedItemInfo>>{},
+      ),
     ];
   }
 
@@ -60,6 +63,8 @@ void main() {
         const <int, List<CollectedItemInfo>>{},
     Map<int, List<CollectedItemInfo>> mangas =
         const <int, List<CollectedItemInfo>>{},
+    Map<int, List<CollectedItemInfo>> animes =
+        const <int, List<CollectedItemInfo>>{},
   }) {
     return <Override>[
       collectedMovieIdsProvider.overrideWith((Ref ref) async => movies),
@@ -72,6 +77,7 @@ void main() {
         (Ref ref) async => visualNovels,
       ),
       collectedMangaIdsProvider.overrideWith((Ref ref) async => mangas),
+      collectedAnimeIdsProvider.overrideWith((Ref ref) async => animes),
     ];
   }
 

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -21,6 +21,7 @@ import 'package:xerabora/core/database/dao/game_dao.dart';
 import 'package:xerabora/core/database/dao/movie_dao.dart';
 import 'package:xerabora/core/database/dao/tv_show_dao.dart';
 import 'package:xerabora/core/database/dao/custom_media_dao.dart';
+import 'package:xerabora/core/database/dao/anime_dao.dart';
 import 'package:xerabora/core/database/dao/manga_dao.dart';
 import 'package:xerabora/core/database/dao/visual_novel_dao.dart';
 import 'package:xerabora/core/database/dao/tag_dao.dart';
@@ -98,6 +99,8 @@ class MockTvShowDao extends Mock implements TvShowDao {}
 class MockVisualNovelDao extends Mock implements VisualNovelDao {}
 
 class MockMangaDao extends Mock implements MangaDao {}
+
+class MockAnimeDao extends Mock implements AnimeDao {}
 
 class MockCustomMediaDao extends Mock implements CustomMediaDao {}
 

--- a/test/shared/models/media_type_test.dart
+++ b/test/shared/models/media_type_test.dart
@@ -6,8 +6,8 @@ import 'package:xerabora/shared/models/media_type.dart';
 void main() {
   group('MediaType', () {
     group('значения enum', () {
-      test('должен содержать 7 значений', () {
-        expect(MediaType.values.length, 7);
+      test('должен содержать 8 значений', () {
+        expect(MediaType.values.length, 8);
       });
 
       test('должен содержать game', () {
@@ -32,6 +32,10 @@ void main() {
 
       test('должен содержать manga', () {
         expect(MediaType.values.contains(MediaType.manga), isTrue);
+      });
+
+      test('должен содержать anime', () {
+        expect(MediaType.values.contains(MediaType.anime), isTrue);
       });
     });
 
@@ -58,6 +62,10 @@ void main() {
 
       test('manga должен иметь значение "manga"', () {
         expect(MediaType.manga.value, 'manga');
+      });
+
+      test('anime должен иметь значение "anime"', () {
+        expect(MediaType.anime.value, 'anime');
       });
     });
 
@@ -115,6 +123,12 @@ void main() {
 
         expect(result, MediaType.manga);
       });
+
+      test('должен вернуть anime для "anime"', () {
+        final MediaType result = MediaType.fromString('anime');
+
+        expect(result, MediaType.anime);
+      });
     });
 
     group('displayLabel', () {
@@ -140,6 +154,10 @@ void main() {
 
       test('manga должен отображаться как "Manga"', () {
         expect(MediaType.manga.displayLabel, 'Manga');
+      });
+
+      test('anime должен отображаться как "Anime"', () {
+        expect(MediaType.anime.displayLabel, 'Anime');
       });
     });
   });


### PR DESCRIPTION
New MediaType.anime for Japanese anime via AniList API. Includes:
- anime_cache table (migration v33), AnimeDao, ImageType.animeCover
- Anime model extended: duration, source, bannerUrl, nextAiringEpisode
- GraphQL queries updated with new fields
- Full search integration: AniListAnimeSource activated, browse grid, ItemDetailsSheet.anime(), search screen handlers
- Detail card with anime-specific chips and backdrop
- AnimeProgressSection: episode progress bar, +1 button, mark completed, auto-status (notStarted→inProgress→completed), next airing info
- Export/import/backup support for anime collections
- Canvas support with anime items
- Filter chips on collection and home screens

Refactored shared widgets:
- CopyableText extracted from ScreenAppBar, reused in ItemDetailsSheet
- MediaProgressRow extracted from MangaProgressSection, shared with anime