### PR TITLE
fix(ra-tracker): scope tracker progress per platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,92 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (raImportSearchingIgdb): New string for the IGDB-search progress stage.
   * test/core/services/ra_import_service_test.dart: New cases — manual link skips IGDB and reuses cached game; broken manual link falls back to IGDB search; `wishlisted=0` when `addToWishlist=false`; `wishlisted=0` when the wishlist row already existed; `RaImportResult.wishlisted` constructor + `toUniversal` mapping. Existing progress test updated to assert `searchingGames` and `matchingGames` both fire.
 
+### Fixed
+
+- **Tracker progress is now scoped per platform, not per IGDB game**
+
+  External tracker data (RetroAchievements progress, achievements, award
+  state, last-played timestamps) was keyed by IGDB game id alone, so a
+  single multi-platform game in the collection could only ever hold one
+  set of stats — syncing a second platform install silently overwrote
+  the first one and its history was lost. Each platform install now
+  owns its own tracker row: the unique index gains
+  `COALESCE(platform_id, -1)`, the model carries `platformId`, and the
+  UI scopes its lookups by the current `CollectionItem.platformId`.
+  Refreshing one install's status / dates no longer touches sibling
+  installs of the same IGDB game. On migration the legacy
+  `platform_id = NULL` rows are backfilled from the user's
+  `collection_items` when exactly one platform install of that game
+  exists; ambiguous rows are dropped so stale data can't leak across
+  platforms. Backups and `.xcoll` / `.xcollx` exports/imports round-trip
+  the new column automatically; archives produced by older versions are
+  tolerated (the fallback lookup still picks up NULL rows restored from
+  legacy backups).
+
+  * lib/core/database/schema.dart (DatabaseSchema.createTrackerGameDataTable):
+    Add `platform_id INTEGER` column; replace the
+    `idx_tracker_game_data_unique` index with one that includes
+    `COALESCE(platform_id, -1)` so distinct platforms keep distinct rows.
+  * lib/core/database/migrations/migration_v37.dart (MigrationV37),
+    lib/core/database/migrations/migration_registry.dart: New v37
+    migration that adds the column and rebuilds the unique index in place.
+  * lib/core/database/migrations/migration_v38.dart (MigrationV38):
+    Backfills `platform_id` on legacy tracker rows by joining each NULL
+    row against `collection_items`: unambiguous matches (exactly one
+    platform in the user's collection for that IGDB game) get filled in,
+    everything else is dropped together with its orphaned achievements
+    so the legacy fallback can't leak data across platform installs.
+  * lib/core/database/database_service.dart: Bump schema version to 38.
+    `getItemIdsByExternalId` gains `platformId` + `filterByPlatform` and
+    returns `platform_id` alongside id/collectionId so the sync code can
+    address one platform install at a time.
+  * lib/shared/models/tracker_game_data.dart (TrackerGameData,
+    TrackerGameData.fromDb, TrackerGameData.toDb, TrackerGameData.copyWith):
+    New `platformId` field threaded through fromDb / toDb / copyWith.
+    `copyWith` adds a `clearPlatformId` sentinel for explicit null-set.
+    All dartdocs translated to English.
+  * lib/core/database/dao/tracker_dao.dart (TrackerDao.getGameData,
+    TrackerDao.getGameDataForAnyPlatform, TrackerDao.deleteGameData):
+    `getGameData` accepts optional `platformId`. New
+    `getGameDataForAnyPlatform` returns every platform variant for a
+    given IGDB game. `deleteGameData` accepts `platformId` /
+    `allPlatforms` so per-platform unlink is possible; achievements for
+    a `tracker_game_id` are dropped only when no other tracker row still
+    references them.
+  * lib/features/collections/providers/tracker_provider.dart (TrackerKey,
+    TrackerDetailNotifier): Provider family key switched from `int` to a
+    `({int gameId, int? platformId})` record. The notifier reads the
+    per-platform row first and falls back to the legacy
+    platform-agnostic row when none exists. `unlinkRaGame` deletes only
+    the current platform's row; `_syncToCollectionItems` filters
+    `CollectionItem`s by `platformId` so PS2 progress doesn't bleed into
+    a GameCube row.
+  * lib/features/collections/widgets/ra_achievements_section.dart
+    (RaAchievementsSection): New `platformId` widget property; every
+    `trackerDetailProvider(...)` call now uses the composite key.
+  * lib/features/collections/screens/item_detail_screen.dart: Pass
+    `(gameId: item.externalId, platformId: item.platformId)` everywhere
+    the tracker provider is read or watched, and forward `platformId`
+    to `RaAchievementsSection`.
+  * lib/core/services/tracker_sync_service.dart
+    (TrackerSyncService.fullSyncRa, ra_to_igdb_mapper import): Bulk RA
+    sync derives the IGDB platform id from `raGame.consoleId` via
+    `RaToIgdbMapper.primaryIgdbPlatformId` and writes it onto the
+    upserted `TrackerGameData`.
+  * lib/core/services/ra_import_service.dart
+    (RaImportService.importFromProfile,
+    RaImportService._saveTrackerGameData): Same platform derivation
+    applied to the import flow; the in-collection duplicate check now
+    passes the derived `platformId` to `findCollectionItem` so a second
+    platform install of the same IGDB title creates a fresh row instead
+    of overwriting the first one.
+  * test/shared/models/tracker_game_data_test.dart (TrackerGameData),
+    test/core/database/dao/tracker_dao_test.dart (TrackerDao): New —
+    14 tests covering fromDb/toDb round-trip (with platformId, NULL,
+    missing key), copyWith semantics, per-platform upsert isolation,
+    NULL bucket behaviour, and the new delete variants including the
+    achievements-cleanup branch.
+
 ## [0.28.0] - 2026-04-23
 
 ### Added

--- a/lib/core/database/dao/tracker_dao.dart
+++ b/lib/core/database/dao/tracker_dao.dart
@@ -76,8 +76,32 @@ class TrackerDao {
 
   // ==================== Game Data ====================
 
-  /// Возвращает tracker data для игры по IGDB ID и типу трекера.
+  /// Returns the tracker row for `(tracker_type, game_id, platform_id)`.
+  /// Pass `platformId = null` to look up the legacy platform-agnostic row.
   Future<TrackerGameData?> getGameData(
+    TrackerType type,
+    int gameId, {
+    int? platformId,
+  }) async {
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> rows = await db.query(
+      'tracker_game_data',
+      where: platformId == null
+          ? 'tracker_type = ? AND game_id = ? AND platform_id IS NULL'
+          : 'tracker_type = ? AND game_id = ? AND platform_id = ?',
+      whereArgs: platformId == null
+          ? <Object?>[type.value, gameId]
+          : <Object?>[type.value, gameId, platformId],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return TrackerGameData.fromDb(rows.first);
+  }
+
+  /// Returns every tracker row tied to `(tracker_type, game_id)` regardless
+  /// of platform — useful when the caller wants to aggregate across all
+  /// platform variants of the same IGDB game.
+  Future<List<TrackerGameData>> getGameDataForAnyPlatform(
     TrackerType type,
     int gameId,
   ) async {
@@ -86,10 +110,8 @@ class TrackerDao {
       'tracker_game_data',
       where: 'tracker_type = ? AND game_id = ?',
       whereArgs: <Object?>[type.value, gameId],
-      limit: 1,
     );
-    if (rows.isEmpty) return null;
-    return TrackerGameData.fromDb(rows.first);
+    return rows.map(TrackerGameData.fromDb).toList();
   }
 
   /// Возвращает все tracker data для типа трекера.
@@ -156,30 +178,66 @@ class TrackerDao {
     });
   }
 
-  /// Удаляет tracker_game_data и связанные achievements для игры.
-  Future<void> deleteGameData(TrackerType type, int gameId) async {
+  /// Drops tracker rows + their per-game achievements. When [platformId] is
+  /// provided only that platform variant is removed; otherwise every platform
+  /// variant for the IGDB game is wiped together.
+  Future<void> deleteGameData(
+    TrackerType type,
+    int gameId, {
+    int? platformId,
+    bool allPlatforms = false,
+  }) async {
     final Database db = await _getDatabase();
 
-    // Сначала получим trackerGameId для удаления achievements.
+    // Locate the tracker_game_id values whose achievements should also go.
+    String gameDataWhere;
+    List<Object?> gameDataArgs;
+    if (allPlatforms) {
+      gameDataWhere = 'tracker_type = ? AND game_id = ?';
+      gameDataArgs = <Object?>[type.value, gameId];
+    } else if (platformId == null) {
+      gameDataWhere =
+          'tracker_type = ? AND game_id = ? AND platform_id IS NULL';
+      gameDataArgs = <Object?>[type.value, gameId];
+    } else {
+      gameDataWhere =
+          'tracker_type = ? AND game_id = ? AND platform_id = ?';
+      gameDataArgs = <Object?>[type.value, gameId, platformId];
+    }
+
     final List<Map<String, dynamic>> rows = await db.query(
       'tracker_game_data',
       columns: <String>['tracker_game_id'],
-      where: 'tracker_type = ? AND game_id = ?',
-      whereArgs: <Object?>[type.value, gameId],
+      where: gameDataWhere,
+      whereArgs: gameDataArgs,
     );
-    if (rows.isNotEmpty) {
-      final String trackerGameId = rows.first['tracker_game_id'] as String;
-      await db.delete(
-        'tracker_achievements',
-        where: 'tracker_type = ? AND tracker_game_id = ?',
-        whereArgs: <Object?>[type.value, trackerGameId],
+    final Set<String> trackerGameIds = <String>{
+      for (final Map<String, dynamic> r in rows) r['tracker_game_id'] as String,
+    };
+    // Only drop achievements when no other tracker_game_data row still
+    // references them — different platform installs can share an RA id only
+    // in theory, but Steam definitely shares AppId across platforms.
+    for (final String trackerGameId in trackerGameIds) {
+      final List<Map<String, Object?>> countRows = await db.rawQuery(
+        'SELECT COUNT(*) AS c FROM tracker_game_data '
+        'WHERE tracker_type = ? AND tracker_game_id = ? '
+        'AND NOT ($gameDataWhere)',
+        <Object?>[type.value, trackerGameId, ...gameDataArgs],
       );
+      final int remaining = (countRows.first['c'] as int?) ?? 0;
+      if (remaining == 0) {
+        await db.delete(
+          'tracker_achievements',
+          where: 'tracker_type = ? AND tracker_game_id = ?',
+          whereArgs: <Object?>[type.value, trackerGameId],
+        );
+      }
     }
 
     await db.delete(
       'tracker_game_data',
-      where: 'tracker_type = ? AND game_id = ?',
-      whereArgs: <Object?>[type.value, gameId],
+      where: gameDataWhere,
+      whereArgs: gameDataArgs,
     );
   }
 

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -199,7 +199,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 36,
+        version: 38,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {
@@ -527,21 +527,38 @@ class DatabaseService {
         lastActivityAt: lastActivityAt,
       );
 
-  Future<List<({int id, int? collectionId})>> getItemIdsByExternalId(
+  Future<List<({int id, int? collectionId, int? platformId})>>
+      getItemIdsByExternalId(
     int externalId,
-    String mediaType,
-  ) async {
+    String mediaType, {
+    int? platformId,
+    bool filterByPlatform = false,
+  }) async {
     final Database db = await database;
+    final List<String> conditions = <String>[
+      'external_id = ?',
+      'media_type = ?',
+    ];
+    final List<Object?> args = <Object?>[externalId, mediaType];
+    if (filterByPlatform) {
+      if (platformId == null) {
+        conditions.add('platform_id IS NULL');
+      } else {
+        conditions.add('platform_id = ?');
+        args.add(platformId);
+      }
+    }
     final List<Map<String, dynamic>> rows = await db.query(
       'collection_items',
-      columns: <String>['id', 'collection_id'],
-      where: 'external_id = ? AND media_type = ?',
-      whereArgs: <Object?>[externalId, mediaType],
+      columns: <String>['id', 'collection_id', 'platform_id'],
+      where: conditions.join(' AND '),
+      whereArgs: args,
     );
     return rows
         .map((Map<String, dynamic> r) => (
               id: r['id'] as int,
               collectionId: r['collection_id'] as int?,
+              platformId: r['platform_id'] as int?,
             ))
         .toList();
   }

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -35,6 +35,8 @@ import 'migration_v33.dart';
 import 'migration_v34.dart';
 import 'migration_v35.dart';
 import 'migration_v36.dart';
+import 'migration_v37.dart';
+import 'migration_v38.dart';
 
 /// Реестр всех миграций базы данных.
 ///
@@ -78,6 +80,8 @@ abstract final class MigrationRegistry {
     MigrationV34(),
     MigrationV35(),
     MigrationV36(),
+    MigrationV37(),
+    MigrationV38(),
   ];
 
   /// Возвращает миграции, ожидающие выполнения для данной версии.

--- a/lib/core/database/migrations/migration_v37.dart
+++ b/lib/core/database/migrations/migration_v37.dart
@@ -1,0 +1,34 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Migration v37: per-platform tracker_game_data.
+///
+/// The original unique index `(tracker_type, game_id)` collapses a single
+/// IGDB game across platforms — syncing RetroAchievements progress for the
+/// GameCube edition would overwrite the PS2 record. Adding `platform_id`
+/// (nullable) and including it in the unique index lets each platform
+/// variant keep its own row. Existing rows stay with NULL platform_id.
+class MigrationV37 extends Migration {
+  @override
+  int get version => 37;
+
+  @override
+  String get description =>
+      'Per-platform tracker_game_data: add platform_id column + unique index';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await db.execute(
+      'ALTER TABLE tracker_game_data ADD COLUMN platform_id INTEGER',
+    );
+    await db.execute('DROP INDEX IF EXISTS idx_tracker_game_data_unique');
+    // SQLite indexes can include expressions, so wrap platform_id in
+    // COALESCE to give NULL a deterministic key — without it two NULLs
+    // would be treated as distinct and we'd lose the upsert guarantee.
+    await db.execute('''
+      CREATE UNIQUE INDEX idx_tracker_game_data_unique
+      ON tracker_game_data(tracker_type, game_id, COALESCE(platform_id, -1))
+    ''');
+  }
+}

--- a/lib/core/database/migrations/migration_v38.dart
+++ b/lib/core/database/migrations/migration_v38.dart
@@ -1,0 +1,92 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Migration v38: backfill `platform_id` on legacy tracker_game_data rows.
+///
+/// v37 added the `platform_id` column but left every existing row with
+/// NULL — the value isn't recoverable from RA without an API round-trip.
+/// We can do better locally: the user's own `collection_items` already
+/// carry the IGDB platform id for the same game. For each NULL tracker
+/// row we look at the matching `collection_items` rows and:
+///
+///   * exactly one distinct platform → set `platform_id` to that;
+///   * zero or >1 distinct platforms → delete the NULL tracker row, since
+///     it can't be unambiguously attributed and would otherwise bleed
+///     across platform installs via the legacy fallback lookup.
+///
+/// Trivial cost (single in-process SQL run) and idempotent — only NULL
+/// rows are touched, so re-running the migration is a no-op.
+class MigrationV38 extends Migration {
+  @override
+  int get version => 38;
+
+  @override
+  String get description =>
+      'Backfill platform_id on legacy tracker_game_data NULL rows';
+
+  @override
+  Future<void> migrate(Database db) async {
+    // Resolve unambiguous platforms in a single statement: an UPDATE that
+    // joins via subquery and only fires when COUNT(DISTINCT platform_id)
+    // is exactly 1.
+    await db.execute('''
+      UPDATE tracker_game_data
+      SET platform_id = (
+        SELECT MIN(ci.platform_id)
+        FROM collection_items ci
+        WHERE ci.external_id = tracker_game_data.game_id
+          AND ci.media_type = 'game'
+          AND ci.platform_id IS NOT NULL
+      )
+      WHERE platform_id IS NULL
+        AND (
+          SELECT COUNT(DISTINCT ci.platform_id)
+          FROM collection_items ci
+          WHERE ci.external_id = tracker_game_data.game_id
+            AND ci.media_type = 'game'
+            AND ci.platform_id IS NOT NULL
+        ) = 1
+    ''');
+
+    // Anything still NULL is ambiguous (no matching items, or multiple
+    // platforms). Drop the row so the legacy fallback lookup can't leak
+    // it across platform installs of the same IGDB game.
+    final List<Map<String, Object?>> orphans = await db.query(
+      'tracker_game_data',
+      columns: <String>['tracker_type', 'tracker_game_id'],
+      where: 'platform_id IS NULL',
+    );
+    final Set<String> orphanKeys = <String>{
+      for (final Map<String, Object?> r in orphans)
+        '${r['tracker_type']}|${r['tracker_game_id']}',
+    };
+
+    await db.delete(
+      'tracker_game_data',
+      where: 'platform_id IS NULL',
+    );
+
+    // Drop the orphan achievements rows too — they're keyed by
+    // `(tracker_type, tracker_game_id)` and have no parent left.
+    for (final String key in orphanKeys) {
+      final List<String> parts = key.split('|');
+      final String type = parts[0];
+      final String trackerGameId = parts[1];
+      final List<Map<String, Object?>> stillReferenced = await db.query(
+        'tracker_game_data',
+        columns: <String>['id'],
+        where: 'tracker_type = ? AND tracker_game_id = ?',
+        whereArgs: <Object?>[type, trackerGameId],
+        limit: 1,
+      );
+      if (stillReferenced.isEmpty) {
+        await db.delete(
+          'tracker_achievements',
+          where: 'tracker_type = ? AND tracker_game_id = ?',
+          whereArgs: <Object?>[type, trackerGameId],
+        );
+      }
+    }
+  }
+}

--- a/lib/core/database/schema.dart
+++ b/lib/core/database/schema.dart
@@ -590,6 +590,7 @@ abstract final class DatabaseSchema {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         tracker_type TEXT NOT NULL,
         game_id INTEGER NOT NULL,
+        platform_id INTEGER,
         tracker_game_id TEXT NOT NULL,
         tracker_game_title TEXT,
         achievements_earned INTEGER,
@@ -605,7 +606,7 @@ abstract final class DatabaseSchema {
     ''');
     await db.execute('''
       CREATE UNIQUE INDEX IF NOT EXISTS idx_tracker_game_data_unique
-      ON tracker_game_data(tracker_type, game_id)
+      ON tracker_game_data(tracker_type, game_id, COALESCE(platform_id, -1))
     ''');
     await db.execute('''
       CREATE INDEX IF NOT EXISTS idx_tracker_game_data_game

--- a/lib/core/services/ra_import_service.dart
+++ b/lib/core/services/ra_import_service.dart
@@ -295,11 +295,17 @@ class RaImportService {
         continue;
       }
 
-      // Проверить дубликат ТОЛЬКО В ЦЕЛЕВОЙ КОЛЛЕКЦИИ.
+      // Match the existing item by (collection, IGDB game, platform). The
+      // RA game id is platform-specific on RA's side, so the same IGDB
+      // title on a different platform must land in its own collection row
+      // instead of overwriting the existing one.
+      final int? raPlatformId =
+          RaToIgdbMapper.primaryIgdbPlatformId(raGame.consoleId);
       final CollectionItem? existing = await _db.findCollectionItem(
         collectionId: targetCollectionId,
         mediaType: MediaType.game,
         externalId: igdbGame.id,
+        platformId: raPlatformId,
       );
 
       final DateTime? completedAt = raGame.highestAwardDate;
@@ -522,7 +528,9 @@ class RaImportService {
     }
   }
 
-  /// Сохраняет/обновляет tracker_game_data для RA игры.
+  /// Saves the per-platform tracker_game_data row for an RA game. The IGDB
+  /// platform id is derived from RA's console id so PS2 and GameCube
+  /// installs of the same IGDB title don't overwrite each other.
   Future<void> _saveTrackerGameData(
     int igdbId,
     RaGameProgress raGame,
@@ -534,11 +542,14 @@ class RaImportService {
     final int? lastPlayedTimestamp = raGame.lastPlayedAt != null
         ? raGame.lastPlayedAt!.millisecondsSinceEpoch ~/ 1000
         : null;
+    final int? platformId =
+        RaToIgdbMapper.primaryIgdbPlatformId(raGame.consoleId);
 
     await _trackerDao.upsertGameData(TrackerGameData(
       id: 0,
       trackerType: TrackerType.ra,
       gameId: igdbId,
+      platformId: platformId,
       trackerGameId: raGame.gameId.toString(),
       trackerGameTitle: raGame.title,
       achievementsEarned: raGame.numAwarded,

--- a/lib/core/services/tracker_sync_service.dart
+++ b/lib/core/services/tracker_sync_service.dart
@@ -11,6 +11,7 @@ import '../../shared/models/tracker_profile.dart';
 import '../api/ra_api.dart';
 import '../database/dao/tracker_dao.dart';
 import '../database/database_service.dart';
+import 'ra_to_igdb_mapper.dart';
 
 /// Провайдер для [TrackerSyncService].
 final Provider<TrackerSyncService> trackerSyncServiceProvider =
@@ -194,6 +195,8 @@ class TrackerSyncService {
       final List<RaGameProgress> realGames =
           raGames.where((RaGameProgress g) => g.isRealGame).toList();
 
+      // Two RA games for the same IGDB title (PS2 + GameCube) have distinct
+      // RA ids, so keying by RA id keeps each platform's row separate.
       final Map<String, TrackerGameData> existingByRaId =
           <String, TrackerGameData>{
         for (final TrackerGameData d in existingData)
@@ -250,10 +253,17 @@ class TrackerSyncService {
           continue;
         }
 
+        // Scope the row by the IGDB platform that matches RA's console so
+        // PS2 progress and GameCube progress can coexist for the same IGDB
+        // game.
+        final int? platformId =
+            RaToIgdbMapper.primaryIgdbPlatformId(raGame.consoleId);
+
         final TrackerGameData data = TrackerGameData(
           id: existing?.id ?? 0,
           trackerType: TrackerType.ra,
           gameId: igdbId,
+          platformId: platformId,
           trackerGameId: raGameId,
           trackerGameTitle: raGame.title,
           achievementsEarned: raGame.numAwarded,

--- a/lib/features/collections/providers/tracker_provider.dart
+++ b/lib/features/collections/providers/tracker_provider.dart
@@ -1,5 +1,3 @@
-// Провайдеры для tracker данных в карточке игры.
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
@@ -15,58 +13,61 @@ import '../../../shared/models/tracker_achievement.dart';
 import '../../../shared/models/tracker_game_data.dart';
 import '../../../shared/models/tracker_profile.dart';
 
-/// Состояние tracker данных для карточки игры.
+/// Composite key for the tracker provider family — IGDB game id plus the
+/// optional platform that scopes the row. A `null` platformId points at the
+/// legacy platform-agnostic record so old data keeps rendering.
+typedef TrackerKey = ({int gameId, int? platformId});
+
 class TrackerDetailState {
-  /// Создаёт [TrackerDetailState].
   const TrackerDetailState({
     this.gameData,
     this.achievements,
     this.isLoadingAchievements = false,
   });
 
-  /// Summary прогресса (из tracker_game_data).
   final TrackerGameData? gameData;
-
-  /// Список достижений (lazy loaded).
   final List<TrackerAchievement>? achievements;
-
-  /// Загружаются ли достижения.
   final bool isLoadingAchievements;
 
-  /// Есть ли RA данные для этой игры.
   bool get hasRaData => gameData != null;
 }
 
-/// Провайдер tracker данных для конкретной игры (по IGDB ID).
-///
-/// AsyncNotifier — `build()` загружает данные, Riverpod управляет
-/// loading/data/error. Виджет использует `asyncValue.when()`.
+/// Tracker data for one (IGDB game, platform) pair.
 final AsyncNotifierProviderFamily<TrackerDetailNotifier, TrackerDetailState,
-        int>
+        TrackerKey>
     trackerDetailProvider = AsyncNotifierProvider.family<
-        TrackerDetailNotifier, TrackerDetailState, int>(
+        TrackerDetailNotifier, TrackerDetailState, TrackerKey>(
   TrackerDetailNotifier.new,
 );
 
-/// Notifier для tracker данных одной игры.
 class TrackerDetailNotifier
-    extends FamilyAsyncNotifier<TrackerDetailState, int> {
+    extends FamilyAsyncNotifier<TrackerDetailState, TrackerKey> {
   static final Logger _log = Logger('TrackerDetailNotifier');
 
   late TrackerDao _trackerDao;
   late TrackerSyncService _syncService;
   late DatabaseService _db;
   late int _gameId;
+  int? _platformId;
 
   @override
-  Future<TrackerDetailState> build(int arg) async {
-    _gameId = arg;
+  Future<TrackerDetailState> build(TrackerKey arg) async {
+    _gameId = arg.gameId;
+    _platformId = arg.platformId;
     _trackerDao = ref.watch(trackerDaoProvider);
     _syncService = ref.watch(trackerSyncServiceProvider);
     _db = ref.watch(databaseServiceProvider);
 
-    final TrackerGameData? data =
-        await _trackerDao.getGameData(TrackerType.ra, _gameId);
+    TrackerGameData? data = await _trackerDao.getGameData(
+      TrackerType.ra,
+      _gameId,
+      platformId: _platformId,
+    );
+    // Fallback to the legacy platform-agnostic row when no per-platform row
+    // exists yet — keeps pre-v37 collections rendering without re-sync.
+    if (data == null && _platformId != null) {
+      data = await _trackerDao.getGameData(TrackerType.ra, _gameId);
+    }
 
     return TrackerDetailState(gameData: data);
   }
@@ -141,11 +142,11 @@ class TrackerDetailNotifier
   }) async {
     final int now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-    // Создаём запись tracker_game_data.
     final TrackerGameData data = TrackerGameData(
       id: 0,
       trackerType: TrackerType.ra,
       gameId: _gameId,
+      platformId: _platformId,
       trackerGameId: raGameId.toString(),
       trackerGameTitle: raTitle,
       achievementsTotal: achievementsTotal,
@@ -160,9 +161,14 @@ class TrackerDetailNotifier
     await refreshAchievements();
   }
 
-  /// Отвязывает игру от RA: удаляет tracker_game_data и achievements.
+  /// Drops the per-platform RA link and its achievements. Other platform
+  /// installs of the same IGDB game keep their data.
   Future<void> unlinkRaGame() async {
-    await _trackerDao.deleteGameData(TrackerType.ra, _gameId);
+    await _trackerDao.deleteGameData(
+      TrackerType.ra,
+      _gameId,
+      platformId: _platformId,
+    );
     state = const AsyncData<TrackerDetailState>(TrackerDetailState());
   }
 
@@ -232,7 +238,9 @@ class TrackerDetailNotifier
     }
   }
 
-  /// Синхронизирует даты и статус из RA во все collection_items этой игры.
+  /// Propagates RA dates/status into every CollectionItem that points at
+  /// this `(IGDB game, platform)` pair. Other platform installs of the same
+  /// IGDB game are intentionally left alone.
   Future<void> _syncToCollectionItems({
     String? awardKind,
     int? awardDate,
@@ -241,8 +249,13 @@ class TrackerDetailNotifier
     int earned = 0,
   }) async {
     try {
-      final List<({int id, int? collectionId})> items =
-          await _db.getItemIdsByExternalId(_gameId, 'game');
+      final List<({int id, int? collectionId, int? platformId})> items =
+          await _db.getItemIdsByExternalId(
+        _gameId,
+        'game',
+        platformId: _platformId,
+        filterByPlatform: true,
+      );
       if (items.isEmpty) return;
 
       final DateTime? startedAt = firstPlayedAt != null
@@ -262,7 +275,8 @@ class TrackerDetailNotifier
         lastPlayedAt: lastActivity,
       );
 
-      for (final ({int id, int? collectionId}) item in items) {
+      for (final ({int id, int? collectionId, int? platformId}) item
+          in items) {
         // Текущий статус для проверки правила dropped.
         final CollectionItem? current = ref
             .read(collectionItemsNotifierProvider(item.collectionId))

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -155,7 +155,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
     if (!enabled) return;
     _discordRpc ??= ref.read(discordRpcServiceProvider);
     final TrackerGameData? raData = item.mediaType == MediaType.game
-        ? ref.read(trackerDetailProvider(item.externalId)).valueOrNull?.gameData
+        ? ref.read(trackerDetailProvider((gameId: item.externalId, platformId: item.platformId))).valueOrNull?.gameData
         : null;
     _discordRpc!.updatePresence(item, raData: raData);
   }
@@ -1004,7 +1004,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
     if (item.mediaType != MediaType.game) return null;
 
     final TrackerGameData? raData = ref
-        .watch(trackerDetailProvider(item.externalId))
+        .watch(trackerDetailProvider((gameId: item.externalId, platformId: item.platformId)))
         .valueOrNull
         ?.gameData;
 
@@ -1044,12 +1044,17 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
   Widget? _buildTrackerSection(CollectionItem item) {
     if (item.mediaType != MediaType.game) return null;
     final bool hasData = ref.watch(
-      trackerDetailProvider(item.externalId).select(
+      trackerDetailProvider((gameId: item.externalId, platformId: item.platformId)).select(
         (AsyncValue<TrackerDetailState> v) =>
             v.valueOrNull?.hasRaData ?? false,
       ),
     );
-    if (hasData) return RaAchievementsSection(gameId: item.externalId);
+    if (hasData) {
+      return RaAchievementsSection(
+        gameId: item.externalId,
+        platformId: item.platformId,
+      );
+    }
     return null;
   }
 
@@ -1378,7 +1383,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
     if (result == null || !mounted) return;
 
     await ref
-        .read(trackerDetailProvider(item.externalId).notifier)
+        .read(trackerDetailProvider((gameId: item.externalId, platformId: item.platformId)).notifier)
         .linkRaGame(
           raGameId: result.raGameId,
           raTitle: result.title,

--- a/lib/features/collections/widgets/ra_achievements_section.dart
+++ b/lib/features/collections/widgets/ra_achievements_section.dart
@@ -38,14 +38,18 @@ enum _AchievementFilter {
 /// Показывается только если для игры есть tracker_game_data.
 /// Достижения подгружаются lazy при появлении секции.
 class RaAchievementsSection extends ConsumerStatefulWidget {
-  /// Создаёт [RaAchievementsSection].
   const RaAchievementsSection({
     required this.gameId,
+    this.platformId,
     super.key,
   });
 
-  /// IGDB ID игры.
+  /// IGDB game id.
   final int gameId;
+
+  /// Optional platform scope — same IGDB game on different platforms holds
+  /// distinct RA progress. `null` falls back to the legacy shared record.
+  final int? platformId;
 
   @override
   ConsumerState<RaAchievementsSection> createState() =>
@@ -63,7 +67,7 @@ class _RaAchievementsSectionState
     setState(() => _isRefreshing = true);
     try {
       await ref
-          .read(trackerDetailProvider(widget.gameId).notifier)
+          .read(trackerDetailProvider((gameId: widget.gameId, platformId: widget.platformId)).notifier)
           .refreshAchievements();
     } finally {
       if (mounted) setState(() => _isRefreshing = false);
@@ -73,7 +77,7 @@ class _RaAchievementsSectionState
   @override
   Widget build(BuildContext context) {
     final AsyncValue<TrackerDetailState> asyncState =
-        ref.watch(trackerDetailProvider(widget.gameId));
+        ref.watch(trackerDetailProvider((gameId: widget.gameId, platformId: widget.platformId)));
 
     return asyncState.when(
       loading: () => const Padding(
@@ -93,7 +97,7 @@ class _RaAchievementsSectionState
         // Lazy load достижений после того как game data загружена.
         if (state.achievements == null && !state.isLoadingAchievements) {
           Future<void>.microtask(() {
-            ref.read(trackerDetailProvider(widget.gameId).notifier)
+            ref.read(trackerDetailProvider((gameId: widget.gameId, platformId: widget.platformId)).notifier)
                 .loadAchievements();
           });
         }
@@ -789,7 +793,7 @@ class _RaAchievementsSectionState
     if (confirmed != true || !context.mounted) return;
 
     await ref
-        .read(trackerDetailProvider(widget.gameId).notifier)
+        .read(trackerDetailProvider((gameId: widget.gameId, platformId: widget.platformId)).notifier)
         .unlinkRaGame();
   }
 

--- a/lib/shared/models/tracker_game_data.dart
+++ b/lib/shared/models/tracker_game_data.dart
@@ -1,21 +1,18 @@
-// Модель прогресса per-game от внешнего трекера.
-
 import 'dart:convert';
 
 import 'tracker_profile.dart';
 
-/// Прогресс по игре от внешнего трекера (RA, Steam).
-///
-/// Привязан к `games.id` (IGDB), а не к `collection_items.id`.
-/// Одна запись на трекер на игру.
+/// Per-game tracker progress (RA, Steam). Linked to `games.id` (IGDB id),
+/// optionally scoped by [platformId] so the same IGDB game can hold separate
+/// progress for each platform installation (PS2, GameCube, …).
 class TrackerGameData {
-  /// Создаёт [TrackerGameData].
   const TrackerGameData({
     required this.id,
     required this.trackerType,
     required this.gameId,
     required this.trackerGameId,
     required this.lastSyncedAt,
+    this.platformId,
     this.trackerGameTitle,
     this.achievementsEarned,
     this.achievementsTotal,
@@ -39,6 +36,7 @@ class TrackerGameData {
       id: row['id'] as int,
       trackerType: TrackerType.fromString(row['tracker_type'] as String),
       gameId: row['game_id'] as int,
+      platformId: row['platform_id'] as int?,
       trackerGameId: row['tracker_game_id'] as String,
       trackerGameTitle: row['tracker_game_title'] as String?,
       achievementsEarned: row['achievements_earned'] as int?,
@@ -54,49 +52,46 @@ class TrackerGameData {
     );
   }
 
-  /// Уникальный ID.
   final int id;
-
-  /// Тип трекера.
   final TrackerType trackerType;
 
-  /// IGDB ID игры (`games.id`).
+  /// IGDB id (`games.id`).
   final int gameId;
 
-  /// ID игры в трекере (RA GameID / Steam AppID).
+  /// Optional platform scope — same IGDB game on PS2 vs GameCube can hold
+  /// separate progress. `null` means "applies to the game regardless of
+  /// platform" (legacy rows, trackers that don't differentiate).
+  final int? platformId;
+
+  /// Provider-side game id (RA GameID / Steam AppID). Different per platform
+  /// on RetroAchievements; same across platforms on Steam.
   final String trackerGameId;
 
-  /// Название в трекере (может отличаться от IGDB).
+  /// Provider-side title, can drift from IGDB.
   final String? trackerGameTitle;
 
-  /// Полученные достижения.
   final int? achievementsEarned;
-
-  /// Всего достижений.
   final int? achievementsTotal;
 
-  /// Hardcore достижения (RA).
+  /// RA-only — hardcore mode counts achievements without save-state cheats.
   final int? achievementsEarnedHardcore;
 
-  /// Тип награды ('mastered-hardcore', 'beaten-softcore', null).
+  /// 'mastered-hardcore', 'beaten-softcore', or null. RA awards.
   final String? awardKind;
 
-  /// Timestamp получения award.
   final int? awardDate;
 
-  /// Время игры в минутах (Steam).
+  /// Steam-only.
   final int? playtimeMinutes;
 
-  /// Timestamp последней активности.
   final int? lastPlayedAt;
 
-  /// JSON для доп. данных.
+  /// Provider-specific opaque blob (e.g. RA recent achievements list).
   final Map<String, dynamic>? trackerData;
 
-  /// Timestamp последнего sync.
   final int lastSyncedAt;
 
-  /// Процент прохождения (0.0–1.0).
+  /// 0.0–1.0; 0.0 when [achievementsTotal] is null / zero.
   double get completionRate {
     if (achievementsTotal == null ||
         achievementsTotal == 0 ||
@@ -106,7 +101,7 @@ class TrackerGameData {
     return achievementsEarned! / achievementsTotal!;
   }
 
-  /// Процент hardcore прохождения (0.0–1.0, RA only).
+  /// 0.0–1.0 for RA hardcore mode.
   double get hardcoreCompletionRate {
     if (achievementsTotal == null ||
         achievementsTotal == 0 ||
@@ -116,31 +111,26 @@ class TrackerGameData {
     return achievementsEarnedHardcore! / achievementsTotal!;
   }
 
-  /// Есть ли award (beaten/mastered).
   bool get hasAward => awardKind != null;
 
-  /// Mastered (все ачивки).
   bool get isMastered =>
       awardKind != null && awardKind!.contains('mastered');
 
-  /// Beaten.
   bool get isBeaten =>
       awardKind != null && awardKind!.contains('beaten');
 
-  /// Hardcore mode.
   bool get isHardcore =>
       awardKind != null && awardKind!.contains('hardcore');
 
-  /// URL страницы игры на RA.
   String get raGameUrl =>
       'https://retroachievements.org/game/$trackerGameId';
 
-  /// Преобразует в Map для БД.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       if (id != 0) 'id': id,
       'tracker_type': trackerType.value,
       'game_id': gameId,
+      'platform_id': platformId,
       'tracker_game_id': trackerGameId,
       'tracker_game_title': trackerGameTitle,
       'achievements_earned': achievementsEarned,
@@ -155,11 +145,12 @@ class TrackerGameData {
     };
   }
 
-  /// Создаёт копию с изменёнными полями.
   TrackerGameData copyWith({
     int? id,
     TrackerType? trackerType,
     int? gameId,
+    int? platformId,
+    bool clearPlatformId = false,
     String? trackerGameId,
     String? trackerGameTitle,
     int? achievementsEarned,
@@ -176,6 +167,8 @@ class TrackerGameData {
       id: id ?? this.id,
       trackerType: trackerType ?? this.trackerType,
       gameId: gameId ?? this.gameId,
+      platformId:
+          clearPlatformId ? null : (platformId ?? this.platformId),
       trackerGameId: trackerGameId ?? this.trackerGameId,
       trackerGameTitle: trackerGameTitle ?? this.trackerGameTitle,
       achievementsEarned: achievementsEarned ?? this.achievementsEarned,

--- a/test/core/database/dao/tracker_dao_test.dart
+++ b/test/core/database/dao/tracker_dao_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:xerabora/core/database/dao/tracker_dao.dart';
+import 'package:xerabora/shared/models/tracker_game_data.dart';
+import 'package:xerabora/shared/models/tracker_profile.dart';
+
+Future<Database> _openTrackerDb() async {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+  return factory.openDatabase(
+    inMemoryDatabasePath,
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (Database db, int version) async {
+        await db.execute('''
+          CREATE TABLE tracker_game_data (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker_type TEXT NOT NULL,
+            game_id INTEGER NOT NULL,
+            platform_id INTEGER,
+            tracker_game_id TEXT NOT NULL,
+            tracker_game_title TEXT,
+            achievements_earned INTEGER,
+            achievements_total INTEGER,
+            achievements_earned_hardcore INTEGER,
+            award_kind TEXT,
+            award_date INTEGER,
+            playtime_minutes INTEGER,
+            last_played_at INTEGER,
+            tracker_data TEXT,
+            last_synced_at INTEGER NOT NULL
+          )
+        ''');
+        await db.execute('''
+          CREATE UNIQUE INDEX idx_tracker_game_data_unique
+          ON tracker_game_data(tracker_type, game_id, COALESCE(platform_id, -1))
+        ''');
+        await db.execute('''
+          CREATE TABLE tracker_achievements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker_type TEXT NOT NULL,
+            tracker_game_id TEXT NOT NULL,
+            achievement_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            points INTEGER,
+            badge_name TEXT,
+            type TEXT,
+            display_order INTEGER NOT NULL DEFAULT 0,
+            earned INTEGER NOT NULL DEFAULT 0,
+            earned_at INTEGER
+          )
+        ''');
+      },
+    ),
+  );
+}
+
+TrackerGameData _data({
+  int? platformId,
+  String trackerGameId = '111',
+  int gameId = 1942,
+}) =>
+    TrackerGameData(
+      id: 0,
+      trackerType: TrackerType.ra,
+      gameId: gameId,
+      platformId: platformId,
+      trackerGameId: trackerGameId,
+      lastSyncedAt: 1700000000,
+    );
+
+void main() {
+  late Database db;
+  late TrackerDao dao;
+
+  setUp(() async {
+    db = await _openTrackerDb();
+    dao = TrackerDao(() async => db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('TrackerDao', () {
+    group('upsertGameData with per-platform rows', () {
+      test('stores two rows for the same game on different platforms', () async {
+        // PS2 console_id 21 maps to IGDB platform 8 (real values not relevant);
+        // here we just pick two distinct platform ids.
+        await dao.upsertGameData(_data(platformId: 8, trackerGameId: 'ra-ps2'));
+        await dao.upsertGameData(_data(platformId: 21, trackerGameId: 'ra-gc'));
+
+        final TrackerGameData? ps2 =
+            await dao.getGameData(TrackerType.ra, 1942, platformId: 8);
+        final TrackerGameData? gc =
+            await dao.getGameData(TrackerType.ra, 1942, platformId: 21);
+
+        expect(ps2?.trackerGameId, 'ra-ps2');
+        expect(gc?.trackerGameId, 'ra-gc');
+      });
+
+      test('replaces the row for the same (game, platform) pair', () async {
+        await dao.upsertGameData(_data(
+          platformId: 8,
+          trackerGameId: 'ra-first',
+        ));
+        await dao.upsertGameData(_data(
+          platformId: 8,
+          trackerGameId: 'ra-second',
+        ));
+
+        final TrackerGameData? row =
+            await dao.getGameData(TrackerType.ra, 1942, platformId: 8);
+        expect(row?.trackerGameId, 'ra-second');
+        // Total rows must stay at 1 — REPLACE happened, not INSERT.
+        final List<TrackerGameData> all =
+            await dao.getGameDataForAnyPlatform(TrackerType.ra, 1942);
+        expect(all, hasLength(1));
+      });
+
+      test('NULL platformId is its own bucket — collides with another NULL',
+          () async {
+        // Both rows have platformId = null → COALESCE(-1) makes them collide.
+        await dao.upsertGameData(_data(trackerGameId: 'first'));
+        await dao.upsertGameData(_data(trackerGameId: 'second'));
+
+        final TrackerGameData? row =
+            await dao.getGameData(TrackerType.ra, 1942);
+        expect(row?.trackerGameId, 'second');
+        expect(
+          await dao.getGameDataForAnyPlatform(TrackerType.ra, 1942),
+          hasLength(1),
+        );
+      });
+
+      test('NULL platformId does not collide with concrete platformId', () async {
+        await dao.upsertGameData(_data(trackerGameId: 'legacy'));
+        await dao.upsertGameData(_data(
+          platformId: 8,
+          trackerGameId: 'ps2',
+        ));
+
+        // Both rows coexist.
+        expect(
+          await dao.getGameDataForAnyPlatform(TrackerType.ra, 1942),
+          hasLength(2),
+        );
+        expect(
+          (await dao.getGameData(TrackerType.ra, 1942))?.trackerGameId,
+          'legacy',
+        );
+        expect(
+          (await dao.getGameData(TrackerType.ra, 1942, platformId: 8))
+              ?.trackerGameId,
+          'ps2',
+        );
+      });
+    });
+
+    group('deleteGameData', () {
+      test('per-platform delete leaves other platform rows intact', () async {
+        await dao.upsertGameData(_data(platformId: 8, trackerGameId: 'ps2'));
+        await dao.upsertGameData(_data(platformId: 21, trackerGameId: 'gc'));
+
+        await dao.deleteGameData(TrackerType.ra, 1942, platformId: 8);
+
+        final List<TrackerGameData> remaining =
+            await dao.getGameDataForAnyPlatform(TrackerType.ra, 1942);
+        expect(remaining, hasLength(1));
+        expect(remaining.single.platformId, 21);
+      });
+
+      test('allPlatforms drops every variant', () async {
+        await dao.upsertGameData(_data(platformId: 8, trackerGameId: 'ps2'));
+        await dao.upsertGameData(_data(platformId: 21, trackerGameId: 'gc'));
+
+        await dao.deleteGameData(TrackerType.ra, 1942, allPlatforms: true);
+
+        expect(
+          await dao.getGameDataForAnyPlatform(TrackerType.ra, 1942),
+          isEmpty,
+        );
+      });
+
+      test('per-platform delete also drops linked achievements when no other '
+          'tracker row references that tracker_game_id', () async {
+        await dao.upsertGameData(_data(platformId: 8, trackerGameId: 'ps2'));
+        await db.insert('tracker_achievements', <String, Object?>{
+          'tracker_type': 'ra',
+          'tracker_game_id': 'ps2',
+          'achievement_id': 'a1',
+          'title': 'Boom',
+        });
+
+        await dao.deleteGameData(TrackerType.ra, 1942, platformId: 8);
+
+        final List<Map<String, Object?>> achievements =
+            await db.query('tracker_achievements');
+        expect(achievements, isEmpty);
+      });
+    });
+  });
+}

--- a/test/core/database/migrations/migration_v38_test.dart
+++ b/test/core/database/migrations/migration_v38_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:xerabora/core/database/migrations/migration_v38.dart';
+
+Future<Database> _openSeededDb() async {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+  return factory.openDatabase(
+    inMemoryDatabasePath,
+    options: OpenDatabaseOptions(
+      version: 1,
+      onCreate: (Database db, int version) async {
+        await db.execute('''
+          CREATE TABLE collection_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            collection_id INTEGER,
+            media_type TEXT NOT NULL,
+            external_id INTEGER NOT NULL,
+            platform_id INTEGER,
+            status TEXT NOT NULL DEFAULT 'not_started',
+            added_at INTEGER NOT NULL
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE tracker_game_data (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker_type TEXT NOT NULL,
+            game_id INTEGER NOT NULL,
+            platform_id INTEGER,
+            tracker_game_id TEXT NOT NULL,
+            tracker_game_title TEXT,
+            achievements_earned INTEGER,
+            achievements_total INTEGER,
+            achievements_earned_hardcore INTEGER,
+            award_kind TEXT,
+            award_date INTEGER,
+            playtime_minutes INTEGER,
+            last_played_at INTEGER,
+            tracker_data TEXT,
+            last_synced_at INTEGER NOT NULL
+          )
+        ''');
+        await db.execute('''
+          CREATE TABLE tracker_achievements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tracker_type TEXT NOT NULL,
+            tracker_game_id TEXT NOT NULL,
+            achievement_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            points INTEGER,
+            badge_name TEXT,
+            type TEXT,
+            display_order INTEGER NOT NULL DEFAULT 0,
+            earned INTEGER NOT NULL DEFAULT 0,
+            earned_at INTEGER
+          )
+        ''');
+      },
+    ),
+  );
+}
+
+Future<int> _insertTrackerRow(
+  Database db, {
+  required int gameId,
+  int? platformId,
+  String trackerGameId = '111',
+}) async {
+  return db.insert('tracker_game_data', <String, Object?>{
+    'tracker_type': 'ra',
+    'game_id': gameId,
+    'platform_id': platformId,
+    'tracker_game_id': trackerGameId,
+    'last_synced_at': 1700000000,
+  });
+}
+
+Future<void> _insertCollectionItem(
+  Database db, {
+  required int externalId,
+  int? platformId,
+}) async {
+  await db.insert('collection_items', <String, Object?>{
+    'media_type': 'game',
+    'external_id': externalId,
+    'platform_id': platformId,
+    'added_at': 1700000000,
+  });
+}
+
+void main() {
+  late Database db;
+
+  setUp(() async {
+    db = await _openSeededDb();
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('MigrationV38', () {
+    test('fills platformId when exactly one platform is in the collection',
+        () async {
+      await _insertTrackerRow(db, gameId: 100, trackerGameId: 'ra100');
+      await _insertCollectionItem(db, externalId: 100, platformId: 8);
+
+      await MigrationV38().migrate(db);
+
+      final List<Map<String, Object?>> rows =
+          await db.query('tracker_game_data');
+      expect(rows, hasLength(1));
+      expect(rows.first['platform_id'], 8);
+    });
+
+    test('drops the NULL row when no matching collection_items exist',
+        () async {
+      await _insertTrackerRow(db, gameId: 100, trackerGameId: 'ra100');
+      // No collection_items for game 100.
+
+      await MigrationV38().migrate(db);
+
+      expect(await db.query('tracker_game_data'), isEmpty);
+    });
+
+    test('drops the NULL row when collection has multiple platforms', () async {
+      await _insertTrackerRow(db, gameId: 100, trackerGameId: 'ra100');
+      await _insertCollectionItem(db, externalId: 100, platformId: 8);
+      await _insertCollectionItem(db, externalId: 100, platformId: 21);
+
+      await MigrationV38().migrate(db);
+
+      expect(await db.query('tracker_game_data'), isEmpty);
+    });
+
+    test('leaves rows that already had platformId untouched', () async {
+      await _insertTrackerRow(db, gameId: 100, platformId: 8, trackerGameId: 'ra-ps2');
+      // No collection_items — wouldn't backfill anyway, but row must survive.
+
+      await MigrationV38().migrate(db);
+
+      final List<Map<String, Object?>> rows =
+          await db.query('tracker_game_data');
+      expect(rows, hasLength(1));
+      expect(rows.first['platform_id'], 8);
+    });
+
+    test('drops orphan achievements when their parent NULL row is removed',
+        () async {
+      await _insertTrackerRow(db, gameId: 100, trackerGameId: 'orphan-ra');
+      await db.insert('tracker_achievements', <String, Object?>{
+        'tracker_type': 'ra',
+        'tracker_game_id': 'orphan-ra',
+        'achievement_id': 'a1',
+        'title': 'Boom',
+      });
+
+      await MigrationV38().migrate(db);
+
+      expect(await db.query('tracker_achievements'), isEmpty);
+    });
+
+    test('keeps achievements when another tracker row still references the '
+        'same tracker_game_id', () async {
+      // Two rows share the same RA tracker_game_id (e.g. legacy NULL row +
+      // a freshly inserted per-platform row). Dropping the NULL row must
+      // not cascade and delete the still-referenced achievements.
+      await _insertTrackerRow(db, gameId: 100, trackerGameId: 'shared');
+      await _insertTrackerRow(
+        db,
+        gameId: 100,
+        platformId: 8,
+        trackerGameId: 'shared',
+      );
+      await db.insert('tracker_achievements', <String, Object?>{
+        'tracker_type': 'ra',
+        'tracker_game_id': 'shared',
+        'achievement_id': 'a1',
+        'title': 'Keep me',
+      });
+
+      await MigrationV38().migrate(db);
+
+      expect(await db.query('tracker_achievements'), hasLength(1));
+    });
+  });
+}

--- a/test/core/services/ra_import_service_test.dart
+++ b/test/core/services/ra_import_service_test.dart
@@ -85,6 +85,7 @@ void main() {
           collectionId: any(named: 'collectionId'),
           mediaType: any(named: 'mediaType'),
           externalId: any(named: 'externalId'),
+          platformId: any(named: 'platformId'),
         )).thenAnswer((_) async => null);
 
     when(() => mockDb.upsertGame(any())).thenAnswer((_) async {});
@@ -666,6 +667,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         final RaImportResult result = await sut.importFromProfile(
@@ -716,6 +718,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         await sut.importFromProfile(
@@ -765,6 +768,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         await sut.importFromProfile(
@@ -821,6 +825,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         await sut.importFromProfile(
@@ -992,6 +997,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         await sut.importFromProfile(
@@ -1036,6 +1042,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         await sut.importFromProfile(
@@ -1079,6 +1086,7 @@ void main() {
               collectionId: 1,
               mediaType: MediaType.game,
               externalId: 100,
+              platformId: any(named: 'platformId'),
             )).thenAnswer((_) async => existing);
 
         final RaImportResult result = await sut.importFromProfile(

--- a/test/shared/models/tracker_game_data_test.dart
+++ b/test/shared/models/tracker_game_data_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/tracker_game_data.dart';
+import 'package:xerabora/shared/models/tracker_profile.dart';
+
+void main() {
+  group('TrackerGameData', () {
+    group('fromDb / toDb round trip', () {
+      test('preserves platformId when set', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 7,
+          'tracker_type': 'ra',
+          'game_id': 1942,
+          'platform_id': 8,
+          'tracker_game_id': '12345',
+          'tracker_game_title': 'SpongeBob: BFBB (PS2)',
+          'achievements_earned': 10,
+          'achievements_total': 50,
+          'achievements_earned_hardcore': 5,
+          'award_kind': 'beaten-hardcore',
+          'award_date': 1700000000,
+          'playtime_minutes': null,
+          'last_played_at': 1701000000,
+          'tracker_data': null,
+          'last_synced_at': 1701123456,
+        };
+
+        final TrackerGameData data = TrackerGameData.fromDb(row);
+
+        expect(data.platformId, 8);
+        expect(data.gameId, 1942);
+        expect(data.trackerGameId, '12345');
+        // toDb round-trips platform_id; id is preserved for non-zero values.
+        final Map<String, dynamic> roundTrip = data.toDb();
+        expect(roundTrip['platform_id'], 8);
+        expect(roundTrip['game_id'], 1942);
+      });
+
+      test('reads NULL platform_id as null (legacy rows)', () {
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'tracker_type': 'ra',
+          'game_id': 1942,
+          'platform_id': null,
+          'tracker_game_id': '12345',
+          'last_synced_at': 1701123456,
+        };
+
+        final TrackerGameData data = TrackerGameData.fromDb(row);
+
+        expect(data.platformId, isNull);
+        expect(data.toDb()['platform_id'], isNull);
+      });
+
+      test('falls back to null when platform_id key is missing entirely', () {
+        // Pre-v37 backup archives won't even carry the key.
+        final Map<String, dynamic> row = <String, dynamic>{
+          'id': 1,
+          'tracker_type': 'ra',
+          'game_id': 1942,
+          'tracker_game_id': '12345',
+          'last_synced_at': 1701123456,
+        };
+
+        expect(TrackerGameData.fromDb(row).platformId, isNull);
+      });
+    });
+
+    group('copyWith', () {
+      const TrackerGameData base = TrackerGameData(
+        id: 1,
+        trackerType: TrackerType.ra,
+        gameId: 1942,
+        platformId: 8,
+        trackerGameId: '12345',
+        lastSyncedAt: 1700000000,
+      );
+
+      test('keeps platformId untouched when not passed', () {
+        expect(base.copyWith(achievementsEarned: 1).platformId, 8);
+      });
+
+      test('replaces platformId when explicitly passed', () {
+        expect(base.copyWith(platformId: 9).platformId, 9);
+      });
+
+      test('clears platformId via the explicit clear flag', () {
+        expect(base.copyWith(clearPlatformId: true).platformId, isNull);
+      });
+
+      test('clearPlatformId wins over a passed platformId', () {
+        // The clear flag is the explicit "set null" sentinel — passing a
+        // value alongside must not resurrect the field.
+        expect(
+          base.copyWith(clearPlatformId: true, platformId: 99).platformId,
+          isNull,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
Tracker rows were keyed by IGDB game id alone, so multi-platform titles could only hold one set of stats — a second platform sync silently overwrote the first. Adds platform_id to tracker_game_data, includes it in the unique index via COALESCE(platform_id, -1), and threads it through the DAO, sync/import services, provider family key and UI. Migration v38 backfills legacy NULL rows from the user's collection_items when unambiguous and drops the rest.

#230 