### PR TITLE
refactor(search): split god class into per-source handlers and fix animation routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,104 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Split search screen god class into per-source handlers and fix animation routing**
+
+  `_SearchScreenState` shrank from ~1500 to ~400 lines. The seven near-duplicate
+  blocks (`_onXTap` / `_addXToCollection` / `_addXToAnyCollection` /
+  `_showXDetails`) per media type were extracted into focused handler classes
+  sharing a `SearchCollectionAdder` that owns the picker → upsert → addItem →
+  image cache → snackbar pipeline. The registry resolves handlers by item
+  runtime type and supports a `registerForSource` override so the same model
+  (e.g. `Game` from a future RAWG source) can plug in source-specific logic
+  without touching the screen.
+
+  Along the way three pre-existing animation-routing bugs were fixed. Every
+  `SearchSource` now declares a fixed `outputMediaType`, which the grid and
+  the Discover feed both consume — replacing hardcoded `MediaType.movie /
+  tvShow` plus a per-item `_isAnimation(genres)` heuristic that silently
+  misclassified TMDB items. As a result on the Animation tab both movies
+  and TV shows now save as `MediaType.animation` (Discover-feed adds went
+  in as `movie/tvShow` before). Lastly `isAnimationGenre` became locale-
+  and case-aware: TMDB returns `"мультфильм"` (lowercase) for `ru-RU`, but
+  our DAO capitalises the first letter on read, so the filter dropped
+  every animation row — `«Аватар: Легенда об Аанге»` was missing from the
+  Animation tab and simultaneously leaked into TV shows.
+
+  * lib/features/search/services/search_collection_adder.dart
+    (SearchCollectionAdder.addToCollection, SearchCollectionAdder.pickCollection,
+    SearchCollectionAdder.collectedCollectionIdsAcross, PickedCollection):
+    New shared service de-duplicating the add-to-collection pipeline; honours
+    `context.mounted` between async hops. `collectedCollectionIdsAcross`
+    unions two collected-id providers — replaces duplicated `Future.wait`
+    blocks in Movie/TvShow handlers.
+  * lib/features/search/handlers/media_action_handler.dart (MediaActionHandler):
+    New flat (non-generic) contract — generics dropped to keep the registry
+    type-erased; concrete handlers downcast internally.
+  * lib/features/search/handlers/game_handler.dart (GameHandler),
+    movie_handler.dart (MovieHandler), tv_show_handler.dart (TvShowHandler):
+    New per-source handlers for the three media types with non-trivial logic.
+    `MovieHandler` and `TvShowHandler` route both regular and
+    `MediaType.animation` (with `AnimationSource.movie/tvShow` platform id);
+    `TvShowHandler` keeps the post-add season/episode preload; `GameHandler`
+    keeps the platform selection dialog.
+  * lib/features/search/handlers/simple_media_handler.dart
+    (SimpleMediaHandler): New generic single-source handler covering Anime,
+    Manga, and VisualNovel — three near-identical handler files (~300 lines
+    of duplication) collapsed into one parameterized class. Each model is
+    wired in `MediaHandlers` via field extractors (`externalIdOf`,
+    `titleOf`, `imageUrlOf`, `upsert`, `sheetBuilder`) and the matching
+    `collected*IdsProvider`.
+  * lib/features/search/handlers/media_handlers.dart (MediaHandlers,
+    MediaHandlers.forItem, MediaHandlers.registerForSource, MediaHandlers.onTap,
+    MediaHandlers.addToAnyCollection): New registry with two-level dispatch
+    (`(sourceId, type)` then `type`).
+  * lib/features/search/models/search_source.dart (SearchSource.outputMediaType):
+    New abstract getter — each source declares the `MediaType` it produces
+    so consumers no longer have to guess from runtime type or genres.
+  * lib/features/search/sources/tmdb_movies_source.dart (TmdbMoviesSource.outputMediaType),
+    tmdb_tv_source.dart (TmdbTvSource.outputMediaType),
+    tmdb_anime_source.dart (TmdbAnimeSource.outputMediaType),
+    igdb_games_source.dart (IgdbGamesSource.outputMediaType),
+    anilist_anime_source.dart (AniListAnimeSource.outputMediaType),
+    anilist_manga_source.dart (AniListMangaSource.outputMediaType),
+    vndb_source.dart (VndbSource.outputMediaType): Override the getter
+    with the source-declared `MediaType`.
+  * lib/features/search/widgets/browse_grid.dart (BrowseGrid._buildCard):
+    Use `state.source.outputMediaType` for every item branch; remove the
+    `_isAnimation(TvShow)` helper, the per-item genre heuristic, and the
+    `isAnimationGenre` import. Per-item `MediaType.movie/tvShow/game/...`
+    hardcodes replaced with the parameterized `mediaType`.
+  * lib/features/search/screens/search_screen.dart (_SearchScreenState,
+    _SearchScreenState._buildContent): Removed all `_addX*` / `_onXTap` /
+    `_showXDetails` methods (~1100 lines); `_onItemTap` now delegates to
+    `MediaHandlers`. DiscoverFeed `onAddMovie`/`onAddTvShow` callbacks
+    now use `browseState.source.outputMediaType` — previously hardcoded
+    to `MediaType.movie`/`MediaType.tvShow`, which silently misclassified
+    every recommendation added from the Animation tab.
+  * lib/features/search/utils/genre_utils.dart (isAnimationGenre):
+    Signature now `(String genre, Map<String, String> genreMap)` and the
+    comparison is case-insensitive — matches the localised genre name
+    returned by TMDB regardless of the DAO's `_capitalize` on read.
+  * lib/features/search/sources/tmdb_anime_source.dart (TmdbAnimeSource._searchWithFilters),
+    tmdb_tv_source.dart (TmdbTvSource.fetch): Pass the loaded `genreMap`
+    to `isAnimationGenre`.
+  * test/features/search/handlers/media_handlers_test.dart: New — locks down
+    type-based dispatch, source-id override precedence, and the no-handler
+    fallback.
+  * test/features/search/handlers/tmdb_handlers_test.dart: New — covers the
+    `MediaType.animation` branch of `MovieHandler`/`TvShowHandler`
+    (verifies `platformId` becomes `AnimationSource.movie`/`tvShow`) and
+    the TvShow post-add preload hook.
+  * test/features/search/sources/source_output_media_type_test.dart: New —
+    one-liner per source verifying the `outputMediaType` contract.
+  * test/features/search/utils/genre_utils_test.dart: Extended for the new
+    signature: localised genre map, case-insensitive matching, RU and EN
+    samples.
+  * test/features/search/models/search_source_test.dart (_TestSource.outputMediaType):
+    Implement the new abstract getter on the in-test source.
+  * test/helpers/fallbacks.dart (_FakeBuildContext): New mocktail fallback
+    for `BuildContext`, needed by the handler tests.
+
 - **Surface the primary action of every floating menu as an always-visible button**
 
   The draggable FAB used to be a single ⋮ that hid every action — including

--- a/lib/features/search/handlers/game_handler.dart
+++ b/lib/features/search/handlers/game_handler.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
+import '../../../shared/models/collected_item_info.dart';
+import '../../../shared/models/game.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/platform.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../services/search_collection_adder.dart';
+import '../widgets/item_details_sheet.dart';
+import 'media_action_handler.dart';
+
+/// Game source handler (IGDB).
+///
+/// Picker does not block any collection: the same game on a different
+/// platform is intentionally allowed. Platform is chosen via a dedicated
+/// dialog before the add.
+class GameHandler implements MediaActionHandler {
+  GameHandler({
+    required WidgetRef ref,
+    required SearchCollectionAdder adder,
+    required Map<int, Platform> Function() platformMap,
+    required int? targetCollectionId,
+    void Function(Game game)? onGameSelected,
+  })  : _ref = ref,
+        _adder = adder,
+        _platformMap = platformMap,
+        _targetCollectionId = targetCollectionId,
+        _onGameSelected = onGameSelected;
+
+  final WidgetRef _ref;
+  final SearchCollectionAdder _adder;
+  final Map<int, Platform> Function() _platformMap;
+  final int? _targetCollectionId;
+  final void Function(Game game)? _onGameSelected;
+
+  @override
+  Future<void> onTap(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final Game game = item as Game;
+    if (_onGameSelected != null) {
+      _onGameSelected(game);
+      return;
+    }
+    if (_targetCollectionId != null) {
+      await _addToCollection(context, _targetCollectionId, game);
+      return;
+    }
+    showDetails(context, game, mediaType);
+  }
+
+  @override
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final Game game = item as Game;
+    final List<CollectedItemInfo> infos = await _collectedInfos(game.id);
+    if (!context.mounted) return;
+
+    // Same game on a different platform is allowed — pass empty alreadyIn.
+    final PickedCollection? picked = await _adder.pickCollection(
+      context: context,
+      alreadyIn: const <int?>{},
+    );
+    if (picked == null || !context.mounted) return;
+
+    final Set<int> alreadyPlatforms = infos
+        .where((CollectedItemInfo i) => i.collectionId == picked.id)
+        .map((CollectedItemInfo i) => i.platformId)
+        .whereType<int>()
+        .toSet();
+
+    final int? platformId = await _selectPlatform(
+      context,
+      game,
+      alreadyPlatforms,
+    );
+    if (platformId == null || !context.mounted) return;
+
+    await _adder.addToCollection(
+      context: context,
+      collectionId: picked.id,
+      collectionName: picked.name,
+      mediaType: MediaType.game,
+      externalId: game.id,
+      platformId: platformId,
+      title: game.name,
+      upsert: () => _ref.read(databaseServiceProvider).upsertGame(game),
+      imageType: ImageType.gameCover,
+      imageId: game.id.toString(),
+      imageUrl: game.coverUrl,
+    );
+  }
+
+  @override
+  void showDetails(BuildContext context, Object item, MediaType mediaType) {
+    final Game game = item as Game;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext _) => ItemDetailsSheet.game(
+        game,
+        onAddToCollection: () => addToAnyCollection(context, game, mediaType),
+      ),
+    );
+  }
+
+  Future<void> _addToCollection(
+    BuildContext context,
+    int collectionId,
+    Game game,
+  ) async {
+    final List<CollectedItemInfo> infos = await _collectedInfos(game.id);
+    final Set<int> alreadyPlatforms = infos
+        .where((CollectedItemInfo i) => i.collectionId == collectionId)
+        .map((CollectedItemInfo i) => i.platformId)
+        .whereType<int>()
+        .toSet();
+
+    if (!context.mounted) return;
+    final int? platformId = await _selectPlatform(
+      context,
+      game,
+      alreadyPlatforms,
+    );
+    if (platformId == null || !context.mounted) return;
+
+    await _adder.addToCollection(
+      context: context,
+      collectionId: collectionId,
+      mediaType: MediaType.game,
+      externalId: game.id,
+      platformId: platformId,
+      title: game.name,
+      upsert: () => _ref.read(databaseServiceProvider).upsertGame(game),
+      imageType: ImageType.gameCover,
+      imageId: game.id.toString(),
+      imageUrl: game.coverUrl,
+    );
+  }
+
+  Future<List<CollectedItemInfo>> _collectedInfos(int gameId) async {
+    final Map<int, List<CollectedItemInfo>> collected =
+        await _ref.read(collectedGameIdsProvider.future);
+    return collected[gameId] ?? <CollectedItemInfo>[];
+  }
+
+  Future<int?> _selectPlatform(
+    BuildContext context,
+    Game game,
+    Set<int> alreadyAdded,
+  ) async {
+    final List<int>? platformIds = game.platformIds;
+    if (platformIds == null || platformIds.isEmpty) return -1;
+    if (platformIds.length == 1) return platformIds.first;
+
+    final Map<int, Platform> map = _platformMap();
+    return showDialog<int>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        scrollable: true,
+        title: Text(S.of(context).searchSelectPlatform),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: platformIds.map((int id) {
+            final Platform? platform = map[id];
+            final String name = platform?.displayName ?? 'Platform $id';
+            final bool already = alreadyAdded.contains(id);
+            return ListTile(
+              leading: Icon(
+                already ? Icons.check_circle : Icons.videogame_asset,
+                size: 24,
+                color: already ? AppColors.success : null,
+              ),
+              title: Text(name),
+              onTap: () => Navigator.of(context).pop(id),
+            );
+          }).toList(),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(S.of(context).cancel),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/search/handlers/media_action_handler.dart
+++ b/lib/features/search/handlers/media_action_handler.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/models/media_type.dart';
+
+/// Contract for source-specific search actions.
+///
+/// Argument type is `Object` (not a generic): Dart generics are invariant,
+/// so a single registry of `MediaActionHandler<T>` cannot be built — each
+/// handler downcasts internally. Animation is a sub-mode of Movie/TvShow
+/// and is dispatched via [MediaType], not a separate handler.
+abstract class MediaActionHandler {
+  Future<void> onTap(BuildContext context, Object item, MediaType mediaType);
+
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  );
+
+  void showDetails(BuildContext context, Object item, MediaType mediaType);
+}

--- a/lib/features/search/handlers/media_handlers.dart
+++ b/lib/features/search/handlers/media_handlers.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
+import '../../../shared/models/anime.dart';
+import '../../../shared/models/game.dart';
+import '../../../shared/models/manga.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/movie.dart';
+import '../../../shared/models/platform.dart';
+import '../../../shared/models/tv_show.dart';
+import '../../../shared/models/visual_novel.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../services/search_collection_adder.dart';
+import '../widgets/item_details_sheet.dart';
+import 'game_handler.dart';
+import 'media_action_handler.dart';
+import 'movie_handler.dart';
+import 'simple_media_handler.dart';
+import 'tv_show_handler.dart';
+
+/// Registry that maps search results to their per-source handlers.
+///
+/// Resolution is two-level:
+/// 1. by `sourceId` — for the case when the same model type comes from
+///    multiple sources (e.g. `Game` from IGDB *and* a future RAWG) and
+///    needs source-specific logic;
+/// 2. fallback by `runtimeType` — the default when no source override is
+///    registered.
+class MediaHandlers {
+  MediaHandlers({
+    required WidgetRef ref,
+    required Map<int, Platform> Function() platformMap,
+    required int? targetCollectionId,
+    void Function(Game game)? onGameSelected,
+  }) {
+    final SearchCollectionAdder adder = SearchCollectionAdder(ref);
+    _byType[Game] = GameHandler(
+      ref: ref,
+      adder: adder,
+      platformMap: platformMap,
+      targetCollectionId: targetCollectionId,
+      onGameSelected: onGameSelected,
+    );
+    _byType[Movie] = MovieHandler(
+      ref: ref,
+      adder: adder,
+      targetCollectionId: targetCollectionId,
+    );
+    _byType[TvShow] = TvShowHandler(
+      ref: ref,
+      adder: adder,
+      targetCollectionId: targetCollectionId,
+    );
+    _byType[VisualNovel] = SimpleMediaHandler<VisualNovel>(
+      ref: ref,
+      adder: adder,
+      targetCollectionId: targetCollectionId,
+      mediaType: MediaType.visualNovel,
+      imageType: ImageType.vnCover,
+      collectedProvider: collectedVisualNovelIdsProvider,
+      externalIdOf: (VisualNovel vn) => vn.numericId,
+      imageIdOf: (VisualNovel vn) => vn.numericId.toString(),
+      titleOf: (VisualNovel vn) => vn.title,
+      imageUrlOf: (VisualNovel vn) => vn.imageUrl,
+      upsert: (VisualNovel vn) =>
+          ref.read(databaseServiceProvider).upsertVisualNovel(vn),
+      sheetBuilder: (VisualNovel vn, VoidCallback onAdd) =>
+          ItemDetailsSheet.visualNovel(vn, onAddToCollection: onAdd),
+    );
+    _byType[Manga] = SimpleMediaHandler<Manga>(
+      ref: ref,
+      adder: adder,
+      targetCollectionId: targetCollectionId,
+      mediaType: MediaType.manga,
+      imageType: ImageType.mangaCover,
+      collectedProvider: collectedMangaIdsProvider,
+      externalIdOf: (Manga m) => m.id,
+      imageIdOf: (Manga m) => m.id.toString(),
+      titleOf: (Manga m) => m.title,
+      imageUrlOf: (Manga m) => m.coverUrl,
+      upsert: (Manga m) => ref.read(databaseServiceProvider).upsertManga(m),
+      sheetBuilder: (Manga m, VoidCallback onAdd) =>
+          ItemDetailsSheet.manga(m, onAddToCollection: onAdd),
+    );
+    _byType[Anime] = SimpleMediaHandler<Anime>(
+      ref: ref,
+      adder: adder,
+      targetCollectionId: targetCollectionId,
+      mediaType: MediaType.anime,
+      imageType: ImageType.animeCover,
+      collectedProvider: collectedAnimeIdsProvider,
+      externalIdOf: (Anime a) => a.id,
+      imageIdOf: (Anime a) => a.id.toString(),
+      titleOf: (Anime a) => a.title,
+      imageUrlOf: (Anime a) => a.coverUrl,
+      upsert: (Anime a) => ref.read(databaseServiceProvider).upsertAnime(a),
+      sheetBuilder: (Anime a, VoidCallback onAdd) =>
+          ItemDetailsSheet.anime(a, onAddToCollection: onAdd),
+    );
+  }
+
+  final Map<Type, MediaActionHandler> _byType =
+      <Type, MediaActionHandler>{};
+  final Map<String, MediaActionHandler> _bySource =
+      <String, MediaActionHandler>{};
+
+  /// Register a source-specific handler. Takes precedence over the
+  /// type-based default for items dispatched with this [sourceId].
+  void registerForSource(String sourceId, MediaActionHandler handler) {
+    _bySource[sourceId] = handler;
+  }
+
+  MediaActionHandler? forItem(Object item, {String? sourceId}) {
+    if (sourceId != null) {
+      final MediaActionHandler? bySource = _bySource[sourceId];
+      if (bySource != null) return bySource;
+    }
+    return _byType[item.runtimeType];
+  }
+
+  Future<void> onTap(
+    BuildContext context,
+    Object item,
+    MediaType mediaType, {
+    String? sourceId,
+  }) async {
+    final MediaActionHandler? handler =
+        forItem(item, sourceId: sourceId);
+    if (handler == null) return;
+    await handler.onTap(context, item, mediaType);
+  }
+
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType, {
+    String? sourceId,
+  }) async {
+    final MediaActionHandler? handler =
+        forItem(item, sourceId: sourceId);
+    if (handler == null) return;
+    await handler.addToAnyCollection(context, item, mediaType);
+  }
+}

--- a/lib/features/search/handlers/movie_handler.dart
+++ b/lib/features/search/handlers/movie_handler.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/movie.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../services/search_collection_adder.dart';
+import '../widgets/item_details_sheet.dart';
+import 'media_action_handler.dart';
+
+/// Movie source handler (TMDB).
+///
+/// Handles both [MediaType.movie] and [MediaType.animation]
+/// (with `platformId = AnimationSource.movie`). The "already in" check
+/// unions movie + animation collections because the same TMDB id may
+/// have been added under either media type.
+class MovieHandler implements MediaActionHandler {
+  const MovieHandler({
+    required WidgetRef ref,
+    required SearchCollectionAdder adder,
+    required int? targetCollectionId,
+  })  : _ref = ref,
+        _adder = adder,
+        _targetCollectionId = targetCollectionId;
+
+  final WidgetRef _ref;
+  final SearchCollectionAdder _adder;
+  final int? _targetCollectionId;
+
+  @override
+  Future<void> onTap(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final Movie movie = item as Movie;
+    if (_targetCollectionId != null) {
+      await _addToCollection(context, _targetCollectionId, movie, mediaType);
+      return;
+    }
+    showDetails(context, movie, mediaType);
+  }
+
+  @override
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final Movie movie = item as Movie;
+    final Set<int?> alreadyIn = await _adder.collectedCollectionIdsAcross(
+      movie.tmdbId,
+      collectedMovieIdsProvider,
+      collectedAnimationIdsProvider,
+    );
+    if (!context.mounted) return;
+
+    final PickedCollection? picked = await _adder.pickCollection(
+      context: context,
+      alreadyIn: alreadyIn,
+    );
+    if (picked == null || !context.mounted) return;
+
+    await _adder.addToCollection(
+      context: context,
+      collectionId: picked.id,
+      collectionName: picked.name,
+      mediaType: mediaType,
+      externalId: movie.tmdbId,
+      platformId: mediaType == MediaType.animation
+          ? AnimationSource.movie
+          : null,
+      title: movie.title,
+      upsert: () => _ref.read(databaseServiceProvider).upsertMovie(movie),
+      imageType: ImageType.moviePoster,
+      imageId: movie.tmdbId.toString(),
+      imageUrl: movie.posterUrl,
+    );
+  }
+
+  @override
+  void showDetails(BuildContext context, Object item, MediaType mediaType) {
+    final Movie movie = item as Movie;
+    final bool isAnim = mediaType == MediaType.animation;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext _) => ItemDetailsSheet.movie(
+        movie,
+        isAnimation: isAnim,
+        onAddToCollection: () => addToAnyCollection(context, movie, mediaType),
+      ),
+    );
+  }
+
+  Future<void> _addToCollection(
+    BuildContext context,
+    int collectionId,
+    Movie movie,
+    MediaType mediaType,
+  ) async {
+    await _adder.addToCollection(
+      context: context,
+      collectionId: collectionId,
+      mediaType: mediaType,
+      externalId: movie.tmdbId,
+      platformId: mediaType == MediaType.animation
+          ? AnimationSource.movie
+          : null,
+      title: movie.title,
+      upsert: () => _ref.read(databaseServiceProvider).upsertMovie(movie),
+      imageType: ImageType.moviePoster,
+      imageId: movie.tmdbId.toString(),
+      imageUrl: movie.posterUrl,
+    );
+  }
+
+}

--- a/lib/features/search/handlers/simple_media_handler.dart
+++ b/lib/features/search/handlers/simple_media_handler.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/services/image_cache_service.dart';
+import '../../../shared/models/collected_item_info.dart';
+import '../../../shared/models/media_type.dart';
+import '../services/search_collection_adder.dart';
+import 'media_action_handler.dart';
+
+/// Single-source media handler — no platform picker, no animation branch,
+/// no post-add side effects. Anime, Manga, and VisualNovel all fit this
+/// shape and previously lived as three near-identical copies.
+///
+/// The handler dispatches on item type at the registry level; the [T]
+/// generic carries the concrete model so accessors don't have to repeat
+/// `as` casts.
+class SimpleMediaHandler<T extends Object> implements MediaActionHandler {
+  SimpleMediaHandler({
+    required WidgetRef ref,
+    required SearchCollectionAdder adder,
+    required int? targetCollectionId,
+    required this.mediaType,
+    required this.imageType,
+    required this.collectedProvider,
+    required this.externalIdOf,
+    required this.imageIdOf,
+    required this.titleOf,
+    required this.imageUrlOf,
+    required this.upsert,
+    required this.sheetBuilder,
+  })  : _ref = ref,
+        _adder = adder,
+        _targetCollectionId = targetCollectionId;
+
+  final WidgetRef _ref;
+  final SearchCollectionAdder _adder;
+  final int? _targetCollectionId;
+
+  final MediaType mediaType;
+  final ImageType imageType;
+  final FutureProvider<Map<int, List<CollectedItemInfo>>> collectedProvider;
+
+  final int Function(T item) externalIdOf;
+  final String Function(T item) imageIdOf;
+  final String Function(T item) titleOf;
+  final String? Function(T item) imageUrlOf;
+  final Future<void> Function(T item) upsert;
+  final Widget Function(T item, VoidCallback onAddToCollection) sheetBuilder;
+
+  @override
+  Future<void> onTap(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final T typed = item as T;
+    if (_targetCollectionId != null) {
+      await _addToCollection(context, _targetCollectionId, typed);
+      return;
+    }
+    showDetails(context, typed, mediaType);
+  }
+
+  @override
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final T typed = item as T;
+    final Set<int?> alreadyIn = await _collectedCollectionIds(externalIdOf(typed));
+    if (!context.mounted) return;
+
+    final PickedCollection? picked = await _adder.pickCollection(
+      context: context,
+      alreadyIn: alreadyIn,
+    );
+    if (picked == null || !context.mounted) return;
+
+    await _adder.addToCollection(
+      context: context,
+      collectionId: picked.id,
+      collectionName: picked.name,
+      mediaType: this.mediaType,
+      externalId: externalIdOf(typed),
+      title: titleOf(typed),
+      upsert: () => upsert(typed),
+      imageType: imageType,
+      imageId: imageIdOf(typed),
+      imageUrl: imageUrlOf(typed),
+    );
+  }
+
+  @override
+  void showDetails(BuildContext context, Object item, MediaType mediaType) {
+    final T typed = item as T;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext _) => sheetBuilder(
+        typed,
+        () => addToAnyCollection(context, typed, mediaType),
+      ),
+    );
+  }
+
+  Future<void> _addToCollection(
+    BuildContext context,
+    int collectionId,
+    T typed,
+  ) async {
+    await _adder.addToCollection(
+      context: context,
+      collectionId: collectionId,
+      mediaType: mediaType,
+      externalId: externalIdOf(typed),
+      title: titleOf(typed),
+      upsert: () => upsert(typed),
+      imageType: imageType,
+      imageId: imageIdOf(typed),
+      imageUrl: imageUrlOf(typed),
+    );
+  }
+
+  Future<Set<int?>> _collectedCollectionIds(int id) async {
+    final Map<int, List<CollectedItemInfo>> collected =
+        await _ref.read(collectedProvider.future);
+    return (collected[id] ?? <CollectedItemInfo>[])
+        .map((CollectedItemInfo i) => i.collectionId)
+        .toSet();
+  }
+}

--- a/lib/features/search/handlers/tv_show_handler.dart
+++ b/lib/features/search/handlers/tv_show_handler.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/tmdb_api.dart';
+import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/models/tv_episode.dart';
+import '../../../shared/models/tv_season.dart';
+import '../../../shared/models/tv_show.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../services/search_collection_adder.dart';
+import '../widgets/item_details_sheet.dart';
+import 'media_action_handler.dart';
+
+/// TV show source handler (TMDB).
+///
+/// Handles both [MediaType.tvShow] and [MediaType.animation]
+/// (with `platformId = AnimationSource.tvShow`). On successful add the
+/// seasons/episodes cache is warmed so the detail screen opens without
+/// a network round-trip.
+class TvShowHandler implements MediaActionHandler {
+  const TvShowHandler({
+    required WidgetRef ref,
+    required SearchCollectionAdder adder,
+    required int? targetCollectionId,
+  })  : _ref = ref,
+        _adder = adder,
+        _targetCollectionId = targetCollectionId;
+
+  final WidgetRef _ref;
+  final SearchCollectionAdder _adder;
+  final int? _targetCollectionId;
+
+  @override
+  Future<void> onTap(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final TvShow tvShow = item as TvShow;
+    if (_targetCollectionId != null) {
+      await _addToCollection(context, _targetCollectionId, tvShow, mediaType);
+      return;
+    }
+    showDetails(context, tvShow, mediaType);
+  }
+
+  @override
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    final TvShow tvShow = item as TvShow;
+    final Set<int?> alreadyIn = await _adder.collectedCollectionIdsAcross(
+      tvShow.tmdbId,
+      collectedTvShowIdsProvider,
+      collectedAnimationIdsProvider,
+    );
+    if (!context.mounted) return;
+
+    final PickedCollection? picked = await _adder.pickCollection(
+      context: context,
+      alreadyIn: alreadyIn,
+    );
+    if (picked == null || !context.mounted) return;
+
+    await _adder.addToCollection(
+      context: context,
+      collectionId: picked.id,
+      collectionName: picked.name,
+      mediaType: mediaType,
+      externalId: tvShow.tmdbId,
+      platformId: mediaType == MediaType.animation
+          ? AnimationSource.tvShow
+          : null,
+      title: tvShow.title,
+      upsert: () => _ref.read(databaseServiceProvider).upsertTvShow(tvShow),
+      imageType: ImageType.tvShowPoster,
+      imageId: tvShow.tmdbId.toString(),
+      imageUrl: tvShow.posterUrl,
+      afterAdd: () => _preloadSeasons(tvShow.tmdbId),
+    );
+  }
+
+  @override
+  void showDetails(BuildContext context, Object item, MediaType mediaType) {
+    final TvShow tvShow = item as TvShow;
+    final bool isAnim = mediaType == MediaType.animation;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext _) => ItemDetailsSheet.tvShow(
+        tvShow,
+        isAnimation: isAnim,
+        onAddToCollection: () => addToAnyCollection(context, tvShow, mediaType),
+      ),
+    );
+  }
+
+  Future<void> _addToCollection(
+    BuildContext context,
+    int collectionId,
+    TvShow tvShow,
+    MediaType mediaType,
+  ) async {
+    await _adder.addToCollection(
+      context: context,
+      collectionId: collectionId,
+      mediaType: mediaType,
+      externalId: tvShow.tmdbId,
+      platformId: mediaType == MediaType.animation
+          ? AnimationSource.tvShow
+          : null,
+      title: tvShow.title,
+      upsert: () => _ref.read(databaseServiceProvider).upsertTvShow(tvShow),
+      imageType: ImageType.tvShowPoster,
+      imageId: tvShow.tmdbId.toString(),
+      imageUrl: tvShow.posterUrl,
+      afterAdd: () => _preloadSeasons(tvShow.tmdbId),
+    );
+  }
+
+  Future<void> _preloadSeasons(int tmdbId) async {
+    try {
+      final DatabaseService db = _ref.read(databaseServiceProvider);
+      final TmdbApi tmdb = _ref.read(tmdbApiProvider);
+
+      List<TvSeason> seasons = await db.getTvSeasonsByShowId(tmdbId);
+      if (seasons.isEmpty) {
+        seasons = await tmdb.getTvSeasons(tmdbId);
+        if (seasons.isNotEmpty) await db.upsertTvSeasons(seasons);
+      }
+      for (final TvSeason season in seasons) {
+        final List<TvEpisode> cached =
+            await db.getEpisodesByShowAndSeason(tmdbId, season.seasonNumber);
+        if (cached.isEmpty) {
+          final List<TvEpisode> episodes =
+              await tmdb.getSeasonEpisodes(tmdbId, season.seasonNumber);
+          if (episodes.isNotEmpty) await db.upsertEpisodes(episodes);
+        }
+      }
+    } catch (_) {
+      // Network/API failure — episodes load on-demand later.
+    }
+  }
+}

--- a/lib/features/search/models/search_source.dart
+++ b/lib/features/search/models/search_source.dart
@@ -210,4 +210,10 @@ abstract class SearchSource {
 
   /// Подсказка для поля поиска (локализованная).
   String searchHint(S l);
+
+  /// MediaType присваиваемый карточкам этого источника при добавлении
+  /// в коллекцию. Совпадает с [BrowseResult.mediaType] и не зависит от
+  /// runtime-типа возвращаемых моделей: TMDB anime tab выдаёт `Movie` и
+  /// `TvShow`, но они классифицируются как [MediaType.animation].
+  MediaType get outputMediaType;
 }

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -1,49 +1,33 @@
-// Экран поиска и просмотра контента.
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
-import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/navigation/search_providers.dart';
 import '../../../shared/keyboard/keyboard_shortcuts.dart';
-import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
-import '../../../core/services/image_cache_service.dart';
 import '../../../shared/models/collected_item_info.dart';
-import '../../../shared/models/collection.dart';
 import '../../../shared/models/game.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/movie.dart';
 import '../../../shared/models/platform.dart';
-import '../../../shared/models/tv_episode.dart';
-import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
-import '../../../shared/models/anime.dart';
-import '../../../shared/models/manga.dart';
-import '../../../shared/models/visual_novel.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
-import '../../../shared/widgets/collection_picker_dialog.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../collections/screens/item_detail_screen.dart';
+import '../handlers/media_handlers.dart';
 import '../providers/browse_provider.dart';
 import '../widgets/browse_grid.dart';
 import '../widgets/discover_customize_sheet.dart';
 import '../widgets/discover_feed.dart';
 import '../widgets/filter_bar.dart';
-import '../widgets/item_details_sheet.dart';
 
-/// Экран поиска и просмотра контента.
-///
-/// Два режима:
-/// - Browse: фильтр-бар + Discover feed / Browse grid
-/// - Search: поле поиска + результаты
+/// Search and browse screen — two modes: Browse (filter bar + Discover/Grid)
+/// and Search (query field + results).
 class SearchScreen extends ConsumerStatefulWidget {
-  /// Создаёт [SearchScreen].
   const SearchScreen({
     this.onGameSelected,
     this.collectionId,
@@ -54,29 +38,16 @@ class SearchScreen extends ConsumerStatefulWidget {
     super.key,
   });
 
-  /// Callback при выборе игры (устаревший режим).
   final void Function(Game game)? onGameSelected;
-
-  /// ID коллекции для добавления элементов.
   final int? collectionId;
-
-  /// Начальный индекс таба (legacy, используется для выбора источника).
   final int? initialTabIndex;
-
-  /// ID источника для предвыбора (например 'manga', 'games', 'tv').
   final String? initialSourceId;
-
-  /// Начальный запрос поиска (предзаполняет поле и запускает поиск).
   final String? initialQuery;
 
-  /// Экран открыт через Navigator.push (не через таб).
-  ///
-  /// В этом режиме глобальный [AppTopBar] перекрыт (push на rootNavigator),
-  /// поэтому экран рисует собственный AppBar с полем поиска, привязанным
-  /// к [searchTabQueryProvider].
+  /// When pushed on the root navigator the global [AppTopBar] is hidden,
+  /// so the screen draws its own AppBar bound to [searchTabQueryProvider].
   final bool isPushed;
 
-  /// Группа хоткеев этого экрана для легенды F1.
   static const ShortcutGroup shortcutGroup = ShortcutGroup(
     title: 'Поиск',
     entries: <ShortcutEntry>[
@@ -93,12 +64,18 @@ class SearchScreen extends ConsumerStatefulWidget {
 class _SearchScreenState extends ConsumerState<SearchScreen> {
   Timer? _searchDebounce;
   TextEditingController? _pushedSearchController;
-
   Map<int, Platform> _platformMap = <int, Platform>{};
+  late final MediaHandlers _handlers;
 
   @override
   void initState() {
     super.initState();
+    _handlers = MediaHandlers(
+      ref: ref,
+      platformMap: () => _platformMap,
+      targetCollectionId: widget.collectionId,
+      onGameSelected: widget.onGameSelected,
+    );
     _loadPlatforms();
 
     if (widget.isPushed) {
@@ -107,7 +84,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       _pushedSearchController = TextEditingController(text: initial);
     }
 
-    // Предвыбор источника
     final String? sourceToSet = widget.initialSourceId ??
         (widget.initialTabIndex == 1 ? 'games' : null);
 
@@ -150,9 +126,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     super.dispose();
   }
 
-  // ==================== Search ====================
-
-  /// Синхронизирует текст из провайдера в browse перед сменой фильтра.
   void _syncSearchText() {
     final String text = ref.read(searchTabQueryProvider).trim();
     if (text.length >= 2) {
@@ -160,7 +133,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     }
   }
 
-  /// Debounced поиск при изменении query в top bar.
   void _onQueryChanged(String query) {
     _searchDebounce?.cancel();
     if (query.isEmpty) {
@@ -175,53 +147,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     });
   }
 
-  // ==================== Image caching ====================
-
-  void _cacheImage(ImageType type, String imageId, String? imageUrl) {
-    if (imageUrl == null || imageUrl.isEmpty) return;
-    final ImageCacheService cacheService = ref.read(imageCacheServiceProvider);
-    cacheService.downloadImage(
-      type: type,
-      imageId: imageId,
-      remoteUrl: imageUrl,
-    );
-  }
-
-  Future<void> _preloadSeasonsAsync(int tmdbId) async {
-    if (!mounted) return;
-    try {
-      final DatabaseService db = ref.read(databaseServiceProvider);
-      final TmdbApi tmdb = ref.read(tmdbApiProvider);
-
-      List<TvSeason> seasons = await db.getTvSeasonsByShowId(tmdbId);
-      if (seasons.isEmpty) {
-        seasons = await tmdb.getTvSeasons(tmdbId);
-        if (seasons.isNotEmpty) await db.upsertTvSeasons(seasons);
-      }
-
-      for (final TvSeason season in seasons) {
-        if (!mounted) return;
-        final List<TvEpisode> cached =
-            await db.getEpisodesByShowAndSeason(tmdbId, season.seasonNumber);
-        if (cached.isEmpty) {
-          final List<TvEpisode> episodes =
-              await tmdb.getSeasonEpisodes(tmdbId, season.seasonNumber);
-          if (episodes.isNotEmpty) await db.upsertEpisodes(episodes);
-        }
-      }
-    } catch (_) {
-      // Episode pre-cache failed (network/API error) — not critical,
-      // episodes will be fetched on demand when user opens the show.
-    }
-  }
-
-  // ==================== Open in collection ====================
-
   Future<void> _openItemInCollection(
     int externalId,
     MediaType mediaType,
   ) async {
-    // Получаем List<CollectedItemInfo> для этого элемента
     final List<CollectedItemInfo> infos = await _getCollectedInfos(
       externalId,
       mediaType,
@@ -233,7 +162,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       return;
     }
 
-    // Несколько коллекций — показываем диалог выбора
     if (!mounted) return;
     final CollectedItemInfo? chosen = await showDialog<CollectedItemInfo>(
       context: context,
@@ -312,7 +240,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       case MediaType.anime:
         collected = await ref.read(collectedAnimeIdsProvider.future);
       case MediaType.custom:
-        return <CollectedItemInfo>[]; // Кастомные элементы не ищутся через API
+        return <CollectedItemInfo>[];
     }
     return collected[externalId] ?? <CollectedItemInfo>[];
   }
@@ -329,1030 +257,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     );
   }
 
-  // ==================== Item tap handler ====================
-
   void _onItemTap(Object item, MediaType mediaType) {
-    if (item is Game) {
-      _onGameTap(item);
-    } else if (item is Movie) {
-      _onMovieTap(item, mediaType);
-    } else if (item is TvShow) {
-      _onTvShowTap(item, mediaType);
-    } else if (item is VisualNovel) {
-      _onVisualNovelTap(item);
-    } else if (item is Manga) {
-      _onMangaTap(item);
-    } else if (item is Anime) {
-      _onAnimeTap(item);
-    }
-  }
-
-  // ==================== Game actions ====================
-
-  void _onGameTap(Game game) {
-    if (widget.onGameSelected != null) {
-      widget.onGameSelected!(game);
-    } else if (widget.collectionId != null) {
-      _addGameToCollection(game);
-    } else {
-      _showGameDetails(game);
-    }
-  }
-
-  Future<void> _addGameToCollection(Game game) async {
-    final String gameName = game.name;
-
-    // Показываем какие платформы уже добавлены в текущую коллекцию.
-    final Map<int, List<CollectedItemInfo>> collectedGames =
-        await ref.read(collectedGameIdsProvider.future);
-    final List<CollectedItemInfo> infos =
-        collectedGames[game.id] ?? <CollectedItemInfo>[];
-    final Set<int> alreadyPlatforms = infos
-        .where((CollectedItemInfo i) => i.collectionId == widget.collectionId)
-        .map((CollectedItemInfo i) => i.platformId)
-        .whereType<int>()
-        .toSet();
-
-    final int? platformId = await _showPlatformSelectionDialog(
-      game,
-      alreadyAddedPlatformIds: alreadyPlatforms,
-    );
-    if (platformId == null || !mounted) return;
-
-    await ref.read(databaseServiceProvider).upsertGame(game);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.game,
-          externalId: game.id,
-          platformId: platformId,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(ImageType.gameCover, game.id.toString(), game.coverUrl);
-        context.showSnack(
-          l.searchAddedToCollection(gameName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(gameName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addGameToAnyCollection(Game game) async {
-    final String gameName = game.name;
-
-    // Для игр не блокируем коллекции — та же игра на другой платформе разрешена.
-    // Сохраняем infos для проверки конкретной платформы после выбора.
-    final Map<int, List<CollectedItemInfo>> collectedGames =
-        await ref.read(collectedGameIdsProvider.future);
-    final List<CollectedItemInfo> infos =
-        collectedGames[game.id] ?? <CollectedItemInfo>[];
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      // Не блокируем коллекции — игру можно добавить на другой платформе.
-      alreadyInCollectionIds: const <int?>{},
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    // Показываем какие платформы уже добавлены в выбранную коллекцию.
-    final Set<int> alreadyPlatforms = infos
-        .where((CollectedItemInfo i) => i.collectionId == collectionId)
-        .map((CollectedItemInfo i) => i.platformId)
-        .whereType<int>()
-        .toSet();
-
-    final int? platformId = await _showPlatformSelectionDialog(
-      game,
-      alreadyAddedPlatformIds: alreadyPlatforms,
-    );
-    if (platformId == null || !mounted) return;
-
-    await ref.read(databaseServiceProvider).upsertGame(game);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.game,
-          externalId: game.id,
-          platformId: platformId,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(ImageType.gameCover, game.id.toString(), game.coverUrl);
-        context.showSnack(
-          l.searchAddedToNamed(gameName, collectionName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(gameName, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  // ==================== Movie actions ====================
-
-  void _onMovieTap(Movie movie, MediaType mediaType) {
-    if (widget.collectionId != null) {
-      if (mediaType == MediaType.animation) {
-        _addAnimationMovieToCollection(movie);
-      } else {
-        _addMovieToCollection(movie);
-      }
-    } else {
-      _showMovieDetails(movie, mediaType);
-    }
-  }
-
-  void _showMovieDetails(Movie movie, MediaType mediaType) {
-    final bool isAnim = mediaType == MediaType.animation;
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (BuildContext context) => ItemDetailsSheet.movie(
-        movie,
-        isAnimation: isAnim,
-        onAddToCollection: () => isAnim
-            ? _addAnimationMovieToAnyCollection(movie)
-            : _addMovieToAnyCollection(movie),
-      ),
-    );
-  }
-
-  Future<void> _addMovieToCollection(Movie movie) async {
-    final String title = movie.title;
-
-    await ref.read(databaseServiceProvider).upsertMovie(movie);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.movie,
-          externalId: movie.tmdbId,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.moviePoster,
-          movie.tmdbId.toString(),
-          movie.posterUrl,
-        );
-        context.showSnack(
-          l.searchAddedToCollection(title),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addMovieToAnyCollection(Movie movie) async {
-    final String title = movie.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedMovies =
-        await ref.read(collectedMovieIdsProvider.future);
-    final Map<int, List<CollectedItemInfo>> collectedAnimations =
-        await ref.read(collectedAnimationIdsProvider.future);
-    final List<CollectedItemInfo> infos = <CollectedItemInfo>[
-      ...collectedMovies[movie.tmdbId] ?? <CollectedItemInfo>[],
-      ...collectedAnimations[movie.tmdbId] ?? <CollectedItemInfo>[],
-    ];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertMovie(movie);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.movie,
-          externalId: movie.tmdbId,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.moviePoster,
-          movie.tmdbId.toString(),
-          movie.posterUrl,
-        );
-        context.showSnack(
-          l.searchAddedToNamed(title, collectionName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  // ==================== TV Show actions ====================
-
-  void _onTvShowTap(TvShow tvShow, MediaType mediaType) {
-    if (widget.collectionId != null) {
-      if (mediaType == MediaType.animation) {
-        _addAnimationTvShowToCollection(tvShow);
-      } else {
-        _addTvShowToCollection(tvShow);
-      }
-    } else {
-      _showTvShowDetails(tvShow, mediaType);
-    }
-  }
-
-  void _showTvShowDetails(TvShow tvShow, MediaType mediaType) {
-    final bool isAnim = mediaType == MediaType.animation;
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (BuildContext context) => ItemDetailsSheet.tvShow(
-        tvShow,
-        isAnimation: isAnim,
-        onAddToCollection: () => isAnim
-            ? _addAnimationTvShowToAnyCollection(tvShow)
-            : _addTvShowToAnyCollection(tvShow),
-      ),
-    );
-  }
-
-  Future<void> _addTvShowToCollection(TvShow tvShow) async {
-    final String title = tvShow.title;
-
-    await ref.read(databaseServiceProvider).upsertTvShow(tvShow);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.tvShow,
-          externalId: tvShow.tmdbId,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.tvShowPoster,
-          tvShow.tmdbId.toString(),
-          tvShow.posterUrl,
-        );
-        await _preloadSeasonsAsync(tvShow.tmdbId);
-        if (mounted) {
-          context.showSnack(
-            l.searchAddedToCollection(title),
-            type: SnackType.success,
-          );
-        }
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addTvShowToAnyCollection(TvShow tvShow) async {
-    final String title = tvShow.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedTvShows =
-        await ref.read(collectedTvShowIdsProvider.future);
-    final Map<int, List<CollectedItemInfo>> collectedAnimations =
-        await ref.read(collectedAnimationIdsProvider.future);
-    final List<CollectedItemInfo> infos = <CollectedItemInfo>[
-      ...collectedTvShows[tvShow.tmdbId] ?? <CollectedItemInfo>[],
-      ...collectedAnimations[tvShow.tmdbId] ?? <CollectedItemInfo>[],
-    ];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertTvShow(tvShow);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.tvShow,
-          externalId: tvShow.tmdbId,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.tvShowPoster,
-          tvShow.tmdbId.toString(),
-          tvShow.posterUrl,
-        );
-        await _preloadSeasonsAsync(tvShow.tmdbId);
-        if (mounted) {
-          context.showSnack(
-            l.searchAddedToNamed(title, collectionName),
-            type: SnackType.success,
-          );
-        }
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  // ==================== Animation actions ====================
-
-  Future<void> _addAnimationMovieToCollection(Movie movie) async {
-    final String title = movie.title;
-
-    await ref.read(databaseServiceProvider).upsertMovie(movie);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.animation,
-          externalId: movie.tmdbId,
-          platformId: AnimationSource.movie,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.moviePoster,
-          movie.tmdbId.toString(),
-          movie.posterUrl,
-        );
-        context.showSnack(
-          l.searchAddedToCollection(title),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addAnimationTvShowToCollection(TvShow tvShow) async {
-    final String title = tvShow.title;
-
-    await ref.read(databaseServiceProvider).upsertTvShow(tvShow);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.animation,
-          externalId: tvShow.tmdbId,
-          platformId: AnimationSource.tvShow,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.tvShowPoster,
-          tvShow.tmdbId.toString(),
-          tvShow.posterUrl,
-        );
-        await _preloadSeasonsAsync(tvShow.tmdbId);
-        if (mounted) {
-          context.showSnack(
-            l.searchAddedToCollection(title),
-            type: SnackType.success,
-          );
-        }
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addAnimationMovieToAnyCollection(Movie movie) async {
-    final String title = movie.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedAnimation =
-        await ref.read(collectedAnimationIdsProvider.future);
-    final Map<int, List<CollectedItemInfo>> collectedMovies =
-        await ref.read(collectedMovieIdsProvider.future);
-    final List<CollectedItemInfo> infos = <CollectedItemInfo>[
-      ...collectedAnimation[movie.tmdbId] ?? <CollectedItemInfo>[],
-      ...collectedMovies[movie.tmdbId] ?? <CollectedItemInfo>[],
-    ];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertMovie(movie);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.animation,
-          externalId: movie.tmdbId,
-          platformId: AnimationSource.movie,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.moviePoster,
-          movie.tmdbId.toString(),
-          movie.posterUrl,
-        );
-        context.showSnack(
-          l.searchAddedToNamed(title, collectionName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addAnimationTvShowToAnyCollection(TvShow tvShow) async {
-    final String title = tvShow.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedAnimation =
-        await ref.read(collectedAnimationIdsProvider.future);
-    final Map<int, List<CollectedItemInfo>> collectedTvShows =
-        await ref.read(collectedTvShowIdsProvider.future);
-    final List<CollectedItemInfo> infos = <CollectedItemInfo>[
-      ...collectedAnimation[tvShow.tmdbId] ?? <CollectedItemInfo>[],
-      ...collectedTvShows[tvShow.tmdbId] ?? <CollectedItemInfo>[],
-    ];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertTvShow(tvShow);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.animation,
-          externalId: tvShow.tmdbId,
-          platformId: AnimationSource.tvShow,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.tvShowPoster,
-          tvShow.tmdbId.toString(),
-          tvShow.posterUrl,
-        );
-        await _preloadSeasonsAsync(tvShow.tmdbId);
-        if (mounted) {
-          context.showSnack(
-            l.searchAddedToNamed(title, collectionName),
-            type: SnackType.success,
-          );
-        }
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  // ==================== Shared dialogs ====================
-
-  Future<int?> _showPlatformSelectionDialog(
-    Game game, {
-    Set<int> alreadyAddedPlatformIds = const <int>{},
-  }) async {
-    final List<int>? platformIds = game.platformIds;
-
-    if (platformIds == null || platformIds.isEmpty) {
-      return -1;
-    }
-
-    if (platformIds.length == 1) {
-      return platformIds.first;
-    }
-
-    return showDialog<int>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        scrollable: true,
-        title: Text(S.of(context).searchSelectPlatform),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: platformIds.map((int id) {
-            final Platform? platform = _platformMap[id];
-            final String platformName =
-                platform?.displayName ?? 'Platform $id';
-            final bool alreadyAdded = alreadyAddedPlatformIds.contains(id);
-            return ListTile(
-              leading: Icon(
-                alreadyAdded
-                    ? Icons.check_circle
-                    : Icons.videogame_asset,
-                size: 24,
-                color: alreadyAdded ? AppColors.success : null,
-              ),
-              title: Text(platformName),
-              onTap: () => Navigator.of(context).pop(id),
-            );
-          }).toList(),
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(S.of(context).cancel),
-          ),
-        ],
-      ),
-    );
-  }
-
-
-  // ==================== Detail sheets ====================
-
-  // ==================== Visual Novel actions ====================
-
-  void _onVisualNovelTap(VisualNovel vn) {
-    if (widget.collectionId != null) {
-      _addVisualNovelToCollection(vn);
-    } else {
-      _showVisualNovelDetails(vn);
-    }
-  }
-
-  Future<void> _addVisualNovelToCollection(VisualNovel vn) async {
-    final String title = vn.title;
-
-    await ref.read(databaseServiceProvider).upsertVisualNovel(vn);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.visualNovel,
-          externalId: vn.numericId,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.vnCover,
-          vn.numericId.toString(),
-          vn.imageUrl,
-        );
-        context.showSnack(
-          l.searchAddedToCollection(title),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addVisualNovelToAnyCollection(VisualNovel vn) async {
-    final String title = vn.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedVns =
-        await ref.read(collectedVisualNovelIdsProvider.future);
-    final List<CollectedItemInfo> infos =
-        collectedVns[vn.numericId] ?? <CollectedItemInfo>[];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertVisualNovel(vn);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.visualNovel,
-          externalId: vn.numericId,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.vnCover,
-          vn.numericId.toString(),
-          vn.imageUrl,
-        );
-        context.showSnack(
-          l.searchAddedToNamed(title, collectionName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  void _showVisualNovelDetails(VisualNovel vn) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (BuildContext context) => ItemDetailsSheet.visualNovel(
-        vn,
-        onAddToCollection: () => _addVisualNovelToAnyCollection(vn),
-      ),
-    );
-  }
-
-  // ==================== Manga actions ====================
-
-  void _onMangaTap(Manga manga) {
-    if (widget.collectionId != null) {
-      _addMangaToCollection(manga);
-    } else {
-      _showMangaDetails(manga);
-    }
-  }
-
-  Future<void> _addMangaToCollection(Manga manga) async {
-    final String title = manga.title;
-
-    await ref.read(databaseServiceProvider).upsertManga(manga);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.manga,
-          externalId: manga.id,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.mangaCover,
-          manga.id.toString(),
-          manga.coverUrl,
-        );
-        context.showSnack(
-          l.searchAddedToCollection(title),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addMangaToAnyCollection(Manga manga) async {
-    final String title = manga.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedManga =
-        await ref.read(collectedMangaIdsProvider.future);
-    final List<CollectedItemInfo> infos =
-        collectedManga[manga.id] ?? <CollectedItemInfo>[];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertManga(manga);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.manga,
-          externalId: manga.id,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.mangaCover,
-          manga.id.toString(),
-          manga.coverUrl,
-        );
-        context.showSnack(
-          l.searchAddedToNamed(title, collectionName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  void _showMangaDetails(Manga manga) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (BuildContext context) => ItemDetailsSheet.manga(
-        manga,
-        onAddToCollection: () => _addMangaToAnyCollection(manga),
-      ),
-    );
-  }
-
-  // ==================== Anime actions ====================
-
-  void _onAnimeTap(Anime anime) {
-    if (widget.collectionId != null) {
-      _addAnimeToCollection(anime);
-    } else {
-      _showAnimeDetails(anime);
-    }
-  }
-
-  Future<void> _addAnimeToCollection(Anime anime) async {
-    final String title = anime.title;
-
-    await ref.read(databaseServiceProvider).upsertAnime(anime);
-
-    final bool success = await ref
-        .read(
-            collectionItemsNotifierProvider(widget.collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.anime,
-          externalId: anime.id,
-        );
-
-    if (mounted) {
-      final S l = S.of(context);
-      if (success) {
-        _cacheImage(
-          ImageType.animeCover,
-          anime.id.toString(),
-          anime.coverUrl,
-        );
-        context.showSnack(
-          l.searchAddedToCollection(title),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInCollection(title),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  Future<void> _addAnimeToAnyCollection(Anime anime) async {
-    final String title = anime.title;
-
-    final Map<int, List<CollectedItemInfo>> collectedAnime =
-        await ref.read(collectedAnimeIdsProvider.future);
-    final List<CollectedItemInfo> infos =
-        collectedAnime[anime.id] ?? <CollectedItemInfo>[];
-    final Set<int?> alreadyIn =
-        infos.map((CollectedItemInfo i) => i.collectionId).toSet();
-
-    if (!mounted) return;
-    final S l = S.of(context);
-    final CollectionChoice? choice = await showCollectionPickerDialog(
-      context: context,
-      ref: ref,
-      title: l.searchAddToCollection,
-      alreadyInCollectionIds: alreadyIn,
-    );
-    if (choice == null || !mounted) return;
-
-    final int? collectionId;
-    final String collectionName;
-    switch (choice) {
-      case ChosenCollection(:final Collection collection):
-        collectionId = collection.id;
-        collectionName = collection.name;
-      case WithoutCollection():
-        collectionId = null;
-        collectionName = l.collectionsUncategorized;
-    }
-
-    await ref.read(databaseServiceProvider).upsertAnime(anime);
-
-    final bool success = await ref
-        .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .addItem(
-          mediaType: MediaType.anime,
-          externalId: anime.id,
-        );
-
-    if (mounted) {
-      if (success) {
-        _cacheImage(
-          ImageType.animeCover,
-          anime.id.toString(),
-          anime.coverUrl,
-        );
-        context.showSnack(
-          l.searchAddedToNamed(title, collectionName),
-          type: SnackType.success,
-        );
-      } else {
-        context.showSnack(
-          l.searchAlreadyInNamed(title, collectionName),
-          type: SnackType.info,
-        );
-      }
-    }
-  }
-
-  void _showAnimeDetails(Anime anime) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (BuildContext context) => ItemDetailsSheet.anime(
-        anime,
-        onAddToCollection: () => _addAnimeToAnyCollection(anime),
-      ),
-    );
-  }
-
-  void _showGameDetails(Game game) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      builder: (BuildContext context) => ItemDetailsSheet.game(
-        game,
-        onAddToCollection: () => _addGameToAnyCollection(game),
-      ),
-    );
+    final String sourceId = ref.read(browseProvider).sourceId;
+    _handlers.onTap(context, item, mediaType, sourceId: sourceId);
   }
 
   void _showDiscoverCustomizeSheet() {
@@ -1371,14 +278,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     );
   }
 
-  // ==================== Build ====================
-
   @override
   Widget build(BuildContext context) {
     final BrowseState browseState = ref.watch(browseProvider);
 
-    // Слушаем глобальный поиск — debounced API запрос + синхронизация
-    // локального контроллера в pushed-режиме.
     ref.listen<String>(searchTabQueryProvider, (String? prev, String next) {
       _onQueryChanged(next);
       final TextEditingController? c = _pushedSearchController;
@@ -1397,15 +300,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
           onDiscoverCustomize: _showDiscoverCustomizeSheet,
         ),
         const SizedBox(height: AppSpacing.xs),
-        Expanded(
-          child: _buildContent(browseState),
-        ),
+        Expanded(child: _buildContent(browseState)),
       ],
     );
 
-    if (!widget.isPushed) {
-      return body;
-    }
+    if (!widget.isPushed) return body;
 
     return Scaffold(
       appBar: AppBar(
@@ -1428,27 +327,28 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     );
   }
 
-  // ==================== Content ====================
-
   Widget _buildContent(BrowseState browseState) {
-    // Без активного запроса (ни текста, ни фильтров)
     if (!browseState.hasActiveQuery) {
       final String sourceId = browseState.sourceId;
-
-      // TMDB источники — показываем Discover feed
       if (sourceId == 'movies' || sourceId == 'tv' || sourceId == 'anime') {
+        final MediaType outputMediaType = browseState.source.outputMediaType;
         return DiscoverFeed(
           sourceId: sourceId,
-          onAddMovie: (Movie movie) => _addMovieToAnyCollection(movie),
-          onAddTvShow: (TvShow tvShow) => _addTvShowToAnyCollection(tvShow),
+          onAddMovie: (Movie movie) => _handlers.addToAnyCollection(
+            context,
+            movie,
+            outputMediaType,
+          ),
+          onAddTvShow: (TvShow tvShow) => _handlers.addToAnyCollection(
+            context,
+            tvShow,
+            outputMediaType,
+          ),
         );
       }
-
-      // Другие источники без Discover — пустое состояние
       return _buildEmptyFilterState();
     }
 
-    // Есть запрос (текст и/или фильтры) → показываем грид результатов
     return BrowseGrid(
       onItemTap: _onItemTap,
       onOpenInCollection: _openItemInCollection,
@@ -1456,8 +356,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       platformMap: _platformMap,
     );
   }
-
-  // ==================== Empty states ====================
 
   Widget _buildEmptyFilterState() {
     final S l = S.of(context);
@@ -1485,5 +383,4 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
       ),
     );
   }
-
 }

--- a/lib/features/search/services/search_collection_adder.dart
+++ b/lib/features/search/services/search_collection_adder.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../core/services/image_cache_service.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/collected_item_info.dart';
+import '../../../shared/models/collection.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/widgets/collection_picker_dialog.dart';
+import '../../collections/providers/collections_provider.dart';
+
+/// Result of the collection picker. `id == null` means Uncategorized.
+class PickedCollection {
+  const PickedCollection(this.id, this.name);
+
+  final int? id;
+  final String name;
+}
+
+/// Shared add-to-collection pipeline: upsert model, call `addItem`, cache
+/// image, fire snackbar. Folded out of the per-source duplication that used
+/// to live in `_SearchScreenState`.
+class SearchCollectionAdder {
+  const SearchCollectionAdder(this._ref);
+
+  final WidgetRef _ref;
+
+  /// Adds [externalId] to [collectionId]. When [collectionName] is provided
+  /// the named snack variant is used; [afterAdd] runs only on success
+  /// (e.g. TV season preload).
+  Future<bool> addToCollection({
+    required BuildContext context,
+    required int? collectionId,
+    required MediaType mediaType,
+    required int externalId,
+    int? platformId,
+    required String title,
+    required Future<void> Function() upsert,
+    required ImageType imageType,
+    required String imageId,
+    String? imageUrl,
+    Future<void> Function()? afterAdd,
+    String? collectionName,
+  }) async {
+    await upsert();
+
+    final bool success = await _ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .addItem(
+          mediaType: mediaType,
+          externalId: externalId,
+          platformId: platformId,
+        );
+
+    if (!context.mounted) return success;
+    final S l = S.of(context);
+
+    if (success) {
+      _cacheImage(imageType, imageId, imageUrl);
+      if (afterAdd != null) {
+        await afterAdd();
+        if (!context.mounted) return success;
+      }
+      context.showSnack(
+        collectionName != null
+            ? l.searchAddedToNamed(title, collectionName)
+            : l.searchAddedToCollection(title),
+        type: SnackType.success,
+      );
+    } else {
+      context.showSnack(
+        collectionName != null
+            ? l.searchAlreadyInNamed(title, collectionName)
+            : l.searchAlreadyInCollection(title),
+        type: SnackType.info,
+      );
+    }
+    return success;
+  }
+
+  /// Returns `null` when the user cancels or the context unmounts.
+  Future<PickedCollection?> pickCollection({
+    required BuildContext context,
+    required Set<int?> alreadyIn,
+  }) async {
+    final S l = S.of(context);
+    final CollectionChoice? choice = await showCollectionPickerDialog(
+      context: context,
+      ref: _ref,
+      title: l.searchAddToCollection,
+      alreadyInCollectionIds: alreadyIn,
+    );
+    if (choice == null || !context.mounted) return null;
+    return switch (choice) {
+      ChosenCollection(:final Collection collection) =>
+        PickedCollection(collection.id, collection.name),
+      WithoutCollection() =>
+        PickedCollection(null, l.collectionsUncategorized),
+    };
+  }
+
+  /// Union of collection IDs that already contain [externalId] across two
+  /// collected-items providers — used by Movie/TvShow handlers where the
+  /// same TMDB id may live under regular or animation media type.
+  Future<Set<int?>> collectedCollectionIdsAcross(
+    int externalId,
+    FutureProvider<Map<int, List<CollectedItemInfo>>> a,
+    FutureProvider<Map<int, List<CollectedItemInfo>>> b,
+  ) async {
+    final List<Map<int, List<CollectedItemInfo>>> both = await Future.wait(
+      <Future<Map<int, List<CollectedItemInfo>>>>[
+        _ref.read(a.future),
+        _ref.read(b.future),
+      ],
+    );
+    return <CollectedItemInfo>[
+      ...both[0][externalId] ?? <CollectedItemInfo>[],
+      ...both[1][externalId] ?? <CollectedItemInfo>[],
+    ].map((CollectedItemInfo i) => i.collectionId).toSet();
+  }
+
+  void _cacheImage(ImageType type, String imageId, String? imageUrl) {
+    if (imageUrl == null || imageUrl.isEmpty) return;
+    _ref.read(imageCacheServiceProvider).downloadImage(
+          type: type,
+          imageId: imageId,
+          remoteUrl: imageUrl,
+        );
+  }
+}

--- a/lib/features/search/sources/anilist_anime_source.dart
+++ b/lib/features/search/sources/anilist_anime_source.dart
@@ -23,6 +23,9 @@ class AniListAnimeSource extends SearchSource {
   String get id => 'anilist_anime';
 
   @override
+  MediaType get outputMediaType => MediaType.anime;
+
+  @override
   String get groupId => 'anilist';
 
   @override

--- a/lib/features/search/sources/anilist_manga_source.dart
+++ b/lib/features/search/sources/anilist_manga_source.dart
@@ -23,6 +23,9 @@ class AniListMangaSource extends SearchSource {
   String get id => 'manga';
 
   @override
+  MediaType get outputMediaType => MediaType.manga;
+
+  @override
   String get groupId => 'anilist';
 
   @override

--- a/lib/features/search/sources/igdb_games_source.dart
+++ b/lib/features/search/sources/igdb_games_source.dart
@@ -21,6 +21,9 @@ class IgdbGamesSource extends SearchSource {
   String get id => 'games';
 
   @override
+  MediaType get outputMediaType => MediaType.game;
+
+  @override
   String get groupId => 'igdb';
 
   @override

--- a/lib/features/search/sources/tmdb_anime_source.dart
+++ b/lib/features/search/sources/tmdb_anime_source.dart
@@ -25,6 +25,9 @@ class TmdbAnimeSource extends SearchSource {
   String get id => 'anime';
 
   @override
+  MediaType get outputMediaType => MediaType.animation;
+
+  @override
   String get groupId => 'tmdb';
 
   @override
@@ -296,7 +299,8 @@ class TmdbAnimeSource extends SearchSource {
       animeTv = tvResult.results
           .where(
             (TvShow s) =>
-                s.genres != null && s.genres!.any(isAnimationGenre),
+                s.genres != null &&
+                s.genres!.any((String g) => isAnimationGenre(g, tvGenreMap)),
           )
           .toList();
     }
@@ -306,7 +310,9 @@ class TmdbAnimeSource extends SearchSource {
       animeMovies = movieResult.results
           .where(
             (Movie m) =>
-                m.genres != null && m.genres!.any(isAnimationGenre),
+                m.genres != null &&
+                m.genres!
+                    .any((String g) => isAnimationGenre(g, movieGenreMap)),
           )
           .toList();
     }

--- a/lib/features/search/sources/tmdb_movies_source.dart
+++ b/lib/features/search/sources/tmdb_movies_source.dart
@@ -23,6 +23,9 @@ class TmdbMoviesSource extends SearchSource {
   String get id => 'movies';
 
   @override
+  MediaType get outputMediaType => MediaType.movie;
+
+  @override
   String get groupId => 'tmdb';
 
   @override

--- a/lib/features/search/sources/tmdb_tv_source.dart
+++ b/lib/features/search/sources/tmdb_tv_source.dart
@@ -23,6 +23,9 @@ class TmdbTvSource extends SearchSource {
   String get id => 'tv';
 
   @override
+  MediaType get outputMediaType => MediaType.tvShow;
+
+  @override
   String get groupId => 'tmdb';
 
   @override
@@ -105,7 +108,8 @@ class TmdbTvSource extends SearchSource {
       List<TvShow> filtered = result.results
           .where(
             (TvShow s) =>
-                s.genres == null || !s.genres!.any(isAnimationGenre),
+                s.genres == null ||
+                !s.genres!.any((String g) => isAnimationGenre(g, genreMap)),
           )
           .toList();
 

--- a/lib/features/search/sources/vndb_source.dart
+++ b/lib/features/search/sources/vndb_source.dart
@@ -20,6 +20,9 @@ class VndbSource extends SearchSource {
   String get id => 'visual_novels';
 
   @override
+  MediaType get outputMediaType => MediaType.visualNovel;
+
+  @override
   String get groupId => 'vndb';
 
   @override

--- a/lib/features/search/utils/genre_utils.dart
+++ b/lib/features/search/utils/genre_utils.dart
@@ -1,14 +1,22 @@
-// Утилиты для работы с жанрами в поисковых источниках.
-
 import '../../../shared/models/movie.dart';
 import '../../../shared/models/tv_show.dart';
 import '../models/search_source.dart' show tmdbAnimationGenreId;
 
-/// Проверяет, является ли строка жанра анимацией (TMDB genre ID 16).
-bool isAnimationGenre(String genre) =>
-    genre == '$tmdbAnimationGenreId' || genre == 'Animation';
+/// True if [genre] is the TMDB animation genre. Accepts the raw id ("16"),
+/// English name, and the localized name resolved via [genreMap].
+///
+/// Comparison is case-insensitive: TMDB returns the localized name as it
+/// stored it (e.g. `"мультфильм"` for `ru-RU`), but our local DAO
+/// capitalises the first letter on read — without ignoreCase the two
+/// would diverge and the filter would silently drop every animation row.
+bool isAnimationGenre(String genre, Map<String, String> genreMap) {
+  if (genre == '$tmdbAnimationGenreId') return true;
+  if (genre.toLowerCase() == 'animation') return true;
+  final String? localized = genreMap['$tmdbAnimationGenreId'];
+  return localized != null && genre.toLowerCase() == localized.toLowerCase();
+}
 
-/// Резолвит ID жанров в названия для списка фильмов.
+/// Replace numeric genre ids on each movie with localized names from [genreMap].
 List<Movie> resolveMovieGenres(
   List<Movie> movies,
   Map<String, String> genreMap,
@@ -22,7 +30,7 @@ List<Movie> resolveMovieGenres(
   }).toList();
 }
 
-/// Резолвит ID жанров в названия для списка сериалов.
+/// Replace numeric genre ids on each TV show with localized names from [genreMap].
 List<TvShow> resolveTvGenres(
   List<TvShow> shows,
   Map<String, String> genreMap,

--- a/lib/features/search/widgets/browse_grid.dart
+++ b/lib/features/search/widgets/browse_grid.dart
@@ -19,7 +19,6 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/api_error_display.dart';
 import '../../../shared/widgets/media_poster_card.dart';
-import '../utils/genre_utils.dart' show isAnimationGenre;
 import '../../../shared/widgets/shimmer_loading.dart' show ShimmerPosterCard;
 import '../../../shared/models/collected_item_info.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -268,15 +267,15 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
 
         final Object item = displayItems[index];
         return _buildCard(
-            item, state.source.id, tmdbIds, gameIds, vnIds, mangaIds,
-            animeIds, variant);
+            item, state.source.outputMediaType, tmdbIds, gameIds, vnIds,
+            mangaIds, animeIds, variant);
       },
     );
   }
 
   Widget _buildCard(
     Object item,
-    String sourceId,
+    MediaType mediaType,
     Set<int> tmdbIds,
     Set<int> gameIds,
     Set<int> vnIds,
@@ -284,7 +283,7 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
     Set<int> animeIds,
     CardVariant variant,
   ) {
-    VoidCallback? openCallback(int externalId, MediaType mediaType, bool inCollection) {
+    VoidCallback? openCallback(int externalId, bool inCollection) {
       if (!inCollection || widget.onOpenInCollection == null) return null;
       return () => widget.onOpenInCollection!(externalId, mediaType);
     }
@@ -299,18 +298,14 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         cacheImageId: item.tmdbId.toString(),
         apiRating: item.rating,
         year: item.releaseYear,
-
-        mediaType: MediaType.movie,
+        mediaType: mediaType,
         isInCollection: inColl,
-        onTap: () => widget.onItemTap(item, MediaType.movie),
-        onOpenInCollection: openCallback(item.tmdbId, MediaType.movie, inColl),
+        onTap: () => widget.onItemTap(item, mediaType),
+        onOpenInCollection: openCallback(item.tmdbId, inColl),
       );
     }
 
     if (item is TvShow) {
-      final MediaType type = _isAnimation(item)
-          ? MediaType.animation
-          : MediaType.tvShow;
       final bool inColl = tmdbIds.contains(item.tmdbId);
       return MediaPosterCard(
         variant: variant,
@@ -320,11 +315,10 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         cacheImageId: item.tmdbId.toString(),
         apiRating: item.rating,
         year: item.firstAirYear,
-
-        mediaType: type,
+        mediaType: mediaType,
         isInCollection: inColl,
-        onTap: () => widget.onItemTap(item, type),
-        onOpenInCollection: openCallback(item.tmdbId, type, inColl),
+        onTap: () => widget.onItemTap(item, mediaType),
+        onOpenInCollection: openCallback(item.tmdbId, inColl),
       );
     }
 
@@ -338,12 +332,11 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         cacheImageId: item.id.toString(),
         apiRating: item.rating != null ? item.rating! / 10.0 : null,
         year: item.releaseYear,
-
         platformLabel: _buildPlatformLabel(item.platformIds),
-        mediaType: MediaType.game,
+        mediaType: mediaType,
         isInCollection: inColl,
-        onTap: () => widget.onItemTap(item, MediaType.game),
-        onOpenInCollection: openCallback(item.id, MediaType.game, inColl),
+        onTap: () => widget.onItemTap(item, mediaType),
+        onOpenInCollection: openCallback(item.id, inColl),
       );
     }
 
@@ -357,11 +350,10 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         cacheImageId: item.numericId.toString(),
         apiRating: item.rating10,
         year: item.releaseYear,
-
-        mediaType: MediaType.visualNovel,
+        mediaType: mediaType,
         isInCollection: inColl,
-        onTap: () => widget.onItemTap(item, MediaType.visualNovel),
-        onOpenInCollection: openCallback(item.numericId, MediaType.visualNovel, inColl),
+        onTap: () => widget.onItemTap(item, mediaType),
+        onOpenInCollection: openCallback(item.numericId, inColl),
       );
     }
 
@@ -375,11 +367,10 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         cacheImageId: item.id.toString(),
         apiRating: item.rating10,
         year: item.releaseYear,
-
-        mediaType: MediaType.manga,
+        mediaType: mediaType,
         isInCollection: inColl,
-        onTap: () => widget.onItemTap(item, MediaType.manga),
-        onOpenInCollection: openCallback(item.id, MediaType.manga, inColl),
+        onTap: () => widget.onItemTap(item, mediaType),
+        onOpenInCollection: openCallback(item.id, inColl),
       );
     }
 
@@ -393,11 +384,10 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         cacheImageId: item.id.toString(),
         apiRating: item.rating10,
         year: item.releaseYear,
-
-        mediaType: MediaType.anime,
+        mediaType: mediaType,
         isInCollection: inColl,
-        onTap: () => widget.onItemTap(item, MediaType.anime),
-        onOpenInCollection: openCallback(item.id, MediaType.anime, inColl),
+        onTap: () => widget.onItemTap(item, mediaType),
+        onOpenInCollection: openCallback(item.id, inColl),
       );
     }
 
@@ -427,11 +417,6 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
     if (item is Manga) return item.title;
     if (item is Anime) return item.title;
     return '';
-  }
-
-  bool _isAnimation(TvShow show) {
-    if (show.genres == null) return false;
-    return show.genres!.any(isAnimationGenre);
   }
 
   /// Максимальная ширина карточки на десктопе (как в collection_screen).

--- a/test/features/search/handlers/media_handlers_test.dart
+++ b/test/features/search/handlers/media_handlers_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/handlers/game_handler.dart';
+import 'package:xerabora/features/search/handlers/media_action_handler.dart';
+import 'package:xerabora/features/search/handlers/media_handlers.dart';
+import 'package:xerabora/features/search/handlers/movie_handler.dart';
+import 'package:xerabora/features/search/handlers/simple_media_handler.dart';
+import 'package:xerabora/features/search/handlers/tv_show_handler.dart';
+import 'package:xerabora/shared/models/anime.dart';
+import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/manga.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/platform.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+import 'package:xerabora/shared/models/visual_novel.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+class _RecordingHandler implements MediaActionHandler {
+  final List<String> calls = <String>[];
+
+  @override
+  Future<void> onTap(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    calls.add('onTap');
+  }
+
+  @override
+  Future<void> addToAnyCollection(
+    BuildContext context,
+    Object item,
+    MediaType mediaType,
+  ) async {
+    calls.add('addToAnyCollection');
+  }
+
+  @override
+  void showDetails(BuildContext context, Object item, MediaType mediaType) {
+    calls.add('showDetails');
+  }
+}
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  group('MediaHandlers', () {
+    late MockWidgetRef ref;
+    late MediaHandlers handlers;
+
+    setUp(() {
+      ref = MockWidgetRef();
+      handlers = MediaHandlers(
+        ref: ref,
+        platformMap: () => const <int, Platform>{},
+        targetCollectionId: null,
+      );
+    });
+
+    group('forItem (type-based dispatch)', () {
+      test('returns GameHandler for Game', () {
+        const Game game = Game(id: 1, name: 'g');
+        expect(handlers.forItem(game), isA<GameHandler>());
+      });
+
+      test('returns MovieHandler for Movie', () {
+        const Movie movie = Movie(tmdbId: 1, title: 'm');
+        expect(handlers.forItem(movie), isA<MovieHandler>());
+      });
+
+      test('returns TvShowHandler for TvShow', () {
+        const TvShow tv = TvShow(tmdbId: 1, title: 't');
+        expect(handlers.forItem(tv), isA<TvShowHandler>());
+      });
+
+      test('returns SimpleMediaHandler<VisualNovel> for VisualNovel', () {
+        const VisualNovel vn = VisualNovel(id: 'v1', title: 'v');
+        expect(handlers.forItem(vn), isA<SimpleMediaHandler<VisualNovel>>());
+      });
+
+      test('returns SimpleMediaHandler<Manga> for Manga', () {
+        const Manga manga = Manga(id: 1, title: 'm');
+        expect(handlers.forItem(manga), isA<SimpleMediaHandler<Manga>>());
+      });
+
+      test('returns SimpleMediaHandler<Anime> for Anime', () {
+        const Anime anime = Anime(id: 1, title: 'a');
+        expect(handlers.forItem(anime), isA<SimpleMediaHandler<Anime>>());
+      });
+
+      test('returns null for unknown type', () {
+        expect(handlers.forItem('a string'), isNull);
+      });
+    });
+
+    group('registerForSource override', () {
+      test('source handler takes precedence over type handler', () {
+        final _RecordingHandler override = _RecordingHandler();
+        handlers.registerForSource('rawg', override);
+
+        const Game game = Game(id: 1, name: 'g');
+        expect(handlers.forItem(game, sourceId: 'rawg'), same(override));
+      });
+
+      test('falls back to type handler when sourceId not registered', () {
+        final _RecordingHandler override = _RecordingHandler();
+        handlers.registerForSource('rawg', override);
+
+        const Game game = Game(id: 1, name: 'g');
+        expect(handlers.forItem(game, sourceId: 'igdb'), isA<GameHandler>());
+      });
+
+      test('falls back to type handler when sourceId not provided', () {
+        final _RecordingHandler override = _RecordingHandler();
+        handlers.registerForSource('rawg', override);
+
+        const Game game = Game(id: 1, name: 'g');
+        expect(handlers.forItem(game), isA<GameHandler>());
+      });
+    });
+
+    group('dispatch helpers', () {
+      testWidgets('onTap routes to handler for item type',
+          (WidgetTester tester) async {
+        final _RecordingHandler rec = _RecordingHandler();
+        handlers.registerForSource('s', rec);
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await handlers.onTap(
+          tester.element(find.byType(SizedBox)),
+          const Game(id: 1, name: 'g'),
+          MediaType.game,
+          sourceId: 's',
+        );
+
+        expect(rec.calls, <String>['onTap']);
+      });
+
+      testWidgets('addToAnyCollection routes to handler',
+          (WidgetTester tester) async {
+        final _RecordingHandler rec = _RecordingHandler();
+        handlers.registerForSource('s', rec);
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await handlers.addToAnyCollection(
+          tester.element(find.byType(SizedBox)),
+          const Game(id: 1, name: 'g'),
+          MediaType.game,
+          sourceId: 's',
+        );
+
+        expect(rec.calls, <String>['addToAnyCollection']);
+      });
+
+      testWidgets('onTap no-ops when no handler registered',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await expectLater(
+          handlers.onTap(
+            tester.element(find.byType(SizedBox)),
+            'unknown',
+            MediaType.custom,
+          ),
+          completes,
+        );
+      });
+    });
+  });
+}

--- a/test/features/search/handlers/tmdb_handlers_test.dart
+++ b/test/features/search/handlers/tmdb_handlers_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/services/image_cache_service.dart';
+import 'package:xerabora/features/search/handlers/movie_handler.dart';
+import 'package:xerabora/features/search/handlers/tv_show_handler.dart';
+import 'package:xerabora/features/search/services/search_collection_adder.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+class _MockAdder extends Mock implements SearchCollectionAdder {}
+
+/// Captured args for the most recent `addToCollection` call.
+class _Capture {
+  int? collectionId;
+  String? collectionName;
+  MediaType? mediaType;
+  int? externalId;
+  int? platformId;
+  String? title;
+  ImageType? imageType;
+  String? imageId;
+  String? imageUrl;
+}
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  late _MockAdder adder;
+  late _Capture cap;
+
+  setUp(() {
+    adder = _MockAdder();
+    cap = _Capture();
+    when(() => adder.addToCollection(
+          context: any(named: 'context'),
+          collectionId: any(named: 'collectionId'),
+          mediaType: any(named: 'mediaType'),
+          externalId: any(named: 'externalId'),
+          platformId: any(named: 'platformId'),
+          title: any(named: 'title'),
+          upsert: any(named: 'upsert'),
+          imageType: any(named: 'imageType'),
+          imageId: any(named: 'imageId'),
+          imageUrl: any(named: 'imageUrl'),
+          afterAdd: any(named: 'afterAdd'),
+          collectionName: any(named: 'collectionName'),
+        )).thenAnswer((Invocation inv) async {
+      cap
+        ..collectionId = inv.namedArguments[#collectionId] as int?
+        ..collectionName = inv.namedArguments[#collectionName] as String?
+        ..mediaType = inv.namedArguments[#mediaType] as MediaType?
+        ..externalId = inv.namedArguments[#externalId] as int?
+        ..platformId = inv.namedArguments[#platformId] as int?
+        ..title = inv.namedArguments[#title] as String?
+        ..imageType = inv.namedArguments[#imageType] as ImageType?
+        ..imageId = inv.namedArguments[#imageId] as String?
+        ..imageUrl = inv.namedArguments[#imageUrl] as String?;
+      return true;
+    });
+  });
+
+  group('MovieHandler.onTap with targetCollectionId', () {
+    testWidgets('regular movie → platformId is null',
+        (WidgetTester tester) async {
+      final MovieHandler handler = MovieHandler(
+        ref: MockWidgetRef(),
+        adder: adder,
+        targetCollectionId: 42,
+      );
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await handler.onTap(
+        tester.element(find.byType(SizedBox)),
+        const Movie(tmdbId: 100, title: 'M'),
+        MediaType.movie,
+      );
+
+      expect(cap.collectionId, 42);
+      expect(cap.mediaType, MediaType.movie);
+      expect(cap.externalId, 100);
+      expect(cap.platformId, isNull);
+      expect(cap.imageType, ImageType.moviePoster);
+    });
+
+    testWidgets('animation movie → platformId = AnimationSource.movie',
+        (WidgetTester tester) async {
+      final MovieHandler handler = MovieHandler(
+        ref: MockWidgetRef(),
+        adder: adder,
+        targetCollectionId: 42,
+      );
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await handler.onTap(
+        tester.element(find.byType(SizedBox)),
+        const Movie(tmdbId: 100, title: 'M'),
+        MediaType.animation,
+      );
+
+      expect(cap.mediaType, MediaType.animation);
+      expect(cap.platformId, 0);
+    });
+  });
+
+  group('TvShowHandler.onTap with targetCollectionId', () {
+    testWidgets('regular tv show → platformId is null, afterAdd is set',
+        (WidgetTester tester) async {
+      final TvShowHandler handler = TvShowHandler(
+        ref: MockWidgetRef(),
+        adder: adder,
+        targetCollectionId: 7,
+      );
+      Future<void> Function()? capturedAfterAdd;
+      when(() => adder.addToCollection(
+            context: any(named: 'context'),
+            collectionId: any(named: 'collectionId'),
+            mediaType: any(named: 'mediaType'),
+            externalId: any(named: 'externalId'),
+            platformId: any(named: 'platformId'),
+            title: any(named: 'title'),
+            upsert: any(named: 'upsert'),
+            imageType: any(named: 'imageType'),
+            imageId: any(named: 'imageId'),
+            imageUrl: any(named: 'imageUrl'),
+            afterAdd: any(named: 'afterAdd'),
+            collectionName: any(named: 'collectionName'),
+          )).thenAnswer((Invocation inv) async {
+        capturedAfterAdd =
+            inv.namedArguments[#afterAdd] as Future<void> Function()?;
+        cap
+          ..mediaType = inv.namedArguments[#mediaType] as MediaType?
+          ..platformId = inv.namedArguments[#platformId] as int?
+          ..imageType = inv.namedArguments[#imageType] as ImageType?;
+        return true;
+      });
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await handler.onTap(
+        tester.element(find.byType(SizedBox)),
+        const TvShow(tmdbId: 200, title: 'T'),
+        MediaType.tvShow,
+      );
+
+      expect(cap.mediaType, MediaType.tvShow);
+      expect(cap.platformId, isNull);
+      expect(cap.imageType, ImageType.tvShowPoster);
+      expect(capturedAfterAdd, isNotNull);
+    });
+
+    testWidgets('animation tv → platformId = AnimationSource.tvShow',
+        (WidgetTester tester) async {
+      final TvShowHandler handler = TvShowHandler(
+        ref: MockWidgetRef(),
+        adder: adder,
+        targetCollectionId: 7,
+      );
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      await handler.onTap(
+        tester.element(find.byType(SizedBox)),
+        const TvShow(tmdbId: 200, title: 'T'),
+        MediaType.animation,
+      );
+
+      expect(cap.mediaType, MediaType.animation);
+      expect(cap.platformId, 1);
+    });
+  });
+}

--- a/test/features/search/models/search_source_test.dart
+++ b/test/features/search/models/search_source_test.dart
@@ -250,6 +250,9 @@ class _TestSource extends SearchSource {
   String get id => 'test_source';
 
   @override
+  MediaType get outputMediaType => MediaType.game;
+
+  @override
   String get groupId => 'test';
 
   @override

--- a/test/features/search/sources/source_output_media_type_test.dart
+++ b/test/features/search/sources/source_output_media_type_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/search/sources/anilist_anime_source.dart';
+import 'package:xerabora/features/search/sources/anilist_manga_source.dart';
+import 'package:xerabora/features/search/sources/igdb_games_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_anime_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_movies_source.dart';
+import 'package:xerabora/features/search/sources/tmdb_tv_source.dart';
+import 'package:xerabora/features/search/sources/vndb_source.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+void main() {
+  group('SearchSource.outputMediaType', () {
+    test('TmdbMoviesSource → MediaType.movie', () {
+      expect(TmdbMoviesSource().outputMediaType, MediaType.movie);
+    });
+
+    test('TmdbTvSource → MediaType.tvShow', () {
+      expect(TmdbTvSource().outputMediaType, MediaType.tvShow);
+    });
+
+    test('TmdbAnimeSource → MediaType.animation', () {
+      expect(TmdbAnimeSource().outputMediaType, MediaType.animation);
+    });
+
+    test('IgdbGamesSource → MediaType.game', () {
+      expect(IgdbGamesSource().outputMediaType, MediaType.game);
+    });
+
+    test('AniListAnimeSource → MediaType.anime', () {
+      expect(AniListAnimeSource().outputMediaType, MediaType.anime);
+    });
+
+    test('AniListMangaSource → MediaType.manga', () {
+      expect(AniListMangaSource().outputMediaType, MediaType.manga);
+    });
+
+    test('VndbSource → MediaType.visualNovel', () {
+      expect(VndbSource().outputMediaType, MediaType.visualNovel);
+    });
+  });
+}

--- a/test/features/search/utils/genre_utils_test.dart
+++ b/test/features/search/utils/genre_utils_test.dart
@@ -5,28 +5,56 @@ import 'package:xerabora/shared/models/tv_show.dart';
 
 void main() {
   group('isAnimationGenre', () {
+    const Map<String, String> empty = <String, String>{};
+    const Map<String, String> ru = <String, String>{'16': 'Мультфильм'};
+
     test('returns true for genre ID "16"', () {
-      expect(isAnimationGenre('16'), isTrue);
+      expect(isAnimationGenre('16', empty), isTrue);
     });
 
     test('returns true for genre name "Animation"', () {
-      expect(isAnimationGenre('Animation'), isTrue);
+      expect(isAnimationGenre('Animation', empty), isTrue);
+    });
+
+    test('returns true for the localized name from the genre map', () {
+      expect(isAnimationGenre('Мультфильм', ru), isTrue);
+    });
+
+    // The local DAO capitalises stored names on read, while TMDB API
+    // returns them as-stored (lowercase for `ru-RU`). The filter must
+    // match across that case mismatch or every animation row gets dropped.
+    test('matches case-insensitively against the localized name', () {
+      expect(isAnimationGenre('мультфильм', ru), isTrue);
+      expect(isAnimationGenre('МУЛЬТФИЛЬМ', ru), isTrue);
+    });
+
+    test('matches English name case-insensitively', () {
+      expect(isAnimationGenre('animation', empty), isTrue);
+      expect(isAnimationGenre('ANIMATION', empty), isTrue);
+    });
+
+    test('still accepts English name even when localized map provided', () {
+      expect(isAnimationGenre('Animation', ru), isTrue);
     });
 
     test('returns false for other genre ID', () {
-      expect(isAnimationGenre('28'), isFalse);
+      expect(isAnimationGenre('28', empty), isFalse);
     });
 
     test('returns false for other genre name', () {
-      expect(isAnimationGenre('Action'), isFalse);
+      expect(isAnimationGenre('Action', empty), isFalse);
+    });
+
+    test('returns false for the localized name without the genre map', () {
+      expect(isAnimationGenre('Мультфильм', empty), isFalse);
     });
 
     test('returns false for empty string', () {
-      expect(isAnimationGenre(''), isFalse);
+      expect(isAnimationGenre('', empty), isFalse);
     });
 
     test('returns false for partial match "16-something"', () {
-      expect(isAnimationGenre('16-something'), isFalse);
+      expect(isAnimationGenre('16-something', empty), isFalse);
     });
   });
 

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
 import 'package:xerabora/shared/models/anime.dart';
 import 'package:xerabora/shared/models/canvas_viewport.dart';
 import 'package:xerabora/shared/models/collection.dart';
@@ -71,4 +72,7 @@ void registerAllFallbacks() {
   registerFallbackValue(Uint8List(0));
   registerFallbackValue(DateTime(2024));
   registerFallbackValue(Options());
+  registerFallbackValue(_FakeBuildContext());
 }
+
+class _FakeBuildContext extends Fake implements BuildContext {}


### PR DESCRIPTION
* extract MediaHandlers registry with per-source handlers; collapse Anime/Manga/VisualNovel into one SimpleMediaHandler<T>
* SearchSource declares outputMediaType; browse_grid + DiscoverFeed use it instead of hardcoded MediaType per item / per callback
* isAnimationGenre takes a genreMap and matches case-insensitively, fixing the ru-RU mismatch where the DAO returned "Мультфильм" while the TMDB API returned "мультфильм" — Avatar: TLA was missing from the Animation tab and leaking into TV shows
* 7 new tests pinning the outputMediaType contract per source, plus Movie/TvShow animation-platformId tests and locale-aware genre tests