### PR TITLE
fix(ui): persistent service badge toggles + Discord always visible

### DIFF
--- a/lib/shared/navigation/service_badges.dart
+++ b/lib/shared/navigation/service_badges.dart
@@ -14,6 +14,7 @@ import '../../features/collections/providers/collection_covers_provider.dart';
 import '../../features/collections/providers/collections_provider.dart';
 import '../../features/home/providers/all_items_provider.dart';
 import '../../features/settings/providers/kodi_settings_provider.dart';
+import '../../features/settings/providers/settings_provider.dart';
 import '../constants/platform_features.dart';
 import '../theme/app_assets.dart';
 import '../theme/app_colors.dart';
@@ -46,7 +47,7 @@ class ServiceBadges extends ConsumerWidget {
 
     final List<Widget> badges = <Widget>[];
 
-    if (status.kodiEnabled) {
+    if (status.kodiConfigured) {
       final bool isActive = status.kodiRunning;
       final String tooltip = status.kodiSyncing
           ? 'Kodi sync: syncing…'
@@ -99,6 +100,7 @@ class ServiceBadges extends ConsumerWidget {
     final KodiSyncService sync = ref.read(kodiSyncServiceProvider);
 
     if (isRunning) {
+      ref.read(kodiSettingsProvider.notifier).setEnabled(enabled: false);
       sync.stop();
       return;
     }
@@ -106,6 +108,7 @@ class ServiceBadges extends ConsumerWidget {
     final KodiSettingsState settings = ref.read(kodiSettingsProvider);
     if (settings.targetCollectionId == null) return;
 
+    ref.read(kodiSettingsProvider.notifier).setEnabled(enabled: true);
     sync.start(
       intervalSeconds: settings.syncIntervalSeconds,
       targetCollectionId: settings.targetCollectionId!,
@@ -137,9 +140,15 @@ class ServiceBadges extends ConsumerWidget {
     final DiscordRpcService rpc = ref.read(discordRpcServiceProvider);
 
     if (isConnected) {
+      ref
+          .read(settingsNotifierProvider.notifier)
+          .setDiscordRpcEnabled(enabled: false);
       rpc.disableRaSync();
       rpc.disable();
     } else {
+      ref
+          .read(settingsNotifierProvider.notifier)
+          .setDiscordRpcEnabled(enabled: true);
       rpc.enable();
     }
   }

--- a/lib/shared/navigation/service_status_provider.dart
+++ b/lib/shared/navigation/service_status_provider.dart
@@ -11,14 +11,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/discord_rpc_service.dart';
 import '../../core/services/kodi_sync_service.dart';
 import '../../features/settings/providers/kodi_settings_provider.dart';
-import '../../features/settings/providers/settings_provider.dart';
 import '../../shared/constants/platform_features.dart';
 
 /// Снимок состояния фоновых сервисов.
 class ServiceStatus {
   /// Создаёт [ServiceStatus].
   const ServiceStatus({
-    this.kodiEnabled = false,
+    this.kodiConfigured = false,
     this.kodiRunning = false,
     this.kodiSyncing = false,
     this.discordEnabled = false,
@@ -26,8 +25,8 @@ class ServiceStatus {
     this.discordRaSyncActive = false,
   });
 
-  /// Kodi sync включён в настройках (бейдж видим).
-  final bool kodiEnabled;
+  /// Kodi sync настроен (host + target collection) — бейдж видим.
+  final bool kodiConfigured;
 
   /// Kodi sync таймер тикает (бейдж цветной).
   final bool kodiRunning;
@@ -35,7 +34,7 @@ class ServiceStatus {
   /// Kodi sync цикл идёт прямо сейчас (пульсация).
   final bool kodiSyncing;
 
-  /// Discord RPC включён в настройках (бейдж видим).
+  /// Discord RPC доступен на платформе (бейдж всегда видим на десктопе).
   final bool discordEnabled;
 
   /// Discord RPC подключён к IPC (бейдж цветной).
@@ -45,7 +44,7 @@ class ServiceStatus {
   final bool discordRaSyncActive;
 
   /// Есть ли хотя бы один сервис, для которого нужен бейдж.
-  bool get hasActiveServices => kodiEnabled || discordEnabled;
+  bool get hasActiveServices => kodiConfigured || discordEnabled;
 }
 
 /// Провайдер состояния фоновых сервисов.
@@ -60,18 +59,14 @@ final AutoDisposeStreamProvider<ServiceStatus> serviceStatusProvider =
   final DiscordRpcService discord = ref.read(discordRpcServiceProvider);
 
   ServiceStatus snapshot() {
-    // Читаем настройки каждый poll — ref.read не создаёт подписку,
-    // так что стрим НЕ инвалидируется при изменении настроек.
     final KodiSettingsState kodiSettings = ref.read(kodiSettingsProvider);
-    final SettingsState settings = ref.read(settingsNotifierProvider);
 
     return ServiceStatus(
-      kodiEnabled: kodiSettings.enabled &&
-          kodiSettings.hasConnection &&
+      kodiConfigured: kodiSettings.hasConnection &&
           kodiSettings.targetCollectionId != null,
       kodiRunning: kodiSync.isRunning,
       kodiSyncing: kodiSync.isSyncing,
-      discordEnabled: kDiscordRpcAvailable && settings.discordRpcEnabled,
+      discordEnabled: kDiscordRpcAvailable,
       discordConnected: discord.isConnected,
       discordRaSyncActive: discord.isRaSyncActive,
     );
@@ -81,10 +76,8 @@ final AutoDisposeStreamProvider<ServiceStatus> serviceStatusProvider =
   final StreamController<ServiceStatus> controller =
       StreamController<ServiceStatus>();
 
-  // Первый снимок сразу.
   controller.add(snapshot());
 
-  // Polling каждые 2 секунды для обновления runtime-состояния.
   final Timer timer = Timer.periodic(
     const Duration(seconds: 2),
     (_) {

--- a/test/shared/navigation/service_badges_test.dart
+++ b/test/shared/navigation/service_badges_test.dart
@@ -3,8 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:xerabora/core/services/discord_rpc_service.dart';
 import 'package:xerabora/core/services/kodi_sync_service.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/shared/navigation/service_badges.dart';
 import 'package:xerabora/shared/navigation/service_status_provider.dart';
 import 'package:xerabora/shared/theme/app_assets.dart';
@@ -40,10 +42,10 @@ void main() {
       expect(find.byType(SvgPicture), findsNothing);
     });
 
-    testWidgets('renders Kodi icon when kodiEnabled',
+    testWidgets('renders Kodi icon when kodiConfigured',
         (WidgetTester tester) async {
       await tester.pumpWidget(buildWidget(
-        status: const ServiceStatus(kodiEnabled: true, kodiRunning: true),
+        status: const ServiceStatus(kodiConfigured: true, kodiRunning: true),
       ));
       await tester.pumpAndSettle();
 
@@ -70,11 +72,11 @@ void main() {
       expect(discordIcon, findsOneWidget);
     });
 
-    testWidgets('renders both icons when both enabled',
+    testWidgets('renders both icons when both active',
         (WidgetTester tester) async {
       await tester.pumpWidget(buildWidget(
         status: const ServiceStatus(
-          kodiEnabled: true,
+          kodiConfigured: true,
           kodiRunning: true,
           discordEnabled: true,
           discordConnected: true,
@@ -85,15 +87,19 @@ void main() {
       expect(find.byType(SvgPicture), findsNWidgets(2));
     });
 
-    testWidgets('Kodi icon tap calls stop when running',
+    testWidgets('Kodi icon tap calls stop and persists disabled',
         (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final SharedPreferences prefs =
+          await SharedPreferences.getInstance();
       final MockKodiSyncService mockSync = MockKodiSyncService();
       when(() => mockSync.isRunning).thenReturn(true);
 
       await tester.pumpWidget(buildWidget(
-        status: const ServiceStatus(kodiEnabled: true, kodiRunning: true),
+        status: const ServiceStatus(kodiConfigured: true, kodiRunning: true),
         extraOverrides: <Override>[
           kodiSyncServiceProvider.overrideWithValue(mockSync),
+          sharedPreferencesProvider.overrideWithValue(prefs),
         ],
       ));
       await tester.pumpAndSettle();
@@ -104,8 +110,11 @@ void main() {
       verify(() => mockSync.stop()).called(1);
     });
 
-    testWidgets('Discord icon tap calls disable when connected',
+    testWidgets('Discord icon tap calls disable and persists',
         (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final SharedPreferences prefs =
+          await SharedPreferences.getInstance();
       final MockDiscordRpcService mockDiscord = MockDiscordRpcService();
       when(() => mockDiscord.disableRaSync()).thenAnswer((_) async {});
       when(() => mockDiscord.disable()).thenAnswer((_) async {});
@@ -115,6 +124,7 @@ void main() {
             discordEnabled: true, discordConnected: true),
         extraOverrides: <Override>[
           discordRpcServiceProvider.overrideWithValue(mockDiscord),
+          sharedPreferencesProvider.overrideWithValue(prefs),
         ],
       ));
       await tester.pumpAndSettle();
@@ -126,8 +136,11 @@ void main() {
       verify(() => mockDiscord.disable()).called(1);
     });
 
-    testWidgets('Discord icon tap calls enable when disconnected',
+    testWidgets('Discord icon tap calls enable and persists',
         (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final SharedPreferences prefs =
+          await SharedPreferences.getInstance();
       final MockDiscordRpcService mockDiscord = MockDiscordRpcService();
       when(() => mockDiscord.enable()).thenAnswer((_) async {});
 
@@ -136,6 +149,7 @@ void main() {
             discordEnabled: true, discordConnected: false),
         extraOverrides: <Override>[
           discordRpcServiceProvider.overrideWithValue(mockDiscord),
+          sharedPreferencesProvider.overrideWithValue(prefs),
         ],
       ));
       await tester.pumpAndSettle();

--- a/test/shared/navigation/service_status_provider_test.dart
+++ b/test/shared/navigation/service_status_provider_test.dart
@@ -6,7 +6,7 @@ void main() {
     test('default constructor has all fields false', () {
       const ServiceStatus status = ServiceStatus();
 
-      expect(status.kodiEnabled, isFalse);
+      expect(status.kodiConfigured, isFalse);
       expect(status.kodiRunning, isFalse);
       expect(status.kodiSyncing, isFalse);
       expect(status.discordEnabled, isFalse);
@@ -19,8 +19,8 @@ void main() {
       expect(status.hasActiveServices, isFalse);
     });
 
-    test('hasActiveServices returns true when kodiEnabled', () {
-      const ServiceStatus status = ServiceStatus(kodiEnabled: true);
+    test('hasActiveServices returns true when kodiConfigured', () {
+      const ServiceStatus status = ServiceStatus(kodiConfigured: true);
       expect(status.hasActiveServices, isTrue);
     });
 
@@ -31,7 +31,7 @@ void main() {
 
     test('hasActiveServices returns true when both enabled', () {
       const ServiceStatus status = ServiceStatus(
-        kodiEnabled: true,
+        kodiConfigured: true,
         discordEnabled: true,
       );
       expect(status.hasActiveServices, isTrue);
@@ -39,7 +39,7 @@ void main() {
 
     test('all fields can be set via constructor', () {
       const ServiceStatus status = ServiceStatus(
-        kodiEnabled: true,
+        kodiConfigured: true,
         kodiRunning: true,
         kodiSyncing: true,
         discordEnabled: true,
@@ -47,7 +47,7 @@ void main() {
         discordRaSyncActive: true,
       );
 
-      expect(status.kodiEnabled, isTrue);
+      expect(status.kodiConfigured, isTrue);
       expect(status.kodiRunning, isTrue);
       expect(status.kodiSyncing, isTrue);
       expect(status.discordEnabled, isTrue);


### PR DESCRIPTION
Badge clicks now persist to SharedPreferences: Kodi setEnabled(), Discord setDiscordRpcEnabled(). After restart the state is preserved. Discord badge always visible on desktop (not gated by setting). Kodi badge visible when configured (host + target collection). Renamed kodiEnabled → kodiConfigured in ServiceStatus.