### PR TITLE
feat(fab): always-visible primary action paired with smaller overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Surface the primary action of every floating menu as an always-visible button**
+
+  The draggable FAB used to be a single ⋮ that hid every action — including
+  "Add" — behind a tap. Each screen now ships a separate, always-visible
+  primary button stacked under the ⋮ overflow so the most common action
+  is one tap away: Add wishlist entry, Add profile, Create tier list,
+  Add tier, Export mood grid image, New collection, Add items, Export
+  gamepad log. The ⋮ stays for less-frequent operations and is rendered
+  ~17% smaller above the primary button, with the fan menu now opening
+  upward/leftward from it so it never overlaps the main button. The
+  whole block drags together; tap targets are independent.
+
+  * lib/shared/widgets/draggable_fab.dart (DraggableFab.mainAction,
+    _DraggableFabState._buildButton, _DraggableFabState._blockWidth,
+    _DraggableFabState._blockHeight, _DraggableFabState._showMenu): New
+    `mainAction` parameter that renders an always-visible 48px button
+    paired with a 40px ⋮ overflow. Each button hosts its own
+    `GestureDetector` for tap routing while sharing pan state for the
+    whole-block drag; menu anchor is computed from the ⋮ position so
+    the fan radiates around it, not the main button.
+  * lib/features/wishlist/screens/wishlist_screen.dart
+    (_WishlistScreenState._buildAddItem, _buildFabItems): Add → main;
+    toggle resolved + clear resolved stay under ⋮.
+  * lib/features/settings/screens/profiles_screen.dart: Add profile →
+    main; ⋮ is hidden when no other actions exist.
+  * lib/features/tier_lists/screens/tier_lists_screen.dart: Create
+    tier list → main; Create mood grid stays under ⋮.
+  * lib/features/tier_lists/screens/tier_list_detail_screen.dart:
+    Add tier → main; Export image + Clear all stay under ⋮.
+  * lib/features/tier_lists/screens/mood_grid_detail_screen.dart:
+    Export image → main; Rename + Delete stay under ⋮.
+  * lib/features/collections/screens/home_screen.dart: New collection
+    → main; Import / view toggle / sort stay under ⋮.
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState._buildMainFabAction): Add items → main
+    (only when editable and not in canvas mode); view toggles and
+    secondary actions stay under ⋮.
+  * lib/features/settings/screens/gamepad_debug_screen.dart: Export
+    log → main; Clear logs stays under ⋮.
+
 - **Make backup restore visibly atomic, faster, and impossible to interrupt by accident**
 
   Restoring a large backup used to look "done" while SQLite was still

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -241,6 +241,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             ],
           ),
           DraggableFab(
+            mainAction: _buildMainFabAction(l),
             primaryItems: _buildPrimaryFabItems(l),
             items: _buildSecondaryFabItems(l),
           ),
@@ -282,18 +283,21 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
   }
 
   /// Основные действия — горизонтальный ряд иконок.
+  DraggableFabItem? _buildMainFabAction(S l) {
+    if (!_canEdit || _isCanvasMode) return null;
+    return DraggableFabItem(
+      icon: Icons.add,
+      label: l.collectionAddItems,
+      onTap: () => CollectionActions.addItems(
+        context: context,
+        ref: ref,
+        collectionId: widget.collectionId,
+      ),
+    );
+  }
+
   List<DraggableFabItem> _buildPrimaryFabItems(S l) {
     return <DraggableFabItem>[
-      if (_canEdit && !_isCanvasMode)
-        DraggableFabItem(
-          icon: Icons.add,
-          label: l.collectionAddItems,
-          onTap: () => CollectionActions.addItems(
-            context: context,
-            ref: ref,
-            collectionId: widget.collectionId,
-          ),
-        ),
       if (!_isCanvasMode)
         DraggableFabItem(
           icon: _isTableMode ? Icons.grid_view : Icons.table_chart_outlined,

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -86,12 +86,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 _buildErrorState(context, ref, error),
           ),
           DraggableFab(
+            mainAction: DraggableFabItem(
+              icon: Icons.add,
+              label: l.collectionsNewCollection,
+              onTap: () => _createCollection(context, ref),
+            ),
             primaryItems: <DraggableFabItem>[
-              DraggableFabItem(
-                icon: Icons.add,
-                label: l.collectionsNewCollection,
-                onTap: () => _createCollection(context, ref),
-              ),
               DraggableFabItem(
                 icon: Icons.file_download_outlined,
                 label: l.collectionsImportCollection,

--- a/lib/features/settings/screens/gamepad_debug_screen.dart
+++ b/lib/features/settings/screens/gamepad_debug_screen.dart
@@ -218,24 +218,26 @@ class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
           ),
           ],
         ),
-        DraggableFab(items: <DraggableFabItem>[
-          DraggableFabItem(
+        DraggableFab(
+          mainAction: DraggableFabItem(
             icon: Icons.save_alt,
             label: l.debugExportLog,
             onTap: _exportLog,
           ),
-          DraggableFabItem(
-            icon: Icons.delete_outline,
-            label: l.debugClearLogs,
-            iconColor: AppColors.error,
-            onTap: () {
-              setState(() {
-                _rawEvents.clear();
-                _serviceEvents.clear();
-              });
-            },
-          ),
-        ]),
+          items: <DraggableFabItem>[
+            DraggableFabItem(
+              icon: Icons.delete_outline,
+              label: l.debugClearLogs,
+              iconColor: AppColors.error,
+              onTap: () {
+                setState(() {
+                  _rawEvents.clear();
+                  _serviceEvents.clear();
+                });
+              },
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/lib/features/settings/screens/profiles_screen.dart
+++ b/lib/features/settings/screens/profiles_screen.dart
@@ -242,14 +242,11 @@ class _ProfilesScreenState extends ConsumerState<ProfilesScreen> {
           ],
         ),
         DraggableFab(
-          icon: Icons.add,
-          items: <DraggableFabItem>[
-            DraggableFabItem(
-              icon: Icons.add,
-              label: l.addProfile,
-              onTap: _createProfile,
-            ),
-          ],
+          mainAction: DraggableFabItem(
+            icon: Icons.add,
+            label: l.addProfile,
+            onTap: _createProfile,
+          ),
         ),
       ],
     );

--- a/lib/features/tier_lists/screens/mood_grid_detail_screen.dart
+++ b/lib/features/tier_lists/screens/mood_grid_detail_screen.dart
@@ -84,25 +84,27 @@ class _MoodGridDetailScreenState extends ConsumerState<MoodGridDetailScreen> {
                 ),
               ],
             ),
-            DraggableFab(items: <DraggableFabItem>[
-              DraggableFabItem(
-                icon: Icons.text_fields,
-                label: l.moodGridRename,
-                onTap: () => _renameGrid(state.grid.name, l),
-              ),
-              DraggableFabItem(
+            DraggableFab(
+              mainAction: DraggableFabItem(
                 icon: Icons.image_outlined,
                 label: l.moodGridExportImage,
                 onTap: () => _exportAsImage(state.grid.name, l),
               ),
-              const DraggableFabDivider(),
-              DraggableFabItem(
-                icon: Icons.delete_outline,
-                label: l.moodGridDelete,
-                iconColor: AppColors.error,
-                onTap: () => _confirmDelete(l),
-              ),
-            ]),
+              items: <DraggableFabItem>[
+                DraggableFabItem(
+                  icon: Icons.text_fields,
+                  label: l.moodGridRename,
+                  onTap: () => _renameGrid(state.grid.name, l),
+                ),
+                const DraggableFabDivider(),
+                DraggableFabItem(
+                  icon: Icons.delete_outline,
+                  label: l.moodGridDelete,
+                  iconColor: AppColors.error,
+                  onTap: () => _confirmDelete(l),
+                ),
+              ],
+            ),
           ],
         );
       },

--- a/lib/features/tier_lists/screens/tier_list_detail_screen.dart
+++ b/lib/features/tier_lists/screens/tier_list_detail_screen.dart
@@ -101,25 +101,27 @@ class _TierListDetailScreenState
             ],
           ),
           if (!state.isLoading)
-            DraggableFab(items: <DraggableFabItem>[
-              DraggableFabItem(
+            DraggableFab(
+              mainAction: DraggableFabItem(
                 icon: Icons.add,
                 label: l.tierListAddTier,
                 onTap: () => _addTier(context),
               ),
-              DraggableFabItem(
-                icon: Icons.image_outlined,
-                label: l.tierListExportImage,
-                onTap: () => _exportAsImage(context, state),
-              ),
-              const DraggableFabDivider(),
-              DraggableFabItem(
-                icon: Icons.clear_all,
-                label: l.tierListClearAll,
-                iconColor: AppColors.error,
-                onTap: () => _handleMenuAction('clear', state),
-              ),
-            ]),
+              items: <DraggableFabItem>[
+                DraggableFabItem(
+                  icon: Icons.image_outlined,
+                  label: l.tierListExportImage,
+                  onTap: () => _exportAsImage(context, state),
+                ),
+                const DraggableFabDivider(),
+                DraggableFabItem(
+                  icon: Icons.clear_all,
+                  label: l.tierListClearAll,
+                  iconColor: AppColors.error,
+                  onTap: () => _handleMenuAction('clear', state),
+                ),
+              ],
+            ),
         ],
       ),
     );

--- a/lib/features/tier_lists/screens/tier_lists_screen.dart
+++ b/lib/features/tier_lists/screens/tier_lists_screen.dart
@@ -160,13 +160,12 @@ class _TierListsScreenState extends ConsumerState<TierListsScreen> {
           },
         ),
           DraggableFab(
-            icon: Icons.add,
+            mainAction: DraggableFabItem(
+              icon: Icons.leaderboard,
+              label: l.tierListCreate,
+              onTap: () => _showCreateDialog(context),
+            ),
             items: <DraggableFabItem>[
-              DraggableFabItem(
-                icon: Icons.leaderboard,
-                label: l.tierListCreate,
-                onTap: () => _showCreateDialog(context),
-              ),
               if (collectionId == null)
                 DraggableFabItem(
                   icon: Icons.grid_view,

--- a/lib/features/wishlist/screens/wishlist_screen.dart
+++ b/lib/features/wishlist/screens/wishlist_screen.dart
@@ -118,7 +118,10 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
               );
             },
           ),
-          DraggableFab(items: _buildFabItems(context)),
+          DraggableFab(
+            mainAction: _buildAddItem(context),
+            items: _buildFabItems(context),
+          ),
         ],
       ),
     );
@@ -154,16 +157,18 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
     return filtered.toList();
   }
 
+  DraggableFabItem _buildAddItem(BuildContext context) {
+    final S l = S.of(context);
+    return DraggableFabItem(
+      icon: Icons.add,
+      label: l.wishlistAddTitle,
+      onTap: () => _addItem(context),
+    );
+  }
+
   List<DraggableFabItem> _buildFabItems(BuildContext context) {
     final S l = S.of(context);
     return <DraggableFabItem>[
-      DraggableFabItem(
-        icon: Icons.add,
-        label: l.wishlistAddTitle,
-        iconColor: AppColors.brand,
-        onTap: () => _addItem(context),
-      ),
-      const DraggableFabDivider(),
       DraggableFabItem(
         icon: _showResolved ? Icons.visibility_off : Icons.visibility,
         label: _showResolved

--- a/lib/shared/widgets/draggable_fab.dart
+++ b/lib/shared/widgets/draggable_fab.dart
@@ -44,25 +44,31 @@ class DraggableFabDivider extends DraggableFabItem {
 
 /// Плавающая кнопка действий, которую можно перетаскивать по экрану.
 ///
-/// Раскрывается веером в 2 стороны:
-/// - [primaryItems] — круглые иконки влево от FAB.
-/// - [items] — круглые иконки вверх от FAB.
+/// Может содержать всегда-видимое [mainAction] и/или скрытое меню,
+/// раскрывающееся веером:
+/// - [primaryItems] — круглые иконки влево от ⋮.
+/// - [items] — круглые иконки вверх от ⋮.
 class DraggableFab extends StatefulWidget {
   /// Создаёт [DraggableFab].
   const DraggableFab({
+    this.mainAction,
     this.primaryItems = const <DraggableFabItem>[],
     this.items = const <DraggableFabItem>[],
     this.icon = Icons.more_vert,
     super.key,
   });
 
-  /// Основные действия — веер влево.
+  /// Всегда-видимая основная кнопка (например, «+»). Рендерится слева
+  /// от ⋮ FAB; перетаскивается вместе с ним как единый блок.
+  final DraggableFabItem? mainAction;
+
+  /// Основные действия — веер влево от ⋮.
   final List<DraggableFabItem> primaryItems;
 
-  /// Остальные действия — веер вверх.
+  /// Остальные действия — веер вверх от ⋮.
   final List<DraggableFabItem> items;
 
-  /// Иконка кнопки.
+  /// Иконка кнопки меню.
   final IconData icon;
 
   @override
@@ -79,38 +85,104 @@ class _DraggableFabState extends State<DraggableFab> {
   double _dragStartBottom = 0;
 
   static const double _fabSize = 48;
+  static const double _menuFabSize = 40;
+  static const double _gap = 8;
+
+  bool get _hasMenu =>
+      widget.primaryItems.isNotEmpty || widget.items.isNotEmpty;
+
+  double get _blockWidth {
+    final bool hasMain = widget.mainAction != null;
+    if (hasMain) return _fabSize;
+    return _menuFabSize;
+  }
+
+  double get _blockHeight {
+    final bool hasMain = widget.mainAction != null;
+    if (hasMain && _hasMenu) return _menuFabSize + _gap + _fabSize;
+    if (hasMain) return _fabSize;
+    return _menuFabSize;
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (widget.primaryItems.isEmpty && widget.items.isEmpty) {
+    final bool hasMain = widget.mainAction != null;
+    if (!hasMain && !_hasMenu) {
       return const SizedBox.shrink();
     }
 
     return Positioned(
       right: _right,
       bottom: _bottom,
-      child: GestureDetector(
-        onPanStart: _onPanStart,
-        onPanUpdate: _onPanUpdate,
-        onPanEnd: _onPanEnd,
-        onTap: _isDragging ? null : () => _showMenu(context),
-        child: Material(
-          elevation: 6,
-          shadowColor: AppColors.brand.withAlpha(80),
-          shape: const CircleBorder(),
-          color: AppColors.brand,
-          child: SizedBox(
-            width: _fabSize,
-            height: _fabSize,
-            child: Icon(
-              widget.icon,
-              color: AppColors.textPrimary,
-              size: 24,
-            ),
-          ),
+      child: SizedBox(
+        width: _blockWidth,
+        height: _blockHeight,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            if (_hasMenu)
+              _buildButton(
+                icon: widget.icon,
+                onTap: () => _showMenu(context),
+                isMenuAnchor: true,
+              ),
+            if (hasMain && _hasMenu) const SizedBox(height: _gap),
+            if (hasMain)
+              _buildButton(
+                icon: widget.mainAction!.icon,
+                iconColor: widget.mainAction!.iconColor,
+                tooltip: widget.mainAction!.label,
+                onTap: widget.mainAction!.onTap,
+              ),
+          ],
         ),
       ),
     );
+  }
+
+  /// Single round button that both handles tap (when not dragging) and
+  /// drags the whole block. Each button has its own gesture detector so
+  /// the tap surface is local; pan state is shared via `_dragStart*` so
+  /// from either button the block moves as one.
+  Widget _buildButton({
+    required IconData icon,
+    Color? iconColor,
+    String? tooltip,
+    required VoidCallback onTap,
+    bool isMenuAnchor = false,
+  }) {
+    final double size = isMenuAnchor ? _menuFabSize : _fabSize;
+    final Widget circle = Material(
+      elevation: 6,
+      shadowColor: AppColors.brand.withAlpha(80),
+      shape: const CircleBorder(),
+      color: AppColors.brand,
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: Icon(
+          icon,
+          color: iconColor ?? AppColors.textPrimary,
+          size: isMenuAnchor ? 20 : 24,
+        ),
+      ),
+    );
+
+    final Widget hosted = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onPanStart: _onPanStart,
+      onPanUpdate: _onPanUpdate,
+      onPanEnd: _onPanEnd,
+      onTap: () {
+        if (_isDragging) return;
+        onTap();
+      },
+      child: circle,
+    );
+
+    if (tooltip == null) return hosted;
+    return Tooltip(message: tooltip, child: hosted);
   }
 
   void _onPanStart(DragStartDetails details) {
@@ -132,29 +204,30 @@ class _DraggableFabState extends State<DraggableFab> {
     final Size parentSize = MediaQuery.sizeOf(context);
     setState(() {
       _right = (_dragStartRight - delta.dx)
-          .clamp(0.0, parentSize.width - _fabSize);
+          .clamp(0.0, parentSize.width - _blockWidth);
       _bottom = (_dragStartBottom - delta.dy)
-          .clamp(0.0, parentSize.height - _fabSize - 100);
+          .clamp(0.0, parentSize.height - _blockHeight - 100);
     });
   }
 
   void _onPanEnd(DragEndDetails details) {
-    if (!_isDragging) {
-      _showMenu(context);
-    }
     _isDragging = false;
   }
 
   void _showMenu(BuildContext context) {
+    // ⋮ sits at the top of the block, horizontally centered above the
+    // main action. Pass its actual screen position so the fan radiates
+    // around the small (40px) menu button, not the larger main one.
     final RenderBox box = context.findRenderObject()! as RenderBox;
-    final Offset fabPos = box.localToGlobal(Offset.zero);
+    final Offset blockPos = box.localToGlobal(Offset.zero);
+    final double menuLeft = blockPos.dx + (_blockWidth - _menuFabSize) / 2;
 
     Navigator.of(context, rootNavigator: true).push(
       _FanMenuRoute(
         primaryItems: widget.primaryItems,
         items: widget.items,
-        fabPosition: fabPos,
-        fabSize: _fabSize,
+        fabPosition: Offset(menuLeft, blockPos.dy),
+        fabSize: _menuFabSize,
       ),
     );
   }


### PR DESCRIPTION
Every screen with a DraggableFab used to hide its main action — Add, Create, Export — behind a tap on ⋮. The widget gains a `mainAction` parameter that renders an always-visible 48px primary button stacked under a smaller 40px ⋮ overflow; the whole block drags as one but each button has its own gesture detector so taps route correctly. The fan menu now anchors around the small ⋮ at the top, so opening the overflow never overlaps the primary button below.

Promoted on every screen with a FAB: Add wishlist entry, Add profile, Create tier list, Add tier, Export mood grid image, New collection, Add items (collection screen, when editable and not in canvas mode), Export gamepad log.