### PR TITLE
feat(bulk-actions): select multiple items and act on them in any view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,87 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Bulk actions across collections and All Items**
+
+  Selection now works everywhere items are shown: the collection table
+  view gets a checkbox column (header has a tristate select-all for the
+  currently visible rows), the collection grid / list / manual-reorder
+  views and the All Items home grid get a Google-Photos-style checkmark
+  overlay in the top-left corner of each card (subtle on hover, brand-
+  filled when selected, with a brand-tinted border around the card).
+  While at least one item is selected, tapping any other card toggles
+  selection instead of opening the detail screen. On every screen,
+  selecting one or more items reveals the same bulk action bar with:
+  move to another collection, copy to another collection, change status
+  (status popup), and remove. Inside a single collection, when sort is
+  manual, the bar also shows move-to-top / move-to-bottom. All bulk
+  operations live in a single helper (`BulkOperations`) so they can be
+  invoked from any screen — they call the existing single-item
+  repository methods in a loop, accumulate affected collections / media
+  types / tier lists, and run the provider invalidation **once** at the
+  end. N items no longer trigger N redundant reloads. Status update
+  path uses `AllItemsNotifier`'s existing `updateStatusLocally` so the
+  home grid does not have to refetch; each affected collection notifier
+  is invalidated once.
+
+  * lib/features/collections/helpers/bulk_operations.dart (BulkOperations,
+    BulkOperations.removeItems, BulkOperations.moveItemsToCollection,
+    BulkOperations.cloneItemsToCollection, BulkOperations.updateItemsStatus,
+    BulkOperations._invalidateAfterMutation, BulkOperations._resolveTargetTagId):
+    New. Collection-agnostic helper — takes `List<CollectionItem>`
+    (each item carries its own `collectionId` and `mediaType`) and a
+    `WidgetRef`; correctly invalidates the union of affected source
+    collections plus the target.
+  * lib/features/collections/providers/collection_selection_provider.dart
+    (CollectionSelectionNotifier, collectionSelectionProvider): New.
+    Per-collection `Set<int>` of selected ids (toggle / selectAll /
+    clear / removeIds), family-keyed by `int?`.
+  * lib/features/collections/providers/all_items_selection_provider.dart
+    (AllItemsSelectionNotifier, allItemsSelectionProvider): New.
+    Global selection for the All Items home screen.
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier.moveItemsToTop, CollectionItemsNotifier.moveItemsToBottom,
+    CollectionItemsNotifier._moveItemsToEdge): New methods that stay on
+    the notifier because they need single-collection `sort_order`
+    context. They preserve the relative order of the selected group.
+  * lib/features/collections/widgets/bulk_action_bar.dart (BulkActionBar):
+    New. Reads its `List<CollectionItem>` and an `onClearSelection`
+    callback from the parent — fully selection-provider-agnostic.
+    Move-to-top / move-to-bottom only render when a `collectionId`
+    is supplied and that collection is in manual sort.
+  * lib/features/collections/widgets/selectable_poster_card.dart
+    (SelectablePosterCard, _CheckCircle): New. Overlay wrapper that
+    adds the corner check-circle and brand border for grid views.
+  * lib/features/collections/widgets/collection_table_view.dart
+    (CollectionTableView, _TableHeader, _TableRow): Add `selectedIds`,
+    `onToggleSelect`, `onToggleSelectAll` parameters. New checkbox
+    column in the header (tristate select-all) and in each row.
+    Selected rows get a brand-tinted background.
+  * lib/features/collections/widgets/collection_items_view.dart
+    (CollectionItemsView.build, CollectionItemsView._buildListTile,
+    CollectionItemsView._buildPosterCard, CollectionItemsView._buildReorderableList):
+    Wire all four item views (table, grid, list, reorderable) to
+    `collectionSelectionProvider`. Grid / list / reorderable wrap each
+    poster or tile in `SelectablePosterCard`; when a selection is
+    active, tapping a card toggles selection instead of opening the
+    detail screen.
+  * lib/features/collections/screens/collection_screen.dart: Mount
+    `BulkActionBar` between the title bar and the item list whenever
+    the user can edit and the selection is non-empty (any view mode).
+    Passes the selected items list + `onClearSelection` callback.
+  * lib/features/home/screens/all_items_screen.dart
+    (_AllItemsScreenState.build, _AllItemsScreenState._buildGridView):
+    Wrap each `MediaPosterCard` in `SelectablePosterCard`; while a
+    selection is active, tapping a card toggles selection instead of
+    opening detail. Mount `BulkActionBar` above the grid when the
+    selection is non-empty.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (bulkSelected,
+    bulkClearSelection, bulkMove, bulkCopy, bulkChangeStatus,
+    bulkRemoveConfirm, bulkResult, bulkRemoved, bulkStatusUpdated): New.
+  * test/features/collections/providers/collection_selection_provider_test.dart:
+    New. 6 cases covering toggle, selectAll, clear, removeIds, and
+    family isolation between collections.
+
 - **Move-to-top / move-to-bottom for collection items in manual sort**
 
   When the collection is sorted manually (Custom order), the row context

--- a/lib/features/collections/helpers/bulk_operations.dart
+++ b/lib/features/collections/helpers/bulk_operations.dart
@@ -1,0 +1,289 @@
+// Шаренный bulk-helper для массовых операций над CollectionItem.
+//
+// Работает на любом экране, где есть selection: коллекция, All Items.
+// Каждый метод вызывает низкоуровневые операции в цикле и инвалидирует
+// все затронутые провайдеры ровно один раз в конце.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/database/dao/tag_dao.dart';
+import '../../../core/database/dao/tier_list_dao.dart';
+import '../../../core/database/database_service.dart';
+import '../../../data/repositories/collection_repository.dart';
+import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/collection_tag.dart';
+import '../../../shared/models/item_status.dart';
+import '../../../shared/models/media_type.dart';
+import '../../home/providers/all_items_provider.dart';
+import '../../tier_lists/providers/tier_list_detail_provider.dart';
+import '../providers/collection_covers_provider.dart';
+import '../providers/collection_tags_provider.dart';
+import '../providers/collections_provider.dart';
+
+/// Static-namespace для bulk-операций над элементами коллекций.
+///
+/// Каждый метод принимает [WidgetRef] и [List<CollectionItem>] и сам
+/// определяет затронутые коллекции / медиа-типы / тир-листы по полям
+/// элементов — поэтому работает и внутри одной коллекции, и на All Items,
+/// где элементы из разных коллекций.
+class BulkOperations {
+  BulkOperations._();
+
+  /// Удаляет элементы из БД, инвалидирует затронутые провайдеры.
+  /// Возвращает количество удалённых.
+  static Future<int> removeItems(
+    WidgetRef ref,
+    List<CollectionItem> items,
+  ) async {
+    if (items.isEmpty) return 0;
+    final CollectionRepository repo =
+        ref.read(collectionRepositoryProvider);
+    final TierListDao tierDao = ref.read(tierListDaoProvider);
+
+    final Set<int?> affectedCollections = <int?>{};
+    final Set<MediaType> affectedTypes = <MediaType>{};
+    final Set<int> affectedTierLists = <int>{};
+    int removed = 0;
+
+    for (final CollectionItem item in items) {
+      affectedTierLists
+          .addAll(await tierDao.getTierListIdsForItem(item.id));
+      await repo.removeItem(item.id);
+      affectedCollections.add(item.collectionId);
+      affectedTypes.add(item.mediaType);
+      removed++;
+    }
+
+    _invalidateAfterMutation(
+      ref,
+      affectedCollections: affectedCollections,
+      affectedTypes: affectedTypes,
+      affectedTierLists: affectedTierLists,
+    );
+    return removed;
+  }
+
+  /// Перемещает элементы в [targetCollectionId] (`null` → uncategorized).
+  /// Возвращает `(moved, skipped)`.
+  static Future<({int moved, int skipped})> moveItemsToCollection(
+    WidgetRef ref,
+    List<CollectionItem> items,
+    int? targetCollectionId,
+  ) async {
+    if (items.isEmpty) return (moved: 0, skipped: 0);
+    final CollectionRepository repo =
+        ref.read(collectionRepositoryProvider);
+    final TierListDao tierDao = ref.read(tierListDaoProvider);
+    final TagDao tagDao = ref.read(tagDaoProvider);
+
+    final Set<int?> affectedCollections = <int?>{targetCollectionId};
+    final Set<MediaType> affectedTypes = <MediaType>{};
+    final Set<int> affectedTierLists = <int>{};
+    bool tagAssignedAny = false;
+    int moved = 0;
+    int skipped = 0;
+
+    for (final CollectionItem item in items) {
+      affectedTierLists
+          .addAll(await tierDao.getTierListIdsForItem(item.id));
+      if (item.collectionId != null) {
+        await tierDao.removeItemFromCollectionTierLists(
+          item.id,
+          item.collectionId!,
+        );
+      }
+
+      final int? resolvedTagId = await _resolveTargetTagId(
+        tagDao: tagDao,
+        sourceTagId: item.tagId,
+        targetCollectionId: targetCollectionId,
+      );
+
+      final bool ok = await repo.moveItemToCollection(
+        item.id,
+        targetCollectionId,
+      );
+      if (!ok) {
+        skipped++;
+        continue;
+      }
+
+      if (item.tagId != null) {
+        await tagDao.setItemTag(item.id, resolvedTagId);
+      }
+      if (resolvedTagId != null) tagAssignedAny = true;
+
+      affectedCollections.add(item.collectionId);
+      affectedTypes.add(item.mediaType);
+      moved++;
+    }
+
+    _invalidateAfterMutation(
+      ref,
+      affectedCollections: affectedCollections,
+      affectedTypes: affectedTypes,
+      affectedTierLists: affectedTierLists,
+      tagAssignedTargetId:
+          tagAssignedAny ? targetCollectionId : null,
+    );
+    return (moved: moved, skipped: skipped);
+  }
+
+  /// Клонирует элементы в [targetCollectionId].
+  /// Возвращает `(cloned, skipped)`.
+  static Future<({int cloned, int skipped})> cloneItemsToCollection(
+    WidgetRef ref,
+    List<CollectionItem> items,
+    int targetCollectionId,
+  ) async {
+    if (items.isEmpty) return (cloned: 0, skipped: 0);
+    final CollectionRepository repo =
+        ref.read(collectionRepositoryProvider);
+    final TagDao tagDao = ref.read(tagDaoProvider);
+
+    final Set<int?> affectedCollections = <int?>{targetCollectionId};
+    final Set<MediaType> affectedTypes = <MediaType>{};
+    bool tagAssignedAny = false;
+    int cloned = 0;
+    int skipped = 0;
+
+    for (final CollectionItem item in items) {
+      final int? newId = await repo.cloneItemToCollection(
+        item.id,
+        targetCollectionId,
+      );
+      if (newId == null) {
+        skipped++;
+        continue;
+      }
+      final int? resolvedTagId = await _resolveTargetTagId(
+        tagDao: tagDao,
+        sourceTagId: item.tagId,
+        targetCollectionId: targetCollectionId,
+      );
+      if (resolvedTagId != null) {
+        await tagDao.setItemTag(newId, resolvedTagId);
+        tagAssignedAny = true;
+      }
+      affectedTypes.add(item.mediaType);
+      cloned++;
+    }
+
+    _invalidateAfterMutation(
+      ref,
+      affectedCollections: affectedCollections,
+      affectedTypes: affectedTypes,
+      affectedTierLists: const <int>{},
+      tagAssignedTargetId:
+          tagAssignedAny ? targetCollectionId : null,
+    );
+    return (cloned: cloned, skipped: skipped);
+  }
+
+  /// Меняет статус у всех переданных элементов.
+  /// Возвращает количество реально изменённых (skipped — те, что уже
+  /// были в целевом статусе).
+  static Future<int> updateItemsStatus(
+    WidgetRef ref,
+    List<CollectionItem> items,
+    ItemStatus status,
+  ) async {
+    if (items.isEmpty) return 0;
+    final CollectionRepository repo =
+        ref.read(collectionRepositoryProvider);
+
+    final Set<int?> affectedCollections = <int?>{};
+    final Set<int> changedIds = <int>{};
+
+    for (final CollectionItem item in items) {
+      if (item.status == status) continue;
+      await repo.updateItemStatus(
+        item.id,
+        status,
+        mediaType: item.mediaType,
+      );
+      changedIds.add(item.id);
+      affectedCollections.add(item.collectionId);
+    }
+    if (changedIds.isEmpty) return 0;
+
+    // Локальный апдейт all-items без перезагрузки списка.
+    final AllItemsNotifier allItems =
+        ref.read(allItemsNotifierProvider.notifier);
+    for (final int id in changedIds) {
+      allItems.updateStatusLocally(id, status);
+    }
+
+    // Каждая затронутая коллекция: инвалидация состояния списка + статов.
+    for (final int? cid in affectedCollections) {
+      ref.invalidate(collectionItemsNotifierProvider(cid));
+      ref.invalidate(collectionStatsProvider(cid));
+    }
+    return changedIds.length;
+  }
+
+  // ---------------------------------------------------------------------------
+
+  static Future<int?> _resolveTargetTagId({
+    required TagDao tagDao,
+    required int? sourceTagId,
+    required int? targetCollectionId,
+  }) async {
+    if (sourceTagId == null || targetCollectionId == null) return null;
+    final CollectionTag? sourceTag = await tagDao.getTagById(sourceTagId);
+    if (sourceTag == null) return null;
+    return tagDao.resolveOrCreateInCollection(
+      targetCollectionId,
+      sourceTag.name,
+      color: sourceTag.color,
+    );
+  }
+
+  /// Единая инвалидация после bulk-операции — touch'ает все затронутые
+  /// коллекции + глобальные счётчики.
+  static void _invalidateAfterMutation(
+    WidgetRef ref, {
+    required Set<int?> affectedCollections,
+    required Set<MediaType> affectedTypes,
+    required Set<int> affectedTierLists,
+    int? tagAssignedTargetId,
+  }) {
+    for (final int? cid in affectedCollections) {
+      ref.invalidate(collectionItemsNotifierProvider(cid));
+      ref.invalidate(collectionStatsProvider(cid));
+      ref.invalidate(collectionCoversProvider(cid));
+    }
+    if (tagAssignedTargetId != null) {
+      ref.invalidate(collectionTagsProvider(tagAssignedTargetId));
+    }
+    for (final MediaType t in affectedTypes) {
+      _invalidateCollectedIds(ref, t);
+    }
+    ref.invalidate(uncategorizedItemCountProvider);
+    ref.invalidate(allItemsNotifierProvider);
+    for (final int tlId in affectedTierLists) {
+      ref.invalidate(tierListDetailProvider(tlId));
+    }
+  }
+
+  static void _invalidateCollectedIds(WidgetRef ref, MediaType type) {
+    switch (type) {
+      case MediaType.game:
+        ref.invalidate(collectedGameIdsProvider);
+      case MediaType.movie:
+        ref.invalidate(collectedMovieIdsProvider);
+      case MediaType.tvShow:
+        ref.invalidate(collectedTvShowIdsProvider);
+      case MediaType.animation:
+        ref.invalidate(collectedAnimationIdsProvider);
+      case MediaType.visualNovel:
+        ref.invalidate(collectedVisualNovelIdsProvider);
+      case MediaType.manga:
+        ref.invalidate(collectedMangaIdsProvider);
+      case MediaType.anime:
+        ref.invalidate(collectedAnimeIdsProvider);
+      case MediaType.custom:
+        break;
+    }
+  }
+}

--- a/lib/features/collections/providers/all_items_selection_provider.dart
+++ b/lib/features/collections/providers/all_items_selection_provider.dart
@@ -1,0 +1,37 @@
+// Глобальный селекшн для экрана All Items (все коллекции вместе).
+//
+// Отдельный провайдер, не часть family `collectionSelectionProvider`,
+// потому что он логически не привязан к одной коллекции.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Набор выделенных id на экране All Items.
+final NotifierProvider<AllItemsSelectionNotifier, Set<int>>
+    allItemsSelectionProvider =
+    NotifierProvider<AllItemsSelectionNotifier, Set<int>>(
+  AllItemsSelectionNotifier.new,
+);
+
+/// Управляет селекшном на All Items.
+class AllItemsSelectionNotifier extends Notifier<Set<int>> {
+  @override
+  Set<int> build() => <int>{};
+
+  /// Переключает выделение для [id].
+  void toggle(int id) {
+    final Set<int> next = Set<int>.of(state);
+    if (!next.add(id)) next.remove(id);
+    state = next;
+  }
+
+  /// Заменяет селекшн на [ids] (select-all).
+  void selectAll(Iterable<int> ids) {
+    state = Set<int>.of(ids);
+  }
+
+  /// Очищает селекшн.
+  void clear() {
+    if (state.isEmpty) return;
+    state = <int>{};
+  }
+}

--- a/lib/features/collections/providers/collection_selection_provider.dart
+++ b/lib/features/collections/providers/collection_selection_provider.dart
@@ -1,0 +1,47 @@
+// Стейт выделенных элементов внутри одной коллекции.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Провайдер набора выделенных id для конкретной коллекции.
+///
+/// Family-параметр — `collectionId` (null для uncategorized).
+/// У каждой коллекции свой набор, переключение между коллекциями
+/// автоматически сбрасывает чужой селекшн.
+final NotifierProviderFamily<CollectionSelectionNotifier, Set<int>, int?>
+    collectionSelectionProvider =
+    NotifierProvider.family<CollectionSelectionNotifier, Set<int>, int?>(
+  CollectionSelectionNotifier.new,
+);
+
+/// Управляет набором выделенных id внутри коллекции.
+class CollectionSelectionNotifier extends FamilyNotifier<Set<int>, int?> {
+  @override
+  Set<int> build(int? arg) => <int>{};
+
+  /// Переключает выделение для [id].
+  void toggle(int id) {
+    final Set<int> next = Set<int>.of(state);
+    if (!next.add(id)) next.remove(id);
+    state = next;
+  }
+
+  /// Заменяет селекшн на [ids] (используется для select-all).
+  void selectAll(Iterable<int> ids) {
+    state = Set<int>.of(ids);
+  }
+
+  /// Очищает селекшн.
+  void clear() {
+    if (state.isEmpty) return;
+    state = <int>{};
+  }
+
+  /// Удаляет переданные [ids] из селекшна (после bulk-remove
+  /// или удаления одиночного элемента).
+  void removeIds(Iterable<int> ids) {
+    if (state.isEmpty) return;
+    final Set<int> next = Set<int>.of(state)..removeAll(ids);
+    if (next.length == state.length) return;
+    state = next;
+  }
+}

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -860,6 +860,71 @@ class CollectionItemsNotifier
         .updateStatusLocally(id, status);
   }
 
+  // ---------------------------------------------------------------------------
+  // Bulk-операции, требующие контекста одной коллекции (sort_order).
+  // Общие массовые операции (remove / move / clone / status) живут в
+  // `BulkOperations` (`helpers/bulk_operations.dart`) — collection-agnostic
+  // и переиспользуются на All Items.
+  // ---------------------------------------------------------------------------
+
+  /// Перемещает группу элементов в начало списка, сохраняя их
+  /// относительный порядок. No-op при пустом наборе или если все
+  /// элементы уже в начале. Имеет смысл только при `sortMode == manual`.
+  Future<void> moveItemsToTop(Iterable<int> ids) async {
+    await _moveItemsToEdge(ids, toTop: true);
+  }
+
+  /// Перемещает группу элементов в конец списка, сохраняя их
+  /// относительный порядок.
+  Future<void> moveItemsToBottom(Iterable<int> ids) async {
+    await _moveItemsToEdge(ids, toTop: false);
+  }
+
+  Future<void> _moveItemsToEdge(
+    Iterable<int> ids, {
+    required bool toTop,
+  }) async {
+    final Set<int> idSet = ids.toSet();
+    if (idSet.isEmpty) return;
+    final List<CollectionItem>? items = state.valueOrNull;
+    if (items == null || items.isEmpty) return;
+
+    final List<CollectionItem> selected = <CollectionItem>[];
+    final List<CollectionItem> rest = <CollectionItem>[];
+    for (final CollectionItem i in items) {
+      if (idSet.contains(i.id)) {
+        selected.add(i);
+      } else {
+        rest.add(i);
+      }
+    }
+    if (selected.isEmpty) return;
+
+    final List<CollectionItem> reordered = toTop
+        ? <CollectionItem>[...selected, ...rest]
+        : <CollectionItem>[...rest, ...selected];
+
+    // No-op если порядок не изменился.
+    bool changed = false;
+    for (int i = 0; i < items.length; i++) {
+      if (items[i].id != reordered[i].id) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return;
+
+    final List<CollectionItem> withSortOrder = <CollectionItem>[
+      for (int i = 0; i < reordered.length; i++)
+        reordered[i].copyWith(sortOrder: i),
+    ];
+    state = AsyncData<List<CollectionItem>>(withSortOrder);
+
+    final List<int> orderedIds =
+        withSortOrder.map((CollectionItem i) => i.id).toList();
+    await _db.reorderItems(_collectionId, orderedIds);
+  }
+
   /// Обновляет даты активности элемента вручную.
   ///
   /// Автоматически синхронизирует статус:

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -31,7 +31,9 @@ import '../widgets/import_progress_dialog.dart';
 import '../helpers/collection_actions.dart';
 import '../providers/collection_covers_provider.dart';
 import '../providers/collection_tags_provider.dart';
+import '../providers/collection_selection_provider.dart';
 import '../providers/collections_provider.dart';
+import '../widgets/bulk_action_bar.dart';
 import '../providers/steamgriddb_panel_provider.dart';
 import '../providers/vgmaps_panel_provider.dart';
 import '../widgets/collection_canvas_layout.dart';
@@ -182,6 +184,31 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
                     ? l.collectionsUncategorized
                     : _collection!.name,
               ),
+              if (_canEdit && !_isCanvasMode)
+                Consumer(builder: (BuildContext context, WidgetRef ref, _) {
+                  final Set<int> selection = ref.watch(
+                      collectionSelectionProvider(widget.collectionId));
+                  if (selection.isEmpty) return const SizedBox.shrink();
+                  final List<CollectionItem> all = ref
+                          .watch(collectionItemsNotifierProvider(
+                              widget.collectionId))
+                          .valueOrNull ??
+                      const <CollectionItem>[];
+                  final List<CollectionItem> selectedItems = <CollectionItem>[
+                    for (final CollectionItem i in all)
+                      if (selection.contains(i.id)) i,
+                  ];
+                  if (selectedItems.isEmpty) return const SizedBox.shrink();
+                  return BulkActionBar(
+                    items: selectedItems,
+                    collectionId: widget.collectionId,
+                    onClearSelection: () => ref
+                        .read(collectionSelectionProvider(
+                                widget.collectionId)
+                            .notifier)
+                        .clear(),
+                  );
+                }),
               Expanded(
                 child: _isCanvasMode
                     ? CollectionCanvasLayout(

--- a/lib/features/collections/widgets/bulk_action_bar.dart
+++ b/lib/features/collections/widgets/bulk_action_bar.dart
@@ -1,0 +1,353 @@
+// Bulk action bar — рендерится поверх контента когда выделен хотя бы
+// один элемент. Работает и в коллекции, и на All Items: оперирует
+// `List<CollectionItem>` через [BulkOperations].
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/collection.dart';
+import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/collection_sort_mode.dart';
+import '../../../shared/models/item_status.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_dialog.dart';
+import '../helpers/bulk_operations.dart';
+import '../providers/collections_provider.dart';
+
+/// Bulk action bar над списком элементов.
+///
+/// - [items] — выделенные элементы (с `id`, `collectionId`, `mediaType`,
+///   `status` — этого хватает для всех операций).
+/// - [onClearSelection] — внешний callback, обнуляющий селекшн на
+///   стороне родителя (бар сам не знает про конкретный селекшн-провайдер).
+/// - [collectionId] — если задан, бар «знает», что мы внутри одной
+///   коллекции: исключает её из целей move/copy и показывает
+///   move-to-top / move-to-bottom при ручной сортировке.
+class BulkActionBar extends ConsumerWidget {
+  /// Создаёт [BulkActionBar].
+  const BulkActionBar({
+    required this.items,
+    required this.onClearSelection,
+    this.collectionId,
+    super.key,
+  });
+
+  /// Выделенные элементы.
+  final List<CollectionItem> items;
+
+  /// Колбэк сброса селекшна.
+  final VoidCallback onClearSelection;
+
+  /// ID контекстной коллекции. `null` если бар стоит на All Items.
+  final int? collectionId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final S l = S.of(context);
+    final ThemeData theme = Theme.of(context);
+    final CollectionSortMode sortMode = collectionId == null
+        ? CollectionSortMode.lastActivity
+        : ref.watch(collectionSortProvider(collectionId));
+    final bool isManualSort = collectionId != null &&
+        sortMode == CollectionSortMode.manual;
+    final int count = items.length;
+
+    return Material(
+      color: AppColors.brand.withAlpha(28),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            top: BorderSide(color: AppColors.brand.withAlpha(60)),
+            bottom: BorderSide(color: AppColors.brand.withAlpha(60)),
+          ),
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.xs,
+        ),
+        child: Row(
+          children: <Widget>[
+            _CloseButton(onPressed: onClearSelection),
+            const SizedBox(width: AppSpacing.sm),
+            Text(
+              l.bulkSelected(count),
+              style: AppTypography.body.copyWith(
+                color: AppColors.brand,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const Spacer(),
+            _BarAction(
+              icon: Icons.drive_file_move_outlined,
+              tooltip: l.collectionMoveToCollection,
+              onTap: () => _handleMove(context, ref),
+            ),
+            _BarAction(
+              icon: Icons.copy_outlined,
+              tooltip: l.collectionCopyToCollection,
+              onTap: () => _handleClone(context, ref),
+            ),
+            _StatusMenuAction(
+              onSelected: (ItemStatus s) => _handleStatus(context, ref, s),
+            ),
+            if (isManualSort) ...<Widget>[
+              const _BarDivider(),
+              _BarAction(
+                icon: Icons.vertical_align_top,
+                tooltip: l.moveToTop,
+                onTap: () => _handleMoveToTop(ref),
+              ),
+              _BarAction(
+                icon: Icons.vertical_align_bottom,
+                tooltip: l.moveToBottom,
+                onTap: () => _handleMoveToBottom(ref),
+              ),
+            ],
+            const _BarDivider(),
+            _BarAction(
+              icon: Icons.delete_outline,
+              tooltip: l.remove,
+              danger: true,
+              onTap: () => _handleRemove(context, ref, theme),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+
+  Future<void> _handleMove(BuildContext context, WidgetRef ref) async {
+    final S l = S.of(context);
+    final CollectionChoice? choice = await showCollectionPickerDialog(
+      context: context,
+      ref: ref,
+      excludeCollectionId: collectionId,
+      showUncategorized: collectionId != null,
+      title: l.bulkMove,
+    );
+    if (choice == null || !context.mounted) return;
+
+    final int? targetId = switch (choice) {
+      ChosenCollection(:final Collection collection) => collection.id,
+      WithoutCollection() => null,
+    };
+
+    final List<CollectionItem> snapshot = List<CollectionItem>.of(items);
+    final ({int moved, int skipped}) result =
+        await BulkOperations.moveItemsToCollection(ref, snapshot, targetId);
+    onClearSelection();
+    if (!context.mounted) return;
+    context.showSnack(
+      l.bulkResult(result.moved, result.skipped),
+      type: SnackType.success,
+    );
+  }
+
+  Future<void> _handleClone(BuildContext context, WidgetRef ref) async {
+    final S l = S.of(context);
+    final CollectionChoice? choice = await showCollectionPickerDialog(
+      context: context,
+      ref: ref,
+      excludeCollectionId: collectionId,
+      showUncategorized: false,
+      title: l.bulkCopy,
+    );
+    if (choice == null || !context.mounted) return;
+
+    final int? targetId = switch (choice) {
+      ChosenCollection(:final Collection collection) => collection.id,
+      WithoutCollection() => null,
+    };
+    if (targetId == null) return;
+
+    final List<CollectionItem> snapshot = List<CollectionItem>.of(items);
+    final ({int cloned, int skipped}) result =
+        await BulkOperations.cloneItemsToCollection(ref, snapshot, targetId);
+    onClearSelection();
+    if (!context.mounted) return;
+    context.showSnack(
+      l.bulkResult(result.cloned, result.skipped),
+      type: SnackType.success,
+    );
+  }
+
+  Future<void> _handleStatus(
+    BuildContext context,
+    WidgetRef ref,
+    ItemStatus status,
+  ) async {
+    final S l = S.of(context);
+    final List<CollectionItem> snapshot = List<CollectionItem>.of(items);
+    final int changed =
+        await BulkOperations.updateItemsStatus(ref, snapshot, status);
+    onClearSelection();
+    if (!context.mounted) return;
+    context.showSnack(
+      l.bulkStatusUpdated(changed),
+      type: SnackType.success,
+    );
+  }
+
+  Future<void> _handleRemove(
+    BuildContext context,
+    WidgetRef ref,
+    ThemeData theme,
+  ) async {
+    final S l = S.of(context);
+    final int count = items.length;
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        final S dl = S.of(dialogContext);
+        return AlertDialog(
+          title: Text(dl.collectionRemoveItemTitle),
+          content: Text(dl.bulkRemoveConfirm(count)),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(dl.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              style: FilledButton.styleFrom(
+                backgroundColor: theme.colorScheme.error,
+              ),
+              child: Text(dl.remove),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true || !context.mounted) return;
+
+    final List<CollectionItem> snapshot = List<CollectionItem>.of(items);
+    final int removed = await BulkOperations.removeItems(ref, snapshot);
+    onClearSelection();
+    if (!context.mounted) return;
+    context.showSnack(
+      l.bulkRemoved(removed),
+      type: SnackType.success,
+    );
+  }
+
+  Future<void> _handleMoveToTop(WidgetRef ref) async {
+    final Set<int> ids = items.map((CollectionItem i) => i.id).toSet();
+    await ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .moveItemsToTop(ids);
+    onClearSelection();
+  }
+
+  Future<void> _handleMoveToBottom(WidgetRef ref) async {
+    final Set<int> ids = items.map((CollectionItem i) => i.id).toSet();
+    await ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .moveItemsToBottom(ids);
+    onClearSelection();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal widgets
+
+class _CloseButton extends StatelessWidget {
+  const _CloseButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.close_rounded),
+      iconSize: 20,
+      visualDensity: VisualDensity.compact,
+      color: AppColors.brand,
+      tooltip: S.of(context).bulkClearSelection,
+      onPressed: onPressed,
+    );
+  }
+}
+
+class _BarAction extends StatelessWidget {
+  const _BarAction({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+    this.danger = false,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+  final bool danger;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(icon),
+      iconSize: 20,
+      visualDensity: VisualDensity.compact,
+      color: danger ? AppColors.error : AppColors.textPrimary,
+      tooltip: tooltip,
+      onPressed: onTap,
+    );
+  }
+}
+
+class _StatusMenuAction extends StatelessWidget {
+  const _StatusMenuAction({required this.onSelected});
+
+  final ValueChanged<ItemStatus> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return PopupMenuButton<ItemStatus>(
+      icon: const Icon(Icons.flag_outlined),
+      iconSize: 20,
+      tooltip: l.bulkChangeStatus,
+      onSelected: onSelected,
+      itemBuilder: (BuildContext context) {
+        return ItemStatus.values.map((ItemStatus s) {
+          return PopupMenuItem<ItemStatus>(
+            value: s,
+            height: 36,
+            child: Row(
+              children: <Widget>[
+                Icon(s.materialIcon, size: 16, color: s.color),
+                const SizedBox(width: AppSpacing.sm),
+                Text(
+                  s.genericLabel(l),
+                  style: AppTypography.body.copyWith(fontSize: 13),
+                ),
+              ],
+            ),
+          );
+        }).toList();
+      },
+    );
+  }
+}
+
+class _BarDivider extends StatelessWidget {
+  const _BarDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      child: Container(
+        width: 1,
+        height: 20,
+        color: AppColors.brand.withAlpha(60),
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -19,9 +19,11 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../settings/providers/settings_provider.dart';
+import '../providers/collection_selection_provider.dart';
 import '../providers/collections_provider.dart';
 import 'collection_item_tile.dart';
 import 'collection_table_view.dart';
+import 'selectable_poster_card.dart';
 import 'status_chip_row.dart';
 
 /// View для отображения элементов коллекции в grid/list/reorder режиме.
@@ -109,6 +111,9 @@ class CollectionItemsView extends ConsumerWidget {
         sortMode == CollectionSortMode.manual && canEdit;
 
     if (isTableMode) {
+      final Set<int>? selectedIds = canEdit
+          ? ref.watch(collectionSelectionProvider(collectionId))
+          : null;
       return _withHeader(Padding(
         padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
         child: CollectionTableView(
@@ -118,6 +123,25 @@ class CollectionItemsView extends ConsumerWidget {
           onItemSecondaryTap: canEdit
               ? (CollectionItem item, Offset pos) =>
                   _showItemContextMenu(context, ref, pos, item)
+              : null,
+          selectedIds: selectedIds,
+          onToggleSelect: canEdit
+              ? (int itemId) => ref
+                  .read(collectionSelectionProvider(collectionId).notifier)
+                  .toggle(itemId)
+              : null,
+          onToggleSelectAll: canEdit
+              ? (bool selectAll) {
+                  final CollectionSelectionNotifier notifier = ref.read(
+                    collectionSelectionProvider(collectionId).notifier,
+                  );
+                  if (selectAll) {
+                    notifier.selectAll(
+                        items.map((CollectionItem i) => i.id));
+                  } else {
+                    notifier.clear();
+                  }
+                }
               : null,
           onRatingChanged: canEdit
               ? (int itemId, int? rating) {
@@ -286,7 +310,13 @@ class CollectionItemsView extends ConsumerWidget {
     WidgetRef ref,
     CollectionItem item,
   ) {
-    return CollectionItemTile(
+    final Set<int> selection = canEdit
+        ? ref.watch(collectionSelectionProvider(collectionId))
+        : const <int>{};
+    final bool selectionActive = selection.isNotEmpty;
+    final bool isSelected = selection.contains(item.id);
+
+    final Widget tile = CollectionItemTile(
       key: ValueKey<int>(item.id),
       item: item,
       isEditable: canEdit,
@@ -297,14 +327,24 @@ class CollectionItemsView extends ConsumerWidget {
           ? (Offset pos) => _showItemContextMenu(context, ref, pos, item)
           : null,
       onLongPress: canEdit
-          ? () => _showItemContextMenu(
-                context,
-                ref,
-                _centerOfContext(context),
-                item,
-              )
+          ? () => ref
+              .read(collectionSelectionProvider(collectionId).notifier)
+              .toggle(item.id)
           : null,
-      onTap: () => onItemTap(item),
+      onTap: selectionActive
+          ? () => ref
+              .read(collectionSelectionProvider(collectionId).notifier)
+              .toggle(item.id)
+          : () => onItemTap(item),
+    );
+    if (!canEdit) return tile;
+    return SelectablePosterCard(
+      isSelected: isSelected,
+      selectionActive: selectionActive,
+      onToggleSelect: () => ref
+          .read(collectionSelectionProvider(collectionId).notifier)
+          .toggle(item.id),
+      child: tile,
     );
   }
 
@@ -462,8 +502,13 @@ class CollectionItemsView extends ConsumerWidget {
   }) {
     final CollectionTag? tag =
         item.tagId != null ? tagById[item.tagId] : null;
+    final Set<int> selection = canEdit
+        ? ref.watch(collectionSelectionProvider(collectionId))
+        : const <int>{};
+    final bool selectionActive = selection.isNotEmpty;
+    final bool isSelected = selection.contains(item.id);
 
-    return MediaPosterCard(
+    final Widget card = MediaPosterCard(
       key: ValueKey<int>(item.id),
       variant: isLandscape || isCompactScreen(context)
           ? CardVariant.compact
@@ -486,21 +531,31 @@ class CollectionItemsView extends ConsumerWidget {
       onTagTap: canEdit && tags.isNotEmpty
           ? (Offset pos) => _showTagPopup(context, pos, item)
           : null,
-      onTap: () => onItemTap(item),
+      onTap: selectionActive
+          ? () => ref
+              .read(collectionSelectionProvider(collectionId).notifier)
+              .toggle(item.id)
+          : () => onItemTap(item),
       onSecondaryTap: canEdit
           ? (Offset pos) => _showItemContextMenu(context, ref, pos, item)
           : null,
       onLongPress: canEdit
-          ? () => _showItemContextMenu(
-                context,
-                ref,
-                _centerOfContext(context),
-                item,
-              )
+          ? () => ref
+              .read(collectionSelectionProvider(collectionId).notifier)
+              .toggle(item.id)
           : null,
       onFocusChanged: onItemFocusChanged != null
           ? (bool hasFocus) => onItemFocusChanged!(item, hasFocus)
           : null,
+    );
+    if (!canEdit) return card;
+    return SelectablePosterCard(
+      isSelected: isSelected,
+      selectionActive: selectionActive,
+      onToggleSelect: () => ref
+          .read(collectionSelectionProvider(collectionId).notifier)
+          .toggle(item.id),
+      child: card,
     );
   }
 
@@ -536,7 +591,13 @@ class CollectionItemsView extends ConsumerWidget {
       },
       itemBuilder: (BuildContext context, int index) {
         final CollectionItem item = items[index];
-        return CollectionItemTile(
+        final Set<int> selection = canEdit
+            ? ref.watch(collectionSelectionProvider(collectionId))
+            : const <int>{};
+        final bool selectionActive = selection.isNotEmpty;
+        final bool isSelected = selection.contains(item.id);
+
+        final Widget tile = CollectionItemTile(
           key: ValueKey<int>(item.id),
           item: item,
           isEditable: canEdit,
@@ -553,26 +614,34 @@ class CollectionItemsView extends ConsumerWidget {
                   )
               : null,
           onLongPress: canEdit
-              ? () => _showItemContextMenu(
-                    context,
-                    ref,
-                    _centerOfContext(context),
-                    item,
-                  )
+              ? () => ref
+                  .read(collectionSelectionProvider(collectionId).notifier)
+                  .toggle(item.id)
               : null,
-          onTap: () => onItemTap(item),
+          onTap: selectionActive
+              ? () => ref
+                  .read(collectionSelectionProvider(collectionId).notifier)
+                  .toggle(item.id)
+              : () => onItemTap(item),
+        );
+        if (!canEdit) {
+          return KeyedSubtree(key: ValueKey<int>(item.id), child: tile);
+        }
+        return KeyedSubtree(
+          key: ValueKey<int>(item.id),
+          child: SelectablePosterCard(
+            isSelected: isSelected,
+            selectionActive: selectionActive,
+            onToggleSelect: () => ref
+                .read(collectionSelectionProvider(collectionId).notifier)
+                .toggle(item.id),
+            child: tile,
+          ),
         );
       },
     ));
   }
 
-
-  /// Показывает контекстное меню ПКМ для элемента коллекции.
-  /// Центр экрана — fallback позиция для контекстного меню без курсора.
-  Offset _centerOfContext(BuildContext context) {
-    final Size size = MediaQuery.sizeOf(context);
-    return Offset(size.width / 2, size.height / 2);
-  }
 
   /// Sentinel value для "без тега" в popup (чтобы отличить от dismiss).
   static const int _noTagSentinel = -1;

--- a/lib/features/collections/widgets/collection_table_view.dart
+++ b/lib/features/collections/widgets/collection_table_view.dart
@@ -61,6 +61,9 @@ class CollectionTableView extends StatefulWidget {
     this.onStatusChanged,
     this.onTagChanged,
     this.onReorder,
+    this.selectedIds,
+    this.onToggleSelect,
+    this.onToggleSelectAll,
     super.key,
   });
 
@@ -91,6 +94,16 @@ class CollectionTableView extends StatefulWidget {
   ///
   /// Если `null`, drag-and-drop отключён.
   final void Function(int oldIndex, int newIndex)? onReorder;
+
+  /// Множество id выделенных элементов. Если не `null` вместе с
+  /// [onToggleSelect], в каждой строке появляется чекбокс.
+  final Set<int>? selectedIds;
+
+  /// Callback тоггла выделения одного элемента.
+  final void Function(int itemId)? onToggleSelect;
+
+  /// Callback тоггла select-all (вызывается с новым желаемым состоянием).
+  final void Function(bool selectAll)? onToggleSelectAll;
 
   @override
   State<CollectionTableView> createState() => _CollectionTableViewState();
@@ -185,6 +198,8 @@ class _CollectionTableViewState extends State<CollectionTableView> {
                         tagMap: tagMap,
                         l: l,
                         isReorderable: isReorderable,
+                        selectionState: _selectionStateForVisible(sorted),
+                        onToggleSelectAll: widget.onToggleSelectAll,
                       ),
                       Expanded(
                         child: isReorderable
@@ -227,6 +242,11 @@ class _CollectionTableViewState extends State<CollectionTableView> {
           thumbWidth: _thumbWidth,
           thumbHeight: _thumbHeight,
           thumbRadius: _thumbRadius,
+          isSelected:
+              widget.selectedIds?.contains(item.id) ?? false,
+          onToggleSelect: widget.onToggleSelect != null
+              ? () => widget.onToggleSelect!(item.id)
+              : null,
         );
       },
     );
@@ -280,6 +300,11 @@ class _CollectionTableViewState extends State<CollectionTableView> {
           thumbHeight: _thumbHeight,
           thumbRadius: _thumbRadius,
           dragIndex: index,
+          isSelected:
+              widget.selectedIds?.contains(item.id) ?? false,
+          onToggleSelect: widget.onToggleSelect != null
+              ? () => widget.onToggleSelect!(item.id)
+              : null,
         );
       },
     );
@@ -399,6 +424,25 @@ class _CollectionTableViewState extends State<CollectionTableView> {
     if (item.tagId == null) return '';
     return _cachedTagMap[item.tagId]?.name ?? '';
   }
+
+  /// Состояние master-чекбокса для текущей видимой выборки.
+  ///
+  /// `null` если селекшн отключён (нет `selectedIds`),
+  /// `true` если все видимые выделены, `false` если ни одного,
+  /// `false` (tristate=true) если часть. Для master-чекбокса используем
+  /// trista через возврат `null` ↦ скрыть, иначе bool.
+  bool? _selectionStateForVisible(List<CollectionItem> visible) {
+    final Set<int>? selected = widget.selectedIds;
+    if (selected == null || widget.onToggleSelect == null) return null;
+    if (visible.isEmpty) return false;
+    int hit = 0;
+    for (final CollectionItem i in visible) {
+      if (selected.contains(i.id)) hit++;
+    }
+    if (hit == 0) return false;
+    if (hit == visible.length) return true;
+    return null; // partial → tristate indeterminate
+  }
 }
 
 /// Формирует метку платформы для строки таблицы.
@@ -426,6 +470,8 @@ class _TableHeader extends StatelessWidget {
     this.filterTagId,
     this.filterPlatform,
     this.isReorderable = false,
+    this.selectionState,
+    this.onToggleSelectAll,
   });
 
   final TableColumn sortColumn;
@@ -439,6 +485,12 @@ class _TableHeader extends StatelessWidget {
   final String? filterPlatform;
   final Map<int, CollectionTag> tagMap;
   final bool isReorderable;
+
+  /// `null` если селекшн выключен (колонка чекбоксов скрыта),
+  /// иначе значение master-чекбокса: true / false / null (tristate-partial).
+  final bool? selectionState;
+
+  final void Function(bool selectAll)? onToggleSelectAll;
 
   @override
   Widget build(BuildContext context) {
@@ -455,6 +507,19 @@ class _TableHeader extends StatelessWidget {
       ),
       child: Row(
         children: <Widget>[
+          // Чекбокс select-all (только когда передан selectionState).
+          if (onToggleSelectAll != null)
+            SizedBox(
+              width: _checkboxColumnWidth,
+              child: Checkbox(
+                value: selectionState,
+                tristate: true,
+                onChanged: (bool? value) {
+                  // Tristate: partial / false → выбрать всё; true → снять.
+                  onToggleSelectAll!(selectionState != true);
+                },
+              ),
+            ),
           // Место под drag-handle (совпадает по ширине с колонкой в строках).
           if (isReorderable) const SizedBox(width: _dragHandleWidth),
           // Место под обложку
@@ -595,6 +660,9 @@ class _TableHeader extends StatelessWidget {
 /// Ширина колонки с drag-handle (используется и в хедере, и в строках).
 const double _dragHandleWidth = 28.0;
 
+/// Ширина колонки с чекбоксом (header + строки).
+const double _checkboxColumnWidth = 40.0;
+
 // ---------------------------------------------------------------------------
 // Row
 // ---------------------------------------------------------------------------
@@ -614,6 +682,8 @@ class _TableRow extends StatefulWidget {
     required this.thumbRadius,
     this.dragIndex,
     this.rowIndex,
+    this.isSelected = false,
+    this.onToggleSelect,
     super.key,
   });
 
@@ -636,6 +706,12 @@ class _TableRow extends StatefulWidget {
   /// Порядковый номер строки в видимом списке (для zebra-фона).
   final int? rowIndex;
 
+  /// Выделена ли строка в режиме селекшна.
+  final bool isSelected;
+
+  /// Если задан — в строке появляется чекбокс; тап toggle'ит выделение.
+  final VoidCallback? onToggleSelect;
+
   @override
   State<_TableRow> createState() => _TableRowState();
 }
@@ -649,8 +725,9 @@ class _TableRowState extends State<_TableRow> {
     final bool isOdd = (widget.rowIndex ?? 0).isOdd;
     final Color baseColor =
         isOdd ? const Color(0x0AFFFFFF) : Colors.transparent;
-    final Color bgColor =
-        _hovered ? AppColors.brand.withAlpha(22) : baseColor;
+    final Color bgColor = widget.isSelected
+        ? AppColors.brand.withAlpha(40)
+        : (_hovered ? AppColors.brand.withAlpha(22) : baseColor);
 
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
@@ -671,6 +748,14 @@ class _TableRowState extends State<_TableRow> {
           ),
           child: Row(
             children: <Widget>[
+              if (widget.onToggleSelect != null)
+                SizedBox(
+                  width: _checkboxColumnWidth,
+                  child: Checkbox(
+                    value: widget.isSelected,
+                    onChanged: (_) => widget.onToggleSelect!(),
+                  ),
+                ),
               if (widget.dragIndex != null)
                 SizedBox(
                   width: _dragHandleWidth,
@@ -1286,3 +1371,5 @@ class _TagCell extends StatelessWidget {
     });
   }
 }
+
+

--- a/lib/features/collections/widgets/selectable_poster_card.dart
+++ b/lib/features/collections/widgets/selectable_poster_card.dart
@@ -1,0 +1,134 @@
+// Обёртка над MediaPosterCard с чекбоксом-оверлеем для bulk selection.
+//
+// Под Google Photos style: круглая «галка» в верхнем левом углу,
+// тап по ней toggle'ит выделение; тап по остальному телу карточки —
+// обычный open. При активном селекшне любая карточка показывает
+// чекмарк (полупрозрачный для невыделенных, brand-tinted для выделенных).
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+
+/// Накладывает чекбокс-оверлей на child-карточку.
+class SelectablePosterCard extends StatefulWidget {
+  /// Создаёт [SelectablePosterCard].
+  const SelectablePosterCard({
+    required this.child,
+    required this.isSelected,
+    required this.onToggleSelect,
+    required this.selectionActive,
+    super.key,
+  });
+
+  /// Карточка постера (обычно [MediaPosterCard]).
+  final Widget child;
+
+  /// Выделена ли карточка.
+  final bool isSelected;
+
+  /// Toggle-колбэк.
+  final VoidCallback onToggleSelect;
+
+  /// Активен ли вообще режим выделения (есть выделенные элементы).
+  /// Когда активен, чекмарки видны всегда; иначе — только на hover.
+  final bool selectionActive;
+
+  @override
+  State<SelectablePosterCard> createState() => _SelectablePosterCardState();
+}
+
+class _SelectablePosterCardState extends State<SelectablePosterCard> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool show = widget.selectionActive ||
+        widget.isSelected ||
+        _hovered;
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: Stack(
+        fit: StackFit.passthrough,
+        children: <Widget>[
+          widget.child,
+          if (widget.isSelected)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.black.withAlpha(120),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+            ),
+          Positioned(
+            top: 6,
+            left: 6,
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 120),
+              opacity: show ? 1 : 0,
+              child: _CheckCircle(
+                isSelected: widget.isSelected,
+                interactive: show,
+                onTap: widget.onToggleSelect,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CheckCircle extends StatelessWidget {
+  const _CheckCircle({
+    required this.isSelected,
+    required this.interactive,
+    required this.onTap,
+  });
+
+  final bool isSelected;
+
+  /// Если кружок невидим (opacity 0), отключаем его в hit-testing,
+  /// чтобы не блокировать клики по карточке.
+  final bool interactive;
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget circle = MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          width: 22,
+          height: 22,
+          decoration: BoxDecoration(
+            color: isSelected
+                ? AppColors.brand
+                : Colors.black.withAlpha(140),
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: isSelected
+                  ? AppColors.brand
+                  : Colors.white.withAlpha(200),
+              width: 1.5,
+            ),
+          ),
+          child: isSelected
+              ? const Icon(
+                  Icons.check_rounded,
+                  size: 14,
+                  color: Colors.white,
+                )
+              : null,
+        ),
+      ),
+    );
+    return interactive ? circle : IgnorePointer(child: circle);
+  }
+}

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -21,8 +21,11 @@ import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/chevron_filter_bar.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../collections/helpers/collection_actions.dart';
+import '../../collections/providers/all_items_selection_provider.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../collections/screens/item_detail_screen.dart';
+import '../../collections/widgets/bulk_action_bar.dart';
+import '../../collections/widgets/selectable_poster_card.dart';
 import '../../collections/widgets/status_chip_row.dart';
 import '../providers/all_items_provider.dart';
 
@@ -60,10 +63,27 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     final ItemStatus? filterStatus = ref.watch(homeStatusFilterProvider);
     final String searchQuery = ref.watch(homeSearchQueryProvider);
 
+    final Set<int> selection = ref.watch(allItemsSelectionProvider);
+    final List<CollectionItem> allItems =
+        itemsAsync.valueOrNull ?? const <CollectionItem>[];
+    final List<CollectionItem> selectedItems = selection.isEmpty
+        ? const <CollectionItem>[]
+        : <CollectionItem>[
+            for (final CollectionItem i in allItems)
+              if (selection.contains(i.id)) i,
+          ];
+
     return Column(
       children: <Widget>[
         _buildMediaTypeBar(itemsAsync, filterStatus),
         _buildPlatformsRow(),
+        if (selectedItems.isNotEmpty)
+          BulkActionBar(
+            items: selectedItems,
+            onClearSelection: () => ref
+                .read(allItemsSelectionProvider.notifier)
+                .clear(),
+          ),
         Expanded(
           child: itemsAsync.when(
             data: (List<CollectionItem> items) {
@@ -384,7 +404,10 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                     final CollectionTag? tag = item.tagId != null
                         ? tagsMap[item.tagId]
                         : null;
-                    return MediaPosterCard(
+                    final Set<int> selection =
+                        ref.watch(allItemsSelectionProvider);
+                    final bool isSelected = selection.contains(item.id);
+                    final MediaPosterCard card = MediaPosterCard(
                       key: ValueKey<int>(item.id),
                       variant: isLandscape ||
                               isCompactScreen(context)
@@ -409,12 +432,25 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                       status: item.status,
                       tagName: tag?.name,
                       tagColor: tag?.color,
-                      onTap: () =>
-                          _showItemDetails(item, collectionNames),
+                      onTap: selection.isEmpty
+                          ? () => _showItemDetails(item, collectionNames)
+                          : () => ref
+                              .read(allItemsSelectionProvider.notifier)
+                              .toggle(item.id),
                       onSecondaryTap: (Offset pos) =>
                           _showItemContextMenu(pos, item),
-                      onLongPress: () =>
-                          _showItemContextMenu(_centerOfContext(), item),
+                      onLongPress: () => ref
+                          .read(allItemsSelectionProvider.notifier)
+                          .toggle(item.id),
+                    );
+                    return SelectablePosterCard(
+                      key: ValueKey<int>(item.id),
+                      isSelected: isSelected,
+                      selectionActive: selection.isNotEmpty,
+                      onToggleSelect: () => ref
+                          .read(allItemsSelectionProvider.notifier)
+                          .toggle(item.id),
+                      child: card,
                     );
                   },
                   childCount: groups[i].items.length,
@@ -556,11 +592,6 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         ],
       ),
     );
-  }
-
-  Offset _centerOfContext() {
-    final Size size = MediaQuery.sizeOf(context);
-    return Offset(size.width / 2, size.height / 2);
   }
 
   bool _isItemEditable(CollectionItem item) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -74,6 +74,41 @@
   "remove": "Remove",
   "moveToTop": "Move to top",
   "moveToBottom": "Move to bottom",
+  "bulkSelected": "{count, plural, =1{1 selected} other{{count} selected}}",
+  "@bulkSelected": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkClearSelection": "Clear selection",
+  "bulkMove": "Move selected to collection",
+  "bulkCopy": "Copy selected to collection",
+  "bulkChangeStatus": "Change status",
+  "bulkRemoveConfirm": "Remove {count, plural, =1{1 item} other{{count} items}} from this collection?",
+  "@bulkRemoveConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkResult": "Done: {done} • Skipped: {skipped}",
+  "@bulkResult": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "skipped": {"type": "int"}
+    }
+  },
+  "bulkRemoved": "Removed: {count}",
+  "@bulkRemoved": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkStatusUpdated": "Status updated for {count, plural, =1{1 item} other{{count} items}}",
+  "@bulkStatusUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "back": "Back",
   "next": "Next",
   "skip": "Skip",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -499,6 +499,60 @@ abstract class S {
   /// **'Move to bottom'**
   String get moveToBottom;
 
+  /// No description provided for @bulkSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 selected} other{{count} selected}}'**
+  String bulkSelected(int count);
+
+  /// No description provided for @bulkClearSelection.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear selection'**
+  String get bulkClearSelection;
+
+  /// No description provided for @bulkMove.
+  ///
+  /// In en, this message translates to:
+  /// **'Move selected to collection'**
+  String get bulkMove;
+
+  /// No description provided for @bulkCopy.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy selected to collection'**
+  String get bulkCopy;
+
+  /// No description provided for @bulkChangeStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Change status'**
+  String get bulkChangeStatus;
+
+  /// No description provided for @bulkRemoveConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove {count, plural, =1{1 item} other{{count} items}} from this collection?'**
+  String bulkRemoveConfirm(int count);
+
+  /// No description provided for @bulkResult.
+  ///
+  /// In en, this message translates to:
+  /// **'Done: {done} • Skipped: {skipped}'**
+  String bulkResult(int done, int skipped);
+
+  /// No description provided for @bulkRemoved.
+  ///
+  /// In en, this message translates to:
+  /// **'Removed: {count}'**
+  String bulkRemoved(int count);
+
+  /// No description provided for @bulkStatusUpdated.
+  ///
+  /// In en, this message translates to:
+  /// **'Status updated for {count, plural, =1{1 item} other{{count} items}}'**
+  String bulkStatusUpdated(int count);
+
   /// No description provided for @back.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -210,6 +210,61 @@ class SEn extends S {
   String get moveToBottom => 'Move to bottom';
 
   @override
+  String bulkSelected(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count selected',
+      one: '1 selected',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkClearSelection => 'Clear selection';
+
+  @override
+  String get bulkMove => 'Move selected to collection';
+
+  @override
+  String get bulkCopy => 'Copy selected to collection';
+
+  @override
+  String get bulkChangeStatus => 'Change status';
+
+  @override
+  String bulkRemoveConfirm(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items',
+      one: '1 item',
+    );
+    return 'Remove $_temp0 from this collection?';
+  }
+
+  @override
+  String bulkResult(int done, int skipped) {
+    return 'Done: $done • Skipped: $skipped';
+  }
+
+  @override
+  String bulkRemoved(int count) {
+    return 'Removed: $count';
+  }
+
+  @override
+  String bulkStatusUpdated(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items',
+      one: '1 item',
+    );
+    return 'Status updated for $_temp0';
+  }
+
+  @override
   String get back => 'Back';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -210,6 +210,67 @@ class SRu extends S {
   String get moveToBottom => 'В конец списка';
 
   @override
+  String bulkSelected(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Выбрано $count',
+      many: 'Выбрано $count',
+      few: 'Выбрано $count',
+      one: 'Выбран 1',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkClearSelection => 'Снять выделение';
+
+  @override
+  String get bulkMove => 'Переместить выделенные в коллекцию';
+
+  @override
+  String get bulkCopy => 'Скопировать выделенные в коллекцию';
+
+  @override
+  String get bulkChangeStatus => 'Изменить статус';
+
+  @override
+  String bulkRemoveConfirm(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count элементов',
+      many: '$count элементов',
+      few: '$count элемента',
+      one: '1 элемент',
+    );
+    return 'Удалить $_temp0 из коллекции?';
+  }
+
+  @override
+  String bulkResult(int done, int skipped) {
+    return 'Выполнено: $done • Пропущено: $skipped';
+  }
+
+  @override
+  String bulkRemoved(int count) {
+    return 'Удалено: $count';
+  }
+
+  @override
+  String bulkStatusUpdated(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count элементов',
+      many: '$count элементов',
+      few: '$count элементов',
+      one: '1 элемента',
+    );
+    return 'Статус обновлён для $_temp0';
+  }
+
+  @override
   String get back => 'Назад';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -74,6 +74,41 @@
   "remove": "Убрать",
   "moveToTop": "В начало списка",
   "moveToBottom": "В конец списка",
+  "bulkSelected": "{count, plural, =1{Выбран 1} few{Выбрано {count}} many{Выбрано {count}} other{Выбрано {count}}}",
+  "@bulkSelected": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkClearSelection": "Снять выделение",
+  "bulkMove": "Переместить выделенные в коллекцию",
+  "bulkCopy": "Скопировать выделенные в коллекцию",
+  "bulkChangeStatus": "Изменить статус",
+  "bulkRemoveConfirm": "Удалить {count, plural, =1{1 элемент} few{{count} элемента} many{{count} элементов} other{{count} элементов}} из коллекции?",
+  "@bulkRemoveConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkResult": "Выполнено: {done} • Пропущено: {skipped}",
+  "@bulkResult": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "skipped": {"type": "int"}
+    }
+  },
+  "bulkRemoved": "Удалено: {count}",
+  "@bulkRemoved": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkStatusUpdated": "Статус обновлён для {count, plural, =1{1 элемента} few{{count} элементов} many{{count} элементов} other{{count} элементов}}",
+  "@bulkStatusUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
   "back": "Назад",
   "next": "Далее",
   "skip": "Пропустить",

--- a/test/features/collections/providers/collection_selection_provider_test.dart
+++ b/test/features/collections/providers/collection_selection_provider_test.dart
@@ -1,0 +1,66 @@
+// Тесты CollectionSelectionNotifier.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/providers/collection_selection_provider.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final ProviderContainer c = ProviderContainer();
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('CollectionSelectionNotifier', () {
+    test('initial state is empty', () {
+      final ProviderContainer c = makeContainer();
+      expect(c.read(collectionSelectionProvider(1)), isEmpty);
+    });
+
+    test('toggle adds id when absent and removes when present', () {
+      final ProviderContainer c = makeContainer();
+      final CollectionSelectionNotifier n =
+          c.read(collectionSelectionProvider(1).notifier);
+      n.toggle(10);
+      n.toggle(20);
+      expect(c.read(collectionSelectionProvider(1)), <int>{10, 20});
+      n.toggle(10);
+      expect(c.read(collectionSelectionProvider(1)), <int>{20});
+    });
+
+    test('selectAll replaces the set', () {
+      final ProviderContainer c = makeContainer();
+      final CollectionSelectionNotifier n =
+          c.read(collectionSelectionProvider(1).notifier);
+      n.toggle(10);
+      n.selectAll(<int>[1, 2, 3]);
+      expect(c.read(collectionSelectionProvider(1)), <int>{1, 2, 3});
+    });
+
+    test('clear empties the set', () {
+      final ProviderContainer c = makeContainer();
+      final CollectionSelectionNotifier n =
+          c.read(collectionSelectionProvider(1).notifier);
+      n.selectAll(<int>[1, 2]);
+      n.clear();
+      expect(c.read(collectionSelectionProvider(1)), isEmpty);
+    });
+
+    test('removeIds drops only the listed ids', () {
+      final ProviderContainer c = makeContainer();
+      final CollectionSelectionNotifier n =
+          c.read(collectionSelectionProvider(1).notifier);
+      n.selectAll(<int>[1, 2, 3, 4]);
+      n.removeIds(<int>[2, 3, 99]);
+      expect(c.read(collectionSelectionProvider(1)), <int>{1, 4});
+    });
+
+    test('selections are isolated between collections (family)', () {
+      final ProviderContainer c = makeContainer();
+      c.read(collectionSelectionProvider(1).notifier).toggle(10);
+      c.read(collectionSelectionProvider(2).notifier).toggle(20);
+      expect(c.read(collectionSelectionProvider(1)), <int>{10});
+      expect(c.read(collectionSelectionProvider(2)), <int>{20});
+    });
+  });
+}


### PR DESCRIPTION
Collection table gets a checkbox column; grid / list / manual-reorder and All Items get a Google-Photos-style check-circle overlay. Hover on desktop or long-press on mobile starts selection; while at least one item is selected, tapping any other card toggles selection.

A shared bulk action bar (move / copy / status / remove, plus move-to-top / move-to-bottom in manual sort) sits above the list and operates through a new collection-agnostic BulkOperations helper that reads each item's collectionId / mediaType / status and invalidates the union of affected providers once per batch. Long-press on mobile no longer opens the per-row context menu — all of its actions are in the bar.