### PR TITLE
fix(db): use rawQuery for WAL pragma so Android opens the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,11 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   per write.
 
   * lib/core/database/database_service.dart (DatabaseService._initDatabase):
-    Issue `PRAGMA journal_mode = WAL` and `PRAGMA synchronous = NORMAL`
-    in `onConfigure`. Single change, broad benefit — applies to every
-    write the app makes, not just restore.
+    Issue `PRAGMA journal_mode = WAL` (via `rawQuery` — Android's
+    SQLiteDatabase rejects PRAGMAs that return a result via `execute`)
+    and `PRAGMA synchronous = NORMAL` in `onConfigure`. Single change,
+    broad benefit — applies to every write the app makes, not just
+    restore.
   * lib/core/services/backup_service.dart (BackupService,
     BackupService.restoreFromBackup, restoreInProgressProvider):
     Inject `DatabaseService` so the restore can issue a final

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -205,12 +205,12 @@ class DatabaseService {
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {
           await db.execute('PRAGMA foreign_keys = ON');
-          // WAL + NORMAL is the SQLite-recommended trade-off for
-          // single-process desktop apps: durable across power loss, but
-          // ~5-10× faster than the default DELETE+FULL because commits
-          // batch into a single fsync per checkpoint instead of one
-          // fsync per write. Restore of large backups was the trigger.
-          await db.execute('PRAGMA journal_mode = WAL');
+          // WAL + NORMAL: SQLite-recommended durable-but-fast combo;
+          // commits batch into one fsync per checkpoint instead of
+          // one per write. `journal_mode` returns the resulting mode,
+          // so Android's SQLiteDatabase rejects it via `execute()` —
+          // use `rawQuery` cross-platform.
+          await db.rawQuery('PRAGMA journal_mode = WAL');
           await db.execute('PRAGMA synchronous = NORMAL');
         },
       ),


### PR DESCRIPTION
Android's SQLiteDatabase rejects `execute()` for PRAGMAs that return a result, including `PRAGMA journal_mode = WAL` (it returns the new mode). The app failed to open the DB on Android right after the desktop-focused WAL change. Switching to `rawQuery` is cross-platform safe: Android now applies WAL successfully, and the FFI-backed desktop wrappers ignore the returned row.