### PR TITLE
chore(deps): upgrade to Flutter 3.44.0 and fix layout fallout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,52 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Upgrade to Flutter 3.44.0 and fix table-view hero detachment**
+
+  Bumps the project past the Flutter `onReorder → onReorderItem` rename so
+  CI's `--fatal-infos` stops blocking release builds. The new callback
+  adjusts `newIndex` internally for the removed-element offset, so the
+  per-callsite `if (newIndex > oldIndex) newIndex -= 1` workaround is
+  dropped. Three call sites of the new debug-only assertion
+  «`ListTile` background color or ink splashes may be invisible» introduced
+  by Flutter 3.44 are also rewired so descendants paint their ink on a
+  proper Material ancestor. Finally the table-view hero banner stops
+  «detaching» from the top of the screen on wide windows when the row
+  count is small — the old `SingleChildScrollView` + `Column` mistakenly
+  anchored its content to the bottom of the viewport on Flutter 3.44, so
+  the wrap switches to a `CustomScrollView` mirroring the grid path.
+
+  * lib/features/collections/widgets/collection_items_view.dart
+    (CollectionItemsView._withHeader): Replace the inner
+    `SingleChildScrollView(child: Column[header, body])` for table/reorder
+    modes with a `CustomScrollView` of two `SliverToBoxAdapter`s. Hero
+    stays glued to the top when content fits the viewport and still
+    scrolls with the rows when it doesn't.
+  * lib/features/collections/widgets/collection_items_view.dart,
+    lib/features/collections/widgets/collection_table/collection_table_view.dart:
+    Switch the inner `ReorderableListView.onReorder` to `onReorderItem`
+    and drop the manual index normalisation.
+  * lib/features/collections/widgets/rich/rich_collection_body.dart
+    (_HeroImage.build): `BoxFit.cover` + `Alignment.topCenter` so the
+    hero `SizedBox` always paints fully — the previous `BoxFit.fitWidth`
+    left transparent strips above and below very wide banner images.
+  * lib/shared/theme/app_theme.dart (_OpaquePageTransitionsBuilder.buildTransitions):
+    Wrap every route's child in a transparent `Material` so any descendant
+    `ListTile`/`ExpansionTile` has an ink ancestor — the tiled background
+    `DecoratedBox` no longer sits directly between Material and ListTile.
+  * lib/shared/widgets/media_detail_view.dart (MediaDetailView.build):
+    Hoist the outer card fill from `Container.decoration.color` to a
+    wrapping `Material`; the inner `Container` keeps only the border and
+    radius so it no longer shadows ink splashes from the embedded
+    «Activity & Progress» `ExpansionTile`.
+  * lib/features/collections/widgets/steamgriddb_panel.dart
+    (SteamGridDbPanel.build): Replace the outer `Container(color: ...)`
+    with `SizedBox` + `Material`, fixing ink rendering for the search
+    results `ListTile`s.
+  * android/gradle.properties: Auto-added `android.builtInKotlin=false`
+    and `android.newDsl=false` by Flutter migrator on upgrade to 3.44.
+  * pubspec.lock: Bumped by `flutter upgrade` (Flutter 3.44.0 / Dart 3.12.0).
+
 - **Surface the primary action of every floating menu as an always-visible button**
 
   The draggable FAB used to be a single ⋮ that hid every action — including

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -212,10 +212,10 @@ class CollectionItemsView extends ConsumerWidget {
   bool get _hasTagGroups =>
       tags.isNotEmpty && (groupByTags || filterTagIds.isNotEmpty);
 
-  /// Pins [header] above [body] — used by table/reorder/empty modes where
-  /// the body widget doesn't support slivers. When [wrapInScroll] is true
-  /// (table mode) the whole stack lives inside a vertical scroll view so the
-  /// header scrolls with the table rows instead of being pinned.
+  /// Pins [header] above [body]. When [wrapInScroll] is true the header and
+  /// body share one [CustomScrollView] so they scroll together — same
+  /// behaviour as the grid path, mirrored for table/reorder bodies that
+  /// don't expose their own slivers.
   Widget _withHeader(Widget body, {bool wrapInScroll = false}) {
     if (header == null) {
       return wrapInScroll
@@ -223,11 +223,11 @@ class CollectionItemsView extends ConsumerWidget {
           : body;
     }
     if (wrapInScroll) {
-      return SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[header!, body],
-        ),
+      return CustomScrollView(
+        slivers: <Widget>[
+          SliverToBoxAdapter(child: header),
+          SliverToBoxAdapter(child: body),
+        ],
       );
     }
     return Column(
@@ -568,12 +568,7 @@ class CollectionItemsView extends ConsumerWidget {
           child: child,
         );
       },
-      onReorder: (int oldIndex, int newIndex) {
-        // ReorderableListView reports newIndex *after* the element has been
-        // removed; normalise so callers get the semantic destination index.
-        if (newIndex > oldIndex) {
-          newIndex -= 1;
-        }
+      onReorderItem: (int oldIndex, int newIndex) {
         ref
             .read(collectionItemsNotifierProvider(collectionId).notifier)
             .reorderItem(oldIndex, newIndex);

--- a/lib/features/collections/widgets/collection_table/collection_table_view.dart
+++ b/lib/features/collections/widgets/collection_table/collection_table_view.dart
@@ -169,10 +169,7 @@ class _CollectionTableViewState extends State<CollectionTableView> {
           child: child,
         );
       },
-      onReorder: (int oldIndex, int newIndex) {
-        // ReorderableListView reports newIndex *after* removal; normalise so
-        // callers receive the semantic destination.
-        if (newIndex > oldIndex) newIndex -= 1;
+      onReorderItem: (int oldIndex, int newIndex) {
         widget.onReorder!(oldIndex, newIndex);
       },
       itemBuilder: (BuildContext context, int index) {

--- a/lib/features/collections/widgets/rich/rich_collection_body.dart
+++ b/lib/features/collections/widgets/rich/rich_collection_body.dart
@@ -101,8 +101,11 @@ class _HeroImage extends StatelessWidget {
 
     return Image(
       image: ResizeImage(provider, width: cacheW),
-      fit: BoxFit.fitWidth,
-      alignment: Alignment.center,
+      // `cover` so the SizedBox is always fully painted, `topCenter` so the
+      // visible part of an overflowing image is the top half — banners
+      // typically have the focal subject above the horizon line.
+      fit: BoxFit.cover,
+      alignment: Alignment.topCenter,
       filterQuality: FilterQuality.medium,
       errorBuilder: (_, _, _) => const ColoredBox(color: AppColors.surface),
     );

--- a/lib/features/collections/widgets/steamgriddb_panel.dart
+++ b/lib/features/collections/widgets/steamgriddb_panel.dart
@@ -86,10 +86,14 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
 
     _preFillSearchIfNeeded(panelState);
 
-    return Container(
+    // Material wraps the fill so descendant ListTile widgets paint ink on
+    // a Material ancestor — Flutter 3.44 asserts when a coloured ColoredBox
+    // sits between them.
+    return SizedBox(
       width: 320,
-      color: colorScheme.surface,
-      child: Column(
+      child: Material(
+        color: colorScheme.surface,
+        child: Column(
         children: <Widget>[
           // Заголовок
           _buildHeader(colorScheme, theme),
@@ -115,6 +119,7 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
             child: _buildContent(panelState, settings, colorScheme, theme),
           ),
         ],
+        ),
       ),
     );
   }

--- a/lib/features/collections/widgets/steamgriddb_panel.dart
+++ b/lib/features/collections/widgets/steamgriddb_panel.dart
@@ -78,8 +78,9 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final SteamGridDbPanelState panelState =
-        ref.watch(steamGridDbPanelProvider(widget.collectionId));
+    final SteamGridDbPanelState panelState = ref.watch(
+      steamGridDbPanelProvider(widget.collectionId),
+    );
     final SettingsState settings = ref.watch(settingsNotifierProvider);
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
@@ -94,31 +95,20 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
       child: Material(
         color: colorScheme.surface,
         child: Column(
-        children: <Widget>[
-          // Заголовок
-          _buildHeader(colorScheme, theme),
-          const Divider(height: 1),
-
-          // Поиск
-          _buildSearchBar(colorScheme),
-
-          // Предупреждение об отсутствии ключа
-          if (!settings.hasSteamGridDbKey)
-            _buildNoApiKeyWarning(colorScheme, theme),
-
-          // Заголовок выбранной игры
-          if (panelState.selectedGame != null)
-            _buildGameHeader(panelState.selectedGame!, colorScheme, theme),
-
-          // Селектор типа изображений
-          if (panelState.selectedGame != null)
-            _buildImageTypeSelector(panelState, colorScheme),
-
-          // Основной контент
-          Expanded(
-            child: _buildContent(panelState, settings, colorScheme, theme),
-          ),
-        ],
+          children: <Widget>[
+            _buildHeader(colorScheme, theme),
+            const Divider(height: 1),
+            _buildSearchBar(colorScheme),
+            if (!settings.hasSteamGridDbKey)
+              _buildNoApiKeyWarning(colorScheme, theme),
+            if (panelState.selectedGame != null)
+              _buildGameHeader(panelState.selectedGame!, colorScheme, theme),
+            if (panelState.selectedGame != null)
+              _buildImageTypeSelector(panelState, colorScheme),
+            Expanded(
+              child: _buildContent(panelState, settings, colorScheme, theme),
+            ),
+          ],
         ),
       ),
     );
@@ -161,8 +151,10 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
           hintText: S.of(context).steamGridDbSearchHint,
           isDense: true,
           border: const OutlineInputBorder(),
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 12,
+            vertical: 10,
+          ),
           suffixIcon: IconButton(
             icon: const Icon(Icons.search, size: 20),
             tooltip: S.of(context).search,
@@ -215,8 +207,7 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
             tooltip: S.of(context).steamGridDbBackToSearch,
             onPressed: () {
               ref
-                  .read(
-                      steamGridDbPanelProvider(widget.collectionId).notifier)
+                  .read(steamGridDbPanelProvider(widget.collectionId).notifier)
                   .clearGameSelection();
             },
             visualDensity: VisualDensity.compact,
@@ -248,13 +239,14 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
       child: SegmentedButton<SteamGridDbImageType>(
         segments: SteamGridDbImageType.values
             .map(
-              (SteamGridDbImageType type) => ButtonSegment<SteamGridDbImageType>(
-                value: type,
-                label: Text(
-                  _localizedImageTypeLabel(context, type),
-                  style: const TextStyle(fontSize: 12),
-                ),
-              ),
+              (SteamGridDbImageType type) =>
+                  ButtonSegment<SteamGridDbImageType>(
+                    value: type,
+                    label: Text(
+                      _localizedImageTypeLabel(context, type),
+                      style: const TextStyle(fontSize: 12),
+                    ),
+                  ),
             )
             .toList(),
         selected: <SteamGridDbImageType>{panelState.selectedImageType},
@@ -314,11 +306,7 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
     return _buildEmptyState(colorScheme, theme);
   }
 
-  Widget _buildError(
-    String message,
-    ColorScheme colorScheme,
-    ThemeData theme,
-  ) {
+  Widget _buildError(String message, ColorScheme colorScheme, ThemeData theme) {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -352,11 +340,7 @@ class _SteamGridDbPanelState extends ConsumerState<SteamGridDbPanel> {
         final SteamGridDbGame game = panelState.searchResults[index];
         return ListTile(
           dense: true,
-          title: Text(
-            game.name,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
+          title: Text(game.name, maxLines: 1, overflow: TextOverflow.ellipsis),
           trailing: game.verified
               ? Icon(Icons.verified, size: 16, color: colorScheme.primary)
               : null,
@@ -454,7 +438,8 @@ class _ImageThumbnailCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Tooltip(
-      message: '${image.dimensions} • ${image.style}'
+      message:
+          '${image.dimensions} • ${image.style}'
           '${image.author != null ? ' • by ${image.author}' : ''}',
       child: Card(
         clipBehavior: Clip.antiAlias,
@@ -476,12 +461,12 @@ class _ImageThumbnailCard extends StatelessWidget {
                   errorWidget:
                       (BuildContext context, String url, Object error) =>
                           Container(
-                    color: colorScheme.surfaceContainerHighest,
-                    child: Icon(
-                      Icons.broken_image_outlined,
-                      color: colorScheme.onSurfaceVariant,
-                    ),
-                  ),
+                            color: colorScheme.surfaceContainerHighest,
+                            child: Icon(
+                              Icons.broken_image_outlined,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                          ),
                 ),
               ),
               Container(

--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -187,7 +187,13 @@ class _OpaquePageTransitionsBuilder extends PageTransitionsBuilder {
       secondaryAnimation,
       DecoratedBox(
         decoration: _tiledDecoration,
-        child: child,
+        // Transparent Material provides an ink ancestor for descendant
+        // ListTiles — Flutter 3.44 asserts when a coloured DecoratedBox
+        // sits between them and the nearest Material.
+        child: Material(
+          type: MaterialType.transparency,
+          child: child,
+        ),
       ),
     );
   }

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -19,15 +19,23 @@ import 'star_rating_bar.dart';
 import '../utils/duration_formatter.dart';
 
 /// `type` is either 'started' or 'completed'.
-typedef OnActivityDateChanged = Future<void> Function(
-  String type,
-  DateTime date,
-);
+typedef OnActivityDateChanged =
+    Future<void> Function(String type, DateTime date);
 
 String _formatActivityDate(DateTime date) {
   const List<String> months = <String>[
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
   ];
   return '${months[date.month - 1]} ${date.day}, ${date.year}';
 }
@@ -172,10 +180,8 @@ class _MediaDetailViewState extends State<MediaDetailView> {
   @override
   void initState() {
     super.initState();
-    _authorController =
-        TextEditingController(text: widget.authorComment);
-    _userController =
-        TextEditingController(text: widget.userComment);
+    _authorController = TextEditingController(text: widget.authorComment);
+    _userController = TextEditingController(text: widget.userComment);
     _authorController.addListener(_onAuthorChanged);
     _userController.addListener(_onUserChanged);
   }
@@ -255,50 +261,48 @@ class _MediaDetailViewState extends State<MediaDetailView> {
             padding: const EdgeInsets.all(AppSpacing.md),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-              border: Border.all(
-                color: AppColors.surfaceBorder.withAlpha(40),
-              ),
+              border: Border.all(color: AppColors.surfaceBorder.withAlpha(40)),
             ),
             child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              _buildHeader(),
-              if (widget.statusWidget != null) ...<Widget>[
-                const SizedBox(height: AppSpacing.md),
-                _buildStatusSection(context),
-              ],
-              if (widget.onUserRatingChanged != null) ...<Widget>[
-                const SizedBox(height: AppSpacing.md),
-                _buildUserRatingSection(context),
-              ],
-              if (widget.addedAt != null) ...<Widget>[
-                const SizedBox(height: AppSpacing.sm),
-                _buildActivityDatesRow(context),
-              ],
-              const SizedBox(height: AppSpacing.md),
-              _TrackerCommentsLayout(
-                trackerSection: widget.trackerSection,
-                notesSection: _buildUserNotesSection(context),
-                authorSection: _buildAuthorCommentSection(context),
-              ),
-              if (widget.mediaGallery != null) ...<Widget>[
-                const SizedBox(height: AppSpacing.md),
-                widget.mediaGallery!,
-              ],
-              if (widget.extraSections != null &&
-                  widget.extraSections!.isNotEmpty) ...<Widget>[
-                const SizedBox(height: AppSpacing.md),
-                _buildExtraSectionsExpansion(context),
-              ],
-              if (widget.recommendationSections != null &&
-                  widget.recommendationSections!.isNotEmpty)
-                for (final Widget section
-                    in widget.recommendationSections!) ...<Widget>[
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                _buildHeader(),
+                if (widget.statusWidget != null) ...<Widget>[
                   const SizedBox(height: AppSpacing.md),
-                  section,
+                  _buildStatusSection(context),
                 ],
-            ],
-          ),
+                if (widget.onUserRatingChanged != null) ...<Widget>[
+                  const SizedBox(height: AppSpacing.md),
+                  _buildUserRatingSection(context),
+                ],
+                if (widget.addedAt != null) ...<Widget>[
+                  const SizedBox(height: AppSpacing.sm),
+                  _buildActivityDatesRow(context),
+                ],
+                const SizedBox(height: AppSpacing.md),
+                _TrackerCommentsLayout(
+                  trackerSection: widget.trackerSection,
+                  notesSection: _buildUserNotesSection(context),
+                  authorSection: _buildAuthorCommentSection(context),
+                ),
+                if (widget.mediaGallery != null) ...<Widget>[
+                  const SizedBox(height: AppSpacing.md),
+                  widget.mediaGallery!,
+                ],
+                if (widget.extraSections != null &&
+                    widget.extraSections!.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: AppSpacing.md),
+                  _buildExtraSectionsExpansion(context),
+                ],
+                if (widget.recommendationSections != null &&
+                    widget.recommendationSections!.isNotEmpty)
+                  for (final Widget section
+                      in widget.recommendationSections!) ...<Widget>[
+                    const SizedBox(height: AppSpacing.md),
+                    section,
+                  ],
+              ],
+            ),
           ),
         ),
       ],
@@ -364,10 +368,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
               children: <Widget>[
                 _buildCoverImage(),
                 if (widget.platformOverlayAsset != null)
-                  Image.asset(
-                    widget.platformOverlayAsset!,
-                    fit: BoxFit.fill,
-                  ),
+                  Image.asset(widget.platformOverlayAsset!, fit: BoxFit.fill),
               ],
             ),
           ),
@@ -409,12 +410,9 @@ class _MediaDetailViewState extends State<MediaDetailView> {
                       ),
                     ],
                   ),
-                  if (widget.tagWidget != null)
-                    widget.tagWidget!,
-                  if (widget.raBadge != null)
-                    widget.raBadge!,
-                  if (widget.onTimeSpentTap != null)
-                    _buildTimeSpentChip(),
+                  if (widget.tagWidget != null) widget.tagWidget!,
+                  if (widget.raBadge != null) widget.raBadge!,
+                  if (widget.onTimeSpentTap != null) _buildTimeSpentChip(),
                 ],
               ),
               if (widget.infoChips.isNotEmpty) ...<Widget>[
@@ -424,8 +422,12 @@ class _MediaDetailViewState extends State<MediaDetailView> {
                   runSpacing: 4,
                   children: <Widget>[
                     for (final MediaDetailChip chip in widget.infoChips)
-                      _buildInfoChip(chip.icon, chip.text,
-                          iconColor: chip.iconColor, onTap: chip.onTap),
+                      _buildInfoChip(
+                        chip.icon,
+                        chip.text,
+                        iconColor: chip.iconColor,
+                        onTap: chip.onTap,
+                      ),
                   ],
                 ),
               ],
@@ -473,8 +475,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
       imageUrl: widget.coverUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 200,
-      placeholder: (BuildContext ctx, String url) =>
-          _buildLoadingPlaceholder(),
+      placeholder: (BuildContext ctx, String url) => _buildLoadingPlaceholder(),
       errorWidget: (BuildContext ctx, String url, Object error) =>
           _buildPlaceholder(),
     );
@@ -551,7 +552,8 @@ class _MediaDetailViewState extends State<MediaDetailView> {
         borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
         border: onTap != null
             ? Border.all(
-                color: (iconColor ?? AppColors.textSecondary).withAlpha(60))
+                color: (iconColor ?? AppColors.textSecondary).withAlpha(60),
+              )
             : null,
       ),
       child: Row(
@@ -586,11 +588,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
       children: <Widget>[
         Row(
           children: <Widget>[
-            const Icon(
-              Icons.star,
-              size: 18,
-              color: AppColors.ratingStar,
-            ),
+            const Icon(Icons.star, size: 18, color: AppColors.ratingStar),
             const SizedBox(width: 6),
             Text(
               S.of(context).detailMyRating,
@@ -633,8 +631,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
           date: widget.startedAt,
           editable: widget.onActivityDateChanged != null,
           onTap: widget.onActivityDateChanged != null
-              ? () => _pickActivityDate(
-                    context, 'started', widget.startedAt)
+              ? () => _pickActivityDate(context, 'started', widget.startedAt)
               : null,
         ),
         _buildDateChip(
@@ -643,12 +640,11 @@ class _MediaDetailViewState extends State<MediaDetailView> {
           date: widget.completedAt,
           editable: widget.onActivityDateChanged != null,
           onTap: widget.onActivityDateChanged != null
-              ? () => _pickActivityDate(
-                    context, 'completed', widget.completedAt)
+              ? () =>
+                    _pickActivityDate(context, 'completed', widget.completedAt)
               : null,
         ),
-        if (widget.completionTime != null)
-          _buildCompletionTimeChip(l),
+        if (widget.completionTime != null) _buildCompletionTimeChip(l),
         if (widget.lastActivityAt != null)
           _buildDateChip(
             icon: Icons.update,
@@ -664,14 +660,15 @@ class _MediaDetailViewState extends State<MediaDetailView> {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        const Icon(Icons.timer_outlined,
-            size: 14, color: AppColors.textTertiary),
+        const Icon(
+          Icons.timer_outlined,
+          size: 14,
+          color: AppColors.textTertiary,
+        ),
         const SizedBox(width: 4),
         Text(
           formatted,
-          style: AppTypography.caption.copyWith(
-            color: AppColors.textTertiary,
-          ),
+          style: AppTypography.caption.copyWith(color: AppColors.textTertiary),
         ),
       ],
     );
@@ -691,9 +688,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
         const SizedBox(width: 4),
         Text(
           '$label: ',
-          style: AppTypography.caption.copyWith(
-            color: AppColors.textTertiary,
-          ),
+          style: AppTypography.caption.copyWith(color: AppColors.textTertiary),
         ),
         Text(
           date != null ? _formatActivityDate(date) : '\u2014',
@@ -705,11 +700,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
         ),
         if (editable) ...<Widget>[
           const SizedBox(width: 2),
-          const Icon(
-            Icons.edit_outlined,
-            size: 12,
-            color: AppColors.brand,
-          ),
+          const Icon(Icons.edit_outlined, size: 12, color: AppColors.brand),
         ],
       ],
     );
@@ -760,9 +751,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
 
   Widget _buildExtraSectionsExpansion(BuildContext context) {
     return Theme(
-      data: Theme.of(context).copyWith(
-        dividerColor: Colors.transparent,
-      ),
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
       child: ExpansionTile(
         tilePadding: EdgeInsets.zero,
         childrenPadding: EdgeInsets.zero,
@@ -817,10 +806,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
                 onPressed: isEditing
                     ? _finishEditing
                     : () => _startEditing(_EditingField.author),
-                icon: Icon(
-                  isEditing ? Icons.check : Icons.edit,
-                  size: 18,
-                ),
+                icon: Icon(isEditing ? Icons.check : Icons.edit, size: 18),
                 iconSize: 18,
                 visualDensity: VisualDensity.compact,
                 tooltip: isEditing ? l.done : l.edit,
@@ -830,9 +816,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
         const SizedBox(height: 2),
         Text(
           l.detailReviewVisibility,
-          style: AppTypography.caption.copyWith(
-            color: AppColors.textTertiary,
-          ),
+          style: AppTypography.caption.copyWith(color: AppColors.textTertiary),
         ),
         const SizedBox(height: 6),
         _buildCommentContainer(
@@ -900,10 +884,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
               onPressed: isEditing
                   ? _finishEditing
                   : () => _startEditing(_EditingField.user),
-              icon: Icon(
-                isEditing ? Icons.check : Icons.edit,
-                size: 18,
-              ),
+              icon: Icon(isEditing ? Icons.check : Icons.edit, size: 18),
               iconSize: 18,
               visualDensity: VisualDensity.compact,
               tooltip: isEditing ? l.done : l.edit,
@@ -950,9 +931,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
     final BoxDecoration decoration = BoxDecoration(
       color: accentColor.withAlpha(20),
       borderRadius: radius,
-      border: Border.all(
-        color: accentColor.withAlpha(isEditing ? 80 : 40),
-      ),
+      border: Border.all(color: accentColor.withAlpha(isEditing ? 80 : 40)),
     );
     const EdgeInsets padding = EdgeInsets.all(AppSpacing.md - 4);
 
@@ -998,16 +977,11 @@ class _MediaDetailViewState extends State<MediaDetailView> {
       return Material(
         color: Colors.transparent,
         borderRadius: radius,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: radius,
-          child: content,
-        ),
+        child: InkWell(onTap: onTap, borderRadius: radius, child: content),
       );
     }
     return content;
   }
-
 }
 
 Future<void> _launchExternalUrl(String url) async {

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -245,16 +245,21 @@ class _MediaDetailViewState extends State<MediaDetailView> {
     final Widget content = ListView(
       padding: const EdgeInsets.all(AppSpacing.md),
       children: <Widget>[
-        Container(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          decoration: BoxDecoration(
-            color: AppColors.surface.withAlpha(80),
-            borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-            border: Border.all(
-              color: AppColors.surfaceBorder.withAlpha(40),
+        // Material wraps the fill so descendant ListTile/ExpansionTile widgets
+        // paint their ink on a Material ancestor — Flutter 3.44 asserts when
+        // a coloured DecoratedBox sits between them.
+        Material(
+          color: AppColors.surface.withAlpha(80),
+          borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+          child: Container(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+              border: Border.all(
+                color: AppColors.surfaceBorder.withAlpha(40),
+              ),
             ),
-          ),
-          child: Column(
+            child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               _buildHeader(),
@@ -293,6 +298,7 @@ class _MediaDetailViewState extends State<MediaDetailView> {
                   section,
                 ],
             ],
+          ),
           ),
         ),
       ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -481,10 +481,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -862,10 +862,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
* migrate ReorderableListView.onReorder → onReorderItem (Flutter rename)
* wrap routes/cards/panels in Material so ListTile/ExpansionTile keep ink ancestor after the 3.44 debug-only assertion
* switch table-view _withHeader from SingleChildScrollView+Column to CustomScrollView so the hero banner stays at the top when the row count is small (old wrap was anchoring content to viewport bottom)
* BoxFit.cover + Alignment.topCenter on RichHeroBanner image so the SizedBox is always fully painted
* auto-migrated android/gradle.properties and bumped pubspec.lock