### PR TITLE
feat(mal-import): tolerate AniList rate limits and protect existing entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Added
+
+- **Harden MyAnimeList XML import against AniList rate limits and protect existing entries**
+
+  Large MAL imports no longer dump everything into Wishlist when AniList
+  throttles or hiccups mid-batch. Each AniList lookup batch now retries
+  up to three times on HTTP 429, honoring `Retry-After` /
+  `X-RateLimit-Reset` (falling back to the documented 60s window), and
+  only the truly unresolvable ids are surfaced as a separate "skipped
+  (AniList unreachable)" counter — those entries are left out of the
+  collection so a future re-import can retry them, instead of being
+  silently misclassified as wishlist items. The import progress UI
+  shows the rate-limit countdown ("Лимит AniList достигнут — ждём
+  N сек, попытка X/3") without resetting the global batch counter, and
+  reports the skipped count alongside imported / wishlisted / updated.
+  A new "Overwrite existing entries" toggle, off by default, protects
+  user edits on re-import: matched items keep their local status,
+  rating, progress, dates and comment; with the toggle on, the previous
+  merge behaviour applies.
+
+  * lib/core/api/anilist_api.dart (AniListApi.maxRateLimitRetries,
+    AniListApi.getAnimeByMalIdsTolerant, AniListApi.getMangaByMalIdsTolerant,
+    AniListRateLimitException, AniListMalLookupResult): New rate-limit aware
+    lookup methods that return partial results plus a list of failed MAL
+    ids, with `onRateLimit` / `onBatchProgress` callbacks so callers can
+    surface wait countdowns. `_handleDioException` now parses retry
+    headers and emits the typed `AniListRateLimitException`.
+  * lib/core/services/mal_import_service.dart (MalImportService.importFiles,
+    MalImportStage.rateLimitWait, MalImportProgress.failedLookupCount,
+    MalImportProgress.rateLimitWaitSeconds, MalImportResult.animeFailedLookup,
+    MalImportResult.mangaFailedLookup, MalImportResult.failedLookup):
+    Switch to the tolerant lookups, track per-kind failed-lookup counts,
+    propagate rate-limit progress without resetting the cumulative
+    counter, and add the `overwriteExistingItems` parameter (default
+    false) that bypasses `_updateExistingItem` so user data survives
+    re-imports.
+  * lib/features/settings/content/mal_import_content.dart
+    (_MalImportContentState._overwriteExisting, _MalImportContentState._buildProgressSection):
+    Add the "Overwrite existing entries" switch, render the new
+    rateLimitWait stage with an indeterminate bar, and show the
+    "skipped (AniList unreachable)" stat row.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (malImportRateLimitWait,
+    malImportFailedLookup, malImportOverwriteExisting,
+    malImportOverwriteExistingHint): New strings; regenerated
+    `app_localizations*.dart`.
+  * test/core/services/mal_import_service_test.dart: Cover the tolerant
+    lookup result shape, the failed-lookup-is-skipped path, and the
+    `overwriteExistingItems=false` no-op-on-existing path; existing
+    dedup test now explicitly passes `overwriteExistingItems: true`.
+
 ## [0.29.0] - 2026-05-16
 
 ### Added

--- a/lib/core/api/anilist_api.dart
+++ b/lib/core/api/anilist_api.dart
@@ -24,6 +24,44 @@ class AniListApiException implements Exception {
       'AniListApiException: $message (status: $statusCode)';
 }
 
+/// AniList rejected the request with 429 Too Many Requests.
+///
+/// [retryAfter] is parsed from the `Retry-After` header (or derived from
+/// `X-RateLimit-Reset` when the former is absent). Falls back to 60s — the
+/// documented timeout window — when no headers are present.
+class AniListRateLimitException extends AniListApiException {
+  /// Creates an [AniListRateLimitException].
+  const AniListRateLimitException(this.retryAfter, {String? detail})
+      : super(
+          'Rate limit exceeded. Please try again later',
+          statusCode: 429,
+          detail: detail,
+        );
+
+  /// How long to wait before retrying.
+  final Duration retryAfter;
+}
+
+/// Result of a tolerant MAL→AniList lookup.
+///
+/// AniList errors are surfaced as [failedIds] (not silently dropped), so the
+/// caller can distinguish "not found on AniList" from "lookup failed".
+class AniListMalLookupResult<T> {
+  /// Creates an [AniListMalLookupResult].
+  const AniListMalLookupResult({
+    required this.resolved,
+    required this.failedIds,
+  });
+
+  /// MAL id → resolved media.
+  final Map<int, T> resolved;
+
+  /// MAL ids that could not be resolved due to AniList API errors (after
+  /// retries). Distinct from ids absent from [resolved] because AniList simply
+  /// has no record.
+  final List<int> failedIds;
+}
+
 /// AniList user does not exist or has no public lists.
 class AniListUserNotFoundException extends AniListApiException {
   /// Creates an [AniListUserNotFoundException].
@@ -726,6 +764,120 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
     return result;
   }
 
+  /// Maximum retries per batch on rate-limit responses.
+  static const int maxRateLimitRetries = 3;
+
+  /// Tolerant variant of [getAnimeByMalIds].
+  ///
+  /// - Retries each batch up to [maxRateLimitRetries] times on 429, waiting
+  ///   [AniListRateLimitException.retryAfter] between attempts.
+  /// - On non-rate-limit failures (or rate-limit exceeding retries), records
+  ///   the MAL ids as failed and continues with the next batch.
+  /// - Calls [onRateLimit] before each rate-limit sleep so the UI can show a
+  ///   countdown.
+  /// - Calls [onBatchProgress] after each batch completes (success or failure).
+  Future<AniListMalLookupResult<Anime>> getAnimeByMalIdsTolerant(
+    List<int> malIds, {
+    void Function(Duration wait, int attempt)? onRateLimit,
+    void Function(int done, int total)? onBatchProgress,
+  }) async {
+    return _lookupByMalIdsTolerant<Anime>(
+      malIds: malIds,
+      fetchBatch: _fetchAnimeByMalBatch,
+      onRateLimit: onRateLimit,
+      onBatchProgress: onBatchProgress,
+      label: 'anime',
+    );
+  }
+
+  /// Tolerant variant of [getMangaByMalIds]. See [getAnimeByMalIdsTolerant].
+  Future<AniListMalLookupResult<Manga>> getMangaByMalIdsTolerant(
+    List<int> malIds, {
+    void Function(Duration wait, int attempt)? onRateLimit,
+    void Function(int done, int total)? onBatchProgress,
+  }) async {
+    return _lookupByMalIdsTolerant<Manga>(
+      malIds: malIds,
+      fetchBatch: _fetchMangaByMalBatch,
+      onRateLimit: onRateLimit,
+      onBatchProgress: onBatchProgress,
+      label: 'manga',
+    );
+  }
+
+  Future<AniListMalLookupResult<T>> _lookupByMalIdsTolerant<T>({
+    required List<int> malIds,
+    required Future<Map<int, T>> Function(List<int>) fetchBatch,
+    required String label,
+    void Function(Duration wait, int attempt)? onRateLimit,
+    void Function(int done, int total)? onBatchProgress,
+  }) async {
+    final Map<int, T> resolved = <int, T>{};
+    final List<int> failed = <int>[];
+
+    if (malIds.isEmpty) {
+      return AniListMalLookupResult<T>(resolved: resolved, failedIds: failed);
+    }
+
+    final int total = malIds.length;
+    int processed = 0;
+
+    for (int i = 0; i < malIds.length; i += _maxPerPage) {
+      final List<int> batch = malIds.sublist(
+        i,
+        i + _maxPerPage > malIds.length ? malIds.length : i + _maxPerPage,
+      );
+
+      final Map<int, T>? batchResult = await _runBatchWithRetry<T>(
+        batch: batch,
+        fetchBatch: fetchBatch,
+        label: label,
+        onRateLimit: onRateLimit,
+      );
+
+      if (batchResult != null) {
+        resolved.addAll(batchResult);
+      } else {
+        failed.addAll(batch);
+      }
+
+      processed += batch.length;
+      onBatchProgress?.call(processed, total);
+    }
+
+    return AniListMalLookupResult<T>(resolved: resolved, failedIds: failed);
+  }
+
+  Future<Map<int, T>?> _runBatchWithRetry<T>({
+    required List<int> batch,
+    required Future<Map<int, T>> Function(List<int>) fetchBatch,
+    required String label,
+    void Function(Duration wait, int attempt)? onRateLimit,
+  }) async {
+    for (int attempt = 1; attempt <= maxRateLimitRetries; attempt++) {
+      try {
+        return await fetchBatch(batch);
+      } on AniListRateLimitException catch (e) {
+        if (attempt >= maxRateLimitRetries) {
+          _log.warning(
+            '$label batch hit rate limit, giving up after $attempt attempts',
+          );
+          return null;
+        }
+        onRateLimit?.call(e.retryAfter, attempt);
+        _log.info(
+          '$label batch rate-limited, waiting ${e.retryAfter.inSeconds}s '
+          '(attempt $attempt/$maxRateLimitRetries)',
+        );
+        await Future<void>.delayed(e.retryAfter);
+      } on AniListApiException catch (e) {
+        _log.warning('$label batch failed: ${e.message}');
+        return null;
+      }
+    }
+    return null;
+  }
+
   Future<Map<int, Anime>> _fetchAnimeByMalBatch(List<int> malIds) async {
     try {
       final Response<dynamic> response = await _dio.post<dynamic>(
@@ -1196,7 +1348,15 @@ query ($userName: String) {
     String message = defaultMessage;
 
     if (statusCode == 429) {
-      message = 'Rate limit exceeded. Please try again later';
+      final Duration retryAfter = _parseRetryAfter(e.response?.headers.map);
+      return AniListRateLimitException(
+        retryAfter,
+        detail: buildApiErrorDetail(
+          apiName: 'AniList',
+          exception: e,
+          userMessage: 'Rate limit exceeded (retry in ${retryAfter.inSeconds}s)',
+        ),
+      );
     } else if (e.type == DioExceptionType.connectionTimeout ||
         e.type == DioExceptionType.receiveTimeout) {
       message = 'Connection timeout';
@@ -1213,6 +1373,34 @@ query ($userName: String) {
         userMessage: message,
       ),
     );
+  }
+
+  /// Parses AniList rate-limit headers into a wait duration.
+  ///
+  /// Prefers `Retry-After` (seconds) when present, falls back to
+  /// `X-RateLimit-Reset` (unix timestamp), then to the documented 60s window.
+  static Duration _parseRetryAfter(Map<String, List<String>>? headers) {
+    if (headers == null) return const Duration(seconds: 60);
+
+    final List<String>? retryAfter = headers['retry-after'];
+    if (retryAfter != null && retryAfter.isNotEmpty) {
+      final int? seconds = int.tryParse(retryAfter.first.trim());
+      if (seconds != null && seconds > 0) {
+        return Duration(seconds: seconds);
+      }
+    }
+
+    final List<String>? reset = headers['x-ratelimit-reset'];
+    if (reset != null && reset.isNotEmpty) {
+      final int? ts = int.tryParse(reset.first.trim());
+      if (ts != null) {
+        final int nowSec = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        final int diff = ts - nowSec;
+        if (diff > 0) return Duration(seconds: diff);
+      }
+    }
+
+    return const Duration(seconds: 60);
   }
 
   void dispose() {

--- a/lib/core/services/mal_import_service.dart
+++ b/lib/core/services/mal_import_service.dart
@@ -29,6 +29,9 @@ enum MalImportStage {
   /// Resolving MAL → AniList IDs for manga.
   resolvingManga,
 
+  /// Waiting out an AniList rate-limit window before retrying.
+  rateLimitWait,
+
   /// Writing entries into the collection.
   matchingEntries,
 
@@ -47,6 +50,10 @@ class MalImportProgress {
     this.importedCount = 0,
     this.wishlistedCount = 0,
     this.updatedCount = 0,
+    this.failedLookupCount = 0,
+    this.rateLimitWaitSeconds,
+    this.rateLimitAttempt,
+    this.rateLimitMaxAttempts,
   });
 
   /// Current stage.
@@ -70,6 +77,19 @@ class MalImportProgress {
   /// Number of updated titles (re-import).
   final int updatedCount;
 
+  /// Number of MAL entries whose AniList lookup failed (after retries).
+  /// Such entries are skipped, not wishlisted — retry import to resolve them.
+  final int failedLookupCount;
+
+  /// Seconds to wait on the current [MalImportStage.rateLimitWait] step.
+  final int? rateLimitWaitSeconds;
+
+  /// Current retry attempt (1-based) when [stage] is [MalImportStage.rateLimitWait].
+  final int? rateLimitAttempt;
+
+  /// Total retry attempts available when [stage] is [MalImportStage.rateLimitWait].
+  final int? rateLimitMaxAttempts;
+
   /// Progress as fraction (0.0 – 1.0).
   double get progress => total > 0 ? current / total : 0;
 }
@@ -89,6 +109,8 @@ class MalImportResult {
     required this.mangaWishlisted,
     required this.animeUpdated,
     required this.mangaUpdated,
+    this.animeFailedLookup = 0,
+    this.mangaFailedLookup = 0,
   });
 
   /// Total imported.
@@ -123,6 +145,15 @@ class MalImportResult {
 
   /// Manga updated.
   final int mangaUpdated;
+
+  /// Anime whose AniList lookup failed (after retries). Skipped, not wishlisted.
+  final int animeFailedLookup;
+
+  /// Manga whose AniList lookup failed (after retries). Skipped, not wishlisted.
+  final int mangaFailedLookup;
+
+  /// Total failed lookups across both kinds.
+  int get failedLookup => animeFailedLookup + mangaFailedLookup;
 }
 
 /// Type of parsed XML file.
@@ -400,11 +431,19 @@ class MalImportService {
   ///
   /// At least one of [animeFile] / [mangaFile] must be provided.
   /// Either [collectionId] or [createCollection] must be provided.
+  ///
+  /// When [overwriteExistingItems] is `false` (default), entries already
+  /// present in the target collection are left untouched — user's status,
+  /// rating, progress, dates and notes survive re-imports. New entries from
+  /// the export are still added. When `true`, existing items are merged with
+  /// MAL data via the standard merge rules (status priority, max progress,
+  /// earliest/latest dates, MAL rating wins, MAL comment overwrites).
   Future<MalImportResult> importFiles({
     File? animeFile,
     File? mangaFile,
     int? collectionId,
     Future<int> Function()? createCollection,
+    bool overwriteExistingItems = false,
     required void Function(MalImportProgress) onProgress,
   }) async {
     if (animeFile == null && mangaFile == null) {
@@ -453,45 +492,77 @@ class MalImportService {
     final int targetCollectionId = collectionId ?? await createCollection!();
 
     final Map<int, Anime> animeByMal = <int, Anime>{};
+    final Set<int> animeFailedIds = <int>{};
     if (animeEntries.isNotEmpty) {
       onProgress(MalImportProgress(
         stage: MalImportStage.resolvingAnime,
         current: 0,
         total: animeEntries.length,
       ));
-      try {
-        animeByMal.addAll(await _aniList.getAnimeByMalIds(
-          animeEntries.map((MalEntry e) => e.malId).toList(),
-        ));
-      } on AniListApiException catch (e) {
-        _log.warning('AniList anime lookup failed: ${e.message}');
-      }
-      onProgress(MalImportProgress(
-        stage: MalImportStage.resolvingAnime,
-        current: animeEntries.length,
-        total: animeEntries.length,
-      ));
+      // Mirror the last reported batch progress into the rate-limit pause so
+      // the global counter doesn't snap back to 0 / total while we're waiting.
+      int lastDone = 0;
+      final int totalAnime = animeEntries.length;
+      final AniListMalLookupResult<Anime> result =
+          await _aniList.getAnimeByMalIdsTolerant(
+        animeEntries.map((MalEntry e) => e.malId).toList(),
+        onRateLimit: (Duration wait, int attempt) {
+          onProgress(MalImportProgress(
+            stage: MalImportStage.rateLimitWait,
+            current: lastDone,
+            total: totalAnime,
+            rateLimitWaitSeconds: wait.inSeconds,
+            rateLimitAttempt: attempt,
+            rateLimitMaxAttempts: AniListApi.maxRateLimitRetries,
+          ));
+        },
+        onBatchProgress: (int done, int total) {
+          lastDone = done;
+          onProgress(MalImportProgress(
+            stage: MalImportStage.resolvingAnime,
+            current: done,
+            total: total,
+          ));
+        },
+      );
+      animeByMal.addAll(result.resolved);
+      animeFailedIds.addAll(result.failedIds);
     }
 
     final Map<int, Manga> mangaByMal = <int, Manga>{};
+    final Set<int> mangaFailedIds = <int>{};
     if (mangaEntries.isNotEmpty) {
       onProgress(MalImportProgress(
         stage: MalImportStage.resolvingManga,
         current: 0,
         total: mangaEntries.length,
       ));
-      try {
-        mangaByMal.addAll(await _aniList.getMangaByMalIds(
-          mangaEntries.map((MalEntry e) => e.malId).toList(),
-        ));
-      } on AniListApiException catch (e) {
-        _log.warning('AniList manga lookup failed: ${e.message}');
-      }
-      onProgress(MalImportProgress(
-        stage: MalImportStage.resolvingManga,
-        current: mangaEntries.length,
-        total: mangaEntries.length,
-      ));
+      int lastDone = 0;
+      final int totalManga = mangaEntries.length;
+      final AniListMalLookupResult<Manga> result =
+          await _aniList.getMangaByMalIdsTolerant(
+        mangaEntries.map((MalEntry e) => e.malId).toList(),
+        onRateLimit: (Duration wait, int attempt) {
+          onProgress(MalImportProgress(
+            stage: MalImportStage.rateLimitWait,
+            current: lastDone,
+            total: totalManga,
+            rateLimitWaitSeconds: wait.inSeconds,
+            rateLimitAttempt: attempt,
+            rateLimitMaxAttempts: AniListApi.maxRateLimitRetries,
+          ));
+        },
+        onBatchProgress: (int done, int total) {
+          lastDone = done;
+          onProgress(MalImportProgress(
+            stage: MalImportStage.resolvingManga,
+            current: done,
+            total: total,
+          ));
+        },
+      );
+      mangaByMal.addAll(result.resolved);
+      mangaFailedIds.addAll(result.failedIds);
     }
 
     if (animeByMal.isNotEmpty) {
@@ -510,6 +581,8 @@ class MalImportService {
     int mangaWishlisted = 0;
     int animeUpdated = 0;
     int mangaUpdated = 0;
+    int animeFailedLookup = 0;
+    int mangaFailedLookup = 0;
 
     int processed = 0;
     final List<MalEntry> allEntries = <MalEntry>[
@@ -527,7 +600,22 @@ class MalImportService {
         importedCount: imported,
         wishlistedCount: wishlisted,
         updatedCount: updated,
+        failedLookupCount: animeFailedLookup + mangaFailedLookup,
       ));
+
+      // Lookup failed at AniList (rate-limit / network) — skip, don't wishlist.
+      // Re-running the import will retry these once AniList is reachable.
+      final bool lookupFailed = entry.kind == MalFileKind.anime
+          ? animeFailedIds.contains(entry.malId)
+          : mangaFailedIds.contains(entry.malId);
+      if (lookupFailed) {
+        if (entry.kind == MalFileKind.anime) {
+          animeFailedLookup++;
+        } else {
+          mangaFailedLookup++;
+        }
+        continue;
+      }
 
       final int? aniListId = entry.kind == MalFileKind.anime
           ? animeByMal[entry.malId]?.id
@@ -556,12 +644,17 @@ class MalImportService {
       );
 
       if (existing != null) {
-        await _updateExistingItem(
-          existing,
-          entry,
-          aniListAnime: animeByMal[entry.malId],
-          aniListManga: mangaByMal[entry.malId],
-        );
+        if (overwriteExistingItems) {
+          await _updateExistingItem(
+            existing,
+            entry,
+            aniListAnime: animeByMal[entry.malId],
+            aniListManga: mangaByMal[entry.malId],
+          );
+        }
+        // When overwrite is off we still count this as "updated" semantically
+        // — the entry was matched against the local collection, just left
+        // intact so the user's edits survive.
         updated++;
         if (entry.kind == MalFileKind.anime) {
           animeUpdated++;
@@ -602,11 +695,13 @@ class MalImportService {
       importedCount: imported,
       wishlistedCount: wishlisted,
       updatedCount: updated,
+      failedLookupCount: animeFailedLookup + mangaFailedLookup,
     ));
 
     _log.info(
       'MAL import complete: $imported imported, $wishlisted wishlisted, '
-      '$updated updated (total $totalEntries)',
+      '$updated updated, ${animeFailedLookup + mangaFailedLookup} '
+      'lookup failures (total $totalEntries)',
     );
 
     return MalImportResult(
@@ -621,6 +716,8 @@ class MalImportService {
       mangaWishlisted: mangaWishlisted,
       animeUpdated: animeUpdated,
       mangaUpdated: mangaUpdated,
+      animeFailedLookup: animeFailedLookup,
+      mangaFailedLookup: mangaFailedLookup,
     );
   }
 

--- a/lib/features/settings/content/mal_import_content.dart
+++ b/lib/features/settings/content/mal_import_content.dart
@@ -44,6 +44,7 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
 
   bool _useNewCollection = true;
   int? _selectedCollectionId;
+  bool _overwriteExisting = false;
 
   _PickedFile? _animePicked;
   _PickedFile? _mangaPicked;
@@ -116,6 +117,23 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
         ),
         const SizedBox(height: AppSpacing.sm),
         _buildCollectionSelector(l),
+        const SizedBox(height: AppSpacing.sm),
+        SwitchListTile(
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+          ),
+          value: _overwriteExisting,
+          onChanged: _isImporting
+              ? null
+              : (bool v) => setState(() => _overwriteExisting = v),
+          title: Text(l.malImportOverwriteExisting),
+          subtitle: Text(
+            l.malImportOverwriteExistingHint,
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
           child: FilledButton.icon(
@@ -305,11 +323,19 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
         stageText = l.malImportResolvingAnime;
       case MalImportStage.resolvingManga:
         stageText = l.malImportResolvingManga;
+      case MalImportStage.rateLimitWait:
+        stageText = l.malImportRateLimitWait(
+          progress.rateLimitWaitSeconds ?? 0,
+          progress.rateLimitAttempt ?? 1,
+          progress.rateLimitMaxAttempts ?? 3,
+        );
       case MalImportStage.matchingEntries:
         stageText = l.malImportMatching;
       case MalImportStage.completed:
         stageText = l.malImportComplete;
     }
+
+    final bool isRateLimitWait = progress.stage == MalImportStage.rateLimitWait;
 
     return SettingsGroup(
       title: stageText,
@@ -323,7 +349,9 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               LinearProgressIndicator(
-                value: progress.total > 0 ? progress.progress : null,
+                value: isRateLimitWait || progress.total == 0
+                    ? null
+                    : progress.progress,
               ),
               if (progress.total > 0) ...<Widget>[
                 const SizedBox(height: AppSpacing.sm),
@@ -359,6 +387,12 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
                 AppColors.statusInProgress,
                 l.malImportUpdated(progress.updatedCount),
               ),
+              if (progress.failedLookupCount > 0)
+                _buildStatRow(
+                  Icons.warning_amber,
+                  AppColors.statusDropped,
+                  l.malImportFailedLookup(progress.failedLookupCount),
+                ),
             ],
           ),
         ),
@@ -456,6 +490,7 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
         animeFile: _animePicked?.file,
         mangaFile: _mangaPicked?.file,
         collectionId: _useNewCollection ? null : _selectedCollectionId,
+        overwriteExistingItems: _overwriteExisting,
         createCollection: _useNewCollection
             ? () async {
                 final DatabaseService db = ref.read(databaseServiceProvider);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1774,6 +1774,22 @@
       "count": {"type": "int"}
     }
   },
+  "malImportOverwriteExisting": "Overwrite existing entries",
+  "malImportOverwriteExistingHint": "When off, items already in the collection keep your local status, rating, progress, dates and notes. New items are still imported.",
+  "malImportFailedLookup": "{count} skipped (AniList unreachable)",
+  "@malImportFailedLookup": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "malImportRateLimitWait": "AniList rate-limit reached — retrying in {seconds}s (attempt {attempt}/{max})",
+  "@malImportRateLimitWait": {
+    "placeholders": {
+      "seconds": {"type": "int"},
+      "attempt": {"type": "int"},
+      "max": {"type": "int"}
+    }
+  },
   "malImportFailed": "Import failed: {error}",
   "@malImportFailed": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6901,6 +6901,30 @@ abstract class S {
   /// **'{count} updated'**
   String malImportUpdated(int count);
 
+  /// No description provided for @malImportOverwriteExisting.
+  ///
+  /// In en, this message translates to:
+  /// **'Overwrite existing entries'**
+  String get malImportOverwriteExisting;
+
+  /// No description provided for @malImportOverwriteExistingHint.
+  ///
+  /// In en, this message translates to:
+  /// **'When off, items already in the collection keep your local status, rating, progress, dates and notes. New items are still imported.'**
+  String get malImportOverwriteExistingHint;
+
+  /// No description provided for @malImportFailedLookup.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} skipped (AniList unreachable)'**
+  String malImportFailedLookup(int count);
+
+  /// No description provided for @malImportRateLimitWait.
+  ///
+  /// In en, this message translates to:
+  /// **'AniList rate-limit reached — retrying in {seconds}s (attempt {attempt}/{max})'**
+  String malImportRateLimitWait(int seconds, int attempt, int max);
+
   /// No description provided for @malImportFailed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3801,6 +3801,23 @@ class SEn extends S {
   }
 
   @override
+  String get malImportOverwriteExisting => 'Overwrite existing entries';
+
+  @override
+  String get malImportOverwriteExistingHint =>
+      'When off, items already in the collection keep your local status, rating, progress, dates and notes. New items are still imported.';
+
+  @override
+  String malImportFailedLookup(int count) {
+    return '$count skipped (AniList unreachable)';
+  }
+
+  @override
+  String malImportRateLimitWait(int seconds, int attempt, int max) {
+    return 'AniList rate-limit reached — retrying in ${seconds}s (attempt $attempt/$max)';
+  }
+
+  @override
   String malImportFailed(String error) {
     return 'Import failed: $error';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3850,6 +3850,23 @@ class SRu extends S {
   }
 
   @override
+  String get malImportOverwriteExisting => 'Перезаписывать существующие';
+
+  @override
+  String get malImportOverwriteExistingHint =>
+      'Если выключено — записи, уже добавленные в коллекцию, не трогаются: ваш статус, оценка, прогресс, даты и заметки сохраняются. Новые записи всё равно импортируются.';
+
+  @override
+  String malImportFailedLookup(int count) {
+    return 'Пропущено: $count (AniList недоступен)';
+  }
+
+  @override
+  String malImportRateLimitWait(int seconds, int attempt, int max) {
+    return 'Лимит AniList достигнут — ждём $seconds сек (попытка $attempt/$max)';
+  }
+
+  @override
   String malImportFailed(String error) {
     return 'Импорт не удался: $error';
   }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1493,6 +1493,22 @@
       "count": {"type": "int"}
     }
   },
+  "malImportOverwriteExisting": "Перезаписывать существующие",
+  "malImportOverwriteExistingHint": "Если выключено — записи, уже добавленные в коллекцию, не трогаются: ваш статус, оценка, прогресс, даты и заметки сохраняются. Новые записи всё равно импортируются.",
+  "malImportFailedLookup": "Пропущено: {count} (AniList недоступен)",
+  "@malImportFailedLookup": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "malImportRateLimitWait": "Лимит AniList достигнут — ждём {seconds} сек (попытка {attempt}/{max})",
+  "@malImportRateLimitWait": {
+    "placeholders": {
+      "seconds": {"type": "int"},
+      "attempt": {"type": "int"},
+      "max": {"type": "int"}
+    }
+  },
   "malImportFailed": "Импорт не удался: {error}",
   "@malImportFailed": {
     "placeholders": {

--- a/test/core/services/mal_import_service_test.dart
+++ b/test/core/services/mal_import_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/anilist_api.dart';
 import 'package:xerabora/core/services/mal_import_service.dart';
 import 'package:xerabora/shared/models/anime.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
@@ -301,10 +302,17 @@ void main() {
       }
 
       test('completed аниме досыпает episode до total из AniList', () async {
-        when(() => mockAniList.getAnimeByMalIds(any())).thenAnswer(
-          (_) async => <int, Anime>{
-            5114: const Anime(id: 999, title: 'FMA', episodes: 64),
-          },
+        when(() => mockAniList.getAnimeByMalIdsTolerant(
+              any(),
+              onRateLimit: any(named: 'onRateLimit'),
+              onBatchProgress: any(named: 'onBatchProgress'),
+            )).thenAnswer(
+          (_) async => const AniListMalLookupResult<Anime>(
+            resolved: <int, Anime>{
+              5114: Anime(id: 999, title: 'FMA', episodes: 64),
+            },
+            failedIds: <int>[],
+          ),
         );
         setupNoExisting();
 
@@ -320,8 +328,14 @@ void main() {
       test(
           'unmatched запись попадает в wishlist с MAL-ссылкой в note',
           () async {
-        when(() => mockAniList.getAnimeByMalIds(any()))
-            .thenAnswer((_) async => <int, Anime>{});
+        when(() => mockAniList.getAnimeByMalIdsTolerant(
+              any(),
+              onRateLimit: any(named: 'onRateLimit'),
+              onBatchProgress: any(named: 'onBatchProgress'),
+            )).thenAnswer((_) async => const AniListMalLookupResult<Anime>(
+              resolved: <int, Anime>{},
+              failedIds: <int>[],
+            ));
         when(() => mockDb.findUnresolvedWishlistItem(any()))
             .thenAnswer((_) async => null);
         when(() => mockDb.addWishlistItem(
@@ -359,10 +373,17 @@ void main() {
 
       test('повторный импорт обновляет существующий, не создаёт новый',
           () async {
-        when(() => mockAniList.getAnimeByMalIds(any())).thenAnswer(
-          (_) async => <int, Anime>{
-            5114: const Anime(id: 999, title: 'FMA', episodes: 64),
-          },
+        when(() => mockAniList.getAnimeByMalIdsTolerant(
+              any(),
+              onRateLimit: any(named: 'onRateLimit'),
+              onBatchProgress: any(named: 'onBatchProgress'),
+            )).thenAnswer(
+          (_) async => const AniListMalLookupResult<Anime>(
+            resolved: <int, Anime>{
+              5114: Anime(id: 999, title: 'FMA', episodes: 64),
+            },
+            failedIds: <int>[],
+          ),
         );
         when(() => mockDb.upsertAnimes(any())).thenAnswer((_) async {});
         when(() => mockDb.upsertMangas(any())).thenAnswer((_) async {});
@@ -404,6 +425,7 @@ void main() {
             final MalImportResult result = await sut.importFiles(
               animeFile: _fileFromPath(path),
               collectionId: 1,
+              overwriteExistingItems: true,
               onProgress: (_) {},
             );
             expect(result.imported, 0);
@@ -413,6 +435,116 @@ void main() {
           },
         );
 
+        verifyNever(() => mockDb.addItemToCollection(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              status: any(named: 'status'),
+            ));
+      });
+
+      test(
+          'overwriteExistingItems=false: существующий не трогается, считается updated',
+          () async {
+        when(() => mockAniList.getAnimeByMalIdsTolerant(
+              any(),
+              onRateLimit: any(named: 'onRateLimit'),
+              onBatchProgress: any(named: 'onBatchProgress'),
+            )).thenAnswer(
+          (_) async => const AniListMalLookupResult<Anime>(
+            resolved: <int, Anime>{
+              5114: Anime(id: 999, title: 'FMA', episodes: 64),
+            },
+            failedIds: <int>[],
+          ),
+        );
+        when(() => mockDb.upsertAnimes(any())).thenAnswer((_) async {});
+
+        final CollectionItem existing = createTestCollectionItem(
+          id: 555,
+          mediaType: MediaType.anime,
+          externalId: 999,
+          status: ItemStatus.inProgress,
+          currentEpisode: 10,
+        );
+        when(() => mockDb.findCollectionItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+            )).thenAnswer((_) async => existing);
+
+        await _runWithTempFile(
+          singleAnimeXml,
+          (String path) async {
+            final MalImportResult result = await sut.importFiles(
+              animeFile: _fileFromPath(path),
+              collectionId: 1,
+              // overwriteExistingItems defaults to false
+              onProgress: (_) {},
+            );
+            expect(result.imported, 0);
+            expect(result.updated, 1);
+            expect(result.wishlisted, 0);
+            return null;
+          },
+        );
+
+        // No user data writes should have happened for the existing item.
+        verifyNever(() => mockDb.updateItemStatus(any(), any(),
+            mediaType: any(named: 'mediaType')));
+        verifyNever(() => mockDb.updateItemProgress(
+              any(),
+              currentEpisode: any(named: 'currentEpisode'),
+              currentSeason: any(named: 'currentSeason'),
+            ));
+        verifyNever(() => mockDb.updateItemUserRating(any(), any()));
+        verifyNever(() => mockDb.updateItemActivityDates(
+              any(),
+              startedAt: any(named: 'startedAt'),
+              completedAt: any(named: 'completedAt'),
+              lastActivityAt: any(named: 'lastActivityAt'),
+            ));
+        verifyNever(() => mockDb.updateItemUserComment(any(), any()));
+      });
+
+      test('failed lookup пропускается, не падает в wishlist',
+          () async {
+        // AniList lookup-error makes the MAL id show up in failedIds — these
+        // entries must be SKIPPED, not silently dumped into the wishlist
+        // (re-importing later will retry them).
+        when(() => mockAniList.getAnimeByMalIdsTolerant(
+              any(),
+              onRateLimit: any(named: 'onRateLimit'),
+              onBatchProgress: any(named: 'onBatchProgress'),
+            )).thenAnswer(
+          (_) async => const AniListMalLookupResult<Anime>(
+            resolved: <int, Anime>{},
+            failedIds: <int>[5114],
+          ),
+        );
+
+        await _runWithTempFile(
+          singleAnimeXml,
+          (String path) async {
+            final MalImportResult result = await sut.importFiles(
+              animeFile: _fileFromPath(path),
+              collectionId: 1,
+              onProgress: (_) {},
+            );
+            expect(result.imported, 0);
+            expect(result.wishlisted, 0);
+            expect(result.animeFailedLookup, 1);
+            expect(result.failedLookup, 1);
+            return null;
+          },
+        );
+
+        verifyNever(() => mockDb.addWishlistItem(
+              text: any(named: 'text'),
+              mediaTypeHint: any(named: 'mediaTypeHint'),
+              note: any(named: 'note'),
+            ));
         verifyNever(() => mockDb.addItemToCollection(
               collectionId: any(named: 'collectionId'),
               mediaType: any(named: 'mediaType'),


### PR DESCRIPTION
Large MAL imports no longer dump entries into Wishlist when AniList throttles or hiccups mid-batch. AniList lookups now retry per-batch on 429 honoring Retry-After / X-RateLimit-Reset, surface unresolvable ids as a separate "skipped" counter (left out of the collection so a future re-import retries them), and report the rate-limit countdown via MalImportStage.rateLimitWait without resetting the cumulative progress. A new "Overwrite existing entries" toggle, off by default, bypasses the merge step so a re-import keeps the user's status, rating, progress, dates and comment on matched items.