### PR TITLE
feat(item): refresh item from source API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Added
+
+- **Refresh a collection item from its source API on demand**
+
+  Item detail's ⋮ menu gains a "Refresh from source" action that
+  re-fetches the metadata and cover from IGDB (games), TMDB (movies,
+  TV, animation), AniList (anime, manga) or VNDB (visual novels),
+  upserts the fresh row into the cache tables, and deletes the
+  cached image so it re-downloads with the new URL. Useful when a
+  cover gets corrupted during sync, the source updated metadata, or
+  a backup restore left stale rows. Custom items are skipped (no
+  external source). The action is single-tap, surfaces success /
+  not-found / unsupported / failed states via snackbar, and
+  invalidates the open detail and collection lists so the UI shows
+  the new data without a manual refresh.
+
+  * lib/features/collections/helpers/collection_actions.dart
+    (CollectionActions.refreshItemFromApi, _refreshItemWork,
+    _RefreshOutcome, _RefreshMessage): New shared action that
+    dispatches by `mediaType`, swaps in the matching API client,
+    and reports the outcome via a context-free helper so UI feedback
+    happens behind a single `context.mounted` check.
+  * lib/features/collections/screens/item_detail_screen.dart
+    (_ItemDetailScreenState._refreshFromApi): Menu entry plus
+    handler that invalidates `collectionItemsNotifierProvider` after
+    a successful refresh.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (refreshItemFromApi,
+    refreshItemSuccess, refreshItemNotFound, refreshItemUnsupported,
+    refreshItemFailed): New strings; regenerated
+    `app_localizations*.dart`.
+
 ### Changed
 
 - **Surface the primary action of every floating menu as an always-visible button**

--- a/lib/features/collections/helpers/collection_actions.dart
+++ b/lib/features/collections/helpers/collection_actions.dart
@@ -4,15 +4,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/api/anilist_api.dart';
+import '../../../core/api/igdb_api.dart';
+import '../../../core/api/tmdb_api.dart';
+import '../../../core/api/vndb_api.dart';
+import '../../../core/database/database_service.dart';
 import '../../../core/services/export_service.dart';
+import '../../../core/services/image_cache_service.dart';
 import '../../../core/services/text_export_service.dart';
 import '../../../core/services/xcoll_file.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/anime.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/game.dart';
+import '../../../shared/models/manga.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/movie.dart';
 import '../../../shared/models/steamgriddb_image.dart';
+import '../../../shared/models/tv_show.dart';
+import '../../../shared/models/visual_novel.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
 import '../providers/canvas_provider.dart';
 import '../providers/collections_provider.dart';
@@ -587,4 +600,113 @@ class CollectionActions {
       );
     }
   }
+
+  /// Re-fetches the item from its source API and upserts the fresh row
+  /// into the matching cache table. The cached cover image is deleted
+  /// first so it gets re-downloaded with the new URL (or the same URL
+  /// re-fetches the bytes if the local file was corrupted). `Custom`
+  /// items have no API origin and are rejected by the caller.
+  static Future<bool> refreshItemFromApi({
+    required BuildContext context,
+    required WidgetRef ref,
+    required CollectionItem item,
+  }) async {
+    final S l = S.of(context);
+
+    final _RefreshOutcome outcome = await _refreshItemWork(ref, item);
+    if (!context.mounted) return outcome.success;
+
+    switch (outcome.message) {
+      case _RefreshMessage.success:
+        ref.invalidate(collectionsProvider);
+        context.showSnack(l.refreshItemSuccess, type: SnackType.success);
+      case _RefreshMessage.notFound:
+        context.showSnack(l.refreshItemNotFound, type: SnackType.error);
+      case _RefreshMessage.unsupported:
+        context.showSnack(l.refreshItemUnsupported, type: SnackType.error);
+      case _RefreshMessage.failed:
+        context.showSnack(
+          l.refreshItemFailed(outcome.error ?? ''),
+          type: SnackType.error,
+        );
+    }
+    return outcome.success;
+  }
+
+  /// Async DB / network work for [refreshItemFromApi]. Kept context-free so
+  /// the lint can see that UI feedback happens behind a single mounted check
+  /// in the caller.
+  static Future<_RefreshOutcome> _refreshItemWork(
+    WidgetRef ref,
+    CollectionItem item,
+  ) async {
+    final DatabaseService db = ref.read(databaseServiceProvider);
+    final ImageCacheService cache = ref.read(imageCacheServiceProvider);
+
+    try {
+      await cache.deleteImage(item.imageType, item.externalId.toString());
+
+      switch (item.mediaType) {
+        case MediaType.game:
+          final Game? game =
+              await ref.read(igdbApiProvider).getGameById(item.externalId);
+          if (game == null) return _RefreshOutcome.notFound();
+          await db.upsertGame(game);
+        case MediaType.movie:
+          final Movie? movie =
+              await ref.read(tmdbApiProvider).getMovie(item.externalId);
+          if (movie == null) return _RefreshOutcome.notFound();
+          await db.upsertMovie(movie);
+        case MediaType.tvShow:
+        case MediaType.animation:
+          final TvShow? show =
+              await ref.read(tmdbApiProvider).getTvShow(item.externalId);
+          if (show == null) return _RefreshOutcome.notFound();
+          await db.upsertTvShow(show);
+        case MediaType.anime:
+          final Anime? anime = await ref
+              .read(aniListApiProvider)
+              .getAnimeById(item.externalId);
+          if (anime == null) return _RefreshOutcome.notFound();
+          await db.upsertAnime(anime);
+        case MediaType.manga:
+          final Manga? manga = await ref
+              .read(aniListApiProvider)
+              .getMangaById(item.externalId);
+          if (manga == null) return _RefreshOutcome.notFound();
+          await db.upsertManga(manga);
+        case MediaType.visualNovel:
+          final VisualNovel? vn = await ref
+              .read(vndbApiProvider)
+              .getVnById(item.externalId.toString());
+          if (vn == null) return _RefreshOutcome.notFound();
+          await db.upsertVisualNovel(vn);
+        case MediaType.custom:
+          return _RefreshOutcome.unsupported();
+      }
+
+      return _RefreshOutcome.success();
+    } catch (e) {
+      return _RefreshOutcome.failed(e.toString());
+    }
+  }
+}
+
+enum _RefreshMessage { success, notFound, unsupported, failed }
+
+class _RefreshOutcome {
+  const _RefreshOutcome._(this.message, this.success, [this.error]);
+
+  factory _RefreshOutcome.success() =>
+      const _RefreshOutcome._(_RefreshMessage.success, true);
+  factory _RefreshOutcome.notFound() =>
+      const _RefreshOutcome._(_RefreshMessage.notFound, false);
+  factory _RefreshOutcome.unsupported() =>
+      const _RefreshOutcome._(_RefreshMessage.unsupported, false);
+  factory _RefreshOutcome.failed(String error) =>
+      _RefreshOutcome._(_RefreshMessage.failed, false, error);
+
+  final _RefreshMessage message;
+  final bool success;
+  final String? error;
 }

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -188,6 +188,18 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
 
   // ==================== Navigation / Actions ====================
 
+  Future<void> _refreshFromApi(CollectionItem item) async {
+    final bool ok = await CollectionActions.refreshItemFromApi(
+      context: context,
+      ref: ref,
+      item: item,
+    );
+    if (!ok || !mounted) return;
+    // The detail screen reads from the cache tables; nudging the items
+    // provider makes sure the refreshed row reaches the open view.
+    ref.invalidate(collectionItemsNotifierProvider(widget.collectionId));
+  }
+
   Future<void> _renameItem(CollectionItem item) async {
     final String original = item.cachedName ?? item.itemName;
     final String? result = await RenameItemDialog.show(
@@ -507,6 +519,8 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
                 ),
                 onSelected: (String value) {
                   switch (value) {
+                    case 'refresh':
+                      _refreshFromApi(item);
                     case 'rename':
                       _renameItem(item);
                     case 'move':
@@ -519,6 +533,15 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
                 },
                 itemBuilder: (BuildContext context) =>
                     <PopupMenuEntry<String>>[
+                  if (item.mediaType != MediaType.custom)
+                    PopupMenuItem<String>(
+                      value: 'refresh',
+                      child: ListTile(
+                        leading: const Icon(Icons.refresh),
+                        title: Text(S.of(context).refreshItemFromApi),
+                        contentPadding: EdgeInsets.zero,
+                      ),
+                    ),
                   if (item.mediaType != MediaType.custom)
                     PopupMenuItem<String>(
                       value: 'rename',

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -527,6 +527,16 @@
   "tagDeleted": "Tag deleted",
   "tagUpdateFailed": "Failed to update tag",
   "renameItem": "Rename",
+  "refreshItemFromApi": "Refresh from source",
+  "refreshItemSuccess": "Item updated from source",
+  "refreshItemNotFound": "Source no longer has this item",
+  "refreshItemUnsupported": "Custom items have no external source",
+  "refreshItemFailed": "Refresh failed: {error}",
+  "@refreshItemFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
   "renameDialogHint": "Display name",
   "renameOriginalLabel": "Original: {name}",
   "@renameOriginalLabel": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2233,6 +2233,36 @@ abstract class S {
   /// **'Rename'**
   String get renameItem;
 
+  /// No description provided for @refreshItemFromApi.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh from source'**
+  String get refreshItemFromApi;
+
+  /// No description provided for @refreshItemSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Item updated from source'**
+  String get refreshItemSuccess;
+
+  /// No description provided for @refreshItemNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Source no longer has this item'**
+  String get refreshItemNotFound;
+
+  /// No description provided for @refreshItemUnsupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom items have no external source'**
+  String get refreshItemUnsupported;
+
+  /// No description provided for @refreshItemFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh failed: {error}'**
+  String refreshItemFailed(String error);
+
   /// No description provided for @renameDialogHint.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1204,6 +1204,23 @@ class SEn extends S {
   String get renameItem => 'Rename';
 
   @override
+  String get refreshItemFromApi => 'Refresh from source';
+
+  @override
+  String get refreshItemSuccess => 'Item updated from source';
+
+  @override
+  String get refreshItemNotFound => 'Source no longer has this item';
+
+  @override
+  String get refreshItemUnsupported => 'Custom items have no external source';
+
+  @override
+  String refreshItemFailed(String error) {
+    return 'Refresh failed: $error';
+  }
+
+  @override
   String get renameDialogHint => 'Display name';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1221,6 +1221,24 @@ class SRu extends S {
   String get renameItem => 'Переименовать';
 
   @override
+  String get refreshItemFromApi => 'Обновить из источника';
+
+  @override
+  String get refreshItemSuccess => 'Запись обновлена из источника';
+
+  @override
+  String get refreshItemNotFound => 'В источнике этой записи больше нет';
+
+  @override
+  String get refreshItemUnsupported =>
+      'У кастомных записей нет внешнего источника';
+
+  @override
+  String refreshItemFailed(String error) {
+    return 'Не удалось обновить: $error';
+  }
+
+  @override
   String get renameDialogHint => 'Отображаемое название';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -465,6 +465,16 @@
   "tagDeleted": "Тег удалён",
   "tagUpdateFailed": "Не удалось обновить тег",
   "renameItem": "Переименовать",
+  "refreshItemFromApi": "Обновить из источника",
+  "refreshItemSuccess": "Запись обновлена из источника",
+  "refreshItemNotFound": "В источнике этой записи больше нет",
+  "refreshItemUnsupported": "У кастомных записей нет внешнего источника",
+  "refreshItemFailed": "Не удалось обновить: {error}",
+  "@refreshItemFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
   "renameDialogHint": "Отображаемое название",
   "renameOriginalLabel": "Оригинал: {name}",
   "renameResetToOriginal": "Сбросить до оригинала",


### PR DESCRIPTION
Item detail's ⋮ menu gets a "Refresh from source" action: it deletes the cached cover, calls the matching API (IGDB / TMDB / AniList / VNDB) by externalId, upserts the fresh row into the cache table, and invalidates the collection providers so the screen reloads with the new metadata and re-downloaded image. Use cases: a cover went corrupt mid-sync, source metadata changed, backup restore left stale rows. Custom items have no external source and are skipped. The async work runs context-free in a private helper; UI feedback (success / not-found / unsupported / failed) happens behind a single mounted check.