### PR TITLE
test: drop visual-only icon assertions in widget tests

### DIFF
--- a/test/features/collections/widgets/activity_dates_section_test.dart
+++ b/test/features/collections/widgets/activity_dates_section_test.dart
@@ -216,32 +216,6 @@ void main() {
     });
 
     group('editable behavior', () {
-      testWidgets('should show edit icons when editable', (WidgetTester tester) async {
-        await tester.pumpApp(
-          ActivityDatesSection(
-            addedAt: DateTime(2025, 1, 15),
-            isEditable: true,
-            onDateChanged: (String type, DateTime date) async {},
-          ),
-        );
-
-        // Edit icons for Started and Completed
-        expect(find.byIcon(Icons.edit_outlined), findsNWidgets(2));
-      });
-
-      testWidgets('should not show edit icons when not editable',
-          (WidgetTester tester) async {
-        await tester.pumpApp(
-          ActivityDatesSection(
-            addedAt: DateTime(2025, 1, 15),
-            isEditable: false,
-            onDateChanged: (String type, DateTime date) async {},
-          ),
-        );
-
-        expect(find.byIcon(Icons.edit_outlined), findsNothing);
-      });
-
       testWidgets('should wrap editable dates in InkWell', (WidgetTester tester) async {
         await tester.pumpApp(
           ActivityDatesSection(
@@ -251,28 +225,21 @@ void main() {
           ),
         );
 
-        // InkWell for Started and Completed
+        // Started and Completed dates are tappable when editable.
         expect(find.byType(InkWell), findsNWidgets(2));
       });
 
-      testWidgets('should call onDateChanged when date is tapped',
+      testWidgets('should not wrap dates in InkWell when not editable',
           (WidgetTester tester) async {
         await tester.pumpApp(
           ActivityDatesSection(
             addedAt: DateTime(2025, 1, 15),
-            isEditable: true,
+            isEditable: false,
             onDateChanged: (String type, DateTime date) async {},
           ),
-          wrapInScaffold: true,
         );
 
-        // Mock showDatePicker by directly testing the callback
-        // In real app, tapping would open date picker, but in test we verify the mechanism exists
-        expect(find.byType(InkWell), findsNWidgets(2));
-
-        // We can't easily test the date picker dialog in widget tests
-        // but we can verify that the onTap handlers exist and the widget is structured correctly
-        expect(find.byIcon(Icons.edit_outlined), findsNWidgets(2));
+        expect(find.byType(InkWell), findsNothing);
       });
     });
   });

--- a/test/features/collections/widgets/canvas_link_item_test.dart
+++ b/test/features/collections/widgets/canvas_link_item_test.dart
@@ -97,22 +97,6 @@ void main() {
     );
 
     testWidgets(
-      'должен показывать иконку ссылки',
-      (WidgetTester tester) async {
-        final CanvasItem item = createLinkItem(
-          data: <String, dynamic>{
-            'url': 'https://example.com',
-            'label': 'Test',
-          },
-        );
-
-        await tester.pumpWidget(buildWidget(item));
-
-        expect(find.byIcon(Icons.link), findsOneWidget);
-      },
-    );
-
-    testWidgets(
       'должен рендерить Card без явного SizedBox (размер от родителя)',
       (WidgetTester tester) async {
         final CanvasItem item = createLinkItem(
@@ -126,10 +110,7 @@ void main() {
 
         await tester.pumpWidget(buildWidget(item));
 
-        // Card рендерится, размеры определяются родителем Positioned
         expect(find.byType(Card), findsOneWidget);
-        // Row внутри Card содержит иконку и текст
-        expect(find.byIcon(Icons.link), findsOneWidget);
         expect(find.text('Test'), findsOneWidget);
       },
     );

--- a/test/features/collections/widgets/canvas_view_test.dart
+++ b/test/features/collections/widgets/canvas_view_test.dart
@@ -328,7 +328,6 @@ void main() {
           await tester.pumpWidget(buildTestWidget(canvasState: normalState));
           await tester.pump();
 
-          expect(find.byIcon(Icons.fit_screen), findsOneWidget);
           expect(find.byTooltip('Center view'), findsOneWidget);
         },
       );
@@ -350,7 +349,6 @@ void main() {
           await tester.pumpWidget(buildTestWidget(canvasState: normalState));
           await tester.pump();
 
-          expect(find.byIcon(Icons.grid_view), findsOneWidget);
           expect(find.byTooltip('Reset positions'), findsOneWidget);
         },
       );
@@ -423,7 +421,6 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.byIcon(Icons.image_search), findsOneWidget);
           expect(find.byTooltip('SteamGridDB Images'), findsOneWidget);
         },
       );
@@ -448,10 +445,8 @@ void main() {
           await tester.pump();
 
           if (kVgMapsEnabled) {
-            expect(find.byIcon(Icons.map), findsOneWidget);
             expect(find.byTooltip('VGMaps Browser'), findsOneWidget);
           } else {
-            expect(find.byIcon(Icons.map), findsNothing);
             expect(find.byTooltip('VGMaps Browser'), findsNothing);
           }
         },
@@ -476,7 +471,7 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.byIcon(Icons.map), findsNothing);
+          expect(find.byTooltip('VGMaps Browser'), findsNothing);
         },
       );
 
@@ -499,7 +494,7 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.byIcon(Icons.image_search), findsNothing);
+          expect(find.byTooltip('SteamGridDB Images'), findsNothing);
         },
       );
 

--- a/test/features/collections/widgets/collection_card_test.dart
+++ b/test/features/collections/widgets/collection_card_test.dart
@@ -590,14 +590,5 @@ void main() {
       expect(tapped, isTrue);
     });
 
-    testWidgets('должен показать иконку inbox', (WidgetTester tester) async {
-      await tester.pumpWidget(_buildTestApp(
-        overrides: <Override>[],
-        child: const UncategorizedCard(count: 1),
-      ));
-      await tester.pumpAndSettle();
-
-      expect(find.byIcon(Icons.inbox_rounded), findsOneWidget);
-    });
   });
 }

--- a/test/features/collections/widgets/steamgriddb_panel_test.dart
+++ b/test/features/collections/widgets/steamgriddb_panel_test.dart
@@ -190,7 +190,6 @@ void main() {
 
         expect(find.text('SteamGridDB API key not set. Configure it in Settings.'),
             findsOneWidget);
-        expect(find.byIcon(Icons.warning_amber), findsOneWidget);
       });
 
       testWidgets('should not show warning when API key is set',
@@ -289,7 +288,6 @@ void main() {
         ));
 
         expect(find.text('Rate limit exceeded'), findsOneWidget);
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
       });
 
       testWidgets('should display image error',

--- a/test/features/collections/widgets/vgmaps_panel_test.dart
+++ b/test/features/collections/widgets/vgmaps_panel_test.dart
@@ -366,7 +366,6 @@ void main() {
         ));
 
         expect(find.text('WebView failed to load'), findsOneWidget);
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
       });
 
       testWidgets('should not show error when no error',
@@ -375,7 +374,7 @@ void main() {
           panelState: const VgMapsPanelState(isOpen: true),
         ));
 
-        expect(find.byIcon(Icons.error_outline), findsNothing);
+        expect(find.textContaining('failed'), findsNothing);
       });
     });
 


### PR DESCRIPTION
Tests should fail only when logic breaks, not when icons change. Removed redundant `find.byIcon` assertions where either a tooltip / InkWell / text finder already covered the same behaviour, and deleted the duplicate UncategorizedCard "inbox icon" test and the two edit-icon visibility tests in ActivityDatesSection (InkWell presence already proves editability).