### PR TITLE
feat(settings): hide empty media type chevrons toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,30 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Setting: hide empty media-type chevrons**
+
+  New toggle in Settings → Appearance hides the chevron segments for
+  media types that have zero items in the current view. Applies to the
+  filter bar inside a collection and to the unified "all items"
+  screen reachable from the home tab. Off by default; a currently
+  selected type stays visible even if its count is zero so the user
+  can still clear the filter.
+
+  * lib/features/settings/providers/settings_provider.dart
+    (SettingsKeys.hideEmptyMediaTypeChevrons, SettingsState.hideEmptyMediaTypeChevrons,
+    SettingsNotifier.setHideEmptyMediaTypeChevrons): New setting plumbing
+    mirroring `showRecommendations`.
+  * lib/features/settings/screens/settings_screen.dart: New SettingsTile
+    with a Switch under Appearance.
+  * lib/features/collections/widgets/collection_filter_bar.dart
+    (_CollectionFilterBarState._buildTypeChevronBar): Filter `_typeEntries`
+    by count > 0 when the setting is on, keeping selected types visible.
+  * lib/features/home/screens/all_items_screen.dart (_buildMediaTypeBar):
+    Same filter applied to `_MediaTypeEntry` list.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb: New keys
+    `settingsHideEmptyMediaTypeChevrons` and
+    `settingsHideEmptyMediaTypeChevronsSubtitle`.
+
 - **Mood Grid — visual N×M boards of items inside the Tier Lists section**
 
   A second board type alongside the existing ranked tier list. A grid is

--- a/lib/features/collections/widgets/collection_filter_bar.dart
+++ b/lib/features/collections/widgets/collection_filter_bar.dart
@@ -20,6 +20,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/chevron_filter_bar.dart';
+import '../../settings/providers/settings_provider.dart';
 import '../providers/collections_provider.dart';
 import 'collection_filter_sheet.dart';
 
@@ -125,6 +126,19 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
 
   Widget _buildTypeChevronBar(S l, CollectionStats? stats) {
     final List<_TypeEntry> entries = _typeEntries(l, stats);
+    final bool hideEmpty = ref.watch(
+      settingsNotifierProvider.select(
+        (SettingsState s) => s.hideEmptyMediaTypeChevrons,
+      ),
+    );
+    final List<_TypeEntry> visibleEntries =
+        (hideEmpty && stats != null)
+            ? entries
+                .where((_TypeEntry e) =>
+                    (e.count ?? 0) > 0 ||
+                    widget.filterTypes.contains(e.type))
+                .toList()
+            : entries;
     final bool compact =
         MediaQuery.sizeOf(context).width < _compactBreakpoint;
     // На узких экранах TagSidebar скрыт — даём кнопку, открывающую sheet
@@ -138,18 +152,21 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
         height: 40,
         child: Row(
           children: <Widget>[
-            for (int i = 0; i < entries.length; i++)
+            for (int i = 0; i < visibleEntries.length; i++)
               Expanded(
                 child: ChevronSegment(
-                  label: entries[i].count != null && entries[i].count! > 0
-                      ? '${entries[i].label} (${entries[i].count})'
-                      : entries[i].label,
-                  icon: MediaTypeTheme.iconFor(entries[i].type),
-                  selected: widget.filterTypes.contains(entries[i].type),
-                  accentColor: MediaTypeTheme.colorFor(entries[i].type),
+                  label: visibleEntries[i].count != null &&
+                          visibleEntries[i].count! > 0
+                      ? '${visibleEntries[i].label} (${visibleEntries[i].count})'
+                      : visibleEntries[i].label,
+                  icon: MediaTypeTheme.iconFor(visibleEntries[i].type),
+                  selected:
+                      widget.filterTypes.contains(visibleEntries[i].type),
+                  accentColor:
+                      MediaTypeTheme.colorFor(visibleEntries[i].type),
                   isFirst: i == 0,
                   isLast: false,
-                  onTap: () => widget.onTypeToggled(entries[i].type),
+                  onTap: () => widget.onTypeToggled(visibleEntries[i].type),
                   compact: compact,
                   tintWhenInactive: true,
                 ),

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -205,6 +205,18 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
 
     final bool compact =
         MediaQuery.sizeOf(context).width < _compactBreakpoint;
+    final bool hideEmpty = ref.watch(
+      settingsNotifierProvider.select(
+        (SettingsState s) => s.hideEmptyMediaTypeChevrons,
+      ),
+    );
+    final List<_MediaTypeEntry> visibleEntries =
+        (hideEmpty && items != null)
+            ? entries
+                .where((_MediaTypeEntry e) =>
+                    e.count > 0 || _selectedTypes.contains(e.type))
+                .toList()
+            : entries;
 
     return ColoredBox(
       color: AppColors.surface,
@@ -212,16 +224,17 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         height: 40,
         child: Row(
           children: <Widget>[
-            for (int i = 0; i < entries.length; i++)
+            for (int i = 0; i < visibleEntries.length; i++)
               Expanded(
                 child: ChevronSegment(
-                  label: entries[i].displayLabel,
-                  icon: MediaTypeTheme.iconFor(entries[i].type),
-                  selected: _selectedTypes.contains(entries[i].type),
-                  accentColor: MediaTypeTheme.colorFor(entries[i].type),
+                  label: visibleEntries[i].displayLabel,
+                  icon: MediaTypeTheme.iconFor(visibleEntries[i].type),
+                  selected: _selectedTypes.contains(visibleEntries[i].type),
+                  accentColor:
+                      MediaTypeTheme.colorFor(visibleEntries[i].type),
                   isFirst: i == 0,
                   isLast: false,
-                  onTap: () => _toggleMediaType(entries[i].type),
+                  onTap: () => _toggleMediaType(visibleEntries[i].type),
                   compact: compact,
                   tintWhenInactive: true,
                 ),

--- a/lib/features/settings/providers/settings_provider.dart
+++ b/lib/features/settings/providers/settings_provider.dart
@@ -68,6 +68,9 @@ abstract class SettingsKeys {
   static const String aniListUsername = 'anilist_username';
 
   static const String richCollectionsEnabled = 'rich_collections_enabled';
+
+  static const String hideEmptyMediaTypeChevrons =
+      'hide_empty_media_type_chevrons';
 }
 
 class SettingsState {
@@ -91,6 +94,7 @@ class SettingsState {
     this.discordRpcEnabled = false,
     this.discordRaSyncEnabled = false,
     this.richCollectionsEnabled = false,
+    this.hideEmptyMediaTypeChevrons = false,
   });
 
   final String? clientId;
@@ -133,6 +137,9 @@ class SettingsState {
 
   /// Hero image + description instead of mosaic.
   final bool richCollectionsEnabled;
+
+  /// Hide media-type chevrons with zero items in the current filter bar.
+  final bool hideEmptyMediaTypeChevrons;
 
   String? resolveOverlay({
     String? platformOverlay,
@@ -210,6 +217,7 @@ class SettingsState {
     bool? discordRpcEnabled,
     bool? discordRaSyncEnabled,
     bool? richCollectionsEnabled,
+    bool? hideEmptyMediaTypeChevrons,
   }) {
     return SettingsState(
       clientId: clientId ?? this.clientId,
@@ -232,6 +240,8 @@ class SettingsState {
       discordRaSyncEnabled: discordRaSyncEnabled ?? this.discordRaSyncEnabled,
       richCollectionsEnabled:
           richCollectionsEnabled ?? this.richCollectionsEnabled,
+      hideEmptyMediaTypeChevrons:
+          hideEmptyMediaTypeChevrons ?? this.hideEmptyMediaTypeChevrons,
     );
   }
 }
@@ -336,6 +346,8 @@ class SettingsNotifier extends Notifier<SettingsState> {
         _prefs.getBool(SettingsKeys.discordRaSyncEnabled) ?? false;
     final bool richCollectionsEnabled =
         _prefs.getBool(SettingsKeys.richCollectionsEnabled) ?? false;
+    final bool hideEmptyMediaTypeChevrons =
+        _prefs.getBool(SettingsKeys.hideEmptyMediaTypeChevrons) ?? false;
 
     // Valid token → connected immediately (skip verify);
     // expired with credentials → trigger auto-verify below.
@@ -363,6 +375,7 @@ class SettingsNotifier extends Notifier<SettingsState> {
       discordRpcEnabled: discordRpcEnabled,
       discordRaSyncEnabled: discordRaSyncEnabled,
       richCollectionsEnabled: richCollectionsEnabled,
+      hideEmptyMediaTypeChevrons: hideEmptyMediaTypeChevrons,
     );
 
     // API keys already wired by apiKeysProvider; only the request-time language param is set here.
@@ -571,6 +584,11 @@ class SettingsNotifier extends Notifier<SettingsState> {
     state = state.copyWith(richCollectionsEnabled: enabled);
   }
 
+  Future<void> setHideEmptyMediaTypeChevrons({required bool enabled}) async {
+    await _prefs.setBool(SettingsKeys.hideEmptyMediaTypeChevrons, enabled);
+    state = state.copyWith(hideEmptyMediaTypeChevrons: enabled);
+  }
+
   /// Falls back to built-in key if available, otherwise clears.
   Future<void> resetTmdbApiKeyToDefault() async {
     await _prefs.remove(SettingsKeys.tmdbApiKey);
@@ -678,6 +696,7 @@ class SettingsNotifier extends Notifier<SettingsState> {
     await _prefs.remove(SettingsKeys.discordRpcEnabled);
     await _prefs.remove(SettingsKeys.discordRaSyncEnabled);
     await _prefs.remove(SettingsKeys.richCollectionsEnabled);
+    await _prefs.remove(SettingsKeys.hideEmptyMediaTypeChevrons);
     await _prefs.remove(SettingsKeys.raUsername);
     await _prefs.remove(SettingsKeys.raApiKey);
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -350,6 +350,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           SettingsTile(
+            leadingIcon: Icons.filter_alt_off_outlined,
+            leadingColor: _kAppearanceColor,
+            title: l.settingsHideEmptyMediaTypeChevrons,
+            subtitle: l.settingsHideEmptyMediaTypeChevronsSubtitle,
+            showChevron: false,
+            trailing: Switch(
+              value: settings.hideEmptyMediaTypeChevrons,
+              onChanged: (bool value) {
+                ref
+                    .read(settingsNotifierProvider.notifier)
+                    .setHideEmptyMediaTypeChevrons(enabled: value);
+              },
+            ),
+          ),
+          SettingsTile(
             leadingIcon: Icons.videogame_asset_outlined,
             leadingColor: _kAppearanceColor,
             title: l.settingsShowPlatformOverlay,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1148,6 +1148,8 @@
 
   "settingsShowRecommendations": "Recommendations",
   "settingsShowRecommendationsSubtitle": "Similar movies and TV shows on detail pages",
+  "settingsHideEmptyMediaTypeChevrons": "Hide empty media type filters",
+  "settingsHideEmptyMediaTypeChevronsSubtitle": "Hide media type chevrons (Games, Movies, etc.) when there are no items of that type",
   "settingsShowPlatformOverlay": "Game platform covers",
   "settingsShowPlatformOverlaySubtitle": "Show platform overlay on game posters (PS5, Switch, etc.)",
   "settingsShowBlurayOverlay": "Blu-ray covers",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4567,6 +4567,18 @@ abstract class S {
   /// **'Similar movies and TV shows on detail pages'**
   String get settingsShowRecommendationsSubtitle;
 
+  /// No description provided for @settingsHideEmptyMediaTypeChevrons.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide empty media type filters'**
+  String get settingsHideEmptyMediaTypeChevrons;
+
+  /// No description provided for @settingsHideEmptyMediaTypeChevronsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide media type chevrons (Games, Movies, etc.) when there are no items of that type'**
+  String get settingsHideEmptyMediaTypeChevronsSubtitle;
+
   /// No description provided for @settingsShowPlatformOverlay.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2506,6 +2506,14 @@ class SEn extends S {
       'Similar movies and TV shows on detail pages';
 
   @override
+  String get settingsHideEmptyMediaTypeChevrons =>
+      'Hide empty media type filters';
+
+  @override
+  String get settingsHideEmptyMediaTypeChevronsSubtitle =>
+      'Hide media type chevrons (Games, Movies, etc.) when there are no items of that type';
+
+  @override
   String get settingsShowPlatformOverlay => 'Game platform covers';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2531,6 +2531,14 @@ class SRu extends S {
       'Похожие фильмы и сериалы на странице деталей';
 
   @override
+  String get settingsHideEmptyMediaTypeChevrons =>
+      'Скрывать пустые фильтры типов';
+
+  @override
+  String get settingsHideEmptyMediaTypeChevronsSubtitle =>
+      'Скрывать шевроны типов медиа (Игры, Фильмы и т.д.), если в коллекции нет таких записей';
+
+  @override
   String get settingsShowPlatformOverlay => 'Обложки платформ';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -924,6 +924,8 @@
 
   "settingsShowRecommendations": "Рекомендации",
   "settingsShowRecommendationsSubtitle": "Похожие фильмы и сериалы на странице деталей",
+  "settingsHideEmptyMediaTypeChevrons": "Скрывать пустые фильтры типов",
+  "settingsHideEmptyMediaTypeChevronsSubtitle": "Скрывать шевроны типов медиа (Игры, Фильмы и т.д.), если в коллекции нет таких записей",
   "settingsShowPlatformOverlay": "Обложки платформ",
   "settingsShowPlatformOverlaySubtitle": "Оверлей платформы на постерах игр (PS5, Switch и т.д.)",
   "settingsShowBlurayOverlay": "Обложки Blu-ray",

--- a/test/features/collections/widgets/collection_filter_bar_test.dart
+++ b/test/features/collections/widgets/collection_filter_bar_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/data/repositories/collection_repository.dart';
 import 'package:xerabora/features/collections/providers/collections_provider.dart';
 import 'package:xerabora/features/collections/widgets/collection_filter_bar.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
 import 'package:xerabora/l10n/app_localizations.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/collection_sort_mode.dart';
@@ -12,6 +13,17 @@ import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/collection_tag.dart';
 import 'package:xerabora/shared/models/platform.dart' as p;
 import 'package:xerabora/shared/widgets/chevron_filter_bar.dart';
+
+class TestSettingsNotifier extends SettingsNotifier {
+  TestSettingsNotifier({this.hideEmptyChevrons = false});
+
+  final bool hideEmptyChevrons;
+
+  @override
+  SettingsState build() {
+    return SettingsState(hideEmptyMediaTypeChevrons: hideEmptyChevrons);
+  }
+}
 
 class TestCollectionSortNotifier extends CollectionSortNotifier {
   TestCollectionSortNotifier(this._initialMode);
@@ -189,6 +201,7 @@ List<Override> _defaultOverrides({
         .overrideWith(() => TestCollectionSortNotifier(sortMode)),
     collectionSortDescProvider
         .overrideWith(() => TestCollectionSortDescNotifier(isDescending)),
+    settingsNotifierProvider.overrideWith(TestSettingsNotifier.new),
   ];
 }
 

--- a/test/features/settings/providers/settings_provider_hide_empty_chevrons_test.dart
+++ b/test/features/settings/providers/settings_provider_hide_empty_chevrons_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/core/api/igdb_api.dart';
+import 'package:xerabora/core/api/steamgriddb_api.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/core/database/database_service.dart';
+import 'package:xerabora/core/services/api_key_initializer.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockIgdbApi mockIgdbApi;
+  late MockSteamGridDbApi mockSteamGridDbApi;
+  late MockTmdbApi mockTmdbApi;
+  late MockDatabaseService mockDbService;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    mockIgdbApi = MockIgdbApi();
+    mockSteamGridDbApi = MockSteamGridDbApi();
+    mockTmdbApi = MockTmdbApi();
+    mockDbService = MockDatabaseService();
+
+    when(() => mockDbService.getPlatformCount()).thenAnswer((_) async => 0);
+  });
+
+  Future<ProviderContainer> createContainer({
+    Map<String, Object> initialPrefs = const <String, Object>{},
+  }) async {
+    SharedPreferences.setMockInitialValues(initialPrefs);
+    prefs = await SharedPreferences.getInstance();
+
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        apiKeysProvider.overrideWithValue(const ApiKeys()),
+        igdbApiProvider.overrideWithValue(mockIgdbApi),
+        steamGridDbApiProvider.overrideWithValue(mockSteamGridDbApi),
+        tmdbApiProvider.overrideWithValue(mockTmdbApi),
+        databaseServiceProvider.overrideWithValue(mockDbService),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SettingsNotifier — hideEmptyMediaTypeChevrons', () {
+    group('значение по умолчанию', () {
+      test('hideEmptyMediaTypeChevrons == false по умолчанию', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.hideEmptyMediaTypeChevrons, isFalse);
+      });
+    });
+
+    group('setHideEmptyMediaTypeChevrons', () {
+      test('enabled: true — сохраняет в prefs и обновляет состояние',
+          () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setHideEmptyMediaTypeChevrons(enabled: true);
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.hideEmptyMediaTypeChevrons, isTrue);
+        expect(prefs.getBool('hide_empty_media_type_chevrons'), isTrue);
+      });
+
+      test('enabled: false — сохраняет в prefs и обновляет состояние',
+          () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'hide_empty_media_type_chevrons': true,
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        SettingsState state = container.read(settingsNotifierProvider);
+        expect(state.hideEmptyMediaTypeChevrons, isTrue);
+
+        await notifier.setHideEmptyMediaTypeChevrons(enabled: false);
+
+        state = container.read(settingsNotifierProvider);
+
+        expect(state.hideEmptyMediaTypeChevrons, isFalse);
+        expect(prefs.getBool('hide_empty_media_type_chevrons'), isFalse);
+      });
+    });
+
+    group('_loadFromPrefs', () {
+      test('загружает true из prefs', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'hide_empty_media_type_chevrons': true,
+          },
+        );
+
+        final SettingsState state =
+            container.read(settingsNotifierProvider);
+
+        expect(state.hideEmptyMediaTypeChevrons, isTrue);
+      });
+    });
+
+    group('clearSettings', () {
+      test('сбрасывает hideEmptyMediaTypeChevrons к false', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'hide_empty_media_type_chevrons': true,
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.clearSettings();
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.hideEmptyMediaTypeChevrons, isFalse);
+        expect(prefs.getBool('hide_empty_media_type_chevrons'), isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('hideEmptyMediaTypeChevrons обновляется через copyWith', () {
+        const SettingsState original =
+            SettingsState(hideEmptyMediaTypeChevrons: false);
+        final SettingsState updated =
+            original.copyWith(hideEmptyMediaTypeChevrons: true);
+
+        expect(updated.hideEmptyMediaTypeChevrons, isTrue);
+        expect(original.hideEmptyMediaTypeChevrons, isFalse);
+      });
+
+      test('copyWith без hideEmptyMediaTypeChevrons сохраняет текущее значение',
+          () {
+        const SettingsState original =
+            SettingsState(hideEmptyMediaTypeChevrons: true);
+        final SettingsState updated = original.copyWith(tmdbApiKey: 'key');
+
+        expect(updated.hideEmptyMediaTypeChevrons, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Adds an opt-in setting that hides media-type filter chevrons (Games, Movies, TV, etc.) when the current view has zero items of that type. Applies to the in-collection filter bar and the unified all-items screen. Off by default; an actively selected type stays visible even if its count is zero.