### PR TITLE
feat(welcome): content language picker with UI-language autosync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,45 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * pubspec.yaml: Add direct `xml: ^6.5.0` dependency.
   * test/core/services/mal_import_service_test.dart: 18 tests covering XML parsing (anime/manga, status mapping, validation, kind fallback), `Completed` back-fill, unmatched-to-wishlist with MAL markdown link, and re-import dedup that updates instead of inserting.
 
+- **Content language picker in welcome wizard with UI-language autosync**
+
+  The wizard language step now lets the user pick the TMDB content
+  language (used for movie / TV descriptions) directly, instead of
+  silently keeping the previous `ru-RU` default while the UI is set
+  to English. Tapping a UI-language option also auto-applies the
+  matching content language (English → `en-US`, Russian → `ru-RU`)
+  until the user picks a content language by hand — after that the
+  manual choice sticks and toggling the UI language stops touching
+  it. The same picker now drives the Settings → Content language
+  dialog, so adding a new locale flows through both surfaces from a
+  single source.
+
+  * lib/shared/constants/tmdb_content_languages.dart (TmdbContentLanguage,
+    kTmdbContentLanguages, defaultContentLanguageForUi): New. Single
+    extensible list of supported TMDB locales plus the UI → content
+    fallback map; new pairs (UI locale + matching `xx-YY` translation)
+    are added here in one place.
+  * lib/features/welcome/widgets/welcome_step_language.dart
+    (WelcomeStepLanguage, _WelcomeStepLanguageState._onUiLanguageSelected,
+    _WelcomeStepLanguageState._onContentLanguageSelected,
+    _ContentLanguageDropdown): Convert to `ConsumerStatefulWidget`;
+    add a styled dropdown bound to `tmdbLanguage`; track a
+    `_contentLangTouched` flag so UI-language taps only seed the
+    content language while the user hasn't customized it.
+  * lib/features/settings/screens/settings_screen.dart
+    (_SettingsScreenState._contentLanguageLabel,
+    _SettingsScreenState._showContentLanguagePicker): Drop the two
+    hardcoded `en-US` / `ru-RU` branches; iterate `kTmdbContentLanguages`
+    for both the tile value and the picker dialog.
+  * test/shared/constants/tmdb_content_languages_test.dart: New. Verifies
+    list non-emptiness, code uniqueness, IETF BCP 47 code format, and
+    `defaultContentLanguageForUi` mapping (including unknown-code
+    fallback to `en-US`).
+  * test/features/welcome/widgets/welcome_step_language_test.dart: Add
+    tests for dropdown presence, content-language save, UI → content
+    autosync for both `en` and `ru`, and that a manual dropdown pick
+    disables the autosync on subsequent UI-language taps.
+
 ### Changed
 
 - **Unified brand-icon rendering across settings, welcome wizard, and search**

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import '../../../core/api/ra_api.dart';
 import '../../../core/services/discord_rpc_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/constants/platform_features.dart';
+import '../../../shared/constants/tmdb_content_languages.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/navigation/search_providers.dart';
 import '../../../shared/theme/app_assets.dart';
@@ -322,7 +323,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             leadingColor: _kAppearanceColor,
             title: l.settingsContentLanguage,
             subtitle: l.settingsContentLanguageSubtitle,
-            value: settings.tmdbLanguage == 'ru-RU' ? 'Русский' : 'English',
+            value: _contentLanguageLabel(settings.tmdbLanguage),
             onTap: () => _showContentLanguagePicker(settings),
           ),
           SettingsTile(
@@ -605,48 +606,38 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
+  String _contentLanguageLabel(String code) {
+    for (final TmdbContentLanguage lang in kTmdbContentLanguages) {
+      if (lang.code == code) return lang.nativeName;
+    }
+    return code;
+  }
+
   void _showContentLanguagePicker(SettingsState settings) {
     showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => SimpleDialog(
         title: Text(S.of(context).settingsContentLanguage),
         children: <Widget>[
-          SimpleDialogOption(
-            onPressed: () {
-              ref
-                  .read(settingsNotifierProvider.notifier)
-                  .setTmdbLanguage('en-US');
-              Navigator.pop(dialogContext);
-            },
-            child: Row(
-              children: <Widget>[
-                if (settings.tmdbLanguage == 'en-US')
-                  const Icon(Icons.check, size: 18, color: AppColors.brand)
-                else
-                  const SizedBox(width: 18),
-                const SizedBox(width: AppSpacing.sm),
-                const Text('English'),
-              ],
+          for (final TmdbContentLanguage lang in kTmdbContentLanguages)
+            SimpleDialogOption(
+              onPressed: () {
+                ref
+                    .read(settingsNotifierProvider.notifier)
+                    .setTmdbLanguage(lang.code);
+                Navigator.pop(dialogContext);
+              },
+              child: Row(
+                children: <Widget>[
+                  if (settings.tmdbLanguage == lang.code)
+                    const Icon(Icons.check, size: 18, color: AppColors.brand)
+                  else
+                    const SizedBox(width: 18),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(lang.nativeName),
+                ],
+              ),
             ),
-          ),
-          SimpleDialogOption(
-            onPressed: () {
-              ref
-                  .read(settingsNotifierProvider.notifier)
-                  .setTmdbLanguage('ru-RU');
-              Navigator.pop(dialogContext);
-            },
-            child: Row(
-              children: <Widget>[
-                if (settings.tmdbLanguage == 'ru-RU')
-                  const Icon(Icons.check, size: 18, color: AppColors.brand)
-                else
-                  const SizedBox(width: 18),
-                const SizedBox(width: AppSpacing.sm),
-                const Text('Русский'),
-              ],
-            ),
-          ),
         ],
       ),
     );

--- a/lib/features/welcome/widgets/welcome_step_language.dart
+++ b/lib/features/welcome/widgets/welcome_step_language.dart
@@ -1,21 +1,46 @@
-// Шаг 3 Welcome Wizard — выбор языка интерфейса.
+// Шаг 3 Welcome Wizard — выбор языка интерфейса и языка контента.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../features/settings/providers/settings_provider.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/constants/tmdb_content_languages.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 
-/// Шаг 3: Language — выбор языка интерфейса.
-class WelcomeStepLanguage extends ConsumerWidget {
+/// Шаг 3: Language — выбор языка интерфейса и языка контента.
+class WelcomeStepLanguage extends ConsumerStatefulWidget {
   /// Создаёт [WelcomeStepLanguage].
   const WelcomeStepLanguage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<WelcomeStepLanguage> createState() =>
+      _WelcomeStepLanguageState();
+}
+
+class _WelcomeStepLanguageState extends ConsumerState<WelcomeStepLanguage> {
+  /// Пользователь явно выбрал язык контента руками — отключаем автосинк
+  /// с UI-языком, чтобы не перезатереть осознанный выбор.
+  bool _contentLangTouched = false;
+
+  void _onUiLanguageSelected(String uiCode) {
+    final SettingsNotifier notifier =
+        ref.read(settingsNotifierProvider.notifier);
+    notifier.setAppLanguage(uiCode);
+    if (!_contentLangTouched) {
+      notifier.setTmdbLanguage(defaultContentLanguageForUi(uiCode));
+    }
+  }
+
+  void _onContentLanguageSelected(String code) {
+    setState(() => _contentLangTouched = true);
+    ref.read(settingsNotifierProvider.notifier).setTmdbLanguage(code);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final SettingsState settings = ref.watch(settingsNotifierProvider);
     final S l = S.of(context);
 
@@ -63,9 +88,7 @@ class WelcomeStepLanguage extends ConsumerWidget {
                   child: _LanguageOption(
                     label: 'English',
                     isSelected: settings.appLanguage == 'en',
-                    onTap: () => ref
-                        .read(settingsNotifierProvider.notifier)
-                        .setAppLanguage('en'),
+                    onTap: () => _onUiLanguageSelected('en'),
                   ),
                 ),
                 const SizedBox(height: AppSpacing.sm),
@@ -74,9 +97,17 @@ class WelcomeStepLanguage extends ConsumerWidget {
                   child: _LanguageOption(
                     label: 'Русский',
                     isSelected: settings.appLanguage == 'ru',
-                    onTap: () => ref
-                        .read(settingsNotifierProvider.notifier)
-                        .setAppLanguage('ru'),
+                    onTap: () => _onUiLanguageSelected('ru'),
+                  ),
+                ),
+                SizedBox(height: isSmallScreen ? AppSpacing.md : AppSpacing.lg),
+                SizedBox(
+                  width: 280,
+                  child: _ContentLanguageDropdown(
+                    value: settings.tmdbLanguage,
+                    label: l.settingsContentLanguage,
+                    subtitle: l.settingsContentLanguageSubtitle,
+                    onChanged: _onContentLanguageSelected,
                   ),
                 ),
                 const SizedBox(height: AppSpacing.md),
@@ -92,6 +123,78 @@ class WelcomeStepLanguage extends ConsumerWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _ContentLanguageDropdown extends StatelessWidget {
+  const _ContentLanguageDropdown({
+    required this.value,
+    required this.label,
+    required this.subtitle,
+    required this.onChanged,
+  });
+
+  final String value;
+  final String label;
+  final String subtitle;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool hasValue = kTmdbContentLanguages
+        .any((TmdbContentLanguage lang) => lang.code == value);
+    final String effectiveValue =
+        hasValue ? value : kTmdbContentLanguages.first.code;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          label,
+          style: AppTypography.body.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          subtitle,
+          style: AppTypography.bodySmall.copyWith(
+            color: AppColors.textTertiary,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            border: Border.all(color: AppColors.surfaceBorder),
+            borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+          ),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              isExpanded: true,
+              value: effectiveValue,
+              icon: const Icon(Icons.arrow_drop_down,
+                  color: AppColors.textTertiary),
+              dropdownColor: AppColors.surface,
+              style: AppTypography.body.copyWith(
+                color: AppColors.textPrimary,
+              ),
+              items: <DropdownMenuItem<String>>[
+                for (final TmdbContentLanguage lang in kTmdbContentLanguages)
+                  DropdownMenuItem<String>(
+                    value: lang.code,
+                    child: Text(lang.nativeName),
+                  ),
+              ],
+              onChanged: (String? code) {
+                if (code != null) onChanged(code);
+              },
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/shared/constants/tmdb_content_languages.dart
+++ b/lib/shared/constants/tmdb_content_languages.dart
@@ -1,0 +1,48 @@
+// Список поддерживаемых языков контента TMDB.
+
+import 'package:flutter/foundation.dart';
+
+/// Локаль контента TMDB (`primary_translations`).
+///
+/// Используется для запросов `language=<code>` к TMDB API и
+/// в UI выбора языка описаний фильмов/сериалов.
+@immutable
+class TmdbContentLanguage {
+  /// Создаёт [TmdbContentLanguage].
+  const TmdbContentLanguage({
+    required this.code,
+    required this.nativeName,
+  });
+
+  /// Код локали в формате IETF BCP 47, например `ru-RU`.
+  final String code;
+
+  /// Название языка на самом этом языке (например, `Русский`, `English`).
+  final String nativeName;
+}
+
+/// Поддерживаемые языки контента TMDB.
+///
+/// Расширяется параллельно с локализацией интерфейса — пара локалей
+/// (UI ↔ TMDB) обычно добавляется одним патчем.
+const List<TmdbContentLanguage> kTmdbContentLanguages = <TmdbContentLanguage>[
+  TmdbContentLanguage(code: 'en-US', nativeName: 'English'),
+  TmdbContentLanguage(code: 'ru-RU', nativeName: 'Русский'),
+];
+
+/// Маппинг кода UI-локали → код языка контента TMDB по умолчанию.
+///
+/// Используется, чтобы при первом выборе UI-языка в визарде
+/// автоматически выставить парный язык контента. Если UI-локали нет
+/// в карте — возвращаем `en-US` как нейтральный fallback.
+const Map<String, String> _kUiToContentLanguage = <String, String>{
+  'en': 'en-US',
+  'ru': 'ru-RU',
+};
+
+/// Возвращает дефолтный TMDB-код для UI-локали.
+///
+/// Расширяется одновременно с [kTmdbContentLanguages].
+String defaultContentLanguageForUi(String uiLanguageCode) {
+  return _kUiToContentLanguage[uiLanguageCode] ?? 'en-US';
+}

--- a/test/features/welcome/widgets/welcome_step_language_test.dart
+++ b/test/features/welcome/widgets/welcome_step_language_test.dart
@@ -69,25 +69,52 @@ void main() {
       await tester.pumpWidget(createWidget());
       await tester.pump();
 
-      expect(find.text('English'), findsOneWidget);
-      expect(find.text('Русский'), findsOneWidget);
+      // "English" встречается в радио UI-языка и в dropdown языка контента;
+      // "Русский" — только в радио (текущая локаль контента — ru-RU дефолт,
+      // её dropdown показывает в свёрнутом виде).
+      expect(find.text('English'), findsWidgets);
+      expect(find.text('Русский'), findsWidgets);
     });
 
-    testWidgets('English is selected by default',
+    testWidgets('English is selected by default in UI radio',
         (WidgetTester tester) async {
       await tester.pumpWidget(createWidget());
       await tester.pump();
 
-      // Default language is 'en', so English should have check_circle
+      // Default appLanguage = 'en' → English-радио с check_circle.
       expect(find.byIcon(Icons.check_circle), findsOneWidget);
       expect(find.byIcon(Icons.radio_button_unchecked), findsOneWidget);
+    });
+
+    testWidgets('shows content language dropdown', (WidgetTester tester) async {
+      await tester.pumpWidget(createWidget());
+      await tester.pump();
+
+      expect(find.byType(DropdownButton<String>), findsOneWidget);
+    });
+
+    testWidgets('changing content language saves tmdbLanguage',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(createWidget());
+      await tester.pump();
+
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+
+      // В открытом меню каждый пункт рендерится дополнительно — выбираем
+      // English (в дефолте tmdbLanguage = ru-RU).
+      await tester.tap(find.text('English').last);
+      await tester.pumpAndSettle();
+
+      expect(prefs.getString(SettingsKeys.tmdbLanguage), 'en-US');
     });
 
     testWidgets('tapping Russian selects it', (WidgetTester tester) async {
       await tester.pumpWidget(createWidget());
       await tester.pump();
 
-      await tester.tap(find.text('Русский'));
+      // first() — радио UI-языка стоит выше dropdown языка контента в дереве.
+      await tester.tap(find.text('Русский').first);
       await tester.pump();
 
       expect(prefs.getString(SettingsKeys.appLanguage), 'ru');
@@ -101,10 +128,59 @@ void main() {
       await tester.pumpWidget(createWidget());
       await tester.pump();
 
-      await tester.tap(find.text('English'));
+      await tester.tap(find.text('English').first);
       await tester.pump();
 
       expect(prefs.getString(SettingsKeys.appLanguage), 'en');
+    });
+
+    testWidgets('selecting English UI sets tmdbLanguage to en-US',
+        (WidgetTester tester) async {
+      // Дефолт tmdbLanguage = ru-RU; нажимаем English UI → ожидаем en-US.
+      await tester.pumpWidget(createWidget());
+      await tester.pump();
+
+      await tester.tap(find.text('English').first);
+      await tester.pump();
+
+      expect(prefs.getString(SettingsKeys.appLanguage), 'en');
+      expect(prefs.getString(SettingsKeys.tmdbLanguage), 'en-US');
+    });
+
+    testWidgets('selecting Russian UI sets tmdbLanguage to ru-RU',
+        (WidgetTester tester) async {
+      // Стартуем с en/en-US, чтобы было что переключать.
+      await prefs.setString(SettingsKeys.tmdbLanguage, 'en-US');
+
+      await tester.pumpWidget(createWidget());
+      await tester.pump();
+
+      await tester.tap(find.text('Русский').first);
+      await tester.pump();
+
+      expect(prefs.getString(SettingsKeys.appLanguage), 'ru');
+      expect(prefs.getString(SettingsKeys.tmdbLanguage), 'ru-RU');
+    });
+
+    testWidgets('manual content language pick disables UI→content sync',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(createWidget());
+      await tester.pump();
+
+      // Юзер явно выбрал English как язык контента (дефолт был ru-RU).
+      await tester.tap(find.byType(DropdownButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('English').last);
+      await tester.pumpAndSettle();
+
+      expect(prefs.getString(SettingsKeys.tmdbLanguage), 'en-US');
+
+      // Теперь меняем UI на Русский — язык контента трогать НЕ должны.
+      await tester.tap(find.text('Русский').first);
+      await tester.pump();
+
+      expect(prefs.getString(SettingsKeys.appLanguage), 'ru');
+      expect(prefs.getString(SettingsKeys.tmdbLanguage), 'en-US');
     });
 
     testWidgets('selected option has check_circle icon',

--- a/test/shared/constants/tmdb_content_languages_test.dart
+++ b/test/shared/constants/tmdb_content_languages_test.dart
@@ -1,0 +1,65 @@
+// Тесты на константу kTmdbContentLanguages и маппинг UI→content.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/constants/tmdb_content_languages.dart';
+
+void main() {
+  group('kTmdbContentLanguages', () {
+    test('не пустой', () {
+      expect(kTmdbContentLanguages, isNotEmpty);
+    });
+
+    test('содержит en-US и ru-RU', () {
+      final Iterable<String> codes =
+          kTmdbContentLanguages.map((TmdbContentLanguage l) => l.code);
+      expect(codes, contains('en-US'));
+      expect(codes, contains('ru-RU'));
+    });
+
+    test('коды уникальны', () {
+      final List<String> codes = kTmdbContentLanguages
+          .map((TmdbContentLanguage l) => l.code)
+          .toList();
+      expect(codes.length, codes.toSet().length);
+    });
+
+    test('у всех нативное имя не пустое', () {
+      for (final TmdbContentLanguage lang in kTmdbContentLanguages) {
+        expect(lang.nativeName, isNotEmpty,
+            reason: 'Пустое nativeName у ${lang.code}');
+      }
+    });
+
+    test('коды в формате xx-XX (IETF BCP 47)', () {
+      final RegExp pattern = RegExp(r'^[a-z]{2}-[A-Z]{2}$');
+      for (final TmdbContentLanguage lang in kTmdbContentLanguages) {
+        expect(pattern.hasMatch(lang.code), isTrue,
+            reason: 'Невалидный код: ${lang.code}');
+      }
+    });
+  });
+
+  group('defaultContentLanguageForUi', () {
+    test('en → en-US', () {
+      expect(defaultContentLanguageForUi('en'), 'en-US');
+    });
+
+    test('ru → ru-RU', () {
+      expect(defaultContentLanguageForUi('ru'), 'ru-RU');
+    });
+
+    test('неизвестная локаль → en-US (fallback)', () {
+      expect(defaultContentLanguageForUi('xx'), 'en-US');
+      expect(defaultContentLanguageForUi(''), 'en-US');
+    });
+
+    test('возвращает код, который есть в kTmdbContentLanguages', () {
+      final Set<String> available = kTmdbContentLanguages
+          .map((TmdbContentLanguage l) => l.code)
+          .toSet();
+      for (final String ui in <String>['en', 'ru', 'unknown']) {
+        expect(available, contains(defaultContentLanguageForUi(ui)));
+      }
+    });
+  });
+}


### PR DESCRIPTION
- Add TmdbContentLanguage constants and defaultContentLanguageForUi map
- Wire content language dropdown in welcome wizard, auto-seed from UI choice until user picks manually
- Drive settings content-language picker from the same source


#203 