### PR TITLE
feat(anilist): import anime/manga lists by public username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,72 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Added
+
+- **Import anime and manga lists from a public AniList username**
+
+  New entry in Settings → Import alongside MyAnimeList / Steam / RA / Trakt.
+  No OAuth required — `MediaListCollection` GraphQL endpoint returns every
+  list (Watching / Completed / Planning / etc.) for any public profile in
+  one call. The form takes a username, lets you toggle anime / manga,
+  pick `Add new only` vs `Overwrite existing`, and target a new or
+  existing collection. The username is remembered across sessions.
+  AniList statuses map onto xerabora's five `ItemStatus` values:
+  CURRENT / REPEATING → inProgress, COMPLETED → completed, PLANNING →
+  planned, DROPPED / PAUSED → dropped. POINT_100 scores are normalised
+  to the local 1..10 scale; 0 is treated as "unrated". On `COMPLETED`
+  entries, episode / chapter / volume counters top up to the AniList
+  totals (mirrors MAL importer semantics). `isAdult` media and AniList
+  custom lists are filtered out to avoid duplicates.
+
+  * lib/core/api/anilist_api.dart (AniListApi.fetchUserMediaList,
+    AniListListEntry, AniListUserNotFoundException,
+    AniListPrivateProfileException, AniListApi._parseListEntry,
+    AniListApi._parseFuzzyDate): New `MediaListCollection` GraphQL
+    queries (anime + manga) and DTO; HTTP 404 and GraphQL
+    "not found" / "private" errors map to typed exceptions.
+  * lib/core/services/anilist_import_service.dart
+    (AniListImportService, AniListImportProgress, AniListImportResult,
+    AniListImportStage, ImportMode, aniListImportServiceProvider): New
+    service. Deduplicates against existing items by
+    (collectionId, mediaType, externalId); upserts the nested `Anime`
+    and `Manga` graphs in parallel before writing entries.
+  * lib/features/settings/screens/anilist_import_screen.dart,
+    lib/features/settings/content/anilist_import_content.dart
+    (AniListImportScreen, AniListImportContent): New screen and form.
+  * lib/features/settings/screens/settings_screen.dart: Adds AniList
+    tile to the Import group.
+  * lib/features/settings/providers/settings_provider.dart
+    (SettingsKeys.aniListUsername): Persists the last-used AniList
+    username after a successful import.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb: AniList import UI strings
+    (settingsAniListImport, aniListImportTitle,
+    aniListImportUsername, aniListImportInclude, aniListImportMode,
+    aniListImportImported, aniListImportUpdated,
+    aniListImportUserNotFound, aniListImportPrivateProfile, etc.).
+
 ### Changed
+
+- **Higher-quality AniList covers in collections and search**
+
+  AniList exposes three cover sizes (`extraLarge` ≈ 460×650,
+  `large` ≈ 230×325, `medium` ≈ 100×146). The app was requesting only
+  `large` / `medium` in GraphQL queries and, worse, the per-anime / manga
+  `thumbUrl` used in collection grids and detail screens preferred
+  `medium`, producing visibly blurry posters compared to the AniList
+  website. All 10 GraphQL `coverImage` selections now include
+  `extraLarge`, the models pick it with a `large` fallback, and the
+  collection-item resolver prefers `coverUrl` over `coverUrlMedium`.
+  Existing cached models keep their old URLs until the next upsert.
+
+  * lib/core/api/anilist_api.dart: Adds `extraLarge` to every
+    `coverImage` GraphQL selection (search, browse, by-id, by-MAL-id,
+    user-list queries).
+  * lib/shared/models/anime.dart (Anime.fromJson),
+    lib/shared/models/manga.dart (Manga.fromJson): Prefer `extraLarge`
+    with `large` fallback.
+  * lib/shared/models/collection_item.dart (_resolvedMedia anime/manga
+    cases): `thumbUrl` falls through `coverUrl ?? coverUrlMedium`.
 
 - **Localization polish: capitalized Russian TMDB genres, plural search tabs, English-only code comments**
 

--- a/lib/core/api/anilist_api.dart
+++ b/lib/core/api/anilist_api.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 import 'api_error_detail.dart';
 import '../../shared/models/anime.dart';
 import '../../shared/models/manga.dart';
+import '../../shared/models/media_type.dart';
 
 /// Провайдер для AniList API клиента.
 final Provider<AniListApi> aniListApiProvider =
@@ -31,6 +32,82 @@ class AniListApiException implements Exception {
   @override
   String toString() =>
       'AniListApiException: $message (status: $statusCode)';
+}
+
+/// AniList user does not exist or has no public lists.
+class AniListUserNotFoundException extends AniListApiException {
+  /// Creates an [AniListUserNotFoundException].
+  const AniListUserNotFoundException(String username)
+      : super('AniList user "$username" not found', statusCode: 404);
+}
+
+/// AniList profile is private — public list endpoints will not return data.
+class AniListPrivateProfileException extends AniListApiException {
+  /// Creates an [AniListPrivateProfileException].
+  const AniListPrivateProfileException(String username)
+      : super(
+          'AniList user "$username" has a private profile',
+          statusCode: 403,
+        );
+}
+
+/// Entry from a user's anime or manga list on AniList.
+class AniListListEntry {
+  /// Creates an [AniListListEntry].
+  const AniListListEntry({
+    required this.mediaId,
+    required this.mediaType,
+    required this.rawStatus,
+    required this.progress,
+    required this.progressVolumes,
+    required this.repeat,
+    this.scoreRaw100,
+    this.notes,
+    this.startedAt,
+    this.completedAt,
+    this.updatedAt,
+    this.anime,
+    this.manga,
+  });
+
+  /// AniList media ID.
+  final int mediaId;
+
+  /// Either [MediaType.anime] or [MediaType.manga].
+  final MediaType mediaType;
+
+  /// Raw AniList status: CURRENT / PLANNING / COMPLETED / DROPPED / PAUSED / REPEATING.
+  final String rawStatus;
+
+  /// Episodes watched (anime) or chapters read (manga).
+  final int progress;
+
+  /// Volumes read. Always 0 for anime.
+  final int progressVolumes;
+
+  /// Rewatch / reread count.
+  final int repeat;
+
+  /// Score on the 0..100 scale, or null if unset.
+  final int? scoreRaw100;
+
+  /// User notes attached to the entry.
+  final String? notes;
+
+  /// Start date (year/month/day from AniList fuzzy date).
+  final DateTime? startedAt;
+
+  /// Completion date.
+  final DateTime? completedAt;
+
+  /// Last time the entry was updated on AniList.
+  final DateTime? updatedAt;
+
+  /// Populated when [mediaType] is [MediaType.anime].
+  final Anime? anime;
+
+  /// Populated when [mediaType] is [MediaType.manga].
+  final Manga? manga;
 }
 
 /// Клиент для работы с AniList GraphQL API.
@@ -72,7 +149,7 @@ query ($page: Int, $perPage: Int, $search: String, $genres: [String],
           sort: $sort) {
       id
       title { romaji english native }
-      coverImage { large medium }
+      coverImage { extraLarge large medium }
       bannerImage
       description(asHtml: false)
       genres
@@ -102,7 +179,7 @@ query ($id: Int) {
   Media(id: $id, type: MANGA) {
     id
     title { romaji english native }
-    coverImage { large medium }
+    coverImage { extraLarge large medium }
     description(asHtml: false)
     genres
     averageScore
@@ -131,7 +208,7 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
     media(type: MANGA, id_in: $ids) {
       id
       title { romaji english native }
-      coverImage { large medium }
+      coverImage { extraLarge large medium }
       bannerImage
       description(asHtml: false)
       genres
@@ -175,7 +252,7 @@ query ($page: Int, $perPage: Int, $search: String, $genres: [String],
           sort: $sort) {
       id
       title { romaji english native }
-      coverImage { large medium }
+      coverImage { extraLarge large medium }
       bannerImage
       description(asHtml: false)
       genres
@@ -203,7 +280,7 @@ query ($id: Int) {
   Media(id: $id, type: ANIME) {
     id
     title { romaji english native }
-    coverImage { large medium }
+    coverImage { extraLarge large medium }
     bannerImage
     description(asHtml: false)
     genres
@@ -232,7 +309,7 @@ query ($page: Int, $perPage: Int, $malIds: [Int]) {
       id
       idMal
       title { romaji english native }
-      coverImage { large medium }
+      coverImage { extraLarge large medium }
       bannerImage
       description(asHtml: false)
       genres
@@ -262,7 +339,7 @@ query ($page: Int, $perPage: Int, $malIds: [Int]) {
       id
       idMal
       title { romaji english native }
-      coverImage { large medium }
+      coverImage { extraLarge large medium }
       bannerImage
       description(asHtml: false)
       genres
@@ -293,7 +370,7 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
     media(type: ANIME, id_in: $ids) {
       id
       title { romaji english native }
-      coverImage { large medium }
+      coverImage { extraLarge large medium }
       bannerImage
       description(asHtml: false)
       genres
@@ -813,6 +890,281 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
       return map;
     } on DioException catch (e) {
       throw _handleDioException(e, 'Failed to fetch manga by MAL IDs');
+    }
+  }
+
+  /// MediaListCollection returns every list (Watching, Completed, etc.) for a
+  /// user in a single response — there is no pagination at this level.
+  static const String _userAnimeListQuery = r'''
+query ($userName: String) {
+  MediaListCollection(userName: $userName, type: ANIME) {
+    lists {
+      isCustomList
+      entries {
+        status
+        score(format: POINT_100)
+        progress
+        progressVolumes
+        repeat
+        notes
+        startedAt { year month day }
+        completedAt { year month day }
+        updatedAt
+        media {
+          id
+          isAdult
+          title { romaji english native }
+          coverImage { extraLarge large medium }
+          bannerImage
+          description(asHtml: false)
+          genres
+          averageScore
+          meanScore
+          popularity
+          status
+          season
+          seasonYear
+          startDate { year month day }
+          episodes
+          duration
+          format
+          source
+          studios(isMain: true) { nodes { name } }
+          nextAiringEpisode { airingAt episode }
+        }
+      }
+    }
+  }
+}
+''';
+
+  static const String _userMangaListQuery = r'''
+query ($userName: String) {
+  MediaListCollection(userName: $userName, type: MANGA) {
+    lists {
+      isCustomList
+      entries {
+        status
+        score(format: POINT_100)
+        progress
+        progressVolumes
+        repeat
+        notes
+        startedAt { year month day }
+        completedAt { year month day }
+        updatedAt
+        media {
+          id
+          isAdult
+          title { romaji english native }
+          coverImage { extraLarge large medium }
+          bannerImage
+          description(asHtml: false)
+          genres
+          averageScore
+          meanScore
+          popularity
+          status
+          startDate { year month day }
+          chapters
+          volumes
+          format
+          countryOfOrigin
+          staff(sort: RELEVANCE, perPage: 5) {
+            edges {
+              node { name { full } }
+              role
+            }
+          }
+        }
+      }
+    }
+  }
+}
+''';
+
+  /// Fetches the public anime or manga list of an AniList user.
+  ///
+  /// Custom lists are skipped because their entries are duplicates of the
+  /// canonical-list entries with identical status/progress/score. `isAdult`
+  /// media is filtered out.
+  ///
+  /// Throws [AniListUserNotFoundException] when the user does not exist,
+  /// [AniListPrivateProfileException] when the profile is private,
+  /// [AniListApiException] otherwise. Only [MediaType.anime] and
+  /// [MediaType.manga] are accepted; other types raise [ArgumentError].
+  Future<List<AniListListEntry>> fetchUserMediaList({
+    required String userName,
+    required MediaType type,
+  }) async {
+    if (type != MediaType.anime && type != MediaType.manga) {
+      throw ArgumentError.value(type, 'type', 'Only anime/manga supported');
+    }
+
+    final String trimmed = userName.trim();
+    if (trimmed.isEmpty) {
+      throw ArgumentError.value(userName, 'userName', 'must not be empty');
+    }
+
+    final String query = type == MediaType.anime
+        ? _userAnimeListQuery
+        : _userMangaListQuery;
+
+    try {
+      final Response<dynamic> response = await _dio.post<dynamic>(
+        _baseUrl,
+        data: <String, dynamic>{
+          'query': query,
+          'variables': <String, dynamic>{'userName': trimmed},
+        },
+      );
+
+      if (response.statusCode == 404) {
+        throw AniListUserNotFoundException(trimmed);
+      }
+      if (response.statusCode != 200 || response.data == null) {
+        throw AniListApiException(
+          'Failed to fetch user media list',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> data =
+          response.data as Map<String, dynamic>;
+
+      // AniList returns GraphQL errors with HTTP 200; check the body before data.
+      final List<dynamic>? errors = data['errors'] as List<dynamic>?;
+      if (errors != null && errors.isNotEmpty) {
+        final Map<String, dynamic> firstError =
+            errors.first as Map<String, dynamic>;
+        final String message =
+            (firstError['message'] as String? ?? '').toLowerCase();
+        if (message.contains('not found') || message.contains('does not exist')) {
+          throw AniListUserNotFoundException(trimmed);
+        }
+        if (message.contains('private')) {
+          throw AniListPrivateProfileException(trimmed);
+        }
+        _log.warning('AniList GraphQL error: ${firstError['message']}');
+        throw AniListApiException(
+          firstError['message'] as String? ?? 'GraphQL error',
+        );
+      }
+
+      final Map<String, dynamic>? dataField =
+          data['data'] as Map<String, dynamic>?;
+      final Map<String, dynamic>? collection =
+          dataField?['MediaListCollection'] as Map<String, dynamic>?;
+      if (collection == null) {
+        return <AniListListEntry>[];
+      }
+
+      final List<dynamic> lists =
+          collection['lists'] as List<dynamic>? ?? <dynamic>[];
+
+      final Map<int, AniListListEntry> dedup = <int, AniListListEntry>{};
+
+      for (final dynamic listRaw in lists) {
+        final Map<String, dynamic> list = listRaw as Map<String, dynamic>;
+        // Кастомные списки дублируют записи из основных — пропускаем.
+        if (list['isCustomList'] as bool? ?? false) continue;
+
+        final List<dynamic> entries =
+            list['entries'] as List<dynamic>? ?? <dynamic>[];
+        for (final dynamic entryRaw in entries) {
+          final AniListListEntry? entry = _parseListEntry(
+            entryRaw as Map<String, dynamic>,
+            type,
+          );
+          if (entry != null) {
+            dedup[entry.mediaId] = entry;
+          }
+        }
+      }
+
+      return dedup.values.toList();
+    } on DioException catch (e) {
+      // AniList returns HTTP 404 when the username does not exist.
+      if (e.response?.statusCode == 404) {
+        throw AniListUserNotFoundException(trimmed);
+      }
+      throw _handleDioException(e, 'Failed to fetch user media list');
+    }
+  }
+
+  AniListListEntry? _parseListEntry(
+    Map<String, dynamic> json,
+    MediaType type,
+  ) {
+    final Map<String, dynamic>? media =
+        json['media'] as Map<String, dynamic>?;
+    if (media == null) return null;
+
+    // Hentai / adult content is excluded from imports.
+    if (media['isAdult'] as bool? ?? false) return null;
+
+    final int? mediaId = media['id'] as int?;
+    if (mediaId == null) return null;
+
+    final String status = (json['status'] as String? ?? '').trim();
+
+    final int scoreRaw = (json['score'] as num?)?.toInt() ?? 0;
+    final int? scoreRaw100 = scoreRaw > 0 ? scoreRaw : null;
+
+    final int progress = (json['progress'] as num?)?.toInt() ?? 0;
+    final int progressVolumes =
+        (json['progressVolumes'] as num?)?.toInt() ?? 0;
+    final int repeat = (json['repeat'] as num?)?.toInt() ?? 0;
+
+    final String? notesRaw = (json['notes'] as String?)?.trim();
+    final String? notes =
+        (notesRaw == null || notesRaw.isEmpty) ? null : notesRaw;
+
+    final DateTime? startedAt =
+        _parseFuzzyDate(json['startedAt'] as Map<String, dynamic>?);
+    final DateTime? completedAt =
+        _parseFuzzyDate(json['completedAt'] as Map<String, dynamic>?);
+
+    final int? updatedAtUnix = (json['updatedAt'] as num?)?.toInt();
+    final DateTime? updatedAt = (updatedAtUnix != null && updatedAtUnix > 0)
+        ? DateTime.fromMillisecondsSinceEpoch(
+            updatedAtUnix * 1000,
+            isUtc: true,
+          )
+        : null;
+
+    final Anime? anime =
+        type == MediaType.anime ? Anime.fromJson(media) : null;
+    final Manga? manga =
+        type == MediaType.manga ? Manga.fromJson(media) : null;
+
+    return AniListListEntry(
+      mediaId: mediaId,
+      mediaType: type,
+      rawStatus: status,
+      progress: progress,
+      progressVolumes: progressVolumes,
+      repeat: repeat,
+      scoreRaw100: scoreRaw100,
+      notes: notes,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      updatedAt: updatedAt,
+      anime: anime,
+      manga: manga,
+    );
+  }
+
+  static DateTime? _parseFuzzyDate(Map<String, dynamic>? raw) {
+    if (raw == null) return null;
+    final int? year = raw['year'] as int?;
+    if (year == null) return null;
+    final int month = raw['month'] as int? ?? 1;
+    final int day = raw['day'] as int? ?? 1;
+    try {
+      return DateTime.utc(year, month, day);
+    } on ArgumentError {
+      return null;
     }
   }
 

--- a/lib/core/services/anilist_import_service.dart
+++ b/lib/core/services/anilist_import_service.dart
@@ -1,0 +1,579 @@
+// Imports anime/manga from a public AniList user list via GraphQL.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import '../../shared/models/anime.dart';
+import '../../shared/models/collection.dart';
+import '../../shared/models/collection_item.dart';
+import '../../shared/models/item_status.dart';
+import '../../shared/models/item_status_logic.dart';
+import '../../shared/models/manga.dart';
+import '../../shared/models/media_type.dart';
+import '../../shared/models/universal_import_result.dart';
+import '../api/anilist_api.dart';
+import '../database/database_service.dart';
+
+/// Stage of AniList import.
+enum AniListImportStage {
+  /// Fetching anime list from AniList.
+  fetchingAnime,
+
+  /// Fetching manga list from AniList.
+  fetchingManga,
+
+  /// Writing entries into the collection.
+  matchingEntries,
+
+  /// Import finished.
+  completed,
+}
+
+/// Progress of AniList import.
+class AniListImportProgress {
+  /// Creates an [AniListImportProgress].
+  const AniListImportProgress({
+    required this.stage,
+    required this.current,
+    required this.total,
+    this.currentName,
+    this.importedCount = 0,
+    this.updatedCount = 0,
+  });
+
+  /// Current stage.
+  final AniListImportStage stage;
+
+  /// Current progress.
+  final int current;
+
+  /// Total count.
+  final int total;
+
+  /// Title currently being processed.
+  final String? currentName;
+
+  /// Number of imported titles.
+  final int importedCount;
+
+  /// Number of updated titles (re-import).
+  final int updatedCount;
+
+  /// Progress as fraction (0.0 – 1.0).
+  double get progress => total > 0 ? current / total : 0;
+}
+
+/// Result of AniList import.
+class AniListImportResult {
+  /// Creates an [AniListImportResult].
+  const AniListImportResult({
+    required this.imported,
+    required this.updated,
+    required this.total,
+    required this.collectionId,
+    required this.animeImported,
+    required this.mangaImported,
+    required this.animeUpdated,
+    required this.mangaUpdated,
+    required this.userName,
+  });
+
+  /// Total imported.
+  final int imported;
+
+  /// Total updated.
+  final int updated;
+
+  /// Total entries fetched.
+  final int total;
+
+  /// Import collection ID.
+  final int collectionId;
+
+  /// Anime imported.
+  final int animeImported;
+
+  /// Manga imported.
+  final int mangaImported;
+
+  /// Anime updated.
+  final int animeUpdated;
+
+  /// Manga updated.
+  final int mangaUpdated;
+
+  /// AniList username the import was made from.
+  final String userName;
+}
+
+/// Provider for [AniListImportService].
+final Provider<AniListImportService> aniListImportServiceProvider =
+    Provider<AniListImportService>((Ref ref) {
+  return AniListImportService(
+    aniListApi: ref.watch(aniListApiProvider),
+    database: ref.watch(databaseServiceProvider),
+  );
+});
+
+/// AniList import service.
+///
+/// Fetches public user lists for anime and manga via GraphQL and writes
+/// them into a collection. No OAuth — works with any public profile.
+class AniListImportService {
+  /// Creates an [AniListImportService].
+  AniListImportService({
+    required AniListApi aniListApi,
+    required DatabaseService database,
+  })  : _aniList = aniListApi,
+        _db = database;
+
+  static final Logger _log = Logger('AniListImportService');
+
+  final AniListApi _aniList;
+  final DatabaseService _db;
+
+  /// Imports AniList user lists into a collection.
+  ///
+  /// At least one of [includeAnime] / [includeManga] must be true.
+  /// Either [collectionId] or [createCollection] must be provided.
+  ///
+  /// Throws [AniListUserNotFoundException] / [AniListPrivateProfileException]
+  /// / [AniListApiException] when the AniList API call fails.
+  Future<AniListImportResult> importUserLists({
+    required String userName,
+    required ImportMode mode,
+    bool includeAnime = true,
+    bool includeManga = true,
+    int? collectionId,
+    Future<int> Function()? createCollection,
+    required void Function(AniListImportProgress) onProgress,
+  }) async {
+    if (!includeAnime && !includeManga) {
+      throw ArgumentError(
+        'At least one of includeAnime / includeManga must be true',
+      );
+    }
+    if (collectionId == null && createCollection == null) {
+      throw ArgumentError(
+        'Either collectionId or createCollection must be provided',
+      );
+    }
+
+    List<AniListListEntry> animeEntries = <AniListListEntry>[];
+    List<AniListListEntry> mangaEntries = <AniListListEntry>[];
+
+    if (includeAnime) {
+      onProgress(const AniListImportProgress(
+        stage: AniListImportStage.fetchingAnime,
+        current: 0,
+        total: 0,
+      ));
+      animeEntries = await _aniList.fetchUserMediaList(
+        userName: userName,
+        type: MediaType.anime,
+      );
+      onProgress(AniListImportProgress(
+        stage: AniListImportStage.fetchingAnime,
+        current: animeEntries.length,
+        total: animeEntries.length,
+      ));
+    }
+
+    if (includeManga) {
+      onProgress(const AniListImportProgress(
+        stage: AniListImportStage.fetchingManga,
+        current: 0,
+        total: 0,
+      ));
+      mangaEntries = await _aniList.fetchUserMediaList(
+        userName: userName,
+        type: MediaType.manga,
+      );
+      onProgress(AniListImportProgress(
+        stage: AniListImportStage.fetchingManga,
+        current: mangaEntries.length,
+        total: mangaEntries.length,
+      ));
+    }
+
+    final int totalEntries = animeEntries.length + mangaEntries.length;
+    if (totalEntries == 0) {
+      throw const FormatException('No entries found in AniList lists');
+    }
+
+    // Create the collection only after a successful fetch.
+    final int targetCollectionId = collectionId ?? await createCollection!();
+
+    final List<Anime> animeMedia = animeEntries
+        .where((AniListListEntry e) => e.anime != null)
+        .map((AniListListEntry e) => e.anime!)
+        .toList();
+    final List<Manga> mangaMedia = mangaEntries
+        .where((AniListListEntry e) => e.manga != null)
+        .map((AniListListEntry e) => e.manga!)
+        .toList();
+    await Future.wait<void>(<Future<void>>[
+      if (animeMedia.isNotEmpty) _db.upsertAnimes(animeMedia),
+      if (mangaMedia.isNotEmpty) _db.upsertMangas(mangaMedia),
+    ]);
+
+    final List<AniListListEntry> allEntries = <AniListListEntry>[
+      ...animeEntries,
+      ...mangaEntries,
+    ];
+
+    int imported = 0;
+    int updated = 0;
+    int animeImported = 0;
+    int mangaImported = 0;
+    int animeUpdated = 0;
+    int mangaUpdated = 0;
+
+    int processed = 0;
+    for (final AniListListEntry entry in allEntries) {
+      processed++;
+      onProgress(AniListImportProgress(
+        stage: AniListImportStage.matchingEntries,
+        current: processed,
+        total: allEntries.length,
+        currentName: _entryTitle(entry),
+        importedCount: imported,
+        updatedCount: updated,
+      ));
+
+      final ItemStatus status = _mapStatus(entry.rawStatus);
+
+      final CollectionItem? existing = await _db.findCollectionItem(
+        collectionId: targetCollectionId,
+        mediaType: entry.mediaType,
+        externalId: entry.mediaId,
+      );
+
+      if (existing != null) {
+        if (mode == ImportMode.newOnly) {
+          continue;
+        }
+        await _updateExistingItem(existing, entry, status);
+        updated++;
+        if (entry.mediaType == MediaType.anime) {
+          animeUpdated++;
+        } else {
+          mangaUpdated++;
+        }
+        continue;
+      }
+
+      final int? itemId = await _db.addItemToCollection(
+        collectionId: targetCollectionId,
+        mediaType: entry.mediaType,
+        externalId: entry.mediaId,
+        status: status,
+      );
+
+      if (itemId != null) {
+        await _writeEntryToItem(itemId, entry, status);
+      }
+
+      imported++;
+      if (entry.mediaType == MediaType.anime) {
+        animeImported++;
+      } else {
+        mangaImported++;
+      }
+    }
+
+    onProgress(AniListImportProgress(
+      stage: AniListImportStage.completed,
+      current: allEntries.length,
+      total: allEntries.length,
+      importedCount: imported,
+      updatedCount: updated,
+    ));
+
+    _log.info(
+      'AniList import complete for "$userName": '
+      '$imported imported, $updated updated (total $totalEntries)',
+    );
+
+    return AniListImportResult(
+      imported: imported,
+      updated: updated,
+      total: totalEntries,
+      collectionId: targetCollectionId,
+      animeImported: animeImported,
+      mangaImported: mangaImported,
+      animeUpdated: animeUpdated,
+      mangaUpdated: mangaUpdated,
+      userName: userName,
+    );
+  }
+
+  Future<void> _writeEntryToItem(
+    int itemId,
+    AniListListEntry entry,
+    ItemStatus status,
+  ) async {
+    final _ResolvedProgress progress = _resolveProgress(entry, status);
+    if (progress.currentEpisode > 0 || progress.currentSeason > 0) {
+      await _db.updateItemProgress(
+        itemId,
+        currentEpisode:
+            progress.currentEpisode > 0 ? progress.currentEpisode : null,
+        currentSeason:
+            progress.currentSeason > 0 ? progress.currentSeason : null,
+      );
+    }
+
+    final int? rating = _resolveRating(entry.scoreRaw100);
+    if (rating != null) {
+      await _db.updateItemUserRating(itemId, rating);
+    }
+
+    final _ResolvedDates dates = _resolveDates(entry, status);
+    if (dates.startedAt != null ||
+        dates.completedAt != null ||
+        dates.lastActivityAt != null) {
+      await _db.updateItemActivityDates(
+        itemId,
+        startedAt: dates.startedAt,
+        completedAt: dates.completedAt,
+        lastActivityAt: dates.lastActivityAt,
+      );
+    }
+
+    final String comment = _buildUserComment(entry);
+    if (comment.isNotEmpty) {
+      await _db.updateItemUserComment(itemId, comment);
+    }
+  }
+
+  Future<void> _updateExistingItem(
+    CollectionItem existing,
+    AniListListEntry entry,
+    ItemStatus status,
+  ) async {
+    final ItemStatus? newStatus = mergeExternalStatus(
+      currentStatus: existing.status,
+      externalStatus: status,
+    );
+    if (newStatus != null) {
+      await _db.updateItemStatus(
+        existing.id,
+        newStatus,
+        mediaType: existing.mediaType,
+      );
+    }
+
+    // Progress: keep max so we never regress local state.
+    final _ResolvedProgress remoteProgress = _resolveProgress(entry, status);
+    final int newEpisode =
+        remoteProgress.currentEpisode > existing.currentEpisode
+            ? remoteProgress.currentEpisode
+            : existing.currentEpisode;
+    final int newSeason = remoteProgress.currentSeason > existing.currentSeason
+        ? remoteProgress.currentSeason
+        : existing.currentSeason;
+    if (newEpisode != existing.currentEpisode ||
+        newSeason != existing.currentSeason) {
+      await _db.updateItemProgress(
+        existing.id,
+        currentEpisode: newEpisode > 0 ? newEpisode : null,
+        currentSeason: newSeason > 0 ? newSeason : null,
+      );
+    }
+
+    final int? rating = _resolveRating(entry.scoreRaw100);
+    if (rating != null && rating != existing.userRating) {
+      await _db.updateItemUserRating(existing.id, rating);
+    }
+
+    // Dates: keep earliest start, latest completion.
+    final _ResolvedDates remoteDates = _resolveDates(entry, status);
+    DateTime? newStarted = existing.startedAt;
+    DateTime? newCompleted = existing.completedAt;
+    if (remoteDates.startedAt != null) {
+      if (newStarted == null || remoteDates.startedAt!.isBefore(newStarted)) {
+        newStarted = remoteDates.startedAt;
+      }
+    }
+    if (remoteDates.completedAt != null) {
+      if (newCompleted == null ||
+          remoteDates.completedAt!.isAfter(newCompleted)) {
+        newCompleted = remoteDates.completedAt;
+      }
+    }
+    if (newStarted != existing.startedAt ||
+        newCompleted != existing.completedAt) {
+      await _db.updateItemActivityDates(
+        existing.id,
+        startedAt: newStarted,
+        completedAt: newCompleted,
+        lastActivityAt: entry.updatedAt ?? DateTime.now(),
+      );
+    }
+
+    final String comment = _buildUserComment(entry);
+    if (comment.isNotEmpty) {
+      await _db.updateItemUserComment(existing.id, comment);
+    }
+  }
+
+  _ResolvedProgress _resolveProgress(
+    AniListListEntry entry,
+    ItemStatus status,
+  ) {
+    int currentEpisode = entry.progress;
+    int currentSeason = entry.mediaType == MediaType.manga
+        ? entry.progressVolumes
+        : 0;
+
+    if (status == ItemStatus.completed) {
+      if (entry.mediaType == MediaType.anime) {
+        final int total = entry.anime?.episodes ?? 0;
+        if (total > currentEpisode) currentEpisode = total;
+      } else {
+        final int chaps = entry.manga?.chapters ?? 0;
+        if (chaps > currentEpisode) currentEpisode = chaps;
+        final int vols = entry.manga?.volumes ?? 0;
+        if (vols > currentSeason) currentSeason = vols;
+      }
+    }
+
+    return _ResolvedProgress(
+      currentEpisode: currentEpisode,
+      currentSeason: currentSeason,
+    );
+  }
+
+  _ResolvedDates _resolveDates(AniListListEntry entry, ItemStatus status) {
+    DateTime? startedAt = entry.startedAt;
+    DateTime? completedAt = entry.completedAt;
+
+    if (status == ItemStatus.completed) {
+      completedAt ??= startedAt ?? entry.updatedAt ?? DateTime.now();
+      startedAt ??= completedAt;
+    }
+
+    return _ResolvedDates(
+      startedAt: startedAt,
+      completedAt: completedAt,
+      lastActivityAt: entry.updatedAt ?? DateTime.now(),
+    );
+  }
+
+  /// Normalizes AniList POINT_100 score to xerabora 1..10.
+  static int? _resolveRating(int? scoreRaw100) {
+    if (scoreRaw100 == null || scoreRaw100 <= 0) return null;
+    final int normalized = scoreRaw100 ~/ 10;
+    if (normalized <= 0) return null;
+    if (normalized > 10) return 10;
+    return normalized;
+  }
+
+  String _buildUserComment(AniListListEntry entry) {
+    final List<String> lines = <String>[];
+
+    final String aniPath =
+        entry.mediaType == MediaType.anime ? 'anime' : 'manga';
+    lines.add('[AniList](https://anilist.co/$aniPath/${entry.mediaId})');
+
+    if (entry.repeat > 0) {
+      final String label = entry.mediaType == MediaType.anime
+          ? 'Rewatched times'
+          : 'Reread times';
+      lines.add('$label: ${entry.repeat}');
+    }
+
+    if (entry.mediaType == MediaType.manga && entry.progressVolumes > 0) {
+      lines.add('Volumes read: ${entry.progressVolumes}');
+    }
+
+    if (entry.notes != null) {
+      lines.add('');
+      lines.add(entry.notes!);
+    }
+
+    return lines.join('\n');
+  }
+
+  String _entryTitle(AniListListEntry entry) {
+    if (entry.anime != null) return entry.anime!.title;
+    if (entry.manga != null) return entry.manga!.title;
+    return '#${entry.mediaId}';
+  }
+
+  static ItemStatus _mapStatus(String raw) {
+    final String s = raw.toUpperCase().trim();
+    switch (s) {
+      case 'CURRENT':
+      case 'REPEATING':
+        return ItemStatus.inProgress;
+      case 'COMPLETED':
+        return ItemStatus.completed;
+      case 'PLANNING':
+        return ItemStatus.planned;
+      case 'DROPPED':
+      case 'PAUSED':
+        return ItemStatus.dropped;
+      default:
+        _log.warning('Unknown AniList status: "$raw" → notStarted');
+        return ItemStatus.notStarted;
+    }
+  }
+}
+
+/// Import behavior when a matching item already exists in the collection.
+enum ImportMode {
+  /// Skip existing items, add only new ones.
+  newOnly,
+
+  /// Overwrite fields on existing items with remote values.
+  overwrite,
+}
+
+class _ResolvedProgress {
+  const _ResolvedProgress({
+    required this.currentEpisode,
+    required this.currentSeason,
+  });
+
+  final int currentEpisode;
+  final int currentSeason;
+}
+
+class _ResolvedDates {
+  const _ResolvedDates({
+    required this.startedAt,
+    required this.completedAt,
+    required this.lastActivityAt,
+  });
+
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+  final DateTime? lastActivityAt;
+}
+
+/// Converts [AniListImportResult] to [UniversalImportResult].
+extension AniListImportResultToUniversal on AniListImportResult {
+  /// Maps to the universal result.
+  UniversalImportResult toUniversal({Collection? collection}) {
+    final Map<MediaType, int> importedByType = <MediaType, int>{};
+    final Map<MediaType, int> updatedByType = <MediaType, int>{};
+
+    if (animeImported > 0) importedByType[MediaType.anime] = animeImported;
+    if (mangaImported > 0) importedByType[MediaType.manga] = mangaImported;
+    if (animeUpdated > 0) updatedByType[MediaType.anime] = animeUpdated;
+    if (mangaUpdated > 0) updatedByType[MediaType.manga] = mangaUpdated;
+
+    return UniversalImportResult(
+      sourceName: 'AniList',
+      success: true,
+      collection: collection,
+      collectionId: collectionId,
+      importedByType: importedByType,
+      wishlistedByType: const <MediaType, int>{},
+      updatedByType: updatedByType,
+      skipped: (total - imported - updated).clamp(0, total),
+    );
+  }
+}

--- a/lib/features/settings/content/anilist_import_content.dart
+++ b/lib/features/settings/content/anilist_import_content.dart
@@ -1,0 +1,527 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../core/api/anilist_api.dart';
+import '../../../core/database/database_service.dart';
+import '../../../core/services/anilist_import_service.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/collection.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../collections/providers/canvas_provider.dart';
+import '../../collections/providers/collection_covers_provider.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../../home/providers/all_items_provider.dart';
+import '../providers/settings_provider.dart';
+import '../screens/import_result_screen.dart';
+import '../widgets/settings_group.dart';
+
+/// Form + progress UI for importing an AniList user's public anime/manga lists.
+class AniListImportContent extends ConsumerStatefulWidget {
+  /// Creates an [AniListImportContent].
+  const AniListImportContent({super.key});
+
+  @override
+  ConsumerState<AniListImportContent> createState() =>
+      _AniListImportContentState();
+}
+
+class _AniListImportContentState extends ConsumerState<AniListImportContent> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _newNameController = TextEditingController();
+
+  bool _isImporting = false;
+  AniListImportProgress? _progress;
+
+  bool _includeAnime = true;
+  bool _includeManga = true;
+  ImportMode _mode = ImportMode.newOnly;
+
+  bool _useNewCollection = true;
+  int? _selectedCollectionId;
+
+  @override
+  void initState() {
+    super.initState();
+    final SharedPreferences prefs = ref.read(sharedPreferencesProvider);
+    final String? saved = prefs.getString(SettingsKeys.aniListUsername);
+    if (saved != null && saved.isNotEmpty) {
+      _usernameController.text = saved;
+    }
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _newNameController.dispose();
+    super.dispose();
+  }
+
+  bool get _canStart {
+    if (_isImporting) return false;
+    if (_usernameController.text.trim().isEmpty) return false;
+    if (!_includeAnime && !_includeManga) return false;
+    if (_useNewCollection) return true;
+    return _selectedCollectionId != null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _buildInputSection(l),
+        if (_isImporting && _progress != null) ...<Widget>[
+          const SizedBox(height: AppSpacing.md),
+          _buildProgressSection(l),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildInputSection(S l) {
+    return SettingsGroup(
+      title: l.aniListImportTitle,
+      subtitle: l.aniListImportSubtitle,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          child: TextField(
+            controller: _usernameController,
+            enabled: !_isImporting,
+            decoration: InputDecoration(
+              labelText: l.aniListImportUsername,
+              hintText: l.aniListImportUsernameHint,
+              prefixIcon: const Icon(Icons.person_outline),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+        ),
+        _buildIncludeSection(l),
+        _buildModeSection(l),
+        const SizedBox(height: AppSpacing.sm),
+        _buildCollectionSelector(l),
+        Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: FilledButton.icon(
+            onPressed: _canStart ? _startImport : null,
+            icon: const Icon(Icons.download),
+            label: Text(l.aniListImportButton),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildIncludeSection(S l) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          child: Text(
+            l.aniListImportInclude,
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        CheckboxListTile(
+          value: _includeAnime,
+          onChanged: _isImporting
+              ? null
+              : (bool? v) => setState(() => _includeAnime = v ?? false),
+          title: Text(l.aniListImportIncludeAnime),
+          dense: true,
+          controlAffinity: ListTileControlAffinity.leading,
+        ),
+        CheckboxListTile(
+          value: _includeManga,
+          onChanged: _isImporting
+              ? null
+              : (bool? v) => setState(() => _includeManga = v ?? false),
+          title: Text(l.aniListImportIncludeManga),
+          dense: true,
+          controlAffinity: ListTileControlAffinity.leading,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModeSection(S l) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          child: Text(
+            l.aniListImportMode,
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        RadioGroup<ImportMode>(
+          groupValue: _mode,
+          onChanged: (ImportMode? value) {
+            if (value == null || _isImporting) return;
+            setState(() => _mode = value);
+          },
+          child: Column(
+            children: <Widget>[
+              ListTile(
+                title: Text(l.aniListImportModeNewOnly),
+                subtitle: Text(l.aniListImportModeNewOnlySubtitle),
+                leading: const Radio<ImportMode>(value: ImportMode.newOnly),
+                dense: true,
+                onTap: _isImporting
+                    ? null
+                    : () => setState(() => _mode = ImportMode.newOnly),
+              ),
+              ListTile(
+                title: Text(l.aniListImportModeOverwrite),
+                subtitle: Text(l.aniListImportModeOverwriteSubtitle),
+                leading: const Radio<ImportMode>(value: ImportMode.overwrite),
+                dense: true,
+                onTap: _isImporting
+                    ? null
+                    : () => setState(() => _mode = ImportMode.overwrite),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCollectionSelector(S l) {
+    final AsyncValue<List<Collection>> collectionsAsync =
+        ref.watch(collectionsProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          child: Text(
+            l.aniListImportTargetCollection,
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        RadioGroup<bool>(
+          groupValue: _useNewCollection,
+          onChanged: (bool? value) {
+            if (value == null || _isImporting) return;
+            setState(() {
+              _useNewCollection = value;
+              if (value) _selectedCollectionId = null;
+            });
+          },
+          child: Column(
+            children: <Widget>[
+              ListTile(
+                title: Text(l.aniListImportCreateNew),
+                leading: const Radio<bool>(value: true),
+                dense: true,
+                onTap: _isImporting
+                    ? null
+                    : () => setState(() {
+                          _useNewCollection = true;
+                          _selectedCollectionId = null;
+                        }),
+              ),
+              ListTile(
+                title: Text(l.aniListImportUseExisting),
+                leading: const Radio<bool>(value: false),
+                dense: true,
+                onTap: _isImporting
+                    ? null
+                    : () => setState(() {
+                          _useNewCollection = false;
+                        }),
+              ),
+            ],
+          ),
+        ),
+        if (_useNewCollection)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+            child: TextField(
+              controller: _newNameController,
+              enabled: !_isImporting,
+              decoration: InputDecoration(
+                labelText: l.aniListImportNewCollectionName,
+                hintText: _defaultCollectionName(l),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+          )
+        else
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+            child: collectionsAsync.when(
+              data: (List<Collection> collections) {
+                if (collections.isEmpty) {
+                  return Text(
+                    l.aniListImportNoCollections,
+                    style: AppTypography.bodySmall.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                  );
+                }
+                final bool selectedExists = _selectedCollectionId != null &&
+                    collections.any(
+                      (Collection c) => c.id == _selectedCollectionId,
+                    );
+                return DropdownButtonFormField<int>(
+                  initialValue: selectedExists ? _selectedCollectionId : null,
+                  hint: Text(l.aniListImportSelectCollection),
+                  isExpanded: true,
+                  items: collections.map((Collection c) {
+                    return DropdownMenuItem<int>(
+                      value: c.id,
+                      child: Text(c.name, overflow: TextOverflow.ellipsis),
+                    );
+                  }).toList(),
+                  onChanged: _isImporting
+                      ? null
+                      : (int? value) {
+                          setState(() => _selectedCollectionId = value);
+                        },
+                );
+              },
+              loading: () =>
+                  const Center(child: CircularProgressIndicator()),
+              error: (Object e, StackTrace s) => Text(
+                l.aniListImportErrorLoadingCollections,
+                style: AppTypography.bodySmall.copyWith(
+                  color: AppColors.statusDropped,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildProgressSection(S l) {
+    final AniListImportProgress progress = _progress!;
+
+    final String stageText;
+    switch (progress.stage) {
+      case AniListImportStage.fetchingAnime:
+        stageText = l.aniListImportFetchingAnime;
+      case AniListImportStage.fetchingManga:
+        stageText = l.aniListImportFetchingManga;
+      case AniListImportStage.matchingEntries:
+        stageText = l.aniListImportMatching;
+      case AniListImportStage.completed:
+        stageText = l.aniListImportComplete;
+    }
+
+    return SettingsGroup(
+      title: stageText,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              LinearProgressIndicator(
+                value: progress.total > 0 ? progress.progress : null,
+              ),
+              if (progress.total > 0) ...<Widget>[
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  '${progress.current} / ${progress.total}',
+                  style: AppTypography.bodySmall,
+                ),
+              ],
+              if (progress.currentName != null) ...<Widget>[
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  l.aniListImportLookingUp(progress.currentName!),
+                  style: AppTypography.bodySmall.copyWith(
+                    color: AppColors.textSecondary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              const SizedBox(height: AppSpacing.sm),
+              _buildStatRow(
+                Icons.check_circle,
+                AppColors.statusCompleted,
+                l.aniListImportImported(progress.importedCount),
+              ),
+              _buildStatRow(
+                Icons.sync,
+                AppColors.statusInProgress,
+                l.aniListImportUpdated(progress.updatedCount),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStatRow(IconData icon, Color color, String text) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Text(text, style: AppTypography.body),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _defaultCollectionName(S l) {
+    final String trimmed = _usernameController.text.trim();
+    if (trimmed.isEmpty) return l.aniListImportNewCollectionDefault('username');
+    return l.aniListImportNewCollectionDefault(trimmed);
+  }
+
+  Future<void> _startImport() async {
+    final S l = S.of(context);
+    final String userName = _usernameController.text.trim();
+    if (userName.isEmpty) {
+      context.showSnack(
+        l.aniListImportEmptyUsername,
+        type: SnackType.error,
+      );
+      return;
+    }
+    if (!_includeAnime && !_includeManga) {
+      context.showSnack(
+        l.aniListImportSelectAtLeastOne,
+        type: SnackType.error,
+      );
+      return;
+    }
+
+    final String authorName =
+        ref.read(settingsNotifierProvider).authorName;
+    final String newCollectionName =
+        _newNameController.text.trim().isEmpty
+            ? _defaultCollectionName(l)
+            : _newNameController.text.trim();
+
+    setState(() {
+      _isImporting = true;
+      _progress = null;
+    });
+
+    try {
+      final AniListImportService service =
+          ref.read(aniListImportServiceProvider);
+
+      final AniListImportResult result = await service.importUserLists(
+        userName: userName,
+        mode: _mode,
+        includeAnime: _includeAnime,
+        includeManga: _includeManga,
+        collectionId: _useNewCollection ? null : _selectedCollectionId,
+        createCollection: _useNewCollection
+            ? () async {
+                final DatabaseService db = ref.read(databaseServiceProvider);
+                final Collection collection = await db.createCollection(
+                  name: newCollectionName,
+                  author: authorName,
+                );
+                return collection.id;
+              }
+            : null,
+        onProgress: (AniListImportProgress progress) {
+          if (mounted) {
+            setState(() => _progress = progress);
+          }
+        },
+      );
+
+      final int collectionId = result.collectionId;
+
+      // Persist the username for the next import — fire and forget.
+      unawaited(
+        ref
+            .read(sharedPreferencesProvider)
+            .setString(SettingsKeys.aniListUsername, userName),
+      );
+
+      if (!mounted) return;
+
+      ref.invalidate(collectionsProvider);
+      ref.invalidate(collectionStatsProvider(collectionId));
+      ref.invalidate(collectionCoversProvider(collectionId));
+      ref.invalidate(collectionItemsNotifierProvider(collectionId));
+      ref.invalidate(canvasNotifierProvider(collectionId));
+      ref.invalidate(allItemsNotifierProvider);
+
+      final Collection? resultCollection = await ref
+          .read(databaseServiceProvider)
+          .getCollectionById(collectionId);
+
+      setState(() => _isImporting = false);
+
+      if (!mounted) return;
+
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => ImportResultScreen(
+            result: result.toUniversal(collection: resultCollection),
+          ),
+        ),
+      );
+    } on AniListUserNotFoundException {
+      if (!mounted) return;
+      setState(() => _isImporting = false);
+      context.showSnack(
+        l.aniListImportUserNotFound(userName),
+        type: SnackType.error,
+      );
+    } on AniListPrivateProfileException {
+      if (!mounted) return;
+      setState(() => _isImporting = false);
+      context.showSnack(
+        l.aniListImportPrivateProfile(userName),
+        type: SnackType.error,
+      );
+    } on Exception catch (e) {
+      if (!mounted) return;
+      setState(() => _isImporting = false);
+      context.showSnack(
+        l.aniListImportFailed(e.toString()),
+        type: SnackType.error,
+      );
+    }
+  }
+}

--- a/lib/features/settings/providers/settings_provider.dart
+++ b/lib/features/settings/providers/settings_provider.dart
@@ -64,6 +64,9 @@ abstract class SettingsKeys {
 
   static const String steamRememberCredentials = 'steam_remember_credentials';
 
+  /// Last AniList username used in import dialog. Persisted on successful import.
+  static const String aniListUsername = 'anilist_username';
+
   static const String richCollectionsEnabled = 'rich_collections_enabled';
 }
 

--- a/lib/features/settings/screens/anilist_import_screen.dart
+++ b/lib/features/settings/screens/anilist_import_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/widgets/sub_screen_title_bar.dart';
+import '../content/anilist_import_content.dart';
+
+/// Screen wrapper around [AniListImportContent] with a title bar.
+class AniListImportScreen extends StatelessWidget {
+  /// Creates an [AniListImportScreen].
+  const AniListImportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final double width = MediaQuery.sizeOf(context).width;
+    final bool isWide = width >= 800;
+
+    return Column(
+      children: <Widget>[
+        SubScreenTitleBar(title: S.of(context).settingsAniListImport),
+        Expanded(
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: isWide ? 600 : double.infinity,
+              ),
+              child: SingleChildScrollView(
+                padding: EdgeInsets.symmetric(
+                  horizontal: isWide ? AppSpacing.lg : AppSpacing.md,
+                  vertical: AppSpacing.sm,
+                ),
+                child: const AniListImportContent(),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -33,6 +33,7 @@ import '../../collections/providers/collections_provider.dart';
 import '../../home/providers/all_items_provider.dart';
 import '../../wishlist/providers/wishlist_provider.dart';
 import 'browse_collections_screen.dart';
+import 'anilist_import_screen.dart';
 import 'mal_import_screen.dart';
 import 'ra_import_screen.dart';
 import 'steam_import_screen.dart';
@@ -277,6 +278,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: l.settingsMalImport,
             subtitle: l.settingsMalImportSubtitle,
             onTap: () => _pushScreen(const MalImportScreen()),
+          ),
+          SettingsTile(
+            leadingAssetPath: AppAssets.iconAnilistColor,
+            leadingAssetColored: true,
+            title: l.settingsAniListImport,
+            subtitle: l.settingsAniListImportSubtitle,
+            onTap: () => _pushScreen(const AniListImportScreen()),
           ),
         ],
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1783,5 +1783,76 @@
       "kind": {"type": "String"},
       "count": {"type": "int"}
     }
-  }
+  },
+
+  "settingsAniListImport": "AniList",
+  "settingsAniListImportSubtitle": "Import anime/manga lists by public username",
+  "aniListImportTitle": "AniList Import",
+  "aniListImportSubtitle": "Fetches public lists from anilist.co — no login required",
+  "aniListImportUsername": "AniList username",
+  "aniListImportUsernameHint": "e.g. yourname",
+  "aniListImportInclude": "What to import",
+  "aniListImportIncludeAnime": "Anime list",
+  "aniListImportIncludeManga": "Manga list",
+  "aniListImportMode": "Mode",
+  "aniListImportModeNewOnly": "Add new only",
+  "aniListImportModeNewOnlySubtitle": "Skip items already in the collection",
+  "aniListImportModeOverwrite": "Overwrite existing",
+  "aniListImportModeOverwriteSubtitle": "Update progress, status and dates from AniList",
+  "aniListImportTargetCollection": "Target collection",
+  "aniListImportCreateNew": "Create new collection",
+  "aniListImportUseExisting": "Use existing collection",
+  "aniListImportSelectCollection": "Select collection",
+  "aniListImportNoCollections": "No collections available",
+  "aniListImportErrorLoadingCollections": "Error loading collections",
+  "aniListImportNewCollectionName": "Collection name",
+  "aniListImportNewCollectionDefault": "AniList Import — {username}",
+  "@aniListImportNewCollectionDefault": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportButton": "Start Import",
+  "aniListImportFetchingAnime": "Fetching anime list...",
+  "aniListImportFetchingManga": "Fetching manga list...",
+  "aniListImportMatching": "Importing entries",
+  "aniListImportComplete": "Import complete!",
+  "aniListImportLookingUp": "Processing: {title}",
+  "@aniListImportLookingUp": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
+  "aniListImportImported": "{count} imported",
+  "@aniListImportImported": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "aniListImportUpdated": "{count} updated",
+  "@aniListImportUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "aniListImportFailed": "Import failed: {error}",
+  "@aniListImportFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "aniListImportUserNotFound": "AniList user \"{username}\" was not found",
+  "@aniListImportUserNotFound": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportPrivateProfile": "AniList profile \"{username}\" is private",
+  "@aniListImportPrivateProfile": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportEmptyUsername": "Enter your AniList username",
+  "aniListImportSelectAtLeastOne": "Select anime or manga to import"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6864,6 +6864,216 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Picked: {kind} ({count, plural, =1{1 entry} other{{count} entries}})'**
   String malImportFilePicked(String kind, int count);
+
+  /// No description provided for @settingsAniListImport.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList'**
+  String get settingsAniListImport;
+
+  /// No description provided for @settingsAniListImportSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import anime/manga lists by public username'**
+  String get settingsAniListImportSubtitle;
+
+  /// No description provided for @aniListImportTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Import'**
+  String get aniListImportTitle;
+
+  /// No description provided for @aniListImportSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Fetches public lists from anilist.co — no login required'**
+  String get aniListImportSubtitle;
+
+  /// No description provided for @aniListImportUsername.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList username'**
+  String get aniListImportUsername;
+
+  /// No description provided for @aniListImportUsernameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. yourname'**
+  String get aniListImportUsernameHint;
+
+  /// No description provided for @aniListImportInclude.
+  ///
+  /// In en, this message translates to:
+  /// **'What to import'**
+  String get aniListImportInclude;
+
+  /// No description provided for @aniListImportIncludeAnime.
+  ///
+  /// In en, this message translates to:
+  /// **'Anime list'**
+  String get aniListImportIncludeAnime;
+
+  /// No description provided for @aniListImportIncludeManga.
+  ///
+  /// In en, this message translates to:
+  /// **'Manga list'**
+  String get aniListImportIncludeManga;
+
+  /// No description provided for @aniListImportMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Mode'**
+  String get aniListImportMode;
+
+  /// No description provided for @aniListImportModeNewOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Add new only'**
+  String get aniListImportModeNewOnly;
+
+  /// No description provided for @aniListImportModeNewOnlySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip items already in the collection'**
+  String get aniListImportModeNewOnlySubtitle;
+
+  /// No description provided for @aniListImportModeOverwrite.
+  ///
+  /// In en, this message translates to:
+  /// **'Overwrite existing'**
+  String get aniListImportModeOverwrite;
+
+  /// No description provided for @aniListImportModeOverwriteSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Update progress, status and dates from AniList'**
+  String get aniListImportModeOverwriteSubtitle;
+
+  /// No description provided for @aniListImportTargetCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Target collection'**
+  String get aniListImportTargetCollection;
+
+  /// No description provided for @aniListImportCreateNew.
+  ///
+  /// In en, this message translates to:
+  /// **'Create new collection'**
+  String get aniListImportCreateNew;
+
+  /// No description provided for @aniListImportUseExisting.
+  ///
+  /// In en, this message translates to:
+  /// **'Use existing collection'**
+  String get aniListImportUseExisting;
+
+  /// No description provided for @aniListImportSelectCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Select collection'**
+  String get aniListImportSelectCollection;
+
+  /// No description provided for @aniListImportNoCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'No collections available'**
+  String get aniListImportNoCollections;
+
+  /// No description provided for @aniListImportErrorLoadingCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'Error loading collections'**
+  String get aniListImportErrorLoadingCollections;
+
+  /// No description provided for @aniListImportNewCollectionName.
+  ///
+  /// In en, this message translates to:
+  /// **'Collection name'**
+  String get aniListImportNewCollectionName;
+
+  /// No description provided for @aniListImportNewCollectionDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Import — {username}'**
+  String aniListImportNewCollectionDefault(String username);
+
+  /// No description provided for @aniListImportButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Import'**
+  String get aniListImportButton;
+
+  /// No description provided for @aniListImportFetchingAnime.
+  ///
+  /// In en, this message translates to:
+  /// **'Fetching anime list...'**
+  String get aniListImportFetchingAnime;
+
+  /// No description provided for @aniListImportFetchingManga.
+  ///
+  /// In en, this message translates to:
+  /// **'Fetching manga list...'**
+  String get aniListImportFetchingManga;
+
+  /// No description provided for @aniListImportMatching.
+  ///
+  /// In en, this message translates to:
+  /// **'Importing entries'**
+  String get aniListImportMatching;
+
+  /// No description provided for @aniListImportComplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Import complete!'**
+  String get aniListImportComplete;
+
+  /// No description provided for @aniListImportLookingUp.
+  ///
+  /// In en, this message translates to:
+  /// **'Processing: {title}'**
+  String aniListImportLookingUp(String title);
+
+  /// No description provided for @aniListImportImported.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} imported'**
+  String aniListImportImported(int count);
+
+  /// No description provided for @aniListImportUpdated.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} updated'**
+  String aniListImportUpdated(int count);
+
+  /// No description provided for @aniListImportFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Import failed: {error}'**
+  String aniListImportFailed(String error);
+
+  /// No description provided for @aniListImportUserNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList user \"{username}\" was not found'**
+  String aniListImportUserNotFound(String username);
+
+  /// No description provided for @aniListImportPrivateProfile.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList profile \"{username}\" is private'**
+  String aniListImportPrivateProfile(String username);
+
+  /// No description provided for @aniListImportEmptyUsername.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your AniList username'**
+  String get aniListImportEmptyUsername;
+
+  /// No description provided for @aniListImportSelectAtLeastOne.
+  ///
+  /// In en, this message translates to:
+  /// **'Select anime or manga to import'**
+  String get aniListImportSelectAtLeastOne;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3790,4 +3790,128 @@ class SEn extends S {
     );
     return 'Picked: $kind ($_temp0)';
   }
+
+  @override
+  String get settingsAniListImport => 'AniList';
+
+  @override
+  String get settingsAniListImportSubtitle =>
+      'Import anime/manga lists by public username';
+
+  @override
+  String get aniListImportTitle => 'AniList Import';
+
+  @override
+  String get aniListImportSubtitle =>
+      'Fetches public lists from anilist.co — no login required';
+
+  @override
+  String get aniListImportUsername => 'AniList username';
+
+  @override
+  String get aniListImportUsernameHint => 'e.g. yourname';
+
+  @override
+  String get aniListImportInclude => 'What to import';
+
+  @override
+  String get aniListImportIncludeAnime => 'Anime list';
+
+  @override
+  String get aniListImportIncludeManga => 'Manga list';
+
+  @override
+  String get aniListImportMode => 'Mode';
+
+  @override
+  String get aniListImportModeNewOnly => 'Add new only';
+
+  @override
+  String get aniListImportModeNewOnlySubtitle =>
+      'Skip items already in the collection';
+
+  @override
+  String get aniListImportModeOverwrite => 'Overwrite existing';
+
+  @override
+  String get aniListImportModeOverwriteSubtitle =>
+      'Update progress, status and dates from AniList';
+
+  @override
+  String get aniListImportTargetCollection => 'Target collection';
+
+  @override
+  String get aniListImportCreateNew => 'Create new collection';
+
+  @override
+  String get aniListImportUseExisting => 'Use existing collection';
+
+  @override
+  String get aniListImportSelectCollection => 'Select collection';
+
+  @override
+  String get aniListImportNoCollections => 'No collections available';
+
+  @override
+  String get aniListImportErrorLoadingCollections =>
+      'Error loading collections';
+
+  @override
+  String get aniListImportNewCollectionName => 'Collection name';
+
+  @override
+  String aniListImportNewCollectionDefault(String username) {
+    return 'AniList Import — $username';
+  }
+
+  @override
+  String get aniListImportButton => 'Start Import';
+
+  @override
+  String get aniListImportFetchingAnime => 'Fetching anime list...';
+
+  @override
+  String get aniListImportFetchingManga => 'Fetching manga list...';
+
+  @override
+  String get aniListImportMatching => 'Importing entries';
+
+  @override
+  String get aniListImportComplete => 'Import complete!';
+
+  @override
+  String aniListImportLookingUp(String title) {
+    return 'Processing: $title';
+  }
+
+  @override
+  String aniListImportImported(int count) {
+    return '$count imported';
+  }
+
+  @override
+  String aniListImportUpdated(int count) {
+    return '$count updated';
+  }
+
+  @override
+  String aniListImportFailed(String error) {
+    return 'Import failed: $error';
+  }
+
+  @override
+  String aniListImportUserNotFound(String username) {
+    return 'AniList user \"$username\" was not found';
+  }
+
+  @override
+  String aniListImportPrivateProfile(String username) {
+    return 'AniList profile \"$username\" is private';
+  }
+
+  @override
+  String get aniListImportEmptyUsername => 'Enter your AniList username';
+
+  @override
+  String get aniListImportSelectAtLeastOne => 'Select anime or manga to import';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3840,4 +3840,143 @@ class SRu extends S {
     );
     return 'Выбрано: $kind ($_temp0)';
   }
+
+  @override
+  String get settingsAniListImport => 'AniList';
+
+  @override
+  String get settingsAniListImportSubtitle =>
+      'Импорт списков аниме и манги по публичному имени';
+
+  @override
+  String get aniListImportTitle => 'Импорт из AniList';
+
+  @override
+  String get aniListImportSubtitle =>
+      'Тянет публичные списки с anilist.co — авторизация не нужна';
+
+  @override
+  String get aniListImportUsername => 'Имя пользователя AniList';
+
+  @override
+  String get aniListImportUsernameHint => 'например, yourname';
+
+  @override
+  String get aniListImportInclude => 'Что импортировать';
+
+  @override
+  String get aniListImportIncludeAnime => 'Список аниме';
+
+  @override
+  String get aniListImportIncludeManga => 'Список манги';
+
+  @override
+  String get aniListImportMode => 'Режим';
+
+  @override
+  String get aniListImportModeNewOnly => 'Только новые';
+
+  @override
+  String get aniListImportModeNewOnlySubtitle =>
+      'Пропустить элементы, уже добавленные в коллекцию';
+
+  @override
+  String get aniListImportModeOverwrite => 'Перезаписать существующие';
+
+  @override
+  String get aniListImportModeOverwriteSubtitle =>
+      'Обновить прогресс, статус и даты из AniList';
+
+  @override
+  String get aniListImportTargetCollection => 'Целевая коллекция';
+
+  @override
+  String get aniListImportCreateNew => 'Создать новую коллекцию';
+
+  @override
+  String get aniListImportUseExisting => 'Добавить в существующую';
+
+  @override
+  String get aniListImportSelectCollection => 'Выберите коллекцию';
+
+  @override
+  String get aniListImportNoCollections => 'Нет коллекций';
+
+  @override
+  String get aniListImportErrorLoadingCollections =>
+      'Ошибка загрузки коллекций';
+
+  @override
+  String get aniListImportNewCollectionName => 'Название коллекции';
+
+  @override
+  String aniListImportNewCollectionDefault(String username) {
+    return 'AniList Import — $username';
+  }
+
+  @override
+  String get aniListImportButton => 'Запустить импорт';
+
+  @override
+  String get aniListImportFetchingAnime => 'Получаем список аниме...';
+
+  @override
+  String get aniListImportFetchingManga => 'Получаем список манги...';
+
+  @override
+  String get aniListImportMatching => 'Импортируем записи';
+
+  @override
+  String get aniListImportComplete => 'Импорт завершён!';
+
+  @override
+  String aniListImportLookingUp(String title) {
+    return 'Обработка: $title';
+  }
+
+  @override
+  String aniListImportImported(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count импортировано',
+      few: '$count импортировано',
+      one: '1 импортирован',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String aniListImportUpdated(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count обновлено',
+      few: '$count обновлено',
+      one: '1 обновлён',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String aniListImportFailed(String error) {
+    return 'Ошибка импорта: $error';
+  }
+
+  @override
+  String aniListImportUserNotFound(String username) {
+    return 'Пользователь AniList «$username» не найден';
+  }
+
+  @override
+  String aniListImportPrivateProfile(String username) {
+    return 'Профиль AniList «$username» приватный';
+  }
+
+  @override
+  String get aniListImportEmptyUsername => 'Введите имя пользователя AniList';
+
+  @override
+  String get aniListImportSelectAtLeastOne =>
+      'Выберите хотя бы один тип: аниме или манга';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1502,5 +1502,76 @@
       "kind": {"type": "String"},
       "count": {"type": "int"}
     }
-  }
+  },
+
+  "settingsAniListImport": "AniList",
+  "settingsAniListImportSubtitle": "Импорт списков аниме и манги по публичному имени",
+  "aniListImportTitle": "Импорт из AniList",
+  "aniListImportSubtitle": "Тянет публичные списки с anilist.co — авторизация не нужна",
+  "aniListImportUsername": "Имя пользователя AniList",
+  "aniListImportUsernameHint": "например, yourname",
+  "aniListImportInclude": "Что импортировать",
+  "aniListImportIncludeAnime": "Список аниме",
+  "aniListImportIncludeManga": "Список манги",
+  "aniListImportMode": "Режим",
+  "aniListImportModeNewOnly": "Только новые",
+  "aniListImportModeNewOnlySubtitle": "Пропустить элементы, уже добавленные в коллекцию",
+  "aniListImportModeOverwrite": "Перезаписать существующие",
+  "aniListImportModeOverwriteSubtitle": "Обновить прогресс, статус и даты из AniList",
+  "aniListImportTargetCollection": "Целевая коллекция",
+  "aniListImportCreateNew": "Создать новую коллекцию",
+  "aniListImportUseExisting": "Добавить в существующую",
+  "aniListImportSelectCollection": "Выберите коллекцию",
+  "aniListImportNoCollections": "Нет коллекций",
+  "aniListImportErrorLoadingCollections": "Ошибка загрузки коллекций",
+  "aniListImportNewCollectionName": "Название коллекции",
+  "aniListImportNewCollectionDefault": "AniList Import — {username}",
+  "@aniListImportNewCollectionDefault": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportButton": "Запустить импорт",
+  "aniListImportFetchingAnime": "Получаем список аниме...",
+  "aniListImportFetchingManga": "Получаем список манги...",
+  "aniListImportMatching": "Импортируем записи",
+  "aniListImportComplete": "Импорт завершён!",
+  "aniListImportLookingUp": "Обработка: {title}",
+  "@aniListImportLookingUp": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
+  "aniListImportImported": "{count, plural, =1{1 импортирован} few{{count} импортировано} other{{count} импортировано}}",
+  "@aniListImportImported": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "aniListImportUpdated": "{count, plural, =1{1 обновлён} few{{count} обновлено} other{{count} обновлено}}",
+  "@aniListImportUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "aniListImportFailed": "Ошибка импорта: {error}",
+  "@aniListImportFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "aniListImportUserNotFound": "Пользователь AniList «{username}» не найден",
+  "@aniListImportUserNotFound": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportPrivateProfile": "Профиль AniList «{username}» приватный",
+  "@aniListImportPrivateProfile": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportEmptyUsername": "Введите имя пользователя AniList",
+  "aniListImportSelectAtLeastOne": "Выберите хотя бы один тип: аниме или манга"
 }

--- a/lib/shared/models/anime.dart
+++ b/lib/shared/models/anime.dart
@@ -87,7 +87,7 @@ class Anime {
       titleEnglish: titleMap?['english'] as String?,
       titleNative: titleMap?['native'] as String?,
       description: description,
-      coverUrl: coverMap?['large'] as String?,
+      coverUrl: (coverMap?['extraLarge'] ?? coverMap?['large']) as String?,
       coverUrlMedium: coverMap?['medium'] as String?,
       averageScore: json['averageScore'] as int?,
       meanScore: json['meanScore'] as int?,

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -387,7 +387,7 @@ class CollectionItem with Exportable {
         return (
           name: manga?.title,
           coverUrl: manga?.coverUrl,
-          thumbUrl: manga?.coverUrlMedium ?? manga?.coverUrl,
+          thumbUrl: manga?.coverUrl ?? manga?.coverUrlMedium,
           description: manga?.description,
           rating: manga?.rating10,
           formattedRating: manga?.formattedRating,
@@ -406,7 +406,7 @@ class CollectionItem with Exportable {
         return (
           name: anime?.title,
           coverUrl: anime?.coverUrl,
-          thumbUrl: anime?.coverUrlMedium ?? anime?.coverUrl,
+          thumbUrl: anime?.coverUrl ?? anime?.coverUrlMedium,
           description: anime?.description,
           rating: anime?.rating10,
           formattedRating: anime?.formattedRating,

--- a/lib/shared/models/manga.dart
+++ b/lib/shared/models/manga.dart
@@ -96,7 +96,7 @@ class Manga {
       titleEnglish: titleMap?['english'] as String?,
       titleNative: titleMap?['native'] as String?,
       description: description,
-      coverUrl: coverMap?['large'] as String?,
+      coverUrl: (coverMap?['extraLarge'] ?? coverMap?['large']) as String?,
       coverUrlMedium: coverMap?['medium'] as String?,
       averageScore: json['averageScore'] as int?,
       meanScore: json['meanScore'] as int?,

--- a/test/core/api/anilist_api_user_list_test.dart
+++ b/test/core/api/anilist_api_user_list_test.dart
@@ -1,0 +1,324 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/anilist_api.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  late MockDio mockDio;
+  late AniListApi api;
+
+  setUp(() {
+    mockDio = MockDio();
+    api = AniListApi(dio: mockDio);
+  });
+
+  Response<dynamic> makeResponse(
+    Map<String, dynamic> data, {
+    int statusCode = 200,
+  }) {
+    return Response<dynamic>(
+      data: data,
+      statusCode: statusCode,
+      requestOptions: RequestOptions(path: ''),
+    );
+  }
+
+  Map<String, dynamic> animeMedia({
+    int id = 100922,
+    bool isAdult = false,
+  }) {
+    return <String, dynamic>{
+      'id': id,
+      'isAdult': isAdult,
+      'title': <String, dynamic>{
+        'romaji': 'Grand Blue',
+        'english': 'Grand Blue Dreaming',
+        'native': 'ぐらんぶる',
+      },
+      'episodes': 12,
+    };
+  }
+
+  Map<String, dynamic> entryJson({
+    String status = 'COMPLETED',
+    int score = 85,
+    int progress = 12,
+    int progressVolumes = 0,
+    int repeat = 0,
+    Map<String, dynamic>? media,
+  }) {
+    return <String, dynamic>{
+      'status': status,
+      'score': score,
+      'progress': progress,
+      'progressVolumes': progressVolumes,
+      'repeat': repeat,
+      'notes': null,
+      'startedAt': <String, dynamic>{'year': 2020, 'month': 1, 'day': 5},
+      'completedAt': <String, dynamic>{'year': 2020, 'month': 3, 'day': 1},
+      'updatedAt': 1609459200,
+      'media': media ?? animeMedia(),
+    };
+  }
+
+  Map<String, dynamic> collectionResponse({
+    required List<Map<String, dynamic>> lists,
+  }) {
+    return <String, dynamic>{
+      'data': <String, dynamic>{
+        'MediaListCollection': <String, dynamic>{
+          'lists': lists,
+        },
+      },
+    };
+  }
+
+  group('AniListApi.fetchUserMediaList', () {
+    test('should reject empty username', () async {
+      expect(
+        () => api.fetchUserMediaList(userName: '   ', type: MediaType.anime),
+        throwsArgumentError,
+      );
+    });
+
+    test('should reject unsupported media types', () async {
+      expect(
+        () => api.fetchUserMediaList(userName: 'u', type: MediaType.game),
+        throwsArgumentError,
+      );
+    });
+
+    test('should parse entries and populate Anime model', () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(collectionResponse(
+                lists: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[entryJson()],
+                  },
+                ],
+              )));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'tester',
+        type: MediaType.anime,
+      );
+
+      expect(entries, hasLength(1));
+      final AniListListEntry e = entries.first;
+      expect(e.mediaId, 100922);
+      expect(e.mediaType, MediaType.anime);
+      expect(e.rawStatus, 'COMPLETED');
+      expect(e.scoreRaw100, 85);
+      expect(e.progress, 12);
+      expect(e.repeat, 0);
+      expect(e.anime, isNotNull);
+      expect(e.anime!.title, 'Grand Blue');
+    });
+
+    test('should treat score 0 as null', () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(collectionResponse(
+                lists: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[entryJson(score: 0)],
+                  },
+                ],
+              )));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'u',
+        type: MediaType.anime,
+      );
+
+      expect(entries.single.scoreRaw100, isNull);
+    });
+
+    test('should skip custom lists', () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(collectionResponse(
+                lists: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'isCustomList': true,
+                    'entries': <Map<String, dynamic>>[
+                      entryJson(media: animeMedia(id: 1)),
+                    ],
+                  },
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[
+                      entryJson(media: animeMedia(id: 2)),
+                    ],
+                  },
+                ],
+              )));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'u',
+        type: MediaType.anime,
+      );
+
+      expect(entries.map((AniListListEntry e) => e.mediaId).toList(), <int>[2]);
+    });
+
+    test('should filter isAdult media', () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(collectionResponse(
+                lists: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[
+                      entryJson(media: animeMedia(id: 1, isAdult: true)),
+                      entryJson(media: animeMedia(id: 2)),
+                    ],
+                  },
+                ],
+              )));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'u',
+        type: MediaType.anime,
+      );
+
+      expect(entries.map((AniListListEntry e) => e.mediaId).toList(), <int>[2]);
+    });
+
+    test('should deduplicate entries by mediaId across lists', () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(collectionResponse(
+                lists: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[
+                      entryJson(media: animeMedia(id: 7)),
+                    ],
+                  },
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[
+                      entryJson(media: animeMedia(id: 7)),
+                    ],
+                  },
+                ],
+              )));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'u',
+        type: MediaType.anime,
+      );
+
+      expect(entries, hasLength(1));
+    });
+
+    test('should throw AniListUserNotFoundException on HTTP 404', () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenThrow(DioException(
+        requestOptions: RequestOptions(path: ''),
+        response: Response<dynamic>(
+          requestOptions: RequestOptions(path: ''),
+          statusCode: 404,
+        ),
+        type: DioExceptionType.badResponse,
+      ));
+
+      expect(
+        () => api.fetchUserMediaList(userName: 'ghost', type: MediaType.anime),
+        throwsA(isA<AniListUserNotFoundException>()),
+      );
+    });
+
+    test(
+        'should throw AniListUserNotFoundException when GraphQL says not found',
+        () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(<String, dynamic>{
+                'errors': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'message': 'User does not exist',
+                  },
+                ],
+              }));
+
+      expect(
+        () => api.fetchUserMediaList(userName: 'ghost', type: MediaType.anime),
+        throwsA(isA<AniListUserNotFoundException>()),
+      );
+    });
+
+    test(
+        'should throw AniListPrivateProfileException when GraphQL says private',
+        () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(<String, dynamic>{
+                'errors': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'message': 'This user is private',
+                  },
+                ],
+              }));
+
+      expect(
+        () => api.fetchUserMediaList(userName: 'tester', type: MediaType.anime),
+        throwsA(isA<AniListPrivateProfileException>()),
+      );
+    });
+
+    test('should return empty list when MediaListCollection is null',
+        () async {
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(<String, dynamic>{
+                'data': <String, dynamic>{'MediaListCollection': null},
+              }));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'u',
+        type: MediaType.anime,
+      );
+
+      expect(entries, isEmpty);
+    });
+
+    test('should parse partial fuzzy dates (year only)', () async {
+      final Map<String, dynamic> json = entryJson();
+      json['startedAt'] = <String, dynamic>{
+        'year': 2018,
+        'month': null,
+        'day': null,
+      };
+      json['completedAt'] = null;
+      when(() => mockDio.post<dynamic>(any(),
+              data: any(named: 'data')))
+          .thenAnswer((_) async => makeResponse(collectionResponse(
+                lists: <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'isCustomList': false,
+                    'entries': <Map<String, dynamic>>[json],
+                  },
+                ],
+              )));
+
+      final List<AniListListEntry> entries = await api.fetchUserMediaList(
+        userName: 'u',
+        type: MediaType.anime,
+      );
+
+      expect(entries.single.startedAt, DateTime.utc(2018, 1, 1));
+      expect(entries.single.completedAt, isNull);
+    });
+  });
+}

--- a/test/core/services/anilist_import_service_test.dart
+++ b/test/core/services/anilist_import_service_test.dart
@@ -1,0 +1,451 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/anilist_api.dart';
+import 'package:xerabora/core/services/anilist_import_service.dart';
+import 'package:xerabora/shared/models/anime.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/manga.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  late AniListImportService sut;
+  late MockAniListApi mockAniList;
+  late MockDatabaseService mockDb;
+
+  setUp(() {
+    mockAniList = MockAniListApi();
+    mockDb = MockDatabaseService();
+    sut = AniListImportService(aniListApi: mockAniList, database: mockDb);
+
+    when(() => mockDb.upsertAnimes(any())).thenAnswer((_) async {});
+    when(() => mockDb.upsertMangas(any())).thenAnswer((_) async {});
+    when(() => mockDb.findCollectionItem(
+      collectionId: any(named: 'collectionId'),
+      mediaType: any(named: 'mediaType'),
+      externalId: any(named: 'externalId'),
+    )).thenAnswer((_) async => null);
+    when(() => mockDb.addItemToCollection(
+      collectionId: any(named: 'collectionId'),
+      mediaType: any(named: 'mediaType'),
+      externalId: any(named: 'externalId'),
+      status: any(named: 'status'),
+    )).thenAnswer((_) async => 999);
+    when(() => mockDb.updateItemProgress(
+      any(),
+      currentEpisode: any(named: 'currentEpisode'),
+      currentSeason: any(named: 'currentSeason'),
+    )).thenAnswer((_) async {});
+    when(() => mockDb.updateItemUserRating(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => mockDb.updateItemActivityDates(
+      any(),
+      startedAt: any(named: 'startedAt'),
+      completedAt: any(named: 'completedAt'),
+      lastActivityAt: any(named: 'lastActivityAt'),
+    )).thenAnswer((_) async {});
+    when(() => mockDb.updateItemUserComment(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => mockDb.updateItemStatus(
+      any(),
+      any(),
+      mediaType: any(named: 'mediaType'),
+    )).thenAnswer((_) async {});
+  });
+
+  AniListListEntry animeEntry({
+    int mediaId = 100922,
+    String rawStatus = 'COMPLETED',
+    int progress = 12,
+    int repeat = 0,
+    int? scoreRaw100 = 85,
+    String? notes,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    int? episodes = 12,
+  }) {
+    return AniListListEntry(
+      mediaId: mediaId,
+      mediaType: MediaType.anime,
+      rawStatus: rawStatus,
+      progress: progress,
+      progressVolumes: 0,
+      repeat: repeat,
+      scoreRaw100: scoreRaw100,
+      notes: notes,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      anime: Anime(id: mediaId, title: 'Grand Blue', episodes: episodes),
+    );
+  }
+
+  AniListListEntry mangaEntry({
+    int mediaId = 30013,
+    String rawStatus = 'CURRENT',
+    int progress = 50,
+    int progressVolumes = 5,
+    int? chapters,
+    int? volumes,
+  }) {
+    return AniListListEntry(
+      mediaId: mediaId,
+      mediaType: MediaType.manga,
+      rawStatus: rawStatus,
+      progress: progress,
+      progressVolumes: progressVolumes,
+      repeat: 0,
+      manga: Manga(
+        id: mediaId,
+        title: 'Berserk',
+        chapters: chapters,
+        volumes: volumes,
+      ),
+    );
+  }
+
+  group('AniListImportService', () {
+    group('importUserLists', () {
+      test('should throw ArgumentError when nothing to import', () async {
+        expect(
+              () => sut.importUserLists(
+            userName: 'u',
+            mode: ImportMode.newOnly,
+            includeAnime: false,
+            includeManga: false,
+            collectionId: 1,
+            onProgress: (_) {},
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('should throw ArgumentError without collection target', () async {
+        expect(
+              () => sut.importUserLists(
+            userName: 'u',
+            mode: ImportMode.newOnly,
+            onProgress: (_) {},
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('should throw FormatException when both lists are empty', () async {
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: any(named: 'type'),
+        )).thenAnswer((_) async => <AniListListEntry>[]);
+
+        expect(
+              () => sut.importUserLists(
+            userName: 'u',
+            mode: ImportMode.newOnly,
+            collectionId: 1,
+            onProgress: (_) {},
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('should fetch only requested types', () async {
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.anime,
+        )).thenAnswer((_) async => <AniListListEntry>[animeEntry()]);
+
+        await sut.importUserLists(
+          userName: 'u',
+          mode: ImportMode.newOnly,
+          includeAnime: true,
+          includeManga: false,
+          collectionId: 1,
+          onProgress: (_) {},
+        );
+
+        verify(() => mockAniList.fetchUserMediaList(
+          userName: 'u',
+          type: MediaType.anime,
+        )).called(1);
+        verifyNever(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.manga,
+        ));
+      });
+
+      test('should create collection lazily and import counts per type',
+              () async {
+            when(() => mockAniList.fetchUserMediaList(
+              userName: any(named: 'userName'),
+              type: MediaType.anime,
+            )).thenAnswer((_) async => <AniListListEntry>[animeEntry()]);
+            when(() => mockAniList.fetchUserMediaList(
+              userName: any(named: 'userName'),
+              type: MediaType.manga,
+            )).thenAnswer((_) async => <AniListListEntry>[mangaEntry()]);
+
+            int factoryCalls = 0;
+            final AniListImportResult result = await sut.importUserLists(
+              userName: 'tester',
+              mode: ImportMode.newOnly,
+              createCollection: () async {
+                factoryCalls++;
+                return 42;
+              },
+              onProgress: (_) {},
+            );
+
+            expect(factoryCalls, 1);
+            expect(result.collectionId, 42);
+            expect(result.animeImported, 1);
+            expect(result.mangaImported, 1);
+            expect(result.total, 2);
+            expect(result.updated, 0);
+          });
+
+      test('should skip existing items in newOnly mode', () async {
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.anime,
+        )).thenAnswer((_) async => <AniListListEntry>[animeEntry()]);
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.manga,
+        )).thenAnswer((_) async => <AniListListEntry>[]);
+        when(() => mockDb.findCollectionItem(
+          collectionId: any(named: 'collectionId'),
+          mediaType: MediaType.anime,
+          externalId: 100922,
+        )).thenAnswer((_) async => createTestCollectionItem(
+          id: 7,
+          collectionId: 1,
+          mediaType: MediaType.anime,
+          externalId: 100922,
+        ));
+
+        final AniListImportResult result = await sut.importUserLists(
+          userName: 'u',
+          mode: ImportMode.newOnly,
+          collectionId: 1,
+          onProgress: (_) {},
+        );
+
+        expect(result.animeImported, 0);
+        expect(result.animeUpdated, 0);
+        verifyNever(() => mockDb.addItemToCollection(
+          collectionId: any(named: 'collectionId'),
+          mediaType: any(named: 'mediaType'),
+          externalId: any(named: 'externalId'),
+          status: any(named: 'status'),
+        ));
+      });
+
+      test('should update existing items in overwrite mode', () async {
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.anime,
+        )).thenAnswer((_) async => <AniListListEntry>[
+          animeEntry(scoreRaw100: 90, progress: 12),
+        ]);
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.manga,
+        )).thenAnswer((_) async => <AniListListEntry>[]);
+        when(() => mockDb.findCollectionItem(
+          collectionId: any(named: 'collectionId'),
+          mediaType: MediaType.anime,
+          externalId: 100922,
+        )).thenAnswer((_) async => createTestCollectionItem(
+          id: 7,
+          collectionId: 1,
+          mediaType: MediaType.anime,
+          externalId: 100922,
+          status: ItemStatus.inProgress,
+          userRating: 7,
+          currentEpisode: 5,
+        ));
+
+        final AniListImportResult result = await sut.importUserLists(
+          userName: 'u',
+          mode: ImportMode.overwrite,
+          collectionId: 1,
+          onProgress: (_) {},
+        );
+
+        expect(result.animeUpdated, 1);
+        expect(result.animeImported, 0);
+        verify(() => mockDb.updateItemUserRating(7, 9)).called(1);
+      });
+
+      test('should top up episodes when status is COMPLETED', () async {
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.anime,
+        )).thenAnswer((_) async => <AniListListEntry>[
+          animeEntry(progress: 8, episodes: 12),
+        ]);
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.manga,
+        )).thenAnswer((_) async => <AniListListEntry>[]);
+
+        await sut.importUserLists(
+          userName: 'u',
+          mode: ImportMode.newOnly,
+          collectionId: 1,
+          onProgress: (_) {},
+        );
+
+        verify(() => mockDb.updateItemProgress(
+          999,
+          currentEpisode: 12,
+          currentSeason: null,
+        )).called(1);
+      });
+
+      test('should map score 0 to null and 100 to 10', () async {
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.anime,
+        )).thenAnswer((_) async => <AniListListEntry>[
+          animeEntry(mediaId: 1, scoreRaw100: 0),
+          animeEntry(mediaId: 2, scoreRaw100: 100),
+          animeEntry(mediaId: 3, scoreRaw100: 47),
+        ]);
+        when(() => mockAniList.fetchUserMediaList(
+          userName: any(named: 'userName'),
+          type: MediaType.manga,
+        )).thenAnswer((_) async => <AniListListEntry>[]);
+
+        await sut.importUserLists(
+          userName: 'u',
+          mode: ImportMode.newOnly,
+          collectionId: 1,
+          onProgress: (_) {},
+        );
+
+        // Score 0 → no rating call at all.
+        // Score 100 → 10. Score 47 → 4 (integer division).
+        verify(() => mockDb.updateItemUserRating(999, 10)).called(1);
+        verify(() => mockDb.updateItemUserRating(999, 4)).called(1);
+        verifyNever(() => mockDb.updateItemUserRating(999, 0));
+      });
+
+      test('should map AniList status values to ItemStatus', () async {
+        const Map<String, ItemStatus> mapping = <String, ItemStatus>{
+          'CURRENT': ItemStatus.inProgress,
+          'REPEATING': ItemStatus.inProgress,
+          'COMPLETED': ItemStatus.completed,
+          'PLANNING': ItemStatus.planned,
+          'DROPPED': ItemStatus.dropped,
+          'PAUSED': ItemStatus.dropped,
+        };
+
+        for (final MapEntry<String, ItemStatus> e in mapping.entries) {
+          clearInteractions(mockDb);
+          when(() => mockAniList.fetchUserMediaList(
+            userName: any(named: 'userName'),
+            type: MediaType.anime,
+          )).thenAnswer((_) async => <AniListListEntry>[
+            animeEntry(rawStatus: e.key),
+          ]);
+          when(() => mockAniList.fetchUserMediaList(
+            userName: any(named: 'userName'),
+            type: MediaType.manga,
+          )).thenAnswer((_) async => <AniListListEntry>[]);
+
+          await sut.importUserLists(
+            userName: 'u',
+            mode: ImportMode.newOnly,
+            collectionId: 1,
+            onProgress: (_) {},
+          );
+
+          verify(() => mockDb.addItemToCollection(
+            collectionId: 1,
+            mediaType: MediaType.anime,
+            externalId: 100922,
+            status: e.value,
+          )).called(1);
+        }
+      });
+
+      test(
+          'should include AniList URL and repeat count in user comment',
+              () async {
+            when(() => mockAniList.fetchUserMediaList(
+              userName: any(named: 'userName'),
+              type: MediaType.anime,
+            )).thenAnswer((_) async => <AniListListEntry>[
+              animeEntry(repeat: 3, notes: 'great show'),
+            ]);
+            when(() => mockAniList.fetchUserMediaList(
+              userName: any(named: 'userName'),
+              type: MediaType.manga,
+            )).thenAnswer((_) async => <AniListListEntry>[]);
+
+            final List<String?> captured = <String?>[];
+            when(() => mockDb.updateItemUserComment(any(), captureAny()))
+                .thenAnswer((Invocation invocation) async {
+              captured.add(invocation.positionalArguments[1] as String?);
+            });
+
+            await sut.importUserLists(
+              userName: 'u',
+              mode: ImportMode.newOnly,
+              collectionId: 1,
+              onProgress: (_) {},
+            );
+
+            expect(captured, hasLength(1));
+            final String comment = captured.first!;
+            expect(comment, contains('https://anilist.co/anime/100922'));
+            expect(comment, contains('Rewatched times: 3'));
+            expect(comment, contains('great show'));
+          });
+
+      test(
+          'should reuse animeEntry totals for manga when COMPLETED tops up chapters and volumes',
+              () async {
+            when(() => mockAniList.fetchUserMediaList(
+              userName: any(named: 'userName'),
+              type: MediaType.anime,
+            )).thenAnswer((_) async => <AniListListEntry>[]);
+            when(() => mockAniList.fetchUserMediaList(
+              userName: any(named: 'userName'),
+              type: MediaType.manga,
+            )).thenAnswer((_) async => <AniListListEntry>[
+              const AniListListEntry(
+                mediaId: 30013,
+                mediaType: MediaType.manga,
+                rawStatus: 'COMPLETED',
+                progress: 100,
+                progressVolumes: 8,
+                repeat: 0,
+                manga: Manga(
+                  id: 30013,
+                  title: 'x',
+                  chapters: 150,
+                  volumes: 10,
+                ),
+              ),
+            ]);
+
+            await sut.importUserLists(
+              userName: 'u',
+              mode: ImportMode.newOnly,
+              collectionId: 1,
+              onProgress: (_) {},
+            );
+
+            verify(() => mockDb.updateItemProgress(
+              999,
+              currentEpisode: 150,
+              currentSeason: 10,
+            )).called(1);
+          });
+    });
+  });
+}

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -1,9 +1,11 @@
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:xerabora/shared/models/anime.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
 import 'package:xerabora/shared/models/collection.dart';
 import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/manga.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/movie.dart';
@@ -40,6 +42,8 @@ void registerAllFallbacks() {
   registerFallbackValue(const <TvSeason>[]);
   registerFallbackValue(const <TvEpisode>[]);
   registerFallbackValue(const <Platform>[]);
+  registerFallbackValue(const <Anime>[]);
+  registerFallbackValue(const <Manga>[]);
   registerFallbackValue(const <int>[]);
 
   registerFallbackValue(<TierDefinition>[]);


### PR DESCRIPTION
Adds a new Settings → Import entry powered by AniList's public MediaListCollection GraphQL endpoint — no OAuth, just a username. Maps AniList statuses onto the local ItemStatus enum (CURRENT / REPEATING → inProgress, PLANNING → planned, PAUSED → dropped), normalises POINT_100 scores to the 1..10 scale, and tops up episode / chapter / volume counters when an entry is COMPLETED. Filters isAdult media and custom-list duplicates. Persists the last-used username via SharedPreferences. Also pulls extraLarge covers from AniList and switches collection thumbnails to the full cover so posters no longer render at 100×146.