### PR TITLE
fix(ra-import): respect manual RA↔IGDB links and report wishlist count honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * lib/features/search/widgets/source_dropdown.dart (SourceDropdown, _sourceGlyph): Render brand PNG (22 px for current source, 20 px for group headers) when asset is set.
   * lib/features/search/widgets/filter_bar.dart: Render group brand PNG (20 px) in the filter-bar popup.
 
+### Fixed
+
+- **RetroAchievements sync now respects manual RA↔IGDB links and reports wishlist count honestly**
+
+  Previously, when a game went to the wishlist because IGDB couldn't match it by name, manually adding the game and linking it to RA via the achievement card had no effect on subsequent syncs — the same game was offered to the wishlist again every run, because the importer only matched via `IgdbApi.multiSearchGamesByName` and never read the `tracker_game_data` table it was already writing to. Now the importer pre-fetches all RA→IGDB rows from `tracker_game_data` before searching IGDB and reuses the cached `Game` instead of doing a name-based lookup; broken links (cached `Game` missing) fall back to the existing IGDB search path. The result struct also separates `unmatched` (no IGDB match and no manual link) from `wishlisted` (rows actually inserted this run), so when `addToWishlist` is off or the wishlist row already existed, the result screen no longer claims new wishlist additions. Progress UI now splits the IGDB lookup phase (`searchingGames`) from the collection-write phase (`matchingGames`) instead of running both under the same stage.
+
+  * lib/core/services/ra_import_service.dart (RaImportService.importFromProfile, RaImportService._resolveIgdbGame, RaImportService._addToWishlistIfNotExists, RaImportStage, RaImportResult, RaImportResultToUniversal): Pre-fetch `tracker_game_data` for `TrackerType.ra`, build `raIdToIgdbId` map, split `games` into linked/unlinked, only batch-search the unlinked subset. New `_resolveIgdbGame` helper picks the cached `Game` for linked entries and falls back to a single IGDB search when the local cache misses. `_addToWishlistIfNotExists` now returns `bool` so the caller increments `wishlisted` only when a new row was actually inserted. `RaImportResult` gains a `wishlisted` field; `toUniversal()` reads `wishlistedByType` from `wishlisted` instead of `unmatched`. New `RaImportStage.searchingGames` covers IGDB lookup; `matchingGames` is reserved for the collection writes. `_trackerDao` is now required (was nullable) — needed for the link lookup to work outside tests.
+  * lib/features/settings/content/ra_import_content.dart (_RaImportContentState._buildProgressSection): Render the new `searchingGames` stage with `l.raImportSearchingIgdb`.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (raImportSearchingIgdb): New string for the IGDB-search progress stage.
+  * test/core/services/ra_import_service_test.dart: New cases — manual link skips IGDB and reuses cached game; broken manual link falls back to IGDB search; `wishlisted=0` when `addToWishlist=false`; `wishlisted=0` when the wishlist row already existed; `RaImportResult.wishlisted` constructor + `toUniversal` mapping. Existing progress test updated to assert `searchingGames` and `matchingGames` both fire.
+
 ## [0.28.0] - 2026-04-23
 
 ### Added

--- a/lib/core/services/ra_import_service.dart
+++ b/lib/core/services/ra_import_service.dart
@@ -31,7 +31,10 @@ enum RaImportStage {
   /// Загрузка библиотеки из RA API.
   fetchingLibrary,
 
-  /// Поиск игр в IGDB и добавление в коллекцию.
+  /// Поиск игр в IGDB (только для игр без ручной привязки).
+  searchingGames,
+
+  /// Запись в коллекцию (добавление/обновление).
   matchingGames,
 
   /// Импорт завершён.
@@ -81,6 +84,7 @@ class RaImportResult {
     required this.added,
     required this.updated,
     required this.unmatched,
+    required this.wishlisted,
     required this.unmatchedTitles,
     required this.collectionId,
   });
@@ -94,8 +98,12 @@ class RaImportResult {
   /// Обновлена мета у существующих.
   final int updated;
 
-  /// Не найдено в IGDB.
+  /// Не найдено в IGDB и нет ручной привязки.
   final int unmatched;
+
+  /// Фактически добавлено новых записей в вишлист в этом синке.
+  /// Не включает уже существовавшие записи (они только обновляются).
+  final int wishlisted;
 
   /// Названия ненайденных игр.
   final List<String> unmatchedTitles;
@@ -119,8 +127,8 @@ extension RaImportResultToUniversal on RaImportResult {
       updatedByType: updated > 0
           ? <MediaType, int>{MediaType.game: updated}
           : <MediaType, int>{},
-      wishlistedByType: unmatched > 0
-          ? <MediaType, int>{MediaType.game: unmatched}
+      wishlistedByType: wishlisted > 0
+          ? <MediaType, int>{MediaType.game: wishlisted}
           : <MediaType, int>{},
     );
   }
@@ -151,7 +159,7 @@ class RaImportService {
     required RaApi raApi,
     required IgdbApi igdbApi,
     required DatabaseService database,
-    TrackerDao? trackerDao,
+    required TrackerDao trackerDao,
   })  : _raApi = raApi,
         _igdbApi = igdbApi,
         _db = database,
@@ -160,7 +168,7 @@ class RaImportService {
   final RaApi _raApi;
   final IgdbApi _igdbApi;
   final DatabaseService _db;
-  final TrackerDao? _trackerDao;
+  final TrackerDao _trackerDao;
   static final Logger _log = Logger('RaImportService');
 
   /// Импортирует игры из RA профиля в коллекцию.
@@ -202,33 +210,60 @@ class RaImportService {
     final int targetCollectionId =
         collectionId ?? await createCollection!();
 
-    // Batch-поиск в IGDB через multiquery (по 10 игр за запрос).
+    // Подтягиваем существующие ручные RA→IGDB привязки из tracker_game_data.
+    // Если игра уже привязана юзером (через showRaLinkDialog/linkRaGame),
+    // не идём в IGDB-поиск, а используем сохранённый IGDB id.
+    final List<TrackerGameData> manualLinks =
+        await _trackerDao.getAllGameData(TrackerType.ra);
+    final Map<int, int> raIdToIgdbId = <int, int>{};
+    for (final TrackerGameData d in manualLinks) {
+      final int? raId = int.tryParse(d.trackerGameId);
+      if (raId != null) raIdToIgdbId[raId] = d.gameId;
+    }
+
+    // IGDB-поиск нужен только для непривязанных игр.
+    final List<RaGameProgress> unlinkedGames = <RaGameProgress>[
+      for (final RaGameProgress g in games)
+        if (!raIdToIgdbId.containsKey(g.gameId)) g,
+    ];
+
+    // Этап 1: IGDB-поиск.
     onProgress(RaImportProgress(
-      stage: RaImportStage.matchingGames,
+      stage: RaImportStage.searchingGames,
       current: 0,
-      total: games.length,
+      total: unlinkedGames.length,
     ));
 
-    final Map<int, Game?> igdbMatches = await _batchFindGames(
-      games,
-      onBatchDone: (int processed) {
-        onProgress(RaImportProgress(
-          stage: RaImportStage.matchingGames,
-          current: processed,
-          total: games.length,
-        ));
-      },
-    );
+    final Map<int, Game?> matchesByIndex = unlinkedGames.isEmpty
+        ? <int, Game?>{}
+        : await _batchFindGames(
+            unlinkedGames,
+            onBatchDone: (int processed) {
+              onProgress(RaImportProgress(
+                stage: RaImportStage.searchingGames,
+                current: processed,
+                total: unlinkedGames.length,
+              ));
+            },
+          );
+
+    // Индексируем по RA gameId — стабильный ключ, без позиционных кёрсоров.
+    final Map<int, Game?> searchByRaId = <int, Game?>{
+      for (int i = 0; i < unlinkedGames.length; i++)
+        unlinkedGames[i].gameId: matchesByIndex[i],
+    };
 
     _log.info(
-      'IGDB matched ${igdbMatches.values.where((Game? g) => g != null).length}'
-      '/${games.length} RA games',
+      'IGDB matched ${searchByRaId.values.where((Game? g) => g != null).length}'
+      '/${unlinkedGames.length} unlinked RA games '
+      '(${raIdToIgdbId.length} already manually linked)',
     );
 
-    // Обработка каждой игры.
+    // Этап 2: запись в коллекцию.
     int added = 0;
     int updated = 0;
     int unmatched = 0;
+    int wishlisted = 0;
     final List<String> unmatchedTitles = <String>[];
 
     for (int i = 0; i < games.length; i++) {
@@ -244,13 +279,18 @@ class RaImportService {
         unmatchedCount: unmatched,
       ));
 
-      final Game? igdbGame = igdbMatches[i];
+      final Game? igdbGame = await _resolveIgdbGame(
+        raGame,
+        linkedIgdbId: raIdToIgdbId[raGame.gameId],
+        searchResult: searchByRaId[raGame.gameId],
+      );
 
       if (igdbGame == null) {
         unmatched++;
         unmatchedTitles.add('${raGame.title} (${raGame.consoleName})');
         if (addToWishlist) {
-          await _addToWishlistIfNotExists(raGame);
+          final bool wasAdded = await _addToWishlistIfNotExists(raGame);
+          if (wasAdded) wishlisted++;
         }
         continue;
       }
@@ -283,7 +323,7 @@ class RaImportService {
         added++;
       }
 
-      // Сохраняем tracker_game_data для RA секции в карточке.
+      // Сохраняем/обновляем tracker_game_data (счётчики ачивок, даты).
       await _saveTrackerGameData(igdbGame.id, raGame);
     }
 
@@ -298,7 +338,8 @@ class RaImportService {
 
     _log.info(
       'RA import done: $added added, $updated updated, '
-      '$unmatched unmatched out of ${games.length}',
+      '$unmatched unmatched ($wishlisted newly wishlisted) '
+      'out of ${games.length}',
     );
 
     return RaImportResult(
@@ -306,9 +347,39 @@ class RaImportService {
       added: added,
       updated: updated,
       unmatched: unmatched,
+      wishlisted: wishlisted,
       unmatchedTitles: unmatchedTitles,
       collectionId: targetCollectionId,
     );
+  }
+
+  /// Возвращает IGDB-игру для RA-записи: сначала по ручной привязке
+  /// (через локальный кэш игр), потом — fallback на результат IGDB-поиска.
+  ///
+  /// Если ручная привязка указывает на IGDB id, которого нет в локальном
+  /// кэше, делает дополнительный точечный поиск по названию (защита
+  /// от устаревшей записи в `tracker_game_data`).
+  Future<Game?> _resolveIgdbGame(
+    RaGameProgress raGame, {
+    required int? linkedIgdbId,
+    required Game? searchResult,
+  }) async {
+    if (linkedIgdbId != null) {
+      final Game? cached = await _db.getGameById(linkedIgdbId);
+      if (cached != null) return cached;
+      _log.warning(
+        'Manual link for RA gameId=${raGame.gameId} → IGDB id=$linkedIgdbId, '
+        'but game not found in local cache. Falling back to IGDB search.',
+      );
+      final RaToIgdbMapper mapper = RaToIgdbMapper(_igdbApi);
+      try {
+        return await mapper.findIgdbGame(raGame);
+      } on IgdbApiException catch (e) {
+        _log.warning('Fallback IGDB search failed: ${e.message}');
+        return null;
+      }
+    }
+    return searchResult;
   }
 
   /// Batch-поиск игр в IGDB через multiquery.
@@ -405,18 +476,22 @@ class RaImportService {
     return true;
   }
 
-  Future<void> _addToWishlistIfNotExists(RaGameProgress raGame) async {
+  /// Возвращает `true` если запись действительно создана,
+  /// `false` если игра уже была в вишлисте (не перезаписываем,
+  /// чтобы не затереть пользовательские правки).
+  Future<bool> _addToWishlistIfNotExists(RaGameProgress raGame) async {
     final String title = '${raGame.title} (${raGame.consoleName})';
     final WishlistItem? existing = await _db.findUnresolvedWishlistItem(title);
-    if (existing != null) return;
+    if (existing != null) return false;
 
     await _db.addWishlistItem(
       text: title,
       mediaTypeHint: MediaType.game,
-      note: 'From RetroAchievements \u2022 '
+      note: 'From RetroAchievements • '
           '${raGame.numAwarded}/${raGame.maxPossible} achievements'
-          '${raGame.highestAwardKind != null ? ' \u2022 ${raGame.highestAwardKind}' : ''}',
+          '${raGame.highestAwardKind != null ? ' • ${raGame.highestAwardKind}' : ''}',
     );
+    return true;
   }
 
   Future<void> _addToCollection({
@@ -452,7 +527,6 @@ class RaImportService {
     int igdbId,
     RaGameProgress raGame,
   ) async {
-    if (_trackerDao == null) return;
     final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final int? awardTimestamp = raGame.highestAwardDate != null
         ? raGame.highestAwardDate!.millisecondsSinceEpoch ~/ 1000

--- a/lib/features/settings/content/ra_import_content.dart
+++ b/lib/features/settings/content/ra_import_content.dart
@@ -345,6 +345,8 @@ class _RaImportContentState extends ConsumerState<RaImportContent> {
     switch (progress.stage) {
       case RaImportStage.fetchingLibrary:
         stageText = l.raImportFetchingLibrary;
+      case RaImportStage.searchingGames:
+        stageText = l.raImportSearchingIgdb;
       case RaImportStage.matchingGames:
         stageText = l.raImportMatching(progress.currentName ?? '');
       case RaImportStage.completed:

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1431,6 +1431,7 @@
   "raImportSelectCollection": "Select collection",
   "raImportErrorLoadingCollections": "Error loading collections",
   "raImportFetchingLibrary": "Fetching RA library...",
+  "raImportSearchingIgdb": "Searching games on IGDB...",
   "raImportMatching": "Matching: {title}",
   "@raImportMatching": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5827,6 +5827,12 @@ abstract class S {
   /// **'Fetching RA library...'**
   String get raImportFetchingLibrary;
 
+  /// No description provided for @raImportSearchingIgdb.
+  ///
+  /// In en, this message translates to:
+  /// **'Searching games on IGDB...'**
+  String get raImportSearchingIgdb;
+
   /// No description provided for @raImportMatching.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3169,6 +3169,9 @@ class SEn extends S {
   String get raImportFetchingLibrary => 'Fetching RA library...';
 
   @override
+  String get raImportSearchingIgdb => 'Searching games on IGDB...';
+
+  @override
   String raImportMatching(String title) {
     return 'Matching: $title';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3188,8 +3188,11 @@ class SRu extends S {
   String get raImportFetchingLibrary => 'Загрузка библиотеки RA...';
 
   @override
+  String get raImportSearchingIgdb => 'Поиск игр на IGDB...';
+
+  @override
   String raImportMatching(String title) {
-    return 'Поиск: $title';
+    return 'Сопоставление: $title';
   }
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1181,7 +1181,8 @@
   "raImportSelectCollection": "Выберите коллекцию",
   "raImportErrorLoadingCollections": "Ошибка загрузки коллекций",
   "raImportFetchingLibrary": "Загрузка библиотеки RA...",
-  "raImportMatching": "Поиск: {title}",
+  "raImportSearchingIgdb": "Поиск игр на IGDB...",
+  "raImportMatching": "Сопоставление: {title}",
   "@raImportMatching": {
     "placeholders": {
       "title": {"type": "String"}

--- a/test/core/services/ra_import_service_test.dart
+++ b/test/core/services/ra_import_service_test.dart
@@ -10,6 +10,8 @@ import 'package:xerabora/shared/models/game.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/ra_game_progress.dart';
+import 'package:xerabora/shared/models/tracker_game_data.dart';
+import 'package:xerabora/shared/models/tracker_profile.dart';
 import 'package:xerabora/shared/models/universal_import_result.dart';
 import '../../helpers/test_helpers.dart';
 
@@ -56,9 +58,11 @@ void main() {
     progressCalls = <RaImportProgress>[];
     igdbGamesByTitle.clear();
 
-    // Default mock для TrackerDao.
+    // Default mocks для TrackerDao.
     when(() => mockTrackerDao.upsertGameData(any()))
         .thenAnswer((_) async {});
+    when(() => mockTrackerDao.getAllGameData(any()))
+        .thenAnswer((_) async => <TrackerGameData>[]);
 
     sut = RaImportService(
       raApi: mockRaApi,
@@ -174,6 +178,7 @@ void main() {
         added: 5,
         updated: 3,
         unmatched: 2,
+        wishlisted: 2,
         unmatchedTitles: <String>['Game A', 'Game B'],
         collectionId: 1,
       );
@@ -182,18 +187,20 @@ void main() {
       expect(result.added, equals(5));
       expect(result.updated, equals(3));
       expect(result.unmatched, equals(2));
+      expect(result.wishlisted, equals(2));
       expect(result.unmatchedTitles, hasLength(2));
       expect(result.collectionId, equals(1));
     });
   });
 
   group('RaImportResultToUniversal', () {
-    test('should convert to UniversalImportResult with added games', () {
+    test('should report wishlist count from wishlisted, not unmatched', () {
       const RaImportResult raResult = RaImportResult(
         totalGames: 10,
         added: 5,
         updated: 3,
         unmatched: 2,
+        wishlisted: 2,
         unmatchedTitles: <String>['A', 'B'],
         collectionId: 1,
       );
@@ -208,12 +215,33 @@ void main() {
       expect(result.wishlistedByType[MediaType.game], equals(2));
     });
 
+    test('should have empty wishlist map when wishlisted=0 even if unmatched>0',
+        () {
+      // addToWishlist=false: unmatched увеличился, но в вишлист ничего
+      // не добавлялось — UI не должен показывать «N в вишлисте».
+      const RaImportResult raResult = RaImportResult(
+        totalGames: 5,
+        added: 3,
+        updated: 0,
+        unmatched: 2,
+        wishlisted: 0,
+        unmatchedTitles: <String>['A', 'B'],
+        collectionId: 1,
+      );
+
+      final UniversalImportResult result = raResult.toUniversal();
+
+      expect(result.importedByType[MediaType.game], equals(3));
+      expect(result.wishlistedByType, isEmpty);
+    });
+
     test('should have empty maps when counts are zero', () {
       const RaImportResult raResult = RaImportResult(
         totalGames: 0,
         added: 0,
         updated: 0,
         unmatched: 0,
+        wishlisted: 0,
         unmatchedTitles: <String>[],
         collectionId: 1,
       );
@@ -231,6 +259,7 @@ void main() {
         added: 3,
         updated: 0,
         unmatched: 0,
+        wishlisted: 0,
         unmatchedTitles: <String>[],
         collectionId: 1,
       );
@@ -317,15 +346,24 @@ void main() {
           onProgress: onProgress,
         );
 
-        // fetchingLibrary, matchingGames (0/N), matchingGames (1/N), completed.
-        expect(progressCalls.length, greaterThanOrEqualTo(3));
+        // fetchingLibrary → searchingGames → matchingGames → completed.
+        expect(progressCalls.length, greaterThanOrEqualTo(4));
         expect(
           progressCalls.first.stage,
           equals(RaImportStage.fetchingLibrary),
         );
         expect(
-          progressCalls[1].stage,
-          equals(RaImportStage.matchingGames),
+          progressCalls.any(
+            (RaImportProgress p) => p.stage == RaImportStage.searchingGames,
+          ),
+          isTrue,
+          reason: 'searchingGames stage should be reported',
+        );
+        expect(
+          progressCalls.any(
+            (RaImportProgress p) => p.stage == RaImportStage.matchingGames,
+          ),
+          isTrue,
         );
         expect(
           progressCalls.last.stage,
@@ -456,7 +494,7 @@ void main() {
         when(() => mockDb.findUnresolvedWishlistItem('Unknown Game (NES)'))
             .thenAnswer((_) async => createTestWishlistItem());
 
-        await sut.importFromProfile(
+        final RaImportResult result = await sut.importFromProfile(
           raUsername: 'TestUser',
           collectionId: 1,
           addToWishlist: true,
@@ -468,6 +506,146 @@ void main() {
               mediaTypeHint: any(named: 'mediaTypeHint'),
               note: any(named: 'note'),
             ));
+        // Дубликат не создавался — счётчик wishlisted остаётся 0,
+        // а unmatched инкрементируется (игра всё равно не нашлась в IGDB).
+        expect(result.unmatched, equals(1));
+        expect(result.wishlisted, equals(0));
+      });
+
+      test('wishlisted counter equals 0 when addToWishlist disabled', () async {
+        final RaGameProgress raGame = createTestRaGameProgress(
+          title: 'Unknown Game',
+          consoleName: 'NES',
+          consoleId: 7,
+        );
+
+        setupRaApiMocks(games: <RaGameProgress>[raGame]);
+        setupIgdbSearchMock(
+          query: 'Unknown Game',
+          platformIds: <int>[18],
+          results: <Game>[],
+        );
+        setupDbMocks();
+
+        final RaImportResult result = await sut.importFromProfile(
+          raUsername: 'TestUser',
+          collectionId: 1,
+          addToWishlist: false,
+          onProgress: onProgress,
+        );
+
+        expect(result.unmatched, equals(1));
+        expect(result.wishlisted, equals(0));
+        // toUniversal не должен показывать вишлист.
+        final UniversalImportResult universal = result.toUniversal();
+        expect(universal.wishlistedByType, isEmpty);
+      });
+
+      test(
+          'manual RA→IGDB link skips IGDB search and reuses cached game',
+          () async {
+        // Юзер ранее руками привязал RA gameId=999 к IGDB id=500.
+        final RaGameProgress raGame = createTestRaGameProgress(
+          gameId: 999,
+          title: 'Obscure ROM Hack',
+          consoleName: 'SNES',
+          consoleId: 3,
+          numAwarded: 10,
+          maxPossible: 50,
+          highestAwardKind: null,
+        );
+        final Game cachedGame = createTestGame(id: 500, name: 'Obscure ROM Hack');
+
+        setupRaApiMocks(games: <RaGameProgress>[raGame]);
+        setupDbMocks();
+
+        when(() => mockTrackerDao.getAllGameData(TrackerType.ra))
+            .thenAnswer((_) async => <TrackerGameData>[
+                  TrackerGameData(
+                    id: 1,
+                    trackerType: TrackerType.ra,
+                    gameId: 500,
+                    trackerGameId: '999',
+                    trackerGameTitle: 'Obscure ROM Hack',
+                    achievementsTotal: 50,
+                    lastSyncedAt:
+                        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                  ),
+                ]);
+        when(() => mockDb.getGameById(500))
+            .thenAnswer((_) async => cachedGame);
+
+        final RaImportResult result = await sut.importFromProfile(
+          raUsername: 'TestUser',
+          collectionId: 1,
+          addToWishlist: true,
+          onProgress: onProgress,
+        );
+
+        expect(result.added, equals(1));
+        expect(result.unmatched, equals(0));
+        expect(result.wishlisted, equals(0));
+
+        // IGDB-поиск НЕ должен вызываться для этой игры.
+        verifyNever(() => mockIgdbApi.multiSearchGamesByName(any()));
+        verify(() => mockDb.getGameById(500)).called(1);
+        // Никаких wishlist-операций.
+        verifyNever(() => mockDb.addWishlistItem(
+              text: any(named: 'text'),
+              mediaTypeHint: any(named: 'mediaTypeHint'),
+              note: any(named: 'note'),
+            ));
+      });
+
+      test('manual link with broken cache falls back to IGDB search',
+          () async {
+        // tracker_game_data ссылается на IGDB id, которого нет в локальном
+        // кэше игр (например, кэш почистили). Должен сработать fallback
+        // к IGDB-поиску по названию.
+        final RaGameProgress raGame = createTestRaGameProgress(
+          gameId: 777,
+          title: 'Cached Game',
+          consoleName: 'SNES',
+          consoleId: 3,
+          highestAwardKind: 'mastered',
+          highestAwardDate: DateTime(2024, 1, 1),
+        );
+        final Game freshGame = createTestGame(id: 600, name: 'Cached Game');
+
+        setupRaApiMocks(games: <RaGameProgress>[raGame]);
+        setupDbMocks();
+
+        when(() => mockTrackerDao.getAllGameData(TrackerType.ra))
+            .thenAnswer((_) async => <TrackerGameData>[
+                  TrackerGameData(
+                    id: 1,
+                    trackerType: TrackerType.ra,
+                    gameId: 600,
+                    trackerGameId: '777',
+                    trackerGameTitle: 'Cached Game',
+                    achievementsTotal: 50,
+                    lastSyncedAt:
+                        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+                  ),
+                ]);
+        // В кэше нет.
+        when(() => mockDb.getGameById(600)).thenAnswer((_) async => null);
+        // Но IGDB-поиск (через RaToIgdbMapper.findIgdbGame) должен сработать.
+        when(() => mockIgdbApi.searchGames(
+              query: 'Cached Game',
+              platformIds: any(named: 'platformIds'),
+            )).thenAnswer((_) async => <Game>[freshGame]);
+
+        final RaImportResult result = await sut.importFromProfile(
+          raUsername: 'TestUser',
+          collectionId: 1,
+          addToWishlist: false,
+          onProgress: onProgress,
+        );
+
+        expect(result.added, equals(1));
+        expect(result.unmatched, equals(0));
+        verify(() => mockDb.getGameById(600)).called(1);
       });
 
       test('should update existing item with higher status', () async {


### PR DESCRIPTION
Pre-fetch tracker_game_data before IGDB search so manually linked games reuse the cached Game instead of going through name-based search every sync. Split progress into searchingGames (IGDB lookup) and matchingGames (collection writes), and count wishlisted only when a new row is actually inserted.