### PR TITLE
Feedback/ux polish v0.28

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,8 +100,9 @@ final databaseServiceProvider = Provider<DatabaseService>((ref) => DatabaseServi
 - API ключи хранятся в SharedPreferences, читаются через `SettingsNotifier`
 
 ### База данных (`lib/core/database/`)
-- SQLite через sqflite_common_ffi, 18 таблиц, текущая версия БД: 24
+- SQLite через sqflite_common_ffi
 - Провайдер: `databaseServiceProvider`
+- Актуальное количество таблиц и номер миграции смотреть в `schema.dart` / `database_service.dart` (`version:` в `_initDatabase()`) — не доверять этому файлу
 
 #### Структура файлов БД:
 ```
@@ -111,7 +112,7 @@ lib/core/database/
 └── migrations/
     ├── migration.dart             # Абстрактный класс Migration (version, description, migrate)
     ├── migration_registry.dart    # MigrationRegistry.all / .pending(oldVersion)
-    ├── migration_v2.dart          # MigrationV2..MigrationV24 — по файлу на версию
+    ├── migration_v2.dart          # MigrationV2..MigrationVN — по файлу на версию
     └── ...
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ## [Unreleased]
 
+### Added
+- **Right-click context menu on the Collections screen** — ПКМ on empty space (between or below cards) opens a popup with the primary FAB actions: Create new collection, Import collection, Toggle grid/list view. The card-level right-click menu (Open/Rename/Delete) is unchanged and keeps priority on cards via the gesture arena (`home_screen.dart`)
+- **Right-click context menu on All Items** — ПКМ on a poster opens Move to collection / Copy to collection / Remove, mirroring the menu inside a collection. Delegates to `CollectionActions` for identical dialogs, snackbars, and invalidation. Editability check extracted into `_isItemEditable` so it's shared with `_showItemDetails` (`all_items_screen.dart`)
+- **Search now matches user notes and author review** — the in-collection search bar and the All Items global search also compare against `CollectionItem.userComment` and `CollectionItem.authorComment`, in addition to `itemName` and tag names. Lets users find titles by what they wrote about them. Case-insensitive (`collection_screen.dart`, `all_items_screen.dart`)
+
+### Changed
+- **Tap anywhere on the review/notes block to edit** — both the author review and personal notes sections on the item detail screen now enter editing mode on a single tap, whether empty or populated. Markdown links inside the rendered text keep working because their `TapGestureRecognizer` wins the gesture arena over the ancestor `InkWell`. Author review stays non-interactive for read-only collections. Trade-off: drag-selection of rendered text is no longer available — users can copy from the TextField after entering edit mode (`media_detail_view.dart`)
+- **Vague UI terms renamed per user feedback**
+  - «Список» (Wishlist nav tab) → **«Желаемое»** in Russian
+  - «Профили» / «Профиль» in Settings — now **«Профили приложения»** / **«Автор коллекций»** (EN: «App profiles» / «Collection author»), resolving the ambiguity between multi-user profiles and the collection author name
+  - «элемент» → **«тайтл»** across 27 strings (including plural forms): FAB labels, stats, snackbars, tier lists, tags, imports, wishlist, all-items. "Element" retained on the canvas where it refers to board primitives (text/sticker/link), not collection items (`app_en.arb`, `app_ru.arb`)
+- **Kodi settings screen fully localized** — ~45 new localization keys cover Connection (Host/Port/Username/Password/Test connection), Sync (Target collection, Enable sync, Sync interval, Sub-collections, Import ratings), Debug (Sync status, Last sync, Clear timestamp, Request log, Raw JSON-RPC). The "Integrations" section header and "Kodi" subtitle on the main Settings screen are also localized. Proper nouns (the word "Kodi", JSON-RPC API examples like `VideoLibrary.GetMovies`) intentionally remain in English (`kodi_screen.dart`, `settings_screen.dart`, `app_en.arb`, `app_ru.arb`)
+- **Empty-collection hint localized** — the two fallback hints below the "No items yet" header (`collectionEmptyAddHint`, `collectionEmptyReadonly`) were still hardcoded English; now translated to Russian (`collection_items_view.dart`)
+
 ## [0.27.0] - 2026-04-18
 
 ### Changed

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -497,13 +497,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
                     onItemRemove: _canEdit
                         ? (CollectionItem item) => _handleRemoveItem(item)
                         : null,
-                    onAddItems: _canEdit
-                        ? () => CollectionActions.addItems(
-                              context: context,
-                              ref: ref,
-                              collectionId: widget.collectionId,
-                            )
-                        : null,
                     onItemFocusChanged: (CollectionItem item, bool hasFocus) {
                       setState(() => _focusedItem = hasFocus ? item : null);
                     },

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -597,7 +597,9 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             (CollectionItem item) =>
                 item.itemName.toLowerCase().contains(query) ||
                 (item.tagId != null &&
-                    (tagNames[item.tagId]?.contains(query) ?? false)),
+                    (tagNames[item.tagId]?.contains(query) ?? false)) ||
+                (item.userComment?.toLowerCase().contains(query) ?? false) ||
+                (item.authorComment?.toLowerCase().contains(query) ?? false),
           )
           .toList();
     }

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -497,6 +497,13 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
                     onItemRemove: _canEdit
                         ? (CollectionItem item) => _handleRemoveItem(item)
                         : null,
+                    onAddItems: _canEdit
+                        ? () => CollectionActions.addItems(
+                              context: context,
+                              ref: ref,
+                              collectionId: widget.collectionId,
+                            )
+                        : null,
                     onItemFocusChanged: (CollectionItem item, bool hasFocus) {
                       setState(() => _focusedItem = hasFocus ? item : null);
                     },

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -232,6 +232,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           behavior: HitTestBehavior.opaque,
           onSecondaryTapUp: (TapUpDetails details) =>
               _showEmptyAreaContextMenu(context, ref, details.globalPosition),
+          onLongPressStart: (LongPressStartDetails details) =>
+              _showEmptyAreaContextMenu(context, ref, details.globalPosition),
           child: GridView.builder(
             padding: const EdgeInsets.all(AppSpacing.md),
             gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
@@ -262,6 +264,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onSecondaryTapUp: (TapUpDetails details) =>
+            _showEmptyAreaContextMenu(context, ref, details.globalPosition),
+        onLongPressStart: (LongPressStartDetails details) =>
             _showEmptyAreaContextMenu(context, ref, details.globalPosition),
         child: ListView.builder(
           padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -228,16 +228,21 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       policy: WidgetOrderTraversalPolicy(),
       child: RefreshIndicator(
         onRefresh: () => ref.read(collectionsProvider.notifier).refresh(),
-        child: GridView.builder(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-            maxCrossAxisExtent: 273,
-            crossAxisSpacing: 8,
-            mainAxisSpacing: 8,
-            childAspectRatio: 1,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onSecondaryTapUp: (TapUpDetails details) =>
+              _showEmptyAreaContextMenu(context, ref, details.globalPosition),
+          child: GridView.builder(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 273,
+              crossAxisSpacing: 8,
+              mainAxisSpacing: 8,
+              childAspectRatio: 1,
+            ),
+            itemCount: gridItems.length,
+            itemBuilder: (BuildContext context, int index) => gridItems[index],
           ),
-          itemCount: gridItems.length,
-          itemBuilder: (BuildContext context, int index) => gridItems[index],
         ),
       ),
     );
@@ -254,25 +259,30 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
     return RefreshIndicator(
       onRefresh: () => ref.read(collectionsProvider.notifier).refresh(),
-      child: ListView.builder(
-        padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-        itemCount: collections.length + offset,
-        itemBuilder: (BuildContext context, int index) {
-          if (index == 0 && offset == 1) {
-            return UncategorizedListTile(
-              count: uncategorizedCount,
-              onTap: () => _navigateToUncategorized(context),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onSecondaryTapUp: (TapUpDetails details) =>
+            _showEmptyAreaContextMenu(context, ref, details.globalPosition),
+        child: ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+          itemCount: collections.length + offset,
+          itemBuilder: (BuildContext context, int index) {
+            if (index == 0 && offset == 1) {
+              return UncategorizedListTile(
+                count: uncategorizedCount,
+                onTap: () => _navigateToUncategorized(context),
+              );
+            }
+            final Collection c = collections[index - offset];
+            return CollectionListTile(
+              collection: c,
+              onTap: () => _navigateToCollection(context, c),
+              onLongPress: () => _showCollectionOptions(context, ref, c),
+              onSecondaryTap: (Offset pos) =>
+                  _showCollectionContextMenu(context, ref, c, pos),
             );
-          }
-          final Collection c = collections[index - offset];
-          return CollectionListTile(
-            collection: c,
-            onTap: () => _navigateToCollection(context, c),
-            onLongPress: () => _showCollectionOptions(context, ref, c),
-            onSecondaryTap: (Offset pos) =>
-                _showCollectionContextMenu(context, ref, c, pos),
-          );
-        },
+          },
+        ),
       ),
     );
   }
@@ -399,6 +409,65 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       if (context.mounted) {
         context.showSnack(S.of(context).collectionsFailedToCreate('$e'), type: SnackType.error);
       }
+    }
+  }
+
+  /// Контекстное меню ПКМ на пустом месте экрана — действия из FAB.
+  Future<void> _showEmptyAreaContextMenu(
+    BuildContext context,
+    WidgetRef ref,
+    Offset position,
+  ) async {
+    final S l = S.of(context);
+    final bool isGridView = ref.read(collectionListViewModeProvider);
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+
+    final String? value = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromRect(
+        position & const Size(1, 1),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<String>>[
+        PopupMenuItem<String>(
+          value: 'create',
+          child: ListTile(
+            leading: const Icon(Icons.add),
+            title: Text(l.collectionsNewCollection),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        PopupMenuItem<String>(
+          value: 'import',
+          child: ListTile(
+            leading: const Icon(Icons.file_download_outlined),
+            title: Text(l.collectionsImportCollection),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<String>(
+          value: 'toggle_view',
+          child: ListTile(
+            leading: Icon(isGridView ? Icons.view_list : Icons.grid_view),
+            title: Text(
+              isGridView ? l.collectionListViewList : l.collectionListViewGrid,
+            ),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
+
+    if (value == null || !context.mounted) return;
+    switch (value) {
+      case 'create':
+        await _createCollection(context, ref);
+      case 'import':
+        await _importCollection(context, ref);
+      case 'toggle_view':
+        ref.read(collectionListViewModeProvider.notifier).toggle();
     }
   }
 

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -39,6 +39,7 @@ class CollectionItemsView extends ConsumerWidget {
     this.onItemMove,
     this.onItemClone,
     this.onItemRemove,
+    this.onAddItems,
     this.onItemFocusChanged,
     this.tags = const <CollectionTag>[],
     this.filterTagIds = const <int>{},
@@ -72,6 +73,9 @@ class CollectionItemsView extends ConsumerWidget {
 
   /// Callback удаления элемента.
   final ValueChanged<CollectionItem>? onItemRemove;
+
+  /// Callback запуска диалога добавления тайтлов (клик/ПКМ по пустой коллекции).
+  final VoidCallback? onAddItems;
 
   /// Callback при изменении фокуса на элементе (для клавиатурных действий).
   final void Function(CollectionItem item, bool hasFocus)? onItemFocusChanged;
@@ -639,14 +643,15 @@ class CollectionItemsView extends ConsumerWidget {
 
   Widget _buildEmptyState(BuildContext context) {
     final S l = S.of(context);
-    return Center(
+    final bool canAdd = canEdit && onAddItems != null;
+    final Widget content = Center(
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(AppSpacing.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             Icon(
-              Icons.shelves,
+              canAdd ? Icons.add_box_outlined : Icons.shelves,
               size: 64,
               color: AppColors.textTertiary.withAlpha(120),
             ),
@@ -654,9 +659,11 @@ class CollectionItemsView extends ConsumerWidget {
             Text(l.collectionNoItemsYet, style: AppTypography.h2),
             const SizedBox(height: AppSpacing.sm),
             Text(
-              canEdit
-                  ? 'Add items to start building your collection.'
-                  : 'This collection is empty.',
+              canAdd
+                  ? l.collectionAddItems
+                  : (canEdit
+                      ? 'Add items to start building your collection.'
+                      : 'This collection is empty.'),
               textAlign: TextAlign.center,
               style: AppTypography.body.copyWith(
                 color: AppColors.textSecondary,
@@ -664,6 +671,17 @@ class CollectionItemsView extends ConsumerWidget {
             ),
           ],
         ),
+      ),
+    );
+
+    if (!canAdd) return content;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onAddItems,
+      onSecondaryTap: onAddItems,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: content,
       ),
     );
   }

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -39,7 +39,6 @@ class CollectionItemsView extends ConsumerWidget {
     this.onItemMove,
     this.onItemClone,
     this.onItemRemove,
-    this.onAddItems,
     this.onItemFocusChanged,
     this.tags = const <CollectionTag>[],
     this.filterTagIds = const <int>{},
@@ -73,9 +72,6 @@ class CollectionItemsView extends ConsumerWidget {
 
   /// Callback удаления элемента.
   final ValueChanged<CollectionItem>? onItemRemove;
-
-  /// Callback запуска диалога добавления тайтлов (клик/ПКМ по пустой коллекции).
-  final VoidCallback? onAddItems;
 
   /// Callback при изменении фокуса на элементе (для клавиатурных действий).
   final void Function(CollectionItem item, bool hasFocus)? onItemFocusChanged;
@@ -643,15 +639,14 @@ class CollectionItemsView extends ConsumerWidget {
 
   Widget _buildEmptyState(BuildContext context) {
     final S l = S.of(context);
-    final bool canAdd = canEdit && onAddItems != null;
-    final Widget content = Center(
+    return Center(
       child: SingleChildScrollView(
         padding: const EdgeInsets.all(AppSpacing.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
             Icon(
-              canAdd ? Icons.add_box_outlined : Icons.shelves,
+              Icons.shelves,
               size: 64,
               color: AppColors.textTertiary.withAlpha(120),
             ),
@@ -659,11 +654,7 @@ class CollectionItemsView extends ConsumerWidget {
             Text(l.collectionNoItemsYet, style: AppTypography.h2),
             const SizedBox(height: AppSpacing.sm),
             Text(
-              canAdd
-                  ? l.collectionAddItems
-                  : (canEdit
-                      ? l.collectionEmptyAddHint
-                      : l.collectionEmptyReadonly),
+              canEdit ? l.collectionEmptyAddHint : l.collectionEmptyReadonly,
               textAlign: TextAlign.center,
               style: AppTypography.body.copyWith(
                 color: AppColors.textSecondary,
@@ -671,17 +662,6 @@ class CollectionItemsView extends ConsumerWidget {
             ),
           ],
         ),
-      ),
-    );
-
-    if (!canAdd) return content;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onAddItems,
-      onSecondaryTap: onAddItems,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: content,
       ),
     );
   }

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -662,8 +662,8 @@ class CollectionItemsView extends ConsumerWidget {
               canAdd
                   ? l.collectionAddItems
                   : (canEdit
-                      ? 'Add items to start building your collection.'
-                      : 'This collection is empty.'),
+                      ? l.collectionEmptyAddHint
+                      : l.collectionEmptyReadonly),
               textAlign: TextAlign.center,
               style: AppTypography.body.copyWith(
                 color: AppColors.textSecondary,

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -20,6 +20,7 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/chevron_filter_bar.dart';
 import '../../../shared/widgets/media_poster_card.dart';
+import '../../collections/helpers/collection_actions.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../collections/screens/item_detail_screen.dart';
 import '../providers/all_items_provider.dart';
@@ -409,6 +410,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                       tagColor: tag?.color,
                       onTap: () =>
                           _showItemDetails(item, collectionNames),
+                      onSecondaryTap: (Offset pos) =>
+                          _showItemContextMenu(pos, item),
                     );
                   },
                   childCount: groups[i].items.length,
@@ -552,23 +555,96 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     );
   }
 
+  bool _isItemEditable(CollectionItem item) {
+    if (item.isUncategorized) return true;
+    final List<Collection>? collections =
+        ref.read(collectionsProvider).valueOrNull;
+    final Collection? collection =
+        collections?.cast<Collection?>().firstWhere(
+      (Collection? c) => c?.id == item.collectionId,
+      orElse: () => null,
+    );
+    return collection?.isEditable ?? false;
+  }
+
+  Future<void> _showItemContextMenu(Offset position, CollectionItem item) async {
+    if (!_isItemEditable(item)) return;
+    final S l = S.of(context);
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+
+    final String? value = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromRect(
+        position & const Size(1, 1),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<String>>[
+        PopupMenuItem<String>(
+          value: 'move',
+          child: ListTile(
+            leading: const Icon(Icons.drive_file_move_outlined),
+            title: Text(l.collectionMoveToCollection),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        PopupMenuItem<String>(
+          value: 'clone',
+          child: ListTile(
+            leading: const Icon(Icons.copy_outlined),
+            title: Text(l.collectionCopyToCollection),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<String>(
+          value: 'remove',
+          child: ListTile(
+            leading: const Icon(
+              Icons.remove_circle_outline,
+              color: AppColors.error,
+            ),
+            title: Text(
+              l.remove,
+              style: const TextStyle(color: AppColors.error),
+            ),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
+
+    if (value == null || !mounted) return;
+    switch (value) {
+      case 'move':
+        await CollectionActions.moveItem(
+          context: context,
+          ref: ref,
+          collectionId: item.collectionId,
+          item: item,
+        );
+      case 'clone':
+        await CollectionActions.cloneItem(
+          context: context,
+          ref: ref,
+          collectionId: item.collectionId,
+          item: item,
+        );
+      case 'remove':
+        await CollectionActions.removeItem(
+          context: context,
+          ref: ref,
+          collectionId: item.collectionId,
+          item: item,
+        );
+    }
+  }
+
   void _showItemDetails(
     CollectionItem item,
     Map<int, String> collectionNames,
   ) {
-    final bool isEditable;
-    if (item.isUncategorized) {
-      isEditable = true;
-    } else {
-      final List<Collection>? collections =
-          ref.read(collectionsProvider).valueOrNull;
-      final Collection? collection =
-          collections?.cast<Collection?>().firstWhere(
-        (Collection? c) => c?.id == item.collectionId,
-        orElse: () => null,
-      );
-      isEditable = collection?.isEditable ?? false;
-    }
+    final bool isEditable = _isItemEditable(item);
 
     Navigator.of(context).push(
       MaterialPageRoute<void>(

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -412,6 +412,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                           _showItemDetails(item, collectionNames),
                       onSecondaryTap: (Offset pos) =>
                           _showItemContextMenu(pos, item),
+                      onLongPress: () =>
+                          _showItemContextMenu(_centerOfContext(), item),
                     );
                   },
                   childCount: groups[i].items.length,
@@ -553,6 +555,11 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         ],
       ),
     );
+  }
+
+  Offset _centerOfContext() {
+    final Size size = MediaQuery.sizeOf(context);
+    return Offset(size.width / 2, size.height / 2);
   }
 
   bool _isItemEditable(CollectionItem item) {

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -115,7 +115,9 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                 item.itemName.toLowerCase().contains(query) ||
                 (item.tagId != null &&
                     (tagsMap[item.tagId]?.name.toLowerCase().contains(query) ??
-                        false)),
+                        false)) ||
+                (item.userComment?.toLowerCase().contains(query) ?? false) ||
+                (item.authorComment?.toLowerCase().contains(query) ?? false),
           )
           .toList();
     }

--- a/lib/features/settings/screens/kodi_screen.dart
+++ b/lib/features/settings/screens/kodi_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/kodi_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../../core/services/kodi_sync_service.dart';
+import '../../../l10n/app_localizations.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/kodi_application_info.dart';
@@ -74,7 +75,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           setState(() {
             _isTesting = false;
             _connectionOk = false;
-            _connectionResult = 'Ping failed — unexpected response';
+            _connectionResult = S.of(context).kodiPingFailed;
           });
         }
         return;
@@ -85,8 +86,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
         setState(() {
           _isTesting = false;
           _connectionOk = true;
-          _connectionResult =
-              'Kodi ${info.versionString} "${info.name}"';
+          _connectionResult = S.of(context).kodiConnectedTo(
+            info.versionString,
+            info.name ?? '',
+          );
         });
       }
     } on KodiApiException catch (e) {
@@ -113,13 +116,13 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           params = decoded;
         } else {
           setState(() {
-            _rawResponse = 'Error: params must be a JSON object';
+            _rawResponse = S.of(context).kodiParamsNotObject;
           });
           return;
         }
       } on FormatException catch (e) {
         setState(() {
-          _rawResponse = 'JSON parse error: ${e.message}';
+          _rawResponse = S.of(context).kodiJsonParseError(e.message);
         });
         return;
       }
@@ -144,8 +147,8 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
       if (mounted) {
         setState(() {
           _isSendingRaw = false;
-          _rawResponse = 'Error: ${e.message}'
-              '${e.detail != null ? '\n${e.detail}' : ''}';
+          _rawResponse = S.of(context).kodiRawError(e.message) +
+              (e.detail != null ? '\n${e.detail}' : '');
         });
       }
     }
@@ -181,7 +184,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             ref.read(kodiSettingsProvider.notifier).setTargetCollectionId(null);
             if (mounted) {
               context.showSnack(
-                'Target collection deleted — sync stopped',
+                S.of(context).kodiTargetDeletedSnack,
                 type: SnackType.error,
               );
             }
@@ -194,7 +197,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
     showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => SimpleDialog(
-        title: const Text('Sync interval'),
+        title: Text(S.of(context).kodiSyncInterval),
         children: <Widget>[
           for (final int seconds in intervals)
             SimpleDialogOption(
@@ -236,7 +239,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
 
     return Column(
       children: <Widget>[
-        const SubScreenTitleBar(title: 'Kodi'),
+        const SubScreenTitleBar(title: 'Kodi'), // proper noun
         Expanded(
           child: Align(
             alignment: Alignment.topCenter,
@@ -270,9 +273,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
   // ==================== Connection ====================
 
   Widget _buildConnectionSection(KodiSettingsState settings) {
+    final S l = S.of(context);
     return SettingsGroup(
-      title: 'Connection',
-      subtitle: 'Kodi HTTP JSON-RPC (Settings → Services → Control)',
+      title: l.kodiConnectionTitle,
+      subtitle: l.kodiConnectionSubtitle,
       children: <Widget>[
         Padding(
           padding: const EdgeInsets.symmetric(
@@ -280,7 +284,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             vertical: AppSpacing.sm,
           ),
           child: InlineTextField(
-            label: 'Host',
+            label: l.kodiHost,
             value: settings.host,
             placeholder: '192.168.1.100',
             compact: true,
@@ -295,7 +299,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             vertical: AppSpacing.sm,
           ),
           child: InlineTextField(
-            label: 'Port',
+            label: l.kodiPort,
             value: settings.port.toString(),
             placeholder: kodiDefaultPort.toString(),
             compact: true,
@@ -313,7 +317,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             vertical: AppSpacing.sm,
           ),
           child: InlineTextField(
-            label: 'Username',
+            label: l.kodiUsername,
             value: settings.username,
             placeholder: 'kodi',
             compact: true,
@@ -328,9 +332,9 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             vertical: AppSpacing.sm,
           ),
           child: InlineTextField(
-            label: 'Password',
+            label: l.kodiPassword,
             value: settings.password,
-            placeholder: 'Enter password',
+            placeholder: l.kodiPasswordHint,
             obscureText: true,
             compact: true,
             onChanged: (String value) {
@@ -339,10 +343,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           ),
         ),
         SettingsTile(
-          title: 'Test connection',
+          title: l.kodiTestConnection,
           showChevron: false,
           value: _isTesting
-              ? 'Connecting...'
+              ? l.kodiConnecting
               : _connectionResult,
           titleColor:
               _connectionResult != null && _connectionOk
@@ -361,41 +365,43 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
   // ==================== Sync ====================
 
   Widget _buildSyncSection(KodiSettingsState settings) {
+    final S l = S.of(context);
     final AsyncValue<List<Collection>> collectionsAsync =
         ref.watch(collectionsProvider);
 
     // Название выбранной коллекции.
     final String targetLabel = collectionsAsync.when(
       data: (List<Collection> cols) {
-        if (settings.targetCollectionId == null) return 'Not selected';
+        if (settings.targetCollectionId == null) return l.kodiTargetNotSelected;
         final Collection? target = cols
             .where((Collection c) => c.id == settings.targetCollectionId)
             .firstOrNull;
-        return target?.name ?? 'Deleted (#${settings.targetCollectionId})';
+        return target?.name ??
+            l.kodiTargetDeletedLabel(settings.targetCollectionId!);
       },
       loading: () => '...',
-      error: (_, _) => 'Error',
+      error: (_, _) => l.kodiTargetError,
     );
 
     final bool canEnable =
         settings.hasConnection && settings.targetCollectionId != null;
 
     return SettingsGroup(
-      title: 'Sync',
+      title: l.kodiSyncTitle,
       children: <Widget>[
         // Выбор целевой коллекции (обязательно).
         SettingsTile(
-          title: 'Target collection',
-          subtitle: 'All Kodi movies sync here',
+          title: l.kodiTargetCollection,
+          subtitle: l.kodiTargetCollectionSubtitle,
           value: targetLabel,
           onTap: () => _showCollectionPicker(settings, collectionsAsync),
         ),
         SettingsTile(
-          title: 'Enable Kodi sync',
+          title: l.kodiEnableSync,
           subtitle: settings.enabled
-              ? 'Active while Tonkatsu is running'
+              ? l.kodiEnableSyncActiveSubtitle
               : !canEnable
-                  ? 'Select a target collection first'
+                  ? l.kodiEnableSyncDisabledSubtitle
                   : null,
           showChevron: false,
           trailing: Switch(
@@ -415,13 +421,13 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           ),
         ),
         SettingsTile(
-          title: 'Sync interval',
+          title: l.kodiSyncInterval,
           value: _formatInterval(settings.syncIntervalSeconds),
           onTap: () => _showIntervalPicker(settings),
         ),
         SettingsTile(
-          title: 'Create sub-collections from Kodi sets',
-          subtitle: 'E.g. "Harry Potter Collection (kodi)"',
+          title: l.kodiCreateSubCollections,
+          subtitle: l.kodiCreateSubCollectionsSubtitle,
           showChevron: false,
           trailing: Switch(
             value: settings.createSubCollections,
@@ -433,8 +439,8 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           ),
         ),
         SettingsTile(
-          title: 'Import ratings from Kodi',
-          subtitle: 'Copy Kodi userrating (1–10)',
+          title: l.kodiImportRatings,
+          subtitle: l.kodiImportRatingsSubtitle,
           showChevron: false,
           trailing: Switch(
             value: settings.importRatings,
@@ -459,16 +465,16 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
     final Object? result = await showDialog<Object>(
       context: context,
       builder: (BuildContext dialogContext) => SimpleDialog(
-        title: const Text('Target collection'),
+        title: Text(S.of(context).kodiTargetCollection),
         children: <Widget>[
           // Create new.
           SimpleDialogOption(
             onPressed: () => Navigator.pop(dialogContext, 'create_new'),
-            child: const Row(
+            child: Row(
               children: <Widget>[
-                Icon(Icons.add, size: 18, color: AppColors.brand),
-                SizedBox(width: AppSpacing.sm),
-                Text('Create new collection'),
+                const Icon(Icons.add, size: 18, color: AppColors.brand),
+                const SizedBox(width: AppSpacing.sm),
+                Text(S.of(context).kodiCollectionPickerCreateNew),
               ],
             ),
           ),
@@ -501,9 +507,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
     if (result == null || !mounted) return;
 
     if (result == 'create_new') {
+      final S l = S.of(context);
       final DatabaseService db = ref.read(databaseServiceProvider);
       final Collection created = await db.createCollection(
-        name: 'Kodi Library',
+        name: l.kodiCollectionLibraryName,
         author: 'Kodi',
       );
       ref.invalidate(collectionsProvider);
@@ -511,7 +518,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           .read(kodiSettingsProvider.notifier)
           .setTargetCollectionId(created.id);
       if (mounted) {
-        context.showSnack('Created "Kodi Library"', type: SnackType.success);
+        context.showSnack(
+          l.kodiCollectionCreated(l.kodiCollectionLibraryName),
+          type: SnackType.success,
+        );
       }
     } else if (result is int) {
       await ref
@@ -521,6 +531,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
   }
 
   Widget _buildRequestLog() {
+    final S l = S.of(context);
     final List<KodiLogEntry> log = ref.read(kodiApiProvider).requestLog;
 
     return Padding(
@@ -531,7 +542,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
           Row(
             children: <Widget>[
               Text(
-                'Request Log (${log.length})',
+                l.kodiRequestLog(log.length),
                 style: AppTypography.bodySmall.copyWith(
                   color: AppColors.textTertiary,
                   fontWeight: FontWeight.w600,
@@ -545,12 +556,12 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
                   visualDensity: VisualDensity.compact,
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
-                  tooltip: 'Copy log',
+                  tooltip: l.kodiCopyLog,
                   onPressed: () {
                     final String text =
                         log.map((KodiLogEntry e) => e.formatted).join('\n');
                     Clipboard.setData(ClipboardData(text: text));
-                    context.showSnack('Log copied');
+                    context.showSnack(l.kodiLogCopied);
                   },
                 ),
               if (log.isNotEmpty)
@@ -560,7 +571,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
                   visualDensity: VisualDensity.compact,
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
-                  tooltip: 'Clear log',
+                  tooltip: l.kodiClearLog,
                   onPressed: () {
                     ref.read(kodiApiProvider).requestLog.clear();
                     setState(() {});
@@ -580,7 +591,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             ),
             child: log.isEmpty
                 ? Text(
-                    'No requests yet',
+                    l.kodiNoRequests,
                     style: AppTypography.bodySmall.copyWith(
                       color: AppColors.textTertiary,
                     ),
@@ -604,8 +615,9 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
   // ==================== Debug ====================
 
   Widget _buildDebugSection(KodiSettingsState settings) {
+    final S l = S.of(context);
     return SettingsGroup(
-      title: 'Debug',
+      title: l.kodiDebugTitle,
       children: <Widget>[
         // — Connection status —
         if (_connectionResult != null)
@@ -638,20 +650,20 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
 
         // — Sync status —
         SettingsTile(
-          title: 'Sync status',
+          title: l.kodiSyncStatus,
           value: ref.read(kodiSyncServiceProvider).isRunning
-              ? 'Running'
-              : 'Stopped',
+              ? l.kodiSyncRunning
+              : l.kodiSyncStopped,
           showChevron: false,
         ),
         SettingsTile(
-          title: 'Last sync',
-          value: settings.lastSyncTimestamp ?? 'Never',
+          title: l.kodiLastSync,
+          value: settings.lastSyncTimestamp ?? l.kodiLastSyncNever,
           showChevron: false,
         ),
         SettingsTile(
-          title: 'Clear last sync timestamp',
-          subtitle: 'Next sync will fetch all watched items',
+          title: l.kodiClearLastSync,
+          subtitle: l.kodiClearLastSyncSubtitle,
           titleColor: AppColors.error,
           onTap: () async {
             await ref
@@ -659,7 +671,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
                 .clearLastSyncTimestamp();
             if (mounted) {
               context.showSnack(
-                'Last sync timestamp cleared',
+                l.kodiLastSyncCleared,
                 type: SnackType.success,
               );
             }
@@ -676,7 +688,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Text(
-                'Raw JSON-RPC',
+                l.kodiRawJsonRpc,
                 style: AppTypography.bodySmall.copyWith(
                   color: AppColors.textTertiary,
                   fontWeight: FontWeight.w600,
@@ -685,10 +697,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
               const SizedBox(height: AppSpacing.sm),
               TextField(
                 controller: _methodController,
-                decoration: const InputDecoration(
-                  labelText: 'Method',
+                decoration: InputDecoration(
+                  labelText: l.kodiMethod,
                   hintText: 'VideoLibrary.GetMovies',
-                  border: OutlineInputBorder(),
+                  border: const OutlineInputBorder(),
                   isDense: true,
                 ),
                 style: AppTypography.bodySmall,
@@ -696,10 +708,10 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
               const SizedBox(height: AppSpacing.sm),
               TextField(
                 controller: _paramsController,
-                decoration: const InputDecoration(
-                  labelText: 'Params (JSON)',
+                decoration: InputDecoration(
+                  labelText: l.kodiParams,
                   hintText: '{"limits": {"start": 0, "end": 5}}',
-                  border: OutlineInputBorder(),
+                  border: const OutlineInputBorder(),
                   isDense: true,
                 ),
                 style: AppTypography.bodySmall,
@@ -721,7 +733,7 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
                           ),
                         )
                       : const Icon(Icons.send, size: 16),
-                  label: const Text('Send'),
+                  label: Text(l.kodiSend),
                 ),
               ),
               if (_rawResponse != null) ...<Widget>[
@@ -756,12 +768,12 @@ class _KodiScreenState extends ConsumerState<KodiScreen> {
                           visualDensity: VisualDensity.compact,
                           padding: EdgeInsets.zero,
                           constraints: const BoxConstraints(),
-                          tooltip: 'Copy to clipboard',
+                          tooltip: l.kodiCopyToClipboard,
                           onPressed: () {
                             Clipboard.setData(
                               ClipboardData(text: _rawResponse!),
                             );
-                            context.showSnack('Copied to clipboard');
+                            context.showSnack(l.kodiCopiedToClipboard);
                           },
                         ),
                       ),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -312,13 +312,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
       // INTEGRATIONS
       SettingsGroup(
-        title: 'Integrations',
+        title: l.settingsIntegrations,
         children: <Widget>[
           SettingsTile(
-            title: 'Kodi',
-            subtitle: 'Watch sync from Kodi media player',
+            title: 'Kodi', // proper noun
+            subtitle: l.settingsKodiSubtitle,
             value: ref.watch(kodiSettingsProvider).enabled
-                ? 'On'
+                ? l.settingsOn
                 : '',
             onTap: () => _pushScreen(const KodiScreen()),
           ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1539,5 +1539,98 @@
   "switchingProfile": "Switching profile…",
   "appWillRestart": "The app will restart to apply changes.",
   "profileCreated": "Profile created",
-  "profileDeleted": "Profile deleted"
+  "profileDeleted": "Profile deleted",
+
+  "settingsIntegrations": "Integrations",
+  "settingsKodiSubtitle": "Watch sync from Kodi media player",
+  "settingsOn": "On",
+
+  "kodiConnectionTitle": "Connection",
+  "kodiConnectionSubtitle": "Kodi HTTP JSON-RPC (Settings → Services → Control)",
+  "kodiHost": "Host",
+  "kodiPort": "Port",
+  "kodiUsername": "Username",
+  "kodiPassword": "Password",
+  "kodiPasswordHint": "Enter password",
+  "kodiTestConnection": "Test connection",
+  "kodiConnecting": "Connecting…",
+  "kodiPingFailed": "Ping failed — unexpected response",
+  "kodiConnectedTo": "Kodi {version} \"{name}\"",
+  "@kodiConnectedTo": {
+    "placeholders": {
+      "version": {"type": "String"},
+      "name": {"type": "String"}
+    }
+  },
+
+  "kodiSyncTitle": "Sync",
+  "kodiTargetCollection": "Target collection",
+  "kodiTargetCollectionSubtitle": "All Kodi movies sync here",
+  "kodiTargetNotSelected": "Not selected",
+  "kodiTargetDeletedLabel": "Deleted (#{id})",
+  "@kodiTargetDeletedLabel": {
+    "placeholders": {
+      "id": {"type": "int"}
+    }
+  },
+  "kodiTargetError": "Error",
+  "kodiEnableSync": "Enable Kodi sync",
+  "kodiEnableSyncActiveSubtitle": "Active while Tonkatsu is running",
+  "kodiEnableSyncDisabledSubtitle": "Select a target collection first",
+  "kodiSyncInterval": "Sync interval",
+  "kodiCreateSubCollections": "Create sub-collections from Kodi sets",
+  "kodiCreateSubCollectionsSubtitle": "E.g. \"Harry Potter Collection (kodi)\"",
+  "kodiImportRatings": "Import ratings from Kodi",
+  "kodiImportRatingsSubtitle": "Copy Kodi userrating (1–10)",
+
+  "kodiCollectionPickerCreateNew": "Create new collection",
+  "kodiCollectionLibraryName": "Kodi Library",
+  "kodiCollectionCreated": "Created \"{name}\"",
+  "@kodiCollectionCreated": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "kodiTargetDeletedSnack": "Target collection deleted — sync stopped",
+
+  "kodiDebugTitle": "Debug",
+  "kodiSyncStatus": "Sync status",
+  "kodiSyncRunning": "Running",
+  "kodiSyncStopped": "Stopped",
+  "kodiLastSync": "Last sync",
+  "kodiLastSyncNever": "Never",
+  "kodiClearLastSync": "Clear last sync timestamp",
+  "kodiClearLastSyncSubtitle": "Next sync will fetch all watched items",
+  "kodiLastSyncCleared": "Last sync timestamp cleared",
+
+  "kodiRequestLog": "Request Log ({count})",
+  "@kodiRequestLog": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "kodiCopyLog": "Copy log",
+  "kodiLogCopied": "Log copied",
+  "kodiClearLog": "Clear log",
+  "kodiNoRequests": "No requests yet",
+
+  "kodiRawJsonRpc": "Raw JSON-RPC",
+  "kodiMethod": "Method",
+  "kodiParams": "Params (JSON)",
+  "kodiSend": "Send",
+  "kodiCopyToClipboard": "Copy to clipboard",
+  "kodiCopiedToClipboard": "Copied to clipboard",
+  "kodiParamsNotObject": "Error: params must be a JSON object",
+  "kodiJsonParseError": "JSON parse error: {message}",
+  "@kodiJsonParseError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  },
+  "kodiRawError": "Error: {message}",
+  "@kodiRawError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -408,6 +408,8 @@
   "collectionExport": "Export",
   "collectionNoItemsYet": "No Items Yet",
   "collectionEmpty": "Empty Collection",
+  "collectionEmptyAddHint": "Add items to start building your collection.",
+  "collectionEmptyReadonly": "This collection is empty.",
   "collectionDeleteEmptyPrompt": "This collection is now empty. Delete it?",
   "collectionRemoveItemTitle": "Remove Item?",
   "collectionRemoveItemMessage": "Remove {name} from this collection?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -81,7 +81,7 @@
   "keep": "Keep",
   "change": "Change",
 
-  "settingsProfile": "Profile",
+  "settingsProfile": "Collection author",
   "settingsProfileSubtitle": "Author name for your collections",
   "settingsAuthorName": "Author name",
   "settingsAuthorPlaceholder": "User",
@@ -1504,7 +1504,7 @@
   "textExportEmptyTemplate": "Template is empty",
   "filtersClear": "Clear",
 
-  "profiles": "Profiles",
+  "profiles": "App profiles",
   "currentProfile": "Current: {name}",
   "@currentProfile": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6036,6 +6036,336 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Profile deleted'**
   String get profileDeleted;
+
+  /// No description provided for @settingsIntegrations.
+  ///
+  /// In en, this message translates to:
+  /// **'Integrations'**
+  String get settingsIntegrations;
+
+  /// No description provided for @settingsKodiSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Watch sync from Kodi media player'**
+  String get settingsKodiSubtitle;
+
+  /// No description provided for @settingsOn.
+  ///
+  /// In en, this message translates to:
+  /// **'On'**
+  String get settingsOn;
+
+  /// No description provided for @kodiConnectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Connection'**
+  String get kodiConnectionTitle;
+
+  /// No description provided for @kodiConnectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Kodi HTTP JSON-RPC (Settings → Services → Control)'**
+  String get kodiConnectionSubtitle;
+
+  /// No description provided for @kodiHost.
+  ///
+  /// In en, this message translates to:
+  /// **'Host'**
+  String get kodiHost;
+
+  /// No description provided for @kodiPort.
+  ///
+  /// In en, this message translates to:
+  /// **'Port'**
+  String get kodiPort;
+
+  /// No description provided for @kodiUsername.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get kodiUsername;
+
+  /// No description provided for @kodiPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Password'**
+  String get kodiPassword;
+
+  /// No description provided for @kodiPasswordHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter password'**
+  String get kodiPasswordHint;
+
+  /// No description provided for @kodiTestConnection.
+  ///
+  /// In en, this message translates to:
+  /// **'Test connection'**
+  String get kodiTestConnection;
+
+  /// No description provided for @kodiConnecting.
+  ///
+  /// In en, this message translates to:
+  /// **'Connecting…'**
+  String get kodiConnecting;
+
+  /// No description provided for @kodiPingFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Ping failed — unexpected response'**
+  String get kodiPingFailed;
+
+  /// No description provided for @kodiConnectedTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Kodi {version} \"{name}\"'**
+  String kodiConnectedTo(String version, String name);
+
+  /// No description provided for @kodiSyncTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync'**
+  String get kodiSyncTitle;
+
+  /// No description provided for @kodiTargetCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Target collection'**
+  String get kodiTargetCollection;
+
+  /// No description provided for @kodiTargetCollectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'All Kodi movies sync here'**
+  String get kodiTargetCollectionSubtitle;
+
+  /// No description provided for @kodiTargetNotSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'Not selected'**
+  String get kodiTargetNotSelected;
+
+  /// No description provided for @kodiTargetDeletedLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted (#{id})'**
+  String kodiTargetDeletedLabel(int id);
+
+  /// No description provided for @kodiTargetError.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get kodiTargetError;
+
+  /// No description provided for @kodiEnableSync.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable Kodi sync'**
+  String get kodiEnableSync;
+
+  /// No description provided for @kodiEnableSyncActiveSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Active while Tonkatsu is running'**
+  String get kodiEnableSyncActiveSubtitle;
+
+  /// No description provided for @kodiEnableSyncDisabledSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a target collection first'**
+  String get kodiEnableSyncDisabledSubtitle;
+
+  /// No description provided for @kodiSyncInterval.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync interval'**
+  String get kodiSyncInterval;
+
+  /// No description provided for @kodiCreateSubCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'Create sub-collections from Kodi sets'**
+  String get kodiCreateSubCollections;
+
+  /// No description provided for @kodiCreateSubCollectionsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'E.g. \"Harry Potter Collection (kodi)\"'**
+  String get kodiCreateSubCollectionsSubtitle;
+
+  /// No description provided for @kodiImportRatings.
+  ///
+  /// In en, this message translates to:
+  /// **'Import ratings from Kodi'**
+  String get kodiImportRatings;
+
+  /// No description provided for @kodiImportRatingsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy Kodi userrating (1–10)'**
+  String get kodiImportRatingsSubtitle;
+
+  /// No description provided for @kodiCollectionPickerCreateNew.
+  ///
+  /// In en, this message translates to:
+  /// **'Create new collection'**
+  String get kodiCollectionPickerCreateNew;
+
+  /// No description provided for @kodiCollectionLibraryName.
+  ///
+  /// In en, this message translates to:
+  /// **'Kodi Library'**
+  String get kodiCollectionLibraryName;
+
+  /// No description provided for @kodiCollectionCreated.
+  ///
+  /// In en, this message translates to:
+  /// **'Created \"{name}\"'**
+  String kodiCollectionCreated(String name);
+
+  /// No description provided for @kodiTargetDeletedSnack.
+  ///
+  /// In en, this message translates to:
+  /// **'Target collection deleted — sync stopped'**
+  String get kodiTargetDeletedSnack;
+
+  /// No description provided for @kodiDebugTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Debug'**
+  String get kodiDebugTitle;
+
+  /// No description provided for @kodiSyncStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync status'**
+  String get kodiSyncStatus;
+
+  /// No description provided for @kodiSyncRunning.
+  ///
+  /// In en, this message translates to:
+  /// **'Running'**
+  String get kodiSyncRunning;
+
+  /// No description provided for @kodiSyncStopped.
+  ///
+  /// In en, this message translates to:
+  /// **'Stopped'**
+  String get kodiSyncStopped;
+
+  /// No description provided for @kodiLastSync.
+  ///
+  /// In en, this message translates to:
+  /// **'Last sync'**
+  String get kodiLastSync;
+
+  /// No description provided for @kodiLastSyncNever.
+  ///
+  /// In en, this message translates to:
+  /// **'Never'**
+  String get kodiLastSyncNever;
+
+  /// No description provided for @kodiClearLastSync.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear last sync timestamp'**
+  String get kodiClearLastSync;
+
+  /// No description provided for @kodiClearLastSyncSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Next sync will fetch all watched items'**
+  String get kodiClearLastSyncSubtitle;
+
+  /// No description provided for @kodiLastSyncCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Last sync timestamp cleared'**
+  String get kodiLastSyncCleared;
+
+  /// No description provided for @kodiRequestLog.
+  ///
+  /// In en, this message translates to:
+  /// **'Request Log ({count})'**
+  String kodiRequestLog(int count);
+
+  /// No description provided for @kodiCopyLog.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy log'**
+  String get kodiCopyLog;
+
+  /// No description provided for @kodiLogCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Log copied'**
+  String get kodiLogCopied;
+
+  /// No description provided for @kodiClearLog.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear log'**
+  String get kodiClearLog;
+
+  /// No description provided for @kodiNoRequests.
+  ///
+  /// In en, this message translates to:
+  /// **'No requests yet'**
+  String get kodiNoRequests;
+
+  /// No description provided for @kodiRawJsonRpc.
+  ///
+  /// In en, this message translates to:
+  /// **'Raw JSON-RPC'**
+  String get kodiRawJsonRpc;
+
+  /// No description provided for @kodiMethod.
+  ///
+  /// In en, this message translates to:
+  /// **'Method'**
+  String get kodiMethod;
+
+  /// No description provided for @kodiParams.
+  ///
+  /// In en, this message translates to:
+  /// **'Params (JSON)'**
+  String get kodiParams;
+
+  /// No description provided for @kodiSend.
+  ///
+  /// In en, this message translates to:
+  /// **'Send'**
+  String get kodiSend;
+
+  /// No description provided for @kodiCopyToClipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy to clipboard'**
+  String get kodiCopyToClipboard;
+
+  /// No description provided for @kodiCopiedToClipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Copied to clipboard'**
+  String get kodiCopiedToClipboard;
+
+  /// No description provided for @kodiParamsNotObject.
+  ///
+  /// In en, this message translates to:
+  /// **'Error: params must be a JSON object'**
+  String get kodiParamsNotObject;
+
+  /// No description provided for @kodiJsonParseError.
+  ///
+  /// In en, this message translates to:
+  /// **'JSON parse error: {message}'**
+  String kodiJsonParseError(String message);
+
+  /// No description provided for @kodiRawError.
+  ///
+  /// In en, this message translates to:
+  /// **'Error: {message}'**
+  String kodiRawError(String message);
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1771,6 +1771,18 @@ abstract class S {
   /// **'Empty Collection'**
   String get collectionEmpty;
 
+  /// No description provided for @collectionEmptyAddHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add items to start building your collection.'**
+  String get collectionEmptyAddHint;
+
+  /// No description provided for @collectionEmptyReadonly.
+  ///
+  /// In en, this message translates to:
+  /// **'This collection is empty.'**
+  String get collectionEmptyReadonly;
+
   /// No description provided for @collectionDeleteEmptyPrompt.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -538,7 +538,7 @@ abstract class S {
   /// No description provided for @settingsProfile.
   ///
   /// In en, this message translates to:
-  /// **'Profile'**
+  /// **'Collection author'**
   String get settingsProfile;
 
   /// No description provided for @settingsProfileSubtitle.
@@ -5920,7 +5920,7 @@ abstract class S {
   /// No description provided for @profiles.
   ///
   /// In en, this message translates to:
-  /// **'Profiles'**
+  /// **'App profiles'**
   String get profiles;
 
   /// No description provided for @currentProfile.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3297,4 +3297,187 @@ class SEn extends S {
 
   @override
   String get profileDeleted => 'Profile deleted';
+
+  @override
+  String get settingsIntegrations => 'Integrations';
+
+  @override
+  String get settingsKodiSubtitle => 'Watch sync from Kodi media player';
+
+  @override
+  String get settingsOn => 'On';
+
+  @override
+  String get kodiConnectionTitle => 'Connection';
+
+  @override
+  String get kodiConnectionSubtitle =>
+      'Kodi HTTP JSON-RPC (Settings → Services → Control)';
+
+  @override
+  String get kodiHost => 'Host';
+
+  @override
+  String get kodiPort => 'Port';
+
+  @override
+  String get kodiUsername => 'Username';
+
+  @override
+  String get kodiPassword => 'Password';
+
+  @override
+  String get kodiPasswordHint => 'Enter password';
+
+  @override
+  String get kodiTestConnection => 'Test connection';
+
+  @override
+  String get kodiConnecting => 'Connecting…';
+
+  @override
+  String get kodiPingFailed => 'Ping failed — unexpected response';
+
+  @override
+  String kodiConnectedTo(String version, String name) {
+    return 'Kodi $version \"$name\"';
+  }
+
+  @override
+  String get kodiSyncTitle => 'Sync';
+
+  @override
+  String get kodiTargetCollection => 'Target collection';
+
+  @override
+  String get kodiTargetCollectionSubtitle => 'All Kodi movies sync here';
+
+  @override
+  String get kodiTargetNotSelected => 'Not selected';
+
+  @override
+  String kodiTargetDeletedLabel(int id) {
+    return 'Deleted (#$id)';
+  }
+
+  @override
+  String get kodiTargetError => 'Error';
+
+  @override
+  String get kodiEnableSync => 'Enable Kodi sync';
+
+  @override
+  String get kodiEnableSyncActiveSubtitle => 'Active while Tonkatsu is running';
+
+  @override
+  String get kodiEnableSyncDisabledSubtitle =>
+      'Select a target collection first';
+
+  @override
+  String get kodiSyncInterval => 'Sync interval';
+
+  @override
+  String get kodiCreateSubCollections =>
+      'Create sub-collections from Kodi sets';
+
+  @override
+  String get kodiCreateSubCollectionsSubtitle =>
+      'E.g. \"Harry Potter Collection (kodi)\"';
+
+  @override
+  String get kodiImportRatings => 'Import ratings from Kodi';
+
+  @override
+  String get kodiImportRatingsSubtitle => 'Copy Kodi userrating (1–10)';
+
+  @override
+  String get kodiCollectionPickerCreateNew => 'Create new collection';
+
+  @override
+  String get kodiCollectionLibraryName => 'Kodi Library';
+
+  @override
+  String kodiCollectionCreated(String name) {
+    return 'Created \"$name\"';
+  }
+
+  @override
+  String get kodiTargetDeletedSnack =>
+      'Target collection deleted — sync stopped';
+
+  @override
+  String get kodiDebugTitle => 'Debug';
+
+  @override
+  String get kodiSyncStatus => 'Sync status';
+
+  @override
+  String get kodiSyncRunning => 'Running';
+
+  @override
+  String get kodiSyncStopped => 'Stopped';
+
+  @override
+  String get kodiLastSync => 'Last sync';
+
+  @override
+  String get kodiLastSyncNever => 'Never';
+
+  @override
+  String get kodiClearLastSync => 'Clear last sync timestamp';
+
+  @override
+  String get kodiClearLastSyncSubtitle =>
+      'Next sync will fetch all watched items';
+
+  @override
+  String get kodiLastSyncCleared => 'Last sync timestamp cleared';
+
+  @override
+  String kodiRequestLog(int count) {
+    return 'Request Log ($count)';
+  }
+
+  @override
+  String get kodiCopyLog => 'Copy log';
+
+  @override
+  String get kodiLogCopied => 'Log copied';
+
+  @override
+  String get kodiClearLog => 'Clear log';
+
+  @override
+  String get kodiNoRequests => 'No requests yet';
+
+  @override
+  String get kodiRawJsonRpc => 'Raw JSON-RPC';
+
+  @override
+  String get kodiMethod => 'Method';
+
+  @override
+  String get kodiParams => 'Params (JSON)';
+
+  @override
+  String get kodiSend => 'Send';
+
+  @override
+  String get kodiCopyToClipboard => 'Copy to clipboard';
+
+  @override
+  String get kodiCopiedToClipboard => 'Copied to clipboard';
+
+  @override
+  String get kodiParamsNotObject => 'Error: params must be a JSON object';
+
+  @override
+  String kodiJsonParseError(String message) {
+    return 'JSON parse error: $message';
+  }
+
+  @override
+  String kodiRawError(String message) {
+    return 'Error: $message';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -228,7 +228,7 @@ class SEn extends S {
   String get change => 'Change';
 
   @override
-  String get settingsProfile => 'Profile';
+  String get settingsProfile => 'Collection author';
 
   @override
   String get settingsProfileSubtitle => 'Author name for your collections';
@@ -3232,7 +3232,7 @@ class SEn extends S {
   String get filtersClear => 'Clear';
 
   @override
-  String get profiles => 'Profiles';
+  String get profiles => 'App profiles';
 
   @override
   String currentProfile(String name) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -934,6 +934,13 @@ class SEn extends S {
   String get collectionEmpty => 'Empty Collection';
 
   @override
+  String get collectionEmptyAddHint =>
+      'Add items to start building your collection.';
+
+  @override
+  String get collectionEmptyReadonly => 'This collection is empty.';
+
+  @override
   String get collectionDeleteEmptyPrompt =>
       'This collection is now empty. Delete it?';
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -18,7 +18,7 @@ class SRu extends S {
   String get navCollections => 'Коллекции';
 
   @override
-  String get navWishlist => 'Список';
+  String get navWishlist => 'Желаемое';
 
   @override
   String get navSearch => 'Поиск';
@@ -228,7 +228,7 @@ class SRu extends S {
   String get change => 'Изменить';
 
   @override
-  String get settingsProfile => 'Профиль';
+  String get settingsProfile => 'Автор коллекций';
 
   @override
   String get settingsProfileSubtitle => 'Имя автора для ваших коллекций';
@@ -364,7 +364,7 @@ class SRu extends S {
 
   @override
   String backupSuccess(int collections, int items) {
-    return 'Бэкап сохранён: $collections коллекций, $items элементов';
+    return 'Бэкап сохранён: $collections коллекций, $items тайтлов';
   }
 
   @override
@@ -372,7 +372,7 @@ class SRu extends S {
 
   @override
   String restoreConfirmBody(int collections, int items, int wishlist) {
-    return '$collections коллекций, $items элементов, $wishlist записей вишлиста';
+    return '$collections коллекций, $items тайтлов, $wishlist записей вишлиста';
   }
 
   @override
@@ -386,7 +386,7 @@ class SRu extends S {
 
   @override
   String restoreSuccess(int collections, int items) {
-    return 'Восстановлено $collections коллекций, $items элементов';
+    return 'Восстановлено $collections коллекций, $items тайтлов';
   }
 
   @override
@@ -786,7 +786,7 @@ class SRu extends S {
 
   @override
   String traktImportedItems(int count) {
-    return 'Импортировано элементов: $count';
+    return 'Импортировано тайтлов: $count';
   }
 
   @override
@@ -859,9 +859,9 @@ class SRu extends S {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count элементов',
-      few: '$count элемента',
-      one: '1 элемент',
+      other: '$count тайтлов',
+      few: '$count тайтла',
+      one: '1 тайтл',
     );
     return '$_temp0';
   }
@@ -889,7 +889,7 @@ class SRu extends S {
 
   @override
   String collectionsImported(String name, int count) {
-    return 'Импортирована \"$name\" — $count элементов';
+    return 'Импортирована \"$name\" — $count тайтлов';
   }
 
   @override
@@ -920,7 +920,7 @@ class SRu extends S {
   String get collectionNotFound => 'Коллекция не найдена';
 
   @override
-  String get collectionAddItems => 'Добавить элементы';
+  String get collectionAddItems => 'Добавить тайтлы';
 
   @override
   String get collectionSwitchToList => 'Переключить на список';
@@ -938,7 +938,7 @@ class SRu extends S {
   String get collectionExport => 'Экспорт';
 
   @override
-  String get collectionNoItemsYet => 'Пока нет элементов';
+  String get collectionNoItemsYet => 'Пока нет тайтлов';
 
   @override
   String get collectionEmpty => 'Пустая коллекция';
@@ -948,7 +948,7 @@ class SRu extends S {
       'Коллекция теперь пуста. Удалить её?';
 
   @override
-  String get collectionRemoveItemTitle => 'Убрать элемент?';
+  String get collectionRemoveItemTitle => 'Убрать тайтл?';
 
   @override
   String collectionRemoveItemMessage(String name) {
@@ -968,7 +968,7 @@ class SRu extends S {
   String get collectionExportLight => 'Лёгкий (.xcoll)';
 
   @override
-  String get collectionExportLightDesc => 'Только элементы, файл меньше';
+  String get collectionExportLightDesc => 'Только тайтлы, файл меньше';
 
   @override
   String get collectionExportFull => 'Полный (.xcollx)';
@@ -985,7 +985,7 @@ class SRu extends S {
       'Статус, даты, заметки, прогресс эпизодов';
 
   @override
-  String get customItemCreate => 'Создать свой элемент';
+  String get customItemCreate => 'Создать свой тайтл';
 
   @override
   String get customItemTitle => 'Название';
@@ -1033,7 +1033,7 @@ class SRu extends S {
   String get customItemCreateButton => 'Создать';
 
   @override
-  String get customItemEdit => 'Редактировать элемент';
+  String get customItemEdit => 'Редактировать тайтл';
 
   @override
   String get customItemAddCover => 'Добавить обложку';
@@ -1067,10 +1067,10 @@ class SRu extends S {
   String get customItemErrorEmptyTitle => 'Название обязательно';
 
   @override
-  String get customItemCreated => 'Элемент создан';
+  String get customItemCreated => 'Тайтл создан';
 
   @override
-  String get customItemUpdated => 'Элемент обновлён';
+  String get customItemUpdated => 'Тайтл обновлён';
 
   @override
   String get tagLabel => 'Тег';
@@ -1092,7 +1092,7 @@ class SRu extends S {
 
   @override
   String tagDeleteConfirm(String name) {
-    return 'Удалить тег «$name»? Элементы останутся без тега.';
+    return 'Удалить тег «$name»? Тайтлы останутся без тега.';
   }
 
   @override
@@ -1689,7 +1689,7 @@ class SRu extends S {
       'Нажмите + чтобы добавить что-нибудь на потом';
 
   @override
-  String get wishlistDeleteItem => 'Удалить элемент';
+  String get wishlistDeleteItem => 'Удалить тайтл';
 
   @override
   String wishlistDeletePrompt(String name) {
@@ -1704,9 +1704,9 @@ class SRu extends S {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Удалить $count выполненных элементов?',
-      few: 'Удалить $count выполненных элемента?',
-      one: 'Удалить 1 выполненный элемент?',
+      other: 'Удалить $count выполненных тайтлов?',
+      few: 'Удалить $count выполненных тайтла?',
+      one: 'Удалить 1 выполненный тайтл?',
     );
     return '$_temp0';
   }
@@ -1906,7 +1906,7 @@ class SRu extends S {
 
   @override
   String get welcomeHowMainDesc =>
-      'Все элементы из всех коллекций в одном месте. Фильтрация по типу, сортировка по оценке.';
+      'Все тайтлы из всех коллекций в одном месте. Фильтрация по типу, сортировка по оценке.';
 
   @override
   String get welcomeHowCollectionsDesc =>
@@ -1914,7 +1914,7 @@ class SRu extends S {
 
   @override
   String get welcomeHowTierListsDesc =>
-      'Ранжируйте и сравнивайте элементы из коллекций с помощью настраиваемых тир-листов.';
+      'Ранжируйте и сравнивайте тайтлы из коллекций с помощью настраиваемых тир-листов.';
 
   @override
   String get welcomeHowWishlistDesc =>
@@ -2075,7 +2075,7 @@ class SRu extends S {
   String get unknownManga => 'Неизвестная манга';
 
   @override
-  String get unknownCustom => 'Неизвестный элемент';
+  String get unknownCustom => 'Неизвестный тайтл';
 
   @override
   String get unknownPlatform => 'Неизвестная платформа';
@@ -2122,17 +2122,17 @@ class SRu extends S {
   String get allItemsRating => 'Оценка';
 
   @override
-  String get allItemsNoItems => 'Пока нет элементов';
+  String get allItemsNoItems => 'Пока нет тайтлов';
 
   @override
-  String get allItemsNoMatch => 'Нет элементов по фильтру';
+  String get allItemsNoMatch => 'Нет тайтлов по фильтру';
 
   @override
   String get allItemsAddViaCollections =>
-      'Перейдите в Коллекции → создайте коллекцию → добавьте\nэлементы через Поиск. Они появятся здесь автоматически.';
+      'Перейдите в Коллекции → создайте коллекцию → добавьте\nтайтлы через Поиск. Они появятся здесь автоматически.';
 
   @override
-  String get allItemsFailedToLoad => 'Не удалось загрузить элементы';
+  String get allItemsFailedToLoad => 'Не удалось загрузить тайтлы';
 
   @override
   String get allItemsFilterPlatformsAll => 'Все платформы';
@@ -2242,9 +2242,9 @@ class SRu extends S {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count элементов',
-      few: '$count элемента',
-      one: '1 элемент',
+      other: '$count тайтлов',
+      few: '$count тайтла',
+      one: '1 тайтл',
     );
     return '$_temp0 · $percent завершено';
   }
@@ -2331,7 +2331,7 @@ class SRu extends S {
   String get canvasBoardEmpty => 'Доска пуста';
 
   @override
-  String get canvasBoardEmptyHint => 'Сначала добавьте элементы в коллекцию';
+  String get canvasBoardEmptyHint => 'Сначала добавьте тайтлы в коллекцию';
 
   @override
   String get canvasCenterView => 'Центрировать вид';
@@ -2493,7 +2493,7 @@ class SRu extends S {
 
   @override
   String get settingsDiscordRpcSubtitle =>
-      'Показывать текущий элемент в статусе Discord';
+      'Показывать текущий тайтл в статусе Discord';
 
   @override
   String get settingsDiscordRaSync => 'Синхронизация RetroAchievements';
@@ -2646,7 +2646,7 @@ class SRu extends S {
   String get tierListNameHint => 'Название тир-листа';
 
   @override
-  String get tierListScopeAll => 'Все элементы';
+  String get tierListScopeAll => 'Все тайтлы';
 
   @override
   String get tierListScopeCollection => 'Из коллекции';
@@ -2690,7 +2690,7 @@ class SRu extends S {
 
   @override
   String get tierListClearConfirm =>
-      'Убрать все элементы из тиров? Они вернутся в «Без тира».';
+      'Убрать все тайтлы из тиров? Они вернутся в «Без тира».';
 
   @override
   String get tierListDeleteConfirm => 'Удалить этот тир-лист?';
@@ -2700,10 +2700,10 @@ class SRu extends S {
 
   @override
   String get tierListEmptyHint =>
-      'Нажмите + чтобы создать тир-лист и ранжировать\nэлементы из ваших коллекций.';
+      'Нажмите + чтобы создать тир-лист и ранжировать\nтайтлы из ваших коллекций.';
 
   @override
-  String get tierListAllRanked => 'Все элементы распределены!';
+  String get tierListAllRanked => 'Все тайтлы распределены!';
 
   @override
   String get tierListNoCollections => 'Нет доступных коллекций';
@@ -2932,7 +2932,7 @@ class SRu extends S {
 
   @override
   String get importResultWishlistHint =>
-      'Элементы, не найденные в базе данных, сохранены в Список желаний.';
+      'Тайтлы, не найденные в базе данных, сохранены в Список желаний.';
 
   @override
   String get importResultSourceCollectionFile => 'Файл коллекции';
@@ -2945,7 +2945,7 @@ class SRu extends S {
 
   @override
   String browseCollectionsSummary(int count, int items) {
-    return '$count коллекций, $items элементов';
+    return '$count коллекций, $items тайтлов';
   }
 
   @override
@@ -2959,7 +2959,7 @@ class SRu extends S {
 
   @override
   String browseCollectionsItems(int count) {
-    return '$count элементов';
+    return '$count тайтлов';
   }
 
   @override
@@ -3215,9 +3215,9 @@ class SRu extends S {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Скопировано $count элементов',
-      few: 'Скопировано $count элемента',
-      one: 'Скопирован 1 элемент',
+      other: 'Скопировано $count тайтлов',
+      few: 'Скопировано $count тайтла',
+      one: 'Скопирован 1 тайтл',
     );
     return '$_temp0';
   }
@@ -3259,7 +3259,7 @@ class SRu extends S {
   String get filtersClear => 'Сбросить';
 
   @override
-  String get profiles => 'Профили';
+  String get profiles => 'Профили приложения';
 
   @override
   String currentProfile(String name) {
@@ -3313,9 +3313,9 @@ class SRu extends S {
     String _temp1 = intl.Intl.pluralLogic(
       items,
       locale: localeName,
-      other: '$items элементов',
-      few: '$items элемента',
-      one: '1 элемент',
+      other: '$items тайтлов',
+      few: '$items тайтла',
+      one: '1 тайтл',
     );
     return '$_temp0, $_temp1';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -944,6 +944,13 @@ class SRu extends S {
   String get collectionEmpty => 'Пустая коллекция';
 
   @override
+  String get collectionEmptyAddHint =>
+      'Добавьте тайтлы, чтобы начать собирать коллекцию.';
+
+  @override
+  String get collectionEmptyReadonly => 'В этой коллекции пока нет тайтлов.';
+
+  @override
   String get collectionDeleteEmptyPrompt =>
       'Коллекция теперь пуста. Удалить её?';
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3339,4 +3339,189 @@ class SRu extends S {
 
   @override
   String get profileDeleted => 'Профиль удалён';
+
+  @override
+  String get settingsIntegrations => 'Интеграции';
+
+  @override
+  String get settingsKodiSubtitle => 'Синхронизация просмотров с Kodi';
+
+  @override
+  String get settingsOn => 'Вкл.';
+
+  @override
+  String get kodiConnectionTitle => 'Подключение';
+
+  @override
+  String get kodiConnectionSubtitle =>
+      'Kodi HTTP JSON-RPC (Настройки → Службы → Управление)';
+
+  @override
+  String get kodiHost => 'Хост';
+
+  @override
+  String get kodiPort => 'Порт';
+
+  @override
+  String get kodiUsername => 'Имя пользователя';
+
+  @override
+  String get kodiPassword => 'Пароль';
+
+  @override
+  String get kodiPasswordHint => 'Введите пароль';
+
+  @override
+  String get kodiTestConnection => 'Проверить подключение';
+
+  @override
+  String get kodiConnecting => 'Подключение…';
+
+  @override
+  String get kodiPingFailed => 'Ping не прошёл — неожиданный ответ';
+
+  @override
+  String kodiConnectedTo(String version, String name) {
+    return 'Kodi $version «$name»';
+  }
+
+  @override
+  String get kodiSyncTitle => 'Синхронизация';
+
+  @override
+  String get kodiTargetCollection => 'Целевая коллекция';
+
+  @override
+  String get kodiTargetCollectionSubtitle => 'Все фильмы из Kodi попадут сюда';
+
+  @override
+  String get kodiTargetNotSelected => 'Не выбрана';
+
+  @override
+  String kodiTargetDeletedLabel(int id) {
+    return 'Удалена (#$id)';
+  }
+
+  @override
+  String get kodiTargetError => 'Ошибка';
+
+  @override
+  String get kodiEnableSync => 'Включить синхронизацию Kodi';
+
+  @override
+  String get kodiEnableSyncActiveSubtitle =>
+      'Работает, пока запущено приложение';
+
+  @override
+  String get kodiEnableSyncDisabledSubtitle =>
+      'Сначала выберите целевую коллекцию';
+
+  @override
+  String get kodiSyncInterval => 'Интервал синхронизации';
+
+  @override
+  String get kodiCreateSubCollections =>
+      'Создавать подколлекции из наборов Kodi';
+
+  @override
+  String get kodiCreateSubCollectionsSubtitle =>
+      'Например, «Harry Potter Collection (kodi)»';
+
+  @override
+  String get kodiImportRatings => 'Импортировать оценки из Kodi';
+
+  @override
+  String get kodiImportRatingsSubtitle => 'Переносить userrating Kodi (1–10)';
+
+  @override
+  String get kodiCollectionPickerCreateNew => 'Создать новую коллекцию';
+
+  @override
+  String get kodiCollectionLibraryName => 'Библиотека Kodi';
+
+  @override
+  String kodiCollectionCreated(String name) {
+    return 'Создана «$name»';
+  }
+
+  @override
+  String get kodiTargetDeletedSnack =>
+      'Целевая коллекция удалена — синхронизация остановлена';
+
+  @override
+  String get kodiDebugTitle => 'Отладка';
+
+  @override
+  String get kodiSyncStatus => 'Статус синхронизации';
+
+  @override
+  String get kodiSyncRunning => 'Активна';
+
+  @override
+  String get kodiSyncStopped => 'Остановлена';
+
+  @override
+  String get kodiLastSync => 'Последняя синхронизация';
+
+  @override
+  String get kodiLastSyncNever => 'Никогда';
+
+  @override
+  String get kodiClearLastSync => 'Сбросить метку последней синхронизации';
+
+  @override
+  String get kodiClearLastSyncSubtitle =>
+      'При следующей синхронизации подтянутся все просмотренные';
+
+  @override
+  String get kodiLastSyncCleared => 'Метка последней синхронизации сброшена';
+
+  @override
+  String kodiRequestLog(int count) {
+    return 'Лог запросов ($count)';
+  }
+
+  @override
+  String get kodiCopyLog => 'Скопировать лог';
+
+  @override
+  String get kodiLogCopied => 'Лог скопирован';
+
+  @override
+  String get kodiClearLog => 'Очистить лог';
+
+  @override
+  String get kodiNoRequests => 'Запросов пока нет';
+
+  @override
+  String get kodiRawJsonRpc => 'Сырой JSON-RPC';
+
+  @override
+  String get kodiMethod => 'Метод';
+
+  @override
+  String get kodiParams => 'Параметры (JSON)';
+
+  @override
+  String get kodiSend => 'Отправить';
+
+  @override
+  String get kodiCopyToClipboard => 'Скопировать в буфер';
+
+  @override
+  String get kodiCopiedToClipboard => 'Скопировано в буфер';
+
+  @override
+  String get kodiParamsNotObject =>
+      'Ошибка: параметры должны быть JSON-объектом';
+
+  @override
+  String kodiJsonParseError(String message) {
+    return 'Ошибка JSON: $message';
+  }
+
+  @override
+  String kodiRawError(String message) {
+    return 'Ошибка: $message';
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1258,5 +1258,98 @@
   "switchingProfile": "Переключение профиля…",
   "appWillRestart": "Приложение перезапустится для применения изменений.",
   "profileCreated": "Профиль создан",
-  "profileDeleted": "Профиль удалён"
+  "profileDeleted": "Профиль удалён",
+
+  "settingsIntegrations": "Интеграции",
+  "settingsKodiSubtitle": "Синхронизация просмотров с Kodi",
+  "settingsOn": "Вкл.",
+
+  "kodiConnectionTitle": "Подключение",
+  "kodiConnectionSubtitle": "Kodi HTTP JSON-RPC (Настройки → Службы → Управление)",
+  "kodiHost": "Хост",
+  "kodiPort": "Порт",
+  "kodiUsername": "Имя пользователя",
+  "kodiPassword": "Пароль",
+  "kodiPasswordHint": "Введите пароль",
+  "kodiTestConnection": "Проверить подключение",
+  "kodiConnecting": "Подключение…",
+  "kodiPingFailed": "Ping не прошёл — неожиданный ответ",
+  "kodiConnectedTo": "Kodi {version} «{name}»",
+  "@kodiConnectedTo": {
+    "placeholders": {
+      "version": {"type": "String"},
+      "name": {"type": "String"}
+    }
+  },
+
+  "kodiSyncTitle": "Синхронизация",
+  "kodiTargetCollection": "Целевая коллекция",
+  "kodiTargetCollectionSubtitle": "Все фильмы из Kodi попадут сюда",
+  "kodiTargetNotSelected": "Не выбрана",
+  "kodiTargetDeletedLabel": "Удалена (#{id})",
+  "@kodiTargetDeletedLabel": {
+    "placeholders": {
+      "id": {"type": "int"}
+    }
+  },
+  "kodiTargetError": "Ошибка",
+  "kodiEnableSync": "Включить синхронизацию Kodi",
+  "kodiEnableSyncActiveSubtitle": "Работает, пока запущено приложение",
+  "kodiEnableSyncDisabledSubtitle": "Сначала выберите целевую коллекцию",
+  "kodiSyncInterval": "Интервал синхронизации",
+  "kodiCreateSubCollections": "Создавать подколлекции из наборов Kodi",
+  "kodiCreateSubCollectionsSubtitle": "Например, «Harry Potter Collection (kodi)»",
+  "kodiImportRatings": "Импортировать оценки из Kodi",
+  "kodiImportRatingsSubtitle": "Переносить userrating Kodi (1–10)",
+
+  "kodiCollectionPickerCreateNew": "Создать новую коллекцию",
+  "kodiCollectionLibraryName": "Библиотека Kodi",
+  "kodiCollectionCreated": "Создана «{name}»",
+  "@kodiCollectionCreated": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "kodiTargetDeletedSnack": "Целевая коллекция удалена — синхронизация остановлена",
+
+  "kodiDebugTitle": "Отладка",
+  "kodiSyncStatus": "Статус синхронизации",
+  "kodiSyncRunning": "Активна",
+  "kodiSyncStopped": "Остановлена",
+  "kodiLastSync": "Последняя синхронизация",
+  "kodiLastSyncNever": "Никогда",
+  "kodiClearLastSync": "Сбросить метку последней синхронизации",
+  "kodiClearLastSyncSubtitle": "При следующей синхронизации подтянутся все просмотренные",
+  "kodiLastSyncCleared": "Метка последней синхронизации сброшена",
+
+  "kodiRequestLog": "Лог запросов ({count})",
+  "@kodiRequestLog": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "kodiCopyLog": "Скопировать лог",
+  "kodiLogCopied": "Лог скопирован",
+  "kodiClearLog": "Очистить лог",
+  "kodiNoRequests": "Запросов пока нет",
+
+  "kodiRawJsonRpc": "Сырой JSON-RPC",
+  "kodiMethod": "Метод",
+  "kodiParams": "Параметры (JSON)",
+  "kodiSend": "Отправить",
+  "kodiCopyToClipboard": "Скопировать в буфер",
+  "kodiCopiedToClipboard": "Скопировано в буфер",
+  "kodiParamsNotObject": "Ошибка: параметры должны быть JSON-объектом",
+  "kodiJsonParseError": "Ошибка JSON: {message}",
+  "@kodiJsonParseError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  },
+  "kodiRawError": "Ошибка: {message}",
+  "@kodiRawError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -351,6 +351,8 @@
   "collectionExport": "Экспорт",
   "collectionNoItemsYet": "Пока нет тайтлов",
   "collectionEmpty": "Пустая коллекция",
+  "collectionEmptyAddHint": "Добавьте тайтлы, чтобы начать собирать коллекцию.",
+  "collectionEmptyReadonly": "В этой коллекции пока нет тайтлов.",
   "collectionDeleteEmptyPrompt": "Коллекция теперь пуста. Удалить её?",
   "collectionRemoveItemTitle": "Убрать тайтл?",
   "collectionRemoveItemMessage": "Убрать {name} из этой коллекции?",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -5,7 +5,7 @@
 
   "navMain": "Главная",
   "navCollections": "Коллекции",
-  "navWishlist": "Список",
+  "navWishlist": "Желаемое",
   "navSearch": "Поиск",
   "navSettings": "Настройки",
 
@@ -81,7 +81,7 @@
   "keep": "Оставить",
   "change": "Изменить",
 
-  "settingsProfile": "Профиль",
+  "settingsProfile": "Автор коллекций",
   "settingsProfileSubtitle": "Имя автора для ваших коллекций",
   "settingsAuthorName": "Имя автора",
   "settingsAuthorPlaceholder": "Пользователь",
@@ -129,7 +129,7 @@
   "settingsBackupAllSubtitle": "Все коллекции, вишлист и настройки",
   "settingsRestoreBackup": "Восстановить из бэкапа",
   "settingsRestoreBackupSubtitle": "Импорт архива бэкапа",
-  "backupSuccess": "Бэкап сохранён: {collections} коллекций, {items} элементов",
+  "backupSuccess": "Бэкап сохранён: {collections} коллекций, {items} тайтлов",
   "@backupSuccess": {
     "placeholders": {
       "collections": {"type": "int"},
@@ -137,7 +137,7 @@
     }
   },
   "restoreConfirmTitle": "Восстановить бэкап?",
-  "restoreConfirmBody": "{collections} коллекций, {items} элементов, {wishlist} записей вишлиста",
+  "restoreConfirmBody": "{collections} коллекций, {items} тайтлов, {wishlist} записей вишлиста",
   "@restoreConfirmBody": {
     "placeholders": {
       "collections": {"type": "int"},
@@ -148,7 +148,7 @@
   "restoreConfirmHint": "Существующие коллекции не будут затронуты",
   "restoreSettings": "Восстановить настройки",
   "restoreWishlist": "Восстановить вишлист",
-  "restoreSuccess": "Восстановлено {collections} коллекций, {items} элементов",
+  "restoreSuccess": "Восстановлено {collections} коллекций, {items} тайтлов",
   "@restoreSuccess": {
     "placeholders": {
       "collections": {"type": "int"},
@@ -298,7 +298,7 @@
   "traktStartImport": "Начать импорт",
   "traktRequiresOwnTmdbKey": "Для импорта из Trakt необходим собственный TMDB API ключ. Добавьте его в Настройки → Учётные данные.",
   "traktInvalidExport": "Некорректный экспорт Trakt",
-  "traktImportedItems": "Импортировано элементов: {count}",
+  "traktImportedItems": "Импортировано тайтлов: {count}",
   "traktImporting": "Импорт из Trakt",
 
   "creditsTitle": "Благодарности",
@@ -320,7 +320,7 @@
   "collectionsFailedToLoad": "Не удалось загрузить коллекции",
   "collectionsCount": "Коллекции ({count})",
   "collectionsUncategorized": "Без категории",
-  "collectionsUncategorizedItems": "{count, plural, =1{1 элемент} few{{count} элемента} other{{count} элементов}}",
+  "collectionsUncategorizedItems": "{count, plural, =1{1 тайтл} few{{count} тайтла} other{{count} тайтлов}}",
   "@collectionsUncategorizedItems": {
     "placeholders": {
       "count": {"type": "int"}
@@ -331,7 +331,7 @@
   "collectionsDeleted": "Коллекция удалена",
   "collectionsFailedToDelete": "Ошибка удаления: {error}",
   "collectionsFailedToCreate": "Ошибка создания коллекции: {error}",
-  "collectionsImported": "Импортирована \"{name}\" — {count} элементов",
+  "collectionsImported": "Импортирована \"{name}\" — {count} тайтлов",
   "collectionsImporting": "Импорт коллекции",
 
   "importTargetTitle": "Импортировать в...",
@@ -343,27 +343,27 @@
   "importStartButton": "Импортировать",
 
   "collectionNotFound": "Коллекция не найдена",
-  "collectionAddItems": "Добавить элементы",
+  "collectionAddItems": "Добавить тайтлы",
   "collectionSwitchToList": "Переключить на список",
   "collectionSwitchToBoard": "Переключить на доску",
   "collectionUnlockBoard": "Разблокировать доску",
   "collectionLockBoard": "Заблокировать доску",
   "collectionExport": "Экспорт",
-  "collectionNoItemsYet": "Пока нет элементов",
+  "collectionNoItemsYet": "Пока нет тайтлов",
   "collectionEmpty": "Пустая коллекция",
   "collectionDeleteEmptyPrompt": "Коллекция теперь пуста. Удалить её?",
-  "collectionRemoveItemTitle": "Убрать элемент?",
+  "collectionRemoveItemTitle": "Убрать тайтл?",
   "collectionRemoveItemMessage": "Убрать {name} из этой коллекции?",
   "collectionMoveToCollection": "Переместить в коллекцию",
   "collectionExportFormat": "Формат экспорта",
   "collectionChooseExportFormat": "Выберите формат экспорта:",
   "collectionExportLight": "Лёгкий (.xcoll)",
-  "collectionExportLightDesc": "Только элементы, файл меньше",
+  "collectionExportLightDesc": "Только тайтлы, файл меньше",
   "collectionExportFull": "Полный (.xcollx)",
   "collectionExportFullDesc": "С изображениями и доской — работает офлайн",
   "collectionExportIncludeUserData": "Включить личные данные",
   "collectionExportIncludeUserDataDesc": "Статус, даты, заметки, прогресс эпизодов",
-  "customItemCreate": "Создать свой элемент",
+  "customItemCreate": "Создать свой тайтл",
   "customItemTitle": "Название",
   "customItemTitleHint": "напр. Моя самодельная игра",
   "customItemAltTitle": "Альтернативное название",
@@ -379,7 +379,7 @@
   "customItemDescriptionHint": "Краткое описание или заметки",
   "customItemOptionalFields": "Дополнительные поля",
   "customItemCreateButton": "Создать",
-  "customItemEdit": "Редактировать элемент",
+  "customItemEdit": "Редактировать тайтл",
   "customItemAddCover": "Добавить обложку",
   "customItemCoverSource": "Источник обложки",
   "customItemCoverRatio": "Рекомендуемое соотношение: 2:3 (напр. 600×900)",
@@ -390,15 +390,15 @@
   "customItemUseCustom": "Использовать свой",
   "customItemExternalUrl": "Внешний URL",
   "customItemErrorEmptyTitle": "Название обязательно",
-  "customItemCreated": "Элемент создан",
-  "customItemUpdated": "Элемент обновлён",
+  "customItemCreated": "Тайтл создан",
+  "customItemUpdated": "Тайтл обновлён",
   "tagLabel": "Тег",
   "tagsLabel": "Теги",
   "tagCreate": "Новый тег",
   "tagCreateHint": "Название тега",
   "tagRename": "Переименовать тег",
   "tagDelete": "Удалить тег",
-  "tagDeleteConfirm": "Удалить тег «{name}»? Элементы останутся без тега.",
+  "tagDeleteConfirm": "Удалить тег «{name}»? Тайтлы останутся без тега.",
   "@tagDeleteConfirm": {
     "placeholders": {
       "name": { "type": "String" }
@@ -602,10 +602,10 @@
   "wishlistClearResolved": "Удалить выполненные",
   "wishlistEmpty": "Список желаний пуст",
   "wishlistEmptyHint": "Нажмите + чтобы добавить что-нибудь на потом",
-  "wishlistDeleteItem": "Удалить элемент",
+  "wishlistDeleteItem": "Удалить тайтл",
   "wishlistDeletePrompt": "Удалить \"{name}\" из списка желаний?",
   "wishlistClearResolvedTitle": "Удалить выполненные",
-  "wishlistClearResolvedMessage": "{count, plural, =1{Удалить 1 выполненный элемент?} few{Удалить {count} выполненных элемента?} other{Удалить {count} выполненных элементов?}}",
+  "wishlistClearResolvedMessage": "{count, plural, =1{Удалить 1 выполненный тайтл?} few{Удалить {count} выполненных тайтла?} other{Удалить {count} выполненных тайтлов?}}",
   "@wishlistClearResolvedMessage": {
     "placeholders": {
       "count": {"type": "int"}
@@ -678,9 +678,9 @@
 
   "welcomeHowTitle": "Как это работает",
   "welcomeHowAppStructure": "Структура приложения",
-  "welcomeHowMainDesc": "Все элементы из всех коллекций в одном месте. Фильтрация по типу, сортировка по оценке.",
+  "welcomeHowMainDesc": "Все тайтлы из всех коллекций в одном месте. Фильтрация по типу, сортировка по оценке.",
   "welcomeHowCollectionsDesc": "Ваши коллекции. Создавайте, организуйте, управляйте. Сетка или список.",
-  "welcomeHowTierListsDesc": "Ранжируйте и сравнивайте элементы из коллекций с помощью настраиваемых тир-листов.",
+  "welcomeHowTierListsDesc": "Ранжируйте и сравнивайте тайтлы из коллекций с помощью настраиваемых тир-листов.",
   "welcomeHowWishlistDesc": "Быстрый список того, что хотите посмотреть позже. API не нужен.",
   "welcomeHowSearchDesc": "Поиск игр, фильмов, сериалов, новелл и манги через API. Добавляйте в любую коллекцию.",
   "welcomeHowSettingsDesc": "Ключи API, кэш, экспорт/импорт БД, отладочные инструменты.",
@@ -732,7 +732,7 @@
   "unknownAnimation": "Неизвестная анимация",
   "unknownVisualNovel": "Неизвестная визуальная новелла",
   "unknownManga": "Неизвестная манга",
-  "unknownCustom": "Неизвестный элемент",
+  "unknownCustom": "Неизвестный тайтл",
   "unknownPlatform": "Неизвестная платформа",
   "defaultAuthor": "Пользователь",
 
@@ -749,10 +749,10 @@
   "allItemsRatingAsc": "Оценка ↑",
   "allItemsRatingDesc": "Оценка ↓",
   "allItemsRating": "Оценка",
-  "allItemsNoItems": "Пока нет элементов",
-  "allItemsNoMatch": "Нет элементов по фильтру",
-  "allItemsAddViaCollections": "Перейдите в Коллекции → создайте коллекцию → добавьте\nэлементы через Поиск. Они появятся здесь автоматически.",
-  "allItemsFailedToLoad": "Не удалось загрузить элементы",
+  "allItemsNoItems": "Пока нет тайтлов",
+  "allItemsNoMatch": "Нет тайтлов по фильтру",
+  "allItemsAddViaCollections": "Перейдите в Коллекции → создайте коллекцию → добавьте\nтайтлы через Поиск. Они появятся здесь автоматически.",
+  "allItemsFailedToLoad": "Не удалось загрузить тайтлы",
   "allItemsFilterPlatformsAll": "Все платформы",
   "allItemsFilterPlatformsSelected": "{count} платформ",
   "@allItemsFilterPlatformsSelected": {
@@ -791,7 +791,7 @@
   "debugLogosTab": "Логотипы",
   "debugIconsTab": "Иконки",
 
-  "collectionTileStats": "{count, plural, =1{1 элемент} few{{count} элемента} other{{count} элементов}} · {percent} завершено",
+  "collectionTileStats": "{count, plural, =1{1 тайтл} few{{count} тайтла} other{{count} тайтлов}} · {percent} завершено",
   "@collectionTileStats": {
     "placeholders": {
       "count": {"type": "int"},
@@ -829,7 +829,7 @@
 
   "canvasFailedToLoad": "Не удалось загрузить доску",
   "canvasBoardEmpty": "Доска пуста",
-  "canvasBoardEmptyHint": "Сначала добавьте элементы в коллекцию",
+  "canvasBoardEmptyHint": "Сначала добавьте тайтлы в коллекцию",
   "canvasCenterView": "Центрировать вид",
   "canvasResetPositions": "Сбросить позиции",
   "canvasVgmapsBrowser": "Браузер VGMaps",
@@ -896,7 +896,7 @@
   "settingsShowBlurayOverlay": "Обложки Blu-ray",
   "settingsShowBlurayOverlaySubtitle": "Оверлей Blu-ray на постерах фильмов и сериалов",
   "settingsDiscordRpc": "Discord Rich Presence",
-  "settingsDiscordRpcSubtitle": "Показывать текущий элемент в статусе Discord",
+  "settingsDiscordRpcSubtitle": "Показывать текущий тайтл в статусе Discord",
   "settingsDiscordRaSync": "Синхронизация RetroAchievements",
   "settingsDiscordRaSyncSubtitle": "Показывать активность RetroAchievements в Discord",
 
@@ -952,7 +952,7 @@
   "tierListCreate": "Новый тир-лист",
   "tierListCreateFromCollection": "Создать тир-лист",
   "tierListNameHint": "Название тир-листа",
-  "tierListScopeAll": "Все элементы",
+  "tierListScopeAll": "Все тайтлы",
   "tierListScopeCollection": "Из коллекции",
   "tierListFromCollection": "Из: {name}",
   "@tierListFromCollection": {
@@ -975,11 +975,11 @@
   "tierListDeleteTier": "Удалить тир",
   "tierListAddTier": "Добавить тир",
   "tierListClearAll": "Очистить всё",
-  "tierListClearConfirm": "Убрать все элементы из тиров? Они вернутся в «Без тира».",
+  "tierListClearConfirm": "Убрать все тайтлы из тиров? Они вернутся в «Без тира».",
   "tierListDeleteConfirm": "Удалить этот тир-лист?",
   "tierListEmpty": "Пока нет тир-листов",
-  "tierListEmptyHint": "Нажмите + чтобы создать тир-лист и ранжировать\nэлементы из ваших коллекций.",
-  "tierListAllRanked": "Все элементы распределены!",
+  "tierListEmptyHint": "Нажмите + чтобы создать тир-лист и ранжировать\nтайтлы из ваших коллекций.",
+  "tierListAllRanked": "Все тайтлы распределены!",
   "tierListNoCollections": "Нет доступных коллекций",
   "tierListErrorEmptyName": "Введите название тир-листа",
   "tierListErrorNoCollection": "Выберите коллекцию",
@@ -1098,16 +1098,16 @@
     }
   },
   "importResultOpenCollection": "Открыть коллекцию",
-  "importResultWishlistHint": "Элементы, не найденные в базе данных, сохранены в Список желаний.",
+  "importResultWishlistHint": "Тайтлы, не найденные в базе данных, сохранены в Список желаний.",
   "importResultSourceCollectionFile": "Файл коллекции",
 
   "settingsBrowseCollections": "Каталог коллекций",
   "settingsBrowseCollectionsSubtitle": "Скачать готовые коллекции",
-  "browseCollectionsSummary": "{count} коллекций, {items} элементов",
+  "browseCollectionsSummary": "{count} коллекций, {items} тайтлов",
   "browseCollectionsSearch": "Поиск коллекций...",
   "browseCollectionsAllPlatforms": "Все платформы",
   "browseCollectionsAllCategories": "Все категории",
-  "browseCollectionsItems": "{count} элементов",
+  "browseCollectionsItems": "{count} тайтлов",
   "browseCollectionsFormatLight": "Лёгкий (нужны API-ключи)",
   "browseCollectionsFormatFull": "Полный (офлайн)",
   "browseCollectionsDownloading": "Загрузка...",
@@ -1225,7 +1225,7 @@
 
   "copyAsList": "Копировать списком",
   "copyAsText": "Копировать как текст…",
-  "copiedToClipboard": "{count,plural, =1{Скопирован 1 элемент} few{Скопировано {count} элемента} other{Скопировано {count} элементов}}",
+  "copiedToClipboard": "{count,plural, =1{Скопирован 1 тайтл} few{Скопировано {count} тайтла} other{Скопировано {count} тайтлов}}",
   "textExportTemplate": "Шаблон",
   "textExportTokens": "Токены",
   "textExportPreview": "Предпросмотр",
@@ -1239,7 +1239,7 @@
   "textExportEmptyTemplate": "Шаблон пустой",
   "filtersClear": "Сбросить",
 
-  "profiles": "Профили",
+  "profiles": "Профили приложения",
   "currentProfile": "Текущий: {name}",
   "switchProfile": "Сменить профиль",
   "addProfile": "Добавить профиль",
@@ -1252,7 +1252,7 @@
   "profileColor": "Цвет",
   "whoIsPlayingToday": "Кто сегодня играет?",
   "dontAskAgain": "Не спрашивать снова",
-  "profileStats": "{collections,plural, =1{1 коллекция} few{{collections} коллекции} other{{collections} коллекций}}, {items,plural, =1{1 элемент} few{{items} элемента} other{{items} элементов}}",
+  "profileStats": "{collections,plural, =1{1 коллекция} few{{collections} коллекции} other{{collections} коллекций}}, {items,plural, =1{1 тайтл} few{{items} тайтла} other{{items} тайтлов}}",
   "switchingProfile": "Переключение профиля…",
   "appWillRestart": "Приложение перезапустится для применения изменений.",
   "profileCreated": "Профиль создан",

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -915,7 +915,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
           controller: _authorController,
           hint: l.detailWriteReviewHint,
           hasContent: widget.hasAuthorComment,
-          onEmptyTap: widget.isEditable
+          onTap: widget.isEditable
               ? () => _startEditing(_EditingField.author)
               : null,
           displayWidget: widget.hasAuthorComment
@@ -991,7 +991,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
           controller: _userController,
           hint: l.detailWriteNotesHint,
           hasContent: widget.hasUserComment,
-          onEmptyTap: () => _startEditing(_EditingField.user),
+          onTap: () => _startEditing(_EditingField.user),
           displayWidget: widget.hasUserComment
               ? MiniMarkdownText(
                   text: widget.userComment!,
@@ -1011,8 +1011,10 @@ class _MediaDetailViewState extends State<MediaDetailView> {
 
   /// Общий контейнер для секции комментария: вид или inline-редактирование.
   ///
-  /// Если блок пустой и передан [onEmptyTap] — клик по контейнеру сразу
+  /// Если передан [onTap] — клик по контейнеру в режиме просмотра сразу
   /// переводит в режим редактирования (без нажатия кнопки «Редактировать»).
+  /// Клики по markdown-ссылкам внутри текста перехватываются span-recognizer'ами
+  /// и продолжают работать.
   Widget _buildCommentContainer({
     required Color accentColor,
     required bool isEditing,
@@ -1020,7 +1022,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
     required String hint,
     required bool hasContent,
     required Widget displayWidget,
-    VoidCallback? onEmptyTap,
+    VoidCallback? onTap,
   }) {
     final BorderRadius radius = BorderRadius.circular(AppSpacing.radiusSm);
     final BoxDecoration decoration = BoxDecoration(
@@ -1070,12 +1072,12 @@ class _MediaDetailViewState extends State<MediaDetailView> {
       child: displayWidget,
     );
 
-    if (!hasContent && onEmptyTap != null) {
+    if (onTap != null) {
       return Material(
         color: Colors.transparent,
         borderRadius: radius,
         child: InkWell(
-          onTap: onEmptyTap,
+          onTap: onTap,
           borderRadius: radius,
           child: content,
         ),

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -915,6 +915,9 @@ class _MediaDetailViewState extends State<MediaDetailView> {
           controller: _authorController,
           hint: l.detailWriteReviewHint,
           hasContent: widget.hasAuthorComment,
+          onEmptyTap: widget.isEditable
+              ? () => _startEditing(_EditingField.author)
+              : null,
           displayWidget: widget.hasAuthorComment
               ? MiniMarkdownText(
                   text: widget.authorComment!,
@@ -988,6 +991,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
           controller: _userController,
           hint: l.detailWriteNotesHint,
           hasContent: widget.hasUserComment,
+          onEmptyTap: () => _startEditing(_EditingField.user),
           displayWidget: widget.hasUserComment
               ? MiniMarkdownText(
                   text: widget.userComment!,
@@ -1006,6 +1010,9 @@ class _MediaDetailViewState extends State<MediaDetailView> {
   }
 
   /// Общий контейнер для секции комментария: вид или inline-редактирование.
+  ///
+  /// Если блок пустой и передан [onEmptyTap] — клик по контейнеру сразу
+  /// переводит в режим редактирования (без нажатия кнопки «Редактировать»).
   Widget _buildCommentContainer({
     required Color accentColor,
     required bool isEditing,
@@ -1013,43 +1020,68 @@ class _MediaDetailViewState extends State<MediaDetailView> {
     required String hint,
     required bool hasContent,
     required Widget displayWidget,
+    VoidCallback? onEmptyTap,
   }) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSpacing.md - 4),
-      decoration: BoxDecoration(
-        color: accentColor.withAlpha(20),
-        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
-        border: Border.all(
-          color: accentColor.withAlpha(isEditing ? 80 : 40),
-        ),
+    final BorderRadius radius = BorderRadius.circular(AppSpacing.radiusSm);
+    final BoxDecoration decoration = BoxDecoration(
+      color: accentColor.withAlpha(20),
+      borderRadius: radius,
+      border: Border.all(
+        color: accentColor.withAlpha(isEditing ? 80 : 40),
       ),
-      child: isEditing
-          ? Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                MarkdownToolbar(controller: controller),
-                const SizedBox(height: 4),
-                TextField(
-                  controller: controller,
-                  maxLines: 5,
-                  minLines: 2,
-                  autofocus: true,
-                  style: AppTypography.body.copyWith(height: 1.5),
-                  decoration: InputDecoration(
-                    hintText: hint,
-                    border: InputBorder.none,
-                    focusedBorder: InputBorder.none,
-                    enabledBorder: InputBorder.none,
-                    filled: false,
-                    isDense: true,
-                    contentPadding: EdgeInsets.zero,
-                  ),
-                ),
-              ],
-            )
-          : displayWidget,
     );
+    const EdgeInsets padding = EdgeInsets.all(AppSpacing.md - 4);
+
+    if (isEditing) {
+      return Container(
+        width: double.infinity,
+        padding: padding,
+        decoration: decoration,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            MarkdownToolbar(controller: controller),
+            const SizedBox(height: 4),
+            TextField(
+              controller: controller,
+              maxLines: 5,
+              minLines: 2,
+              autofocus: true,
+              style: AppTypography.body.copyWith(height: 1.5),
+              decoration: InputDecoration(
+                hintText: hint,
+                border: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                filled: false,
+                isDense: true,
+                contentPadding: EdgeInsets.zero,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final Widget content = Container(
+      width: double.infinity,
+      padding: padding,
+      decoration: decoration,
+      child: displayWidget,
+    );
+
+    if (!hasContent && onEmptyTap != null) {
+      return Material(
+        color: Colors.transparent,
+        borderRadius: radius,
+        child: InkWell(
+          onTap: onEmptyTap,
+          borderRadius: radius,
+          child: content,
+        ),
+      );
+    }
+    return content;
   }
 
 }

--- a/test/features/collections/screens/collection_screen_test.dart
+++ b/test/features/collections/screens/collection_screen_test.dart
@@ -507,6 +507,68 @@ void main() {
         expect(find.text('Inception'), findsOneWidget);
         expect(find.text('Breaking Bad'), findsOneWidget);
       });
+
+      testWidgets('должен находить по тексту в userComment (заметки)',
+          (WidgetTester tester) async {
+        final List<CollectionItem> itemsWithNotes = <CollectionItem>[
+          testItems[0].copyWith(
+            userComment: 'настоящий шедевр геймдева',
+          ), // Zelda
+          testItems[1], // Inception — без заметки
+          testItems[2], // Breaking Bad — без заметки
+        ];
+        when(() => mockRepo.getItemsWithData(
+              1,
+              mediaType: any(named: 'mediaType'),
+            )).thenAnswer((_) async => itemsWithNotes);
+
+        await tester.pumpWidget(createWidget(searchQuery: 'шедевр'));
+        await pumpScreen(tester);
+
+        expect(find.text('Zelda'), findsOneWidget);
+        expect(find.text('Inception'), findsNothing);
+        expect(find.text('Breaking Bad'), findsNothing);
+      });
+
+      testWidgets('должен находить по тексту в authorComment (рецензия)',
+          (WidgetTester tester) async {
+        final List<CollectionItem> itemsWithReviews = <CollectionItem>[
+          testItems[0], // Zelda — без рецензии
+          testItems[1].copyWith(
+            authorComment: 'переоценённый проходняк',
+          ), // Inception
+          testItems[2], // Breaking Bad — без рецензии
+        ];
+        when(() => mockRepo.getItemsWithData(
+              1,
+              mediaType: any(named: 'mediaType'),
+            )).thenAnswer((_) async => itemsWithReviews);
+
+        await tester.pumpWidget(createWidget(searchQuery: 'проходняк'));
+        await pumpScreen(tester);
+
+        expect(find.text('Inception'), findsOneWidget);
+        expect(find.text('Zelda'), findsNothing);
+        expect(find.text('Breaking Bad'), findsNothing);
+      });
+
+      testWidgets('поиск по заметкам должен быть case-insensitive',
+          (WidgetTester tester) async {
+        final List<CollectionItem> itemsWithNotes = <CollectionItem>[
+          testItems[0].copyWith(userComment: 'Настоящий ШЕДЕВР'),
+          testItems[1],
+        ];
+        when(() => mockRepo.getItemsWithData(
+              1,
+              mediaType: any(named: 'mediaType'),
+            )).thenAnswer((_) async => itemsWithNotes);
+
+        await tester.pumpWidget(createWidget(searchQuery: 'шедевр'));
+        await pumpScreen(tester);
+
+        expect(find.text('Zelda'), findsOneWidget);
+        expect(find.text('Inception'), findsNothing);
+      });
     });
 
     group('комбинированные фильтры', () {

--- a/test/features/settings/screens/kodi_screen_test.dart
+++ b/test/features/settings/screens/kodi_screen_test.dart
@@ -102,11 +102,11 @@ void main() {
             )),
         ...extraOverrides,
       ],
-      child: MaterialApp(
+      child: const MaterialApp(
         localizationsDelegates: S.localizationsDelegates,
         supportedLocales: S.supportedLocales,
-        locale: const Locale('en'),
-        home: const Scaffold(body: KodiScreen()),
+        locale: Locale('en'),
+        home: Scaffold(body: KodiScreen()),
       ),
     );
   }

--- a/test/features/settings/screens/kodi_screen_test.dart
+++ b/test/features/settings/screens/kodi_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:xerabora/features/settings/providers/profile_provider.dart';
 import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/features/settings/screens/kodi_screen.dart';
 import 'package:xerabora/features/settings/widgets/settings_group.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
 import 'package:xerabora/features/settings/widgets/settings_tile.dart';
 import 'package:xerabora/shared/models/kodi_application_info.dart';
 import 'package:xerabora/shared/models/profile.dart';
@@ -101,8 +102,11 @@ void main() {
             )),
         ...extraOverrides,
       ],
-      child: const MaterialApp(
-        home: Scaffold(body: KodiScreen()),
+      child: MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        locale: const Locale('en'),
+        home: const Scaffold(body: KodiScreen()),
       ),
     );
   }


### PR DESCRIPTION
## 🇬🇧 English

### ✨ Added

- **Right-click / long-press on empty area of the Collections screen** opens a popup with the FAB primary actions: New Collection, Import Collection, Toggle grid/list view. The card-level right-click menu (Open/Rename/Delete) is unchanged and keeps priority on cards.
- **Right-click / long-press on a card in All Items** opens Move to collection / Copy to collection / Remove — same menu as inside a collection.
- **Search now matches user notes and author review** — the in-collection search bar and the All Items global search also check `userComment` and `authorComment`, in addition to title and tag name. Case-insensitive.

### 🔧 Changed (UX)

- **Tap anywhere on the review/notes block to edit** — no need to find the ✏️ icon anymore. A single tap puts the field into editing mode (empty or populated). Markdown links inside rendered text still work. Author review stays read-only in read-only collections.
- **Kodi settings screen fully localized** — Connection, Sync, Debug, Request Log sections, and all field labels/status strings now display in Russian. Technical Raw JSON-RPC labels (Kodi API method names) stay in English because they match Kodi's API.
- **Vague UI terms renamed:**
  - «Список» (Wishlist nav tab) → **«Желаемое»** in Russian
  - «Профили» / «Профиль» in Settings → **«Профили приложения»** / **«Автор коллекций»** (EN: "App profiles" / "Collection author"), resolving the ambiguity between multi-user profiles and the collection author name
  - «элемент» → **«тайтл»** across ~27 strings (stats, plurals, snackbars, tier lists, tags, imports, wishlist, all-items). "Element" kept on the canvas where it refers to board primitives (text/sticker/link), not collection items.

### 🐞 Fixed

- Fallback hints on an empty collection («Add items to start building your collection.», «This collection is empty.») were still hardcoded English — now localized.

### 🧪 Tests

- Covered the note/review search filter (3 cases: userComment match, authorComment match, case-insensitive).
- Full suite: **4768 passed**, `flutter analyze --fatal-infos --fatal-warnings` clean.

### 📚 Docs

- `CHANGELOG.md` — `[Unreleased]` section filled in.
- Wiki: annotations tagged `(since v0.28.0)` added on **Collections**, **Item-Details**, **Settings**, **Wishlist**, **Kodi-Sync** pages (both EN and RU).

### 🧹 Tech debt

- Removed the stale line «18 таблиц, текущая версия БД: 24» from `.claude/CLAUDE.md` — it drifted 10+ migrations behind. Replaced with a pointer to the code as the source of truth.

---

## 🇷🇺 Русский

### ✨ Новое

- **ПКМ / длинное нажатие по пустому месту экрана коллекций** открывает меню с действиями FAB: «Новая коллекция», «Импорт коллекции», «Переключить вид». Правый клик по самой карточке по-прежнему даёт Open/Rename/Delete.
- **ПКМ / длинное нажатие на карточке во «Все тайтлы»** — меню «Переместить» / «Скопировать» / «Убрать», такое же как внутри коллекции.
- **Поиск ищет по личным заметкам и авторской рецензии** — и в коллекции, и на «Все тайтлы». Теперь можно найти тайтл по тому, что вы о нём написали. Регистро-нечувствительный.

### 🔧 Улучшения UX

- **Клик по блоку заметок/рецензии = редактирование** — больше не нужно искать иконку «✏️». Одиночный клик переводит поле в режим редактирования (как для пустого блока, так и для блока с текстом). Markdown-ссылки внутри продолжают работать. В read-only коллекциях клик по рецензии автора не реагирует.
- **Экран Kodi полностью переведён на русский** — секции «Подключение», «Синхронизация», «Отладка», «Лог запросов», а также поля и статусы. Технические надписи Raw JSON-RPC оставлены на английском (соответствуют API Kodi).
- **Переименование запутанных терминов:**
  - «Список» (вкладка в сайдбаре) → **«Желаемое»**
  - «Профили» / «Профиль» (в настройках) → **«Профили приложения»** / **«Автор коллекций»** (EN: «App profiles» / «Collection author») — чтобы не путать профили приложения с именем автора коллекций
  - «элемент» → **«тайтл»** по всему UI (~27 строк: статистика, плюрал-формы, снэкбары, тир-листы, теги, импорты, вишлист, «Все тайтлы»). «Элемент» оставлен на канвасе — там речь про текст/стикер/картинку, а не про тайтл.

### 🐞 Исправления

- Подсказки на пустой коллекции («Add items to start building your collection.», «This collection is empty.») оставались на английском — теперь переведены.

### 🧪 Тесты

- Покрыт фильтр поиска по заметкам/рецензии (3 кейса: userComment, authorComment, регистро-нечувствительность).
- Полный прогон: **4768 passed**, `flutter analyze --fatal-infos --fatal-warnings` чисто.

### 📚 Документация

- `CHANGELOG.md` — заполнена секция `[Unreleased]`.
- Wiki: на страницах **Collections**, **Item-Details**, **Settings**, **Wishlist**, **Kodi-Sync** (EN + RU) добавлены пометки `(с v0.28.0)`.

### 🧹 Tech debt

- Из `.claude/CLAUDE.md` удалена устаревшая строка «18 таблиц, текущая версия БД: 24» — отставала от кода на 10+ миграций. Вместо конкретного числа теперь ссылка на код как на источник правды.
