### PR TITLE
refactor(canvas): bugfixes, dialog extraction, two-phase load, panel reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,104 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Refactor canvas dialogs and load the board in two phases**
+
+  The 800-line `_CanvasViewState` shed all its dialog plumbing into a
+  dedicated service; the remaining state class now only carries layout,
+  gestures, and the build tree. The board also paints sooner: instead of
+  blocking the first frame on the seven join queries that hydrate cover
+  art and titles, it now renders a skeleton of positions and types as
+  soon as the bare canvas rows are loaded, then swaps the hydrated items
+  in on the next state tick. Personal (per-item) canvas uses the same
+  two-phase shape for symmetry, even though its one-to-few items make
+  the perf win negligible there.
+
+  * lib/features/collections/widgets/canvas_item_actions.dart
+    (CanvasItemActions.addText, CanvasItemActions.addImage,
+    CanvasItemActions.addLink, CanvasItemActions.editItem,
+    CanvasItemActions.editConnection): New service that owns the
+    add/edit dialogs (text, image, link, edit-connection). Internal
+    `_showAndApply` helper collapses the seven copies of the
+    show-dialog → null-check → `context.mounted` check →
+    forward-to-controller pattern.
+  * lib/features/collections/widgets/canvas_view.dart
+    (_CanvasViewState): Removed `_handleAddText`, `_handleAddImage`,
+    `_handleAddLink`, `_handleEditItem`, `_editTextItem`,
+    `_editImageItem`, `_editLinkItem`, `_handleEditConnection`
+    (~120 lines). Call sites in `_onCanvasSecondaryTap`,
+    `_onItemSecondaryTap`, `_showConnectionContextMenu` now delegate
+    to a `late final` `_actions` field.
+  * lib/data/repositories/canvas_repository.dart
+    (CanvasRepository.enrichItems): New public wrapper around the
+    existing `_enrichItemsWithMediaData`. Lets callers split skeleton
+    load from media hydration without exposing the private method.
+  * lib/features/collections/providers/canvas_provider.dart
+    (CanvasNotifier._loadCanvas, CanvasNotifier._loadGeneration),
+    lib/features/collections/providers/game_canvas_provider.dart
+    (GameCanvasNotifier._loadCanvas, GameCanvasNotifier._loadGeneration):
+    Two-phase load — phase 1 fetches positions / viewport / connections
+    in parallel and updates state with `isLoading: false`, phase 2
+    calls `enrichItems` and swaps in the hydrated list. A
+    `_loadGeneration` counter discards phase-2 results from a load
+    that was superseded by another reload.
+
+- **Fix canvas regressions on first init, FAB overlap, and stale side-panel state**
+
+  Anime and custom items on a freshly-created board used to open with
+  empty cards (no cover, no title) because `CanvasItem.copyWith` in
+  the init path silently dropped the `anime` and `customMedia` fields
+  while accepting game / movie / TV show. Reloading the canvas hid the
+  bug because the read path enriches from cache; first-render was the
+  only window. The collection screen's ⋮ FAB also got moved inward
+  on canvas mode so it stops landing on top of the canvas-side
+  toolbar buttons (VgMaps, SteamGridDB, center-view, reset). And the
+  SteamGridDB / VgMaps side panels stop carrying their previous search
+  and browser state across canvases — both providers are keyed by
+  `collectionId`, so per-item canvases inside the same collection used
+  to inherit each other's queries until the panel was closed.
+
+  * lib/data/repositories/canvas_repository.dart
+    (CanvasRepository.initializeCanvas): Copy `anime` and
+    `customMedia` through to the freshly-created `CanvasItem`s.
+  * lib/features/collections/providers/game_canvas_provider.dart
+    (GameCanvasNotifier._initializeWithCollectionItem): Copy `anime`
+    through to the per-item canvas item.
+  * lib/shared/widgets/draggable_fab.dart (DraggableFab.initialRight,
+    DraggableFab.initialBottom): New constructor params let callers
+    pre-position the FAB without breaking the user's drag-to-relocate
+    state.
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState.build): Pass `initialRight: 72` while in
+    canvas mode and key the `DraggableFab` on `_isCanvasMode` so the
+    position resets cleanly when the user toggles modes.
+  * test/data/repositories/canvas_repository_test.dart
+    (CanvasRepository.initializeCanvas should propagate every
+    media-type field from CollectionItem): New table-driven test that
+    walks every media-type-specific field. Adding a new media type
+    requires adding a row here, so the «one type silently forgotten»
+    class of bug can't reappear.
+  * test/features/collections/providers/game_canvas_provider_test.dart:
+    New file mirroring the same propagation check for the per-item
+    canvas (seven media types, seven tests).
+  * test/features/collections/providers/canvas_provider_test.dart:
+    Updated mocks to cover the new `enrichItems` and the split
+    `getItems`/`getGameCanvasItems` calls in the two-phase load.
+  * lib/features/collections/providers/steamgriddb_panel_provider.dart
+    (SteamGridDbPanelNotifier.closePanel): Reset search input,
+    results, selection, and current images on close while preserving
+    `imageCache`. Translated the file's dartdocs to English while
+    touching it.
+  * lib/features/collections/providers/vgmaps_panel_provider.dart
+    (VgMapsPanelNotifier.closePanel): Reset to a fresh
+    `VgMapsPanelState` on close so the captured image URL and the
+    last-visited page don't bleed into the next canvas. Translated
+    dartdocs to English.
+  * test/features/collections/providers/steamgriddb_panel_provider_test.dart,
+    test/features/collections/providers/vgmaps_panel_provider_test.dart:
+    Add a regression test per panel that confirms `closePanel` wipes
+    the search/browser side of the state and (for SteamGridDB) keeps
+    `imageCache`.
+
 - **Split search screen god class into per-source handlers and fix animation routing**
 
   `_SearchScreenState` shrank from ~1500 to ~400 lines. The seven near-duplicate

--- a/lib/data/repositories/canvas_repository.dart
+++ b/lib/data/repositories/canvas_repository.dart
@@ -45,6 +45,13 @@ class CanvasRepository {
     return _enrichItemsWithMediaData(items);
   }
 
+  /// Hydrate the `game/movie/tvShow/...` slots on already-loaded items.
+  /// Lets callers paint a skeleton canvas first (positions + types) and
+  /// fill in the heavy joined data in a second pass — see
+  /// [CanvasNotifier._loadCanvas].
+  Future<List<CanvasItem>> enrichItems(List<CanvasItem> items) =>
+      _enrichItemsWithMediaData(items);
+
   Future<CanvasItem> createItem(CanvasItem item) async {
     final int id = await _db.insertCanvasItem(item.toDb());
     return item.copyWith(id: id);
@@ -439,6 +446,8 @@ class CanvasRepository {
           tvShow: items[i].tvShow,
           visualNovel: items[i].visualNovel,
           manga: items[i].manga,
+          anime: items[i].anime,
+          customMedia: items[i].customMedia,
         ),
     ];
 

--- a/lib/features/collections/providers/canvas_provider.dart
+++ b/lib/features/collections/providers/canvas_provider.dart
@@ -36,6 +36,11 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int?>
   late int? _collectionId;
   bool _isSyncing = false;
 
+  /// Bumped on every `_loadCanvas` so async hydration tasks started by an
+  /// earlier load know to drop their result instead of overwriting fresh
+  /// state — see the phase-2 enrichment in [_loadCanvas].
+  int _loadGeneration = 0;
+
   // CanvasTimerMixin
   @override
   CanvasRepository get timerRepository => _repository;
@@ -95,33 +100,47 @@ class CanvasNotifier extends FamilyNotifier<CanvasState, int?>
   Future<void> _loadCanvas() async {
     if (_collectionId == null) return;
     final int cId = _collectionId!;
+    final int gen = ++_loadGeneration;
     try {
       final bool hasItems = await _repository.hasCanvasItems(cId);
 
       if (!hasItems) {
         await _initializeFromItems();
-      } else {
-        await _syncCanvasWithItems();
-
-        final (
-          List<CanvasItem> items,
-          CanvasViewport? viewport,
-          List<CanvasConnection> connections,
-        ) = await (
-          _repository.getItemsWithData(cId),
-          _repository.getViewport(cId),
-          _repository.getConnections(cId),
-        ).wait;
-
-        state = state.copyWith(
-          items: items,
-          connections: connections,
-          viewport: viewport ?? CanvasViewport(collectionId: cId),
-          isLoading: false,
-          isInitialized: true,
-        );
+        return;
       }
+
+      await _syncCanvasWithItems();
+
+      // Phase 1: paint a skeleton canvas with positions and types as soon
+      // as the bare item rows are loaded — the media-table joins for
+      // covers/titles run in phase 2 below.
+      final (
+        List<CanvasItem> rawItems,
+        CanvasViewport? viewport,
+        List<CanvasConnection> connections,
+      ) = await (
+        _repository.getItems(cId),
+        _repository.getViewport(cId),
+        _repository.getConnections(cId),
+      ).wait;
+      if (gen != _loadGeneration) return;
+
+      state = state.copyWith(
+        items: rawItems,
+        connections: connections,
+        viewport: viewport ?? CanvasViewport(collectionId: cId),
+        isLoading: false,
+        isInitialized: true,
+      );
+
+      // Phase 2: hydrate cover images and titles. A concurrent reload
+      // (gen mismatch) discards this result, since its state is stale.
+      final List<CanvasItem> enriched =
+          await _repository.enrichItems(rawItems);
+      if (gen != _loadGeneration) return;
+      state = state.copyWith(items: enriched);
     } catch (e) {
+      if (gen != _loadGeneration) return;
       state = state.copyWith(
         isLoading: false,
         error: e.toString(),

--- a/lib/features/collections/providers/game_canvas_provider.dart
+++ b/lib/features/collections/providers/game_canvas_provider.dart
@@ -31,6 +31,10 @@ class GameCanvasNotifier
   late int? _collectionId;
   late int _collectionItemId;
 
+  /// Mirrors [CanvasNotifier._loadGeneration]: protects the phase-2
+  /// enrichment from overwriting state if a concurrent reload superseded it.
+  int _loadGeneration = 0;
+
   // CanvasTimerMixin
   @override
   CanvasRepository get timerRepository => _repository;
@@ -105,6 +109,7 @@ class GameCanvasNotifier
   }
 
   Future<void> _loadCanvas() async {
+    final int gen = ++_loadGeneration;
     try {
       final bool hasItems =
           await _repository.hasGameCanvasItems(_collectionItemId);
@@ -114,25 +119,34 @@ class GameCanvasNotifier
         return;
       }
 
+      // Phase 1: skeleton — positions and types only.
       final (
-        List<CanvasItem> items,
+        List<CanvasItem> rawItems,
         CanvasViewport? viewport,
         List<CanvasConnection> connections,
       ) = await (
-        _repository.getGameCanvasItemsWithData(_collectionItemId),
+        _repository.getGameCanvasItems(_collectionItemId),
         _repository.getGameCanvasViewport(_collectionItemId),
         _repository.getGameCanvasConnections(_collectionItemId),
       ).wait;
+      if (gen != _loadGeneration) return;
 
       state = state.copyWith(
-        items: items,
+        items: rawItems,
         connections: connections,
         viewport: viewport ??
             CanvasViewport(collectionId: _collectionItemId),
         isLoading: false,
         isInitialized: true,
       );
+
+      // Phase 2: cover image + title hydration.
+      final List<CanvasItem> enriched =
+          await _repository.enrichItems(rawItems);
+      if (gen != _loadGeneration) return;
+      state = state.copyWith(items: enriched);
     } catch (e) {
+      if (gen != _loadGeneration) return;
       state = state.copyWith(
         isLoading: false,
         error: e.toString(),
@@ -193,6 +207,7 @@ class GameCanvasNotifier
       tvShow: collectionItem.tvShow,
       visualNovel: collectionItem.visualNovel,
       manga: collectionItem.manga,
+      anime: collectionItem.anime,
       customMedia: collectionItem.customMedia,
     );
 

--- a/lib/features/collections/providers/steamgriddb_panel_provider.dart
+++ b/lib/features/collections/providers/steamgriddb_panel_provider.dart
@@ -5,29 +5,21 @@ import '../../../shared/models/steamgriddb_game.dart';
 import '../../../shared/models/steamgriddb_image.dart';
 import '../../settings/providers/settings_provider.dart';
 
-/// Тип изображений SteamGridDB для фильтрации в панели.
+/// SteamGridDB image kind shown by the side panel.
 enum SteamGridDbImageType {
-  /// Обложки (box art).
   grids('Grids'),
-
-  /// Баннеры.
   heroes('Heroes'),
-
-  /// Логотипы.
   logos('Logos'),
-
-  /// Иконки.
   icons('Icons');
 
   const SteamGridDbImageType(this.label);
 
-  /// Отображаемое название.
+  /// Display label.
   final String label;
 }
 
-/// Состояние боковой панели SteamGridDB.
+/// State for the SteamGridDB side panel.
 class SteamGridDbPanelState {
-  /// Создаёт экземпляр [SteamGridDbPanelState].
   const SteamGridDbPanelState({
     this.isOpen = false,
     this.searchTerm = '',
@@ -42,40 +34,25 @@ class SteamGridDbPanelState {
     this.imageCache = const <String, List<SteamGridDbImage>>{},
   });
 
-  /// Открыта ли панель.
   final bool isOpen;
-
-  /// Текущий поисковый запрос.
   final String searchTerm;
-
-  /// Результаты поиска игр.
   final List<SteamGridDbGame> searchResults;
 
-  /// Выбранная игра (null = показываем результаты поиска).
+  /// Currently selected game; `null` means the panel is showing search
+  /// results, not a specific game's image grid.
   final SteamGridDbGame? selectedGame;
 
-  /// Выбранный тип изображений.
   final SteamGridDbImageType selectedImageType;
-
-  /// Текущие изображения для отображения.
   final List<SteamGridDbImage> images;
-
-  /// Идёт поиск игр.
   final bool isSearching;
-
-  /// Идёт загрузка изображений.
   final bool isLoadingImages;
-
-  /// Ошибка при поиске.
   final String? searchError;
-
-  /// Ошибка при загрузке изображений.
   final String? imageError;
 
-  /// Кэш изображений по ключу "$gameId:$imageType".
+  /// Per-`(gameId, imageType)` cache survives close/open so reopening the
+  /// panel for a recently-viewed game does not re-hit the API.
   final Map<String, List<SteamGridDbImage>> imageCache;
 
-  /// Создаёт копию с изменёнными полями.
   SteamGridDbPanelState copyWith({
     bool? isOpen,
     String? searchTerm,
@@ -110,7 +87,6 @@ class SteamGridDbPanelState {
   }
 }
 
-/// Провайдер для управления боковой панелью SteamGridDB.
 final NotifierProviderFamily<SteamGridDbPanelNotifier, SteamGridDbPanelState,
         int?> steamGridDbPanelProvider =
     NotifierProvider.family<SteamGridDbPanelNotifier, SteamGridDbPanelState,
@@ -118,7 +94,6 @@ final NotifierProviderFamily<SteamGridDbPanelNotifier, SteamGridDbPanelState,
   SteamGridDbPanelNotifier.new,
 );
 
-/// Notifier для управления состоянием боковой панели SteamGridDB.
 class SteamGridDbPanelNotifier
     extends FamilyNotifier<SteamGridDbPanelState, int?> {
   late SteamGridDbApi _api;
@@ -129,22 +104,21 @@ class SteamGridDbPanelNotifier
     return const SteamGridDbPanelState();
   }
 
-  /// Переключает видимость панели.
   void togglePanel() {
     state = state.copyWith(isOpen: !state.isOpen);
   }
 
-  /// Открывает панель.
   void openPanel() {
     state = state.copyWith(isOpen: true);
   }
 
-  /// Закрывает панель.
+  /// Resets the search input, results, and selection while keeping
+  /// [imageCache]. Without this reset the previous query leaked across
+  /// canvases that share the provider key (`collectionId`).
   void closePanel() {
-    state = state.copyWith(isOpen: false);
+    state = SteamGridDbPanelState(imageCache: state.imageCache);
   }
 
-  /// Ищет игры по названию.
   Future<void> searchGames(String term) async {
     final String trimmedTerm = term.trim();
     if (trimmedTerm.isEmpty) return;
@@ -180,7 +154,7 @@ class SteamGridDbPanelNotifier
     }
   }
 
-  /// Выбирает игру и загружает изображения по умолчанию (grids).
+  /// Selects a game and fetches its grids by default.
   Future<void> selectGame(SteamGridDbGame game) async {
     state = state.copyWith(
       selectedGame: game,
@@ -191,7 +165,7 @@ class SteamGridDbPanelNotifier
     await _loadImages();
   }
 
-  /// Очищает выбор игры, возвращаясь к результатам поиска.
+  /// Returns from a selected game back to the search-results view.
   void clearGameSelection() {
     state = state.copyWith(
       clearSelectedGame: true,
@@ -200,7 +174,6 @@ class SteamGridDbPanelNotifier
     );
   }
 
-  /// Выбирает тип изображений и загружает их.
   Future<void> selectImageType(SteamGridDbImageType type) async {
     state = state.copyWith(
       selectedImageType: type,
@@ -210,19 +183,16 @@ class SteamGridDbPanelNotifier
     await _loadImages();
   }
 
-  /// Возвращает ключ кэша для пары (gameId, imageType).
   String _cacheKey(int gameId, SteamGridDbImageType type) {
     return '$gameId:${type.name}';
   }
 
-  /// Загружает изображения для выбранной игры и типа.
   Future<void> _loadImages() async {
     final SteamGridDbGame? game = state.selectedGame;
     if (game == null) return;
 
     final String key = _cacheKey(game.id, state.selectedImageType);
 
-    // Проверяем кэш
     final List<SteamGridDbImage>? cached = state.imageCache[key];
     if (cached != null) {
       state = state.copyWith(images: cached);
@@ -244,7 +214,6 @@ class SteamGridDbPanelNotifier
           results = await _api.getIcons(game.id);
       }
 
-      // Сохраняем в кэш
       final Map<String, List<SteamGridDbImage>> updatedCache =
           Map<String, List<SteamGridDbImage>>.of(state.imageCache);
       updatedCache[key] = results;

--- a/lib/features/collections/providers/vgmaps_panel_provider.dart
+++ b/lib/features/collections/providers/vgmaps_panel_provider.dart
@@ -1,11 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// Домашний URL VGMaps (Better VGMaps).
 const String vgMapsHomeUrl = 'https://vgmaps.de/';
 
-/// Состояние боковой панели VGMaps Browser.
+/// State for the VGMaps browser side panel.
 class VgMapsPanelState {
-  /// Создаёт экземпляр [VgMapsPanelState].
   const VgMapsPanelState({
     this.isOpen = false,
     this.currentUrl = vgMapsHomeUrl,
@@ -18,34 +16,19 @@ class VgMapsPanelState {
     this.error,
   });
 
-  /// Открыта ли панель.
   final bool isOpen;
-
-  /// Текущий URL в WebView.
   final String currentUrl;
-
-  /// Можно ли перейти назад.
   final bool canGoBack;
-
-  /// Можно ли перейти вперёд.
   final bool canGoForward;
-
-  /// Идёт ли загрузка страницы.
   final bool isLoading;
 
-  /// URL захваченного изображения (из JS injection).
+  /// Image URL captured via the page's JS injection.
   final String? capturedImageUrl;
-
-  /// Ширина захваченного изображения.
   final int? capturedImageWidth;
-
-  /// Высота захваченного изображения.
   final int? capturedImageHeight;
 
-  /// Ошибка.
   final String? error;
 
-  /// Создаёт копию с изменёнными полями.
   VgMapsPanelState copyWith({
     bool? isOpen,
     String? currentUrl,
@@ -79,41 +62,38 @@ class VgMapsPanelState {
   }
 }
 
-/// Провайдер для управления боковой панелью VGMaps Browser.
 final NotifierProviderFamily<VgMapsPanelNotifier, VgMapsPanelState, int?>
     vgMapsPanelProvider =
     NotifierProvider.family<VgMapsPanelNotifier, VgMapsPanelState, int?>(
   VgMapsPanelNotifier.new,
 );
 
-/// Notifier для управления состоянием боковой панели VGMaps Browser.
 class VgMapsPanelNotifier extends FamilyNotifier<VgMapsPanelState, int?> {
   @override
   VgMapsPanelState build(int? arg) {
     return const VgMapsPanelState();
   }
 
-  /// Переключает видимость панели.
   void togglePanel() {
     state = state.copyWith(isOpen: !state.isOpen);
   }
 
-  /// Открывает панель.
   void openPanel() {
     state = state.copyWith(isOpen: true);
   }
 
-  /// Закрывает панель.
+  /// Resets browser navigation and any captured-image state. Mirrors
+  /// [SteamGridDbPanelNotifier.closePanel]: the provider is keyed by
+  /// `collectionId`, so without this the previous URL / captured image
+  /// would leak into the next canvas opening the same panel.
   void closePanel() {
-    state = state.copyWith(isOpen: false);
+    state = const VgMapsPanelState();
   }
 
-  /// Обновляет текущий URL при навигации.
   void setCurrentUrl(String url) {
     state = state.copyWith(currentUrl: url);
   }
 
-  /// Обновляет состояние навигации (назад/вперёд).
   void setNavigationState({
     required bool canGoBack,
     required bool canGoForward,
@@ -124,12 +104,11 @@ class VgMapsPanelNotifier extends FamilyNotifier<VgMapsPanelState, int?> {
     );
   }
 
-  /// Устанавливает состояние загрузки страницы.
   void setLoading({required bool isLoading}) {
     state = state.copyWith(isLoading: isLoading);
   }
 
-  /// Захватывает URL изображения из JS injection.
+  /// Capture an image URL reported by the page's JS injection.
   void captureImage(String url, {int? width, int? height}) {
     state = state.copyWith(
       capturedImageUrl: url,
@@ -138,17 +117,14 @@ class VgMapsPanelNotifier extends FamilyNotifier<VgMapsPanelState, int?> {
     );
   }
 
-  /// Очищает захваченное изображение.
   void clearCapturedImage() {
     state = state.copyWith(clearCapturedImage: true);
   }
 
-  /// Устанавливает ошибку.
   void setError(String error) {
     state = state.copyWith(error: error);
   }
 
-  /// Очищает ошибку.
   void clearError() {
     state = state.copyWith(clearError: true);
   }

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -241,9 +241,11 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             ],
           ),
           DraggableFab(
+            key: ValueKey<bool>(_isCanvasMode),
             mainAction: _buildMainFabAction(l),
             primaryItems: _buildPrimaryFabItems(l),
             items: _buildSecondaryFabItems(l),
+            initialRight: _isCanvasMode ? 72 : null,
           ),
         ],
       ),

--- a/lib/features/collections/widgets/canvas_item_actions.dart
+++ b/lib/features/collections/widgets/canvas_item_actions.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/widgets.dart';
+
+import '../providers/canvas_state.dart';
+import '../../../shared/models/canvas_connection.dart';
+import '../../../shared/models/canvas_item.dart';
+import 'dialogs/add_image_dialog.dart';
+import 'dialogs/add_link_dialog.dart';
+import 'dialogs/add_text_dialog.dart';
+import 'dialogs/edit_connection_dialog.dart';
+
+/// Shows the canvas add/edit dialogs and forwards the result to the
+/// controller. Lifted out of `_CanvasViewState` so the screen widget stays
+/// focused on layout and gesture wiring.
+///
+/// Every entry point follows the same shape: show dialog → bail on null
+/// or unmounted context → dispatch to [controller]. `context.mounted` is
+/// rechecked after each `await` because dialogs may outlive the host
+/// widget.
+class CanvasItemActions {
+  CanvasItemActions({
+    required BuildContext context,
+    required BaseCanvasController Function() controller,
+  })  : _context = context,
+        _controller = controller;
+
+  final BuildContext _context;
+  final BaseCanvasController Function() _controller;
+
+  Future<void> addText(double x, double y) async {
+    await _showAndApply(
+      AddTextDialog.show(_context),
+      (Map<String, dynamic> r) => _controller().addTextItem(
+        x,
+        y,
+        r['content'] as String,
+        (r['fontSize'] as num).toDouble(),
+      ),
+    );
+  }
+
+  Future<void> addImage(double x, double y) async {
+    await _showAndApply(
+      AddImageDialog.show(_context),
+      (Map<String, dynamic> r) => _controller().addImageItem(x, y, r),
+    );
+  }
+
+  Future<void> addLink(double x, double y) async {
+    await _showAndApply(
+      AddLinkDialog.show(_context),
+      (Map<String, dynamic> r) => _controller().addLinkItem(
+        x,
+        y,
+        r['url'] as String,
+        r['label'] as String,
+      ),
+    );
+  }
+
+  /// Routes to the right edit dialog by item type; media-card items have
+  /// no inline edit (their data lives in the upstream cache tables).
+  Future<void> editItem(CanvasItem item) async {
+    switch (item.itemType) {
+      case CanvasItemType.text:
+        await _showAndApply(
+          AddTextDialog.show(
+            _context,
+            initialContent: item.data?['content'] as String?,
+            initialFontSize: (item.data?['fontSize'] as num?)?.toDouble(),
+          ),
+          (Map<String, dynamic> r) =>
+              _controller().updateItemData(item.id, r),
+        );
+      case CanvasItemType.image:
+        await _showAndApply(
+          AddImageDialog.show(
+            _context,
+            initialUrl: item.data?['url'] as String?,
+          ),
+          (Map<String, dynamic> r) =>
+              _controller().updateItemData(item.id, r),
+        );
+      case CanvasItemType.link:
+        await _showAndApply(
+          AddLinkDialog.show(
+            _context,
+            initialUrl: item.data?['url'] as String?,
+            initialLabel: item.data?['label'] as String?,
+          ),
+          (Map<String, dynamic> r) =>
+              _controller().updateItemData(item.id, r),
+        );
+      case CanvasItemType.game:
+      case CanvasItemType.movie:
+      case CanvasItemType.tvShow:
+      case CanvasItemType.animation:
+      case CanvasItemType.visualNovel:
+      case CanvasItemType.manga:
+      case CanvasItemType.anime:
+      case CanvasItemType.custom:
+        break;
+    }
+  }
+
+  Future<void> editConnection(int connectionId, CanvasState canvasState) async {
+    final CanvasConnection? conn = canvasState.connections
+        .where((CanvasConnection c) => c.id == connectionId)
+        .firstOrNull;
+    if (conn == null) return;
+
+    await _showAndApply(
+      EditConnectionDialog.show(
+        _context,
+        initialLabel: conn.label,
+        initialColor: conn.color,
+        initialStyle: conn.style,
+      ),
+      (Map<String, dynamic> r) => _controller().updateConnection(
+        connectionId,
+        label: r['label'] as String?,
+        color: r['color'] as String?,
+        style: r['style'] != null
+            ? ConnectionStyle.fromString(r['style'] as String)
+            : null,
+      ),
+    );
+  }
+
+  Future<void> _showAndApply(
+    Future<Map<String, dynamic>?> dialog,
+    void Function(Map<String, dynamic>) apply,
+  ) async {
+    final Map<String, dynamic>? result = await dialog;
+    if (result == null || !_context.mounted) return;
+    apply(result);
+  }
+}

--- a/lib/features/collections/widgets/canvas_view.dart
+++ b/lib/features/collections/widgets/canvas_view.dart
@@ -6,21 +6,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/constants/platform_features.dart';
-import '../../../shared/models/canvas_connection.dart';
 import '../../../shared/models/canvas_item.dart';
-import '../providers/canvas_provider.dart';
-import 'canvas_connection_painter.dart';
-import 'canvas_context_menu.dart';
 import '../../../shared/widgets/media_poster_card.dart';
-import 'canvas_image_item.dart';
-import 'canvas_link_item.dart';
-import 'canvas_text_item.dart';
-import 'dialogs/add_image_dialog.dart';
-import 'dialogs/add_link_dialog.dart';
-import 'dialogs/add_text_dialog.dart';
-import 'dialogs/edit_connection_dialog.dart';
+import '../providers/canvas_provider.dart';
 import '../providers/steamgriddb_panel_provider.dart';
 import '../providers/vgmaps_panel_provider.dart';
+import 'canvas_connection_painter.dart';
+import 'canvas_context_menu.dart';
+import 'canvas_image_item.dart';
+import 'canvas_item_actions.dart';
+import 'canvas_link_item.dart';
+import 'canvas_text_item.dart';
 
 class CanvasView extends ConsumerStatefulWidget {
   const CanvasView({
@@ -72,6 +68,11 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
       canvasNotifierProvider(widget.collectionId).notifier,
     );
   }
+
+  late final CanvasItemActions _actions = CanvasItemActions(
+    context: context,
+    controller: _readNotifier,
+  );
 
   static const double _minScale = 0.1;
   static const double _maxScale = 3.0;
@@ -196,9 +197,9 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
     CanvasContextMenu.showCanvasMenu(
       context,
       position: globalPosition,
-      onAddText: () => _handleAddText(canvasX, canvasY),
-      onAddImage: () => _handleAddImage(canvasX, canvasY),
-      onAddLink: () => _handleAddLink(canvasX, canvasY),
+      onAddText: () => _actions.addText(canvasX, canvasY),
+      onAddImage: () => _actions.addImage(canvasX, canvasY),
+      onAddLink: () => _actions.addLink(canvasX, canvasY),
       onFindImages: widget.isEditable
           ? () {
               ref
@@ -234,7 +235,7 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
       context,
       position: globalPosition,
       itemType: item.itemType,
-      onEdit: () => _handleEditItem(item),
+      onEdit: () => _actions.editItem(item),
       onDelete: () => notifier.deleteItem(item.id),
       onBringToFront: () => notifier.bringToFront(item.id),
       onSendToBack: () => notifier.sendToBack(item.id),
@@ -243,95 +244,6 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
         _focusNode.requestFocus();
       },
     );
-  }
-
-  Future<void> _handleAddText(double x, double y) async {
-    final Map<String, dynamic>? result = await AddTextDialog.show(context);
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().addTextItem(
-      x,
-      y,
-      result['content'] as String,
-      (result['fontSize'] as num).toDouble(),
-    );
-  }
-
-  Future<void> _handleAddImage(double x, double y) async {
-    final Map<String, dynamic>? result = await AddImageDialog.show(context);
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().addImageItem(x, y, result);
-  }
-
-  Future<void> _handleAddLink(double x, double y) async {
-    final Map<String, dynamic>? result = await AddLinkDialog.show(context);
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().addLinkItem(
-      x,
-      y,
-      result['url'] as String,
-      result['label'] as String,
-    );
-  }
-
-  Future<void> _handleEditItem(CanvasItem item) async {
-    switch (item.itemType) {
-      case CanvasItemType.text:
-        await _editTextItem(item);
-      case CanvasItemType.image:
-        await _editImageItem(item);
-      case CanvasItemType.link:
-        await _editLinkItem(item);
-      case CanvasItemType.game:
-      case CanvasItemType.movie:
-      case CanvasItemType.tvShow:
-      case CanvasItemType.animation:
-      case CanvasItemType.visualNovel:
-      case CanvasItemType.manga:
-      case CanvasItemType.anime:
-      case CanvasItemType.custom:
-        break;
-    }
-  }
-
-  Future<void> _editTextItem(CanvasItem item) async {
-    final Map<String, dynamic>? result = await AddTextDialog.show(
-      context,
-      initialContent: item.data?['content'] as String?,
-      initialFontSize: (item.data?['fontSize'] as num?)?.toDouble(),
-    );
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().updateItemData(item.id, result);
-  }
-
-  Future<void> _editImageItem(CanvasItem item) async {
-    final Map<String, dynamic>? result = await AddImageDialog.show(
-      context,
-      initialUrl: item.data?['url'] as String?,
-    );
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().updateItemData(item.id, result);
-  }
-
-  Future<void> _editLinkItem(CanvasItem item) async {
-    final Map<String, dynamic>? result = await AddLinkDialog.show(
-      context,
-      initialUrl: item.data?['url'] as String?,
-      initialLabel: item.data?['label'] as String?,
-    );
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().updateItemData(item.id, result);
   }
 
   void _onCanvasSecondaryTapWithConnections(
@@ -361,39 +273,11 @@ class _CanvasViewState extends ConsumerState<CanvasView> {
     CanvasContextMenu.showConnectionMenu(
       context,
       position: globalPosition,
-      onEdit: () => _handleEditConnection(connectionId, canvasState),
+      onEdit: () => _actions.editConnection(connectionId, canvasState),
       onDelete: () {
         _readNotifier().deleteConnection(connectionId);
       },
     );
-  }
-
-  Future<void> _handleEditConnection(
-    int connectionId,
-    CanvasState canvasState,
-  ) async {
-    final CanvasConnection? conn = canvasState.connections
-        .where((CanvasConnection c) => c.id == connectionId)
-        .firstOrNull;
-    if (conn == null) return;
-
-    final Map<String, dynamic>? result = await EditConnectionDialog.show(
-      context,
-      initialLabel: conn.label,
-      initialColor: conn.color,
-      initialStyle: conn.style,
-    );
-    if (result == null) return;
-    if (!mounted) return;
-
-    _readNotifier().updateConnection(
-      connectionId,
-          label: result['label'] as String?,
-          color: result['color'] as String?,
-          style: result['style'] != null
-              ? ConnectionStyle.fromString(result['style'] as String)
-              : null,
-        );
   }
 
   void _handleConnectionModeClick(CanvasItem item) {

--- a/lib/shared/widgets/draggable_fab.dart
+++ b/lib/shared/widgets/draggable_fab.dart
@@ -55,6 +55,8 @@ class DraggableFab extends StatefulWidget {
     this.primaryItems = const <DraggableFabItem>[],
     this.items = const <DraggableFabItem>[],
     this.icon = Icons.more_vert,
+    this.initialRight,
+    this.initialBottom,
     super.key,
   });
 
@@ -71,13 +73,21 @@ class DraggableFab extends StatefulWidget {
   /// Иконка кнопки меню.
   final IconData icon;
 
+  /// Initial right offset (defaults to [AppSpacing.md]). Set on the canvas
+  /// view so the FAB clears the right-side toolbar column instead of
+  /// overlapping it.
+  final double? initialRight;
+
+  /// Initial bottom offset (defaults to [AppSpacing.md]).
+  final double? initialBottom;
+
   @override
   State<DraggableFab> createState() => _DraggableFabState();
 }
 
 class _DraggableFabState extends State<DraggableFab> {
-  double _right = AppSpacing.md;
-  double _bottom = AppSpacing.md;
+  late double _right = widget.initialRight ?? AppSpacing.md;
+  late double _bottom = widget.initialBottom ?? AppSpacing.md;
 
   bool _isDragging = false;
   Offset _dragStart = Offset.zero;

--- a/test/data/repositories/canvas_repository_test.dart
+++ b/test/data/repositories/canvas_repository_test.dart
@@ -7,7 +7,10 @@ import 'package:xerabora/shared/models/canvas_viewport.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/anime.dart';
+import 'package:xerabora/shared/models/custom_media.dart';
 import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/manga.dart';
 import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/tv_show.dart';
 import 'package:xerabora/shared/models/visual_novel.dart';
@@ -705,6 +708,113 @@ void main() {
         expect(result[0].itemRefId, 17);
         expect(result[0].visualNovel, isNotNull);
         expect(result[0].visualNovel!.title, 'Ever17');
+      });
+
+      // Regression: `initializeCanvas` must propagate every media-type-specific
+      // field (game/movie/tvShow/visualNovel/manga/anime/customMedia) from the
+      // CollectionItem to the freshly-created CanvasItem. Forgetting one means
+      // the canvas opens with empty cards (no cover image, no title) for that
+      // type — exactly what happened to anime and custom items historically.
+      // When a new media type is added, add a case here so the same regression
+      // can't slip in.
+      test(
+          'should propagate every media-type field from CollectionItem',
+          () async {
+        const Game testGame = Game(id: 100, name: 'Hades');
+        const Movie testMovie = Movie(tmdbId: 200, title: 'Spirited Away');
+        const TvShow testTvShow = TvShow(tmdbId: 300, title: 'Breaking Bad');
+        const VisualNovel testVn = VisualNovel(id: 'v17', title: 'Ever17');
+        const Manga testManga = Manga(id: 500, title: 'Berserk');
+        const Anime testAnime = Anime(id: 600, title: 'Cowboy Bebop');
+        const CustomMedia testCustom =
+            CustomMedia(id: 700, title: 'My homebrew');
+
+        final List<CollectionItem> items = <CollectionItem>[
+          CollectionItem(
+            id: 1,
+            collectionId: 10,
+            mediaType: MediaType.game,
+            externalId: 100,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            game: testGame,
+          ),
+          CollectionItem(
+            id: 2,
+            collectionId: 10,
+            mediaType: MediaType.movie,
+            externalId: 200,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            movie: testMovie,
+          ),
+          CollectionItem(
+            id: 3,
+            collectionId: 10,
+            mediaType: MediaType.tvShow,
+            externalId: 300,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            tvShow: testTvShow,
+          ),
+          CollectionItem(
+            id: 4,
+            collectionId: 10,
+            mediaType: MediaType.visualNovel,
+            externalId: 17,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            visualNovel: testVn,
+          ),
+          CollectionItem(
+            id: 5,
+            collectionId: 10,
+            mediaType: MediaType.manga,
+            externalId: 500,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            manga: testManga,
+          ),
+          CollectionItem(
+            id: 6,
+            collectionId: 10,
+            mediaType: MediaType.anime,
+            externalId: 600,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            anime: testAnime,
+          ),
+          CollectionItem(
+            id: 7,
+            collectionId: 10,
+            mediaType: MediaType.custom,
+            externalId: 700,
+            status: ItemStatus.notStarted,
+            addedAt: testDate,
+            customMedia: testCustom,
+          ),
+        ];
+
+        when(() => mockDb.insertCanvasItemsBatch(any()))
+            .thenAnswer((_) async => <int>[1, 2, 3, 4, 5, 6, 7]);
+        when(() => mockDb.upsertCanvasViewport(
+              collectionId: any(named: 'collectionId'),
+              scale: any(named: 'scale'),
+              offsetX: any(named: 'offsetX'),
+              offsetY: any(named: 'offsetY'),
+            )).thenAnswer((_) async {});
+
+        final List<CanvasItem> result =
+            await repository.initializeCanvas(10, items);
+
+        expect(result.length, 7);
+        expect(result[0].game?.id, testGame.id);
+        expect(result[1].movie?.tmdbId, testMovie.tmdbId);
+        expect(result[2].tvShow?.tmdbId, testTvShow.tmdbId);
+        expect(result[3].visualNovel?.id, testVn.id);
+        expect(result[4].manga?.id, testManga.id);
+        expect(result[5].anime?.id, testAnime.id);
+        expect(result[6].customMedia?.id, testCustom.id);
       });
 
       test('should handle empty games list', () async {

--- a/test/features/collections/providers/canvas_provider_test.dart
+++ b/test/features/collections/providers/canvas_provider_test.dart
@@ -280,6 +280,9 @@ void main() {
           .thenAnswer((_) async => effectiveItems);
       when(() => mockRepository.getItemsWithData(collectionId))
           .thenAnswer((_) async => effectiveItems);
+      when(() => mockRepository.enrichItems(any()))
+          .thenAnswer((Invocation inv) async =>
+              inv.positionalArguments.first as List<CanvasItem>);
       when(() => mockRepository.getViewport(collectionId))
           .thenAnswer((_) async => viewport);
       when(() => mockRepository.deleteItem(any()))
@@ -351,7 +354,10 @@ void main() {
           expect(loadedState.error, isNull);
 
           verify(() => mockRepository.hasCanvasItems(collectionId)).called(1);
-          verify(() => mockRepository.getItemsWithData(collectionId)).called(1);
+          // Twice: once in `_syncCanvasWithItems` (diff against collection),
+          // once in phase 1 of the two-phase load.
+          verify(() => mockRepository.getItems(collectionId)).called(2);
+          verify(() => mockRepository.enrichItems(any())).called(1);
           verify(() => mockRepository.getViewport(collectionId)).called(1);
         },
       );
@@ -682,8 +688,9 @@ void main() {
               .thenAnswer((_) async => true);
           when(() => mockRepository.getItems(collectionId))
               .thenAnswer((_) async => testItems);
-          when(() => mockRepository.getItemsWithData(collectionId))
-              .thenAnswer((_) async => testItems);
+          when(() => mockRepository.enrichItems(any()))
+              .thenAnswer((Invocation inv) async =>
+                  inv.positionalArguments.first as List<CanvasItem>);
           when(() => mockRepository.getViewport(collectionId))
               .thenAnswer((_) async => null);
           when(() => mockRepository.getConnections(collectionId))
@@ -707,7 +714,7 @@ void main() {
 
           verify(() => mockCollectionRepo.getItemsWithData(collectionId))
               .called(1);
-          verify(() => mockRepository.getItemsWithData(collectionId)).called(1);
+          verify(() => mockRepository.enrichItems(any())).called(1);
           verifyNever(() => mockRepository.deleteItemsBatch(any()));
         },
       );
@@ -793,8 +800,11 @@ void main() {
           );
 
           final List<CanvasItem> updatedItems = <CanvasItem>[testItems[0]];
-          when(() => mockRepository.getItemsWithData(collectionId))
+          when(() => mockRepository.getItems(collectionId))
               .thenAnswer((_) async => updatedItems);
+          when(() => mockRepository.enrichItems(any()))
+              .thenAnswer((Invocation inv) async =>
+                  inv.positionalArguments.first as List<CanvasItem>);
 
           final CanvasNotifier notifier = container
               .read(canvasNotifierProvider(collectionId).notifier);
@@ -2155,8 +2165,11 @@ void main() {
     }) {
       when(() => mockRepository.hasGameCanvasItems(collectionItemId))
           .thenAnswer((_) async => true);
-      when(() => mockRepository.getGameCanvasItemsWithData(collectionItemId))
+      when(() => mockRepository.getGameCanvasItems(collectionItemId))
           .thenAnswer((_) async => items ?? testItems);
+      when(() => mockRepository.enrichItems(any()))
+          .thenAnswer((Invocation inv) async =>
+              inv.positionalArguments.first as List<CanvasItem>);
       when(() => mockRepository.getGameCanvasViewport(collectionItemId))
           .thenAnswer(
         (_) async =>

--- a/test/features/collections/providers/game_canvas_provider_test.dart
+++ b/test/features/collections/providers/game_canvas_provider_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/data/repositories/canvas_repository.dart';
+import 'package:xerabora/features/collections/providers/canvas_state.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/features/collections/providers/game_canvas_provider.dart';
+import 'package:xerabora/shared/models/anime.dart';
+import 'package:xerabora/shared/models/canvas_item.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/custom_media.dart';
+import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/manga.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/models/movie.dart';
+import 'package:xerabora/shared/models/tv_show.dart';
+import 'package:xerabora/shared/models/visual_novel.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  group('GameCanvasNotifier._initializeWithCollectionItem', () {
+    late MockCanvasRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockCanvasRepository();
+      when(() => mockRepository.hasGameCanvasItems(any()))
+          .thenAnswer((_) async => false);
+      when(() => mockRepository.saveGameCanvasViewport(
+            any(),
+            any(),
+          )).thenAnswer((_) async {});
+      when(() => mockRepository.createItem(any()))
+          .thenAnswer((Invocation inv) async {
+        final CanvasItem incoming = inv.positionalArguments.first as CanvasItem;
+        return incoming.copyWith(id: 42);
+      });
+    });
+
+    ProviderContainer createContainer({
+      required CollectionItem collectionItem,
+    }) {
+      return ProviderContainer(
+        overrides: <Override>[
+          canvasRepositoryProvider.overrideWithValue(mockRepository),
+          collectionItemsNotifierProvider.overrideWith(
+            () => MockCollectionItemsNotifier(
+              AsyncData<List<CollectionItem>>(<CollectionItem>[collectionItem]),
+            ),
+          ),
+        ],
+      );
+    }
+
+    Future<CanvasItem> initAndGetFirstItem(CollectionItem ci) async {
+      final ProviderContainer container =
+          createContainer(collectionItem: ci);
+      addTearDown(container.dispose);
+
+      container.read(gameCanvasNotifierProvider(
+        (collectionId: 10, collectionItemId: ci.id),
+      ));
+
+      for (int i = 0; i < 50; i++) {
+        await Future<void>.delayed(Duration.zero);
+        final CanvasState s = container.read(gameCanvasNotifierProvider(
+          (collectionId: 10, collectionItemId: ci.id),
+        ));
+        if (s.isInitialized && s.items.isNotEmpty) return s.items.first;
+      }
+      fail('Canvas did not initialise within 50 microtasks');
+    }
+
+    // Regression: the per-item canvas (opened from a single collection item)
+    // must copy every media-type-specific field through to its CanvasItem.
+    // Anime was historically forgotten in the copyWith call and the canvas
+    // opened with an empty card (no cover image, no title). When a new media
+    // type is added, mirror it here so the same regression can't slip in.
+
+    test('should propagate game data', () async {
+      const Game testGame = Game(id: 100, name: 'Hades');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 1,
+        collectionId: 10,
+        mediaType: MediaType.game,
+        externalId: 100,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        game: testGame,
+      ));
+      expect(item.game?.id, testGame.id);
+    });
+
+    test('should propagate movie data', () async {
+      const Movie testMovie = Movie(tmdbId: 200, title: 'Spirited Away');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 2,
+        collectionId: 10,
+        mediaType: MediaType.movie,
+        externalId: 200,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        movie: testMovie,
+      ));
+      expect(item.movie?.tmdbId, testMovie.tmdbId);
+    });
+
+    test('should propagate tvShow data', () async {
+      const TvShow testTv = TvShow(tmdbId: 300, title: 'Breaking Bad');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 3,
+        collectionId: 10,
+        mediaType: MediaType.tvShow,
+        externalId: 300,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        tvShow: testTv,
+      ));
+      expect(item.tvShow?.tmdbId, testTv.tmdbId);
+    });
+
+    test('should propagate visualNovel data', () async {
+      const VisualNovel testVn = VisualNovel(id: 'v17', title: 'Ever17');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 4,
+        collectionId: 10,
+        mediaType: MediaType.visualNovel,
+        externalId: 17,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        visualNovel: testVn,
+      ));
+      expect(item.visualNovel?.id, testVn.id);
+    });
+
+    test('should propagate manga data', () async {
+      const Manga testManga = Manga(id: 500, title: 'Berserk');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 5,
+        collectionId: 10,
+        mediaType: MediaType.manga,
+        externalId: 500,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        manga: testManga,
+      ));
+      expect(item.manga?.id, testManga.id);
+    });
+
+    test('should propagate anime data', () async {
+      const Anime testAnime = Anime(id: 600, title: 'Cowboy Bebop');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 6,
+        collectionId: 10,
+        mediaType: MediaType.anime,
+        externalId: 600,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        anime: testAnime,
+      ));
+      expect(item.anime?.id, testAnime.id);
+    });
+
+    test('should propagate customMedia data', () async {
+      const CustomMedia testCustom =
+          CustomMedia(id: 700, title: 'My homebrew');
+      final CanvasItem item = await initAndGetFirstItem(CollectionItem(
+        id: 7,
+        collectionId: 10,
+        mediaType: MediaType.custom,
+        externalId: 700,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2024),
+        customMedia: testCustom,
+      ));
+      expect(item.customMedia?.id, testCustom.id);
+    });
+  });
+}

--- a/test/features/collections/providers/steamgriddb_panel_provider_test.dart
+++ b/test/features/collections/providers/steamgriddb_panel_provider_test.dart
@@ -269,6 +269,44 @@ void main() {
             container.read(steamGridDbPanelProvider(testCollectionId));
         expect(state.isOpen, false);
       });
+
+      // Regression: provider was keyed by `collectionId`, so canvases that
+      // share a collection id (different per-item canvases inside the same
+      // collection) used to see each other's stale search results. Closing
+      // the panel must reset the search-side state so the next open is
+      // fresh, regardless of who reopens it.
+      test('should reset search/results/selection but keep imageCache', () {
+        when(() => mockApi.searchGames('Chrono')).thenAnswer(
+          (_) async => const <SteamGridDbGame>[testGame],
+        );
+
+        final ProviderContainer container = createContainer();
+        final SteamGridDbPanelNotifier notifier =
+            container.read(steamGridDbPanelProvider(testCollectionId).notifier);
+
+        // Prime some state plus the image cache.
+        notifier.openPanel();
+        notifier.state = notifier.state.copyWith(
+          searchTerm: 'Chrono',
+          searchResults: const <SteamGridDbGame>[testGame],
+          selectedGame: testGame,
+          images: const <SteamGridDbImage>[],
+          imageCache: const <String, List<SteamGridDbImage>>{
+            '1:grids': <SteamGridDbImage>[],
+          },
+        );
+
+        notifier.closePanel();
+
+        final SteamGridDbPanelState state =
+            container.read(steamGridDbPanelProvider(testCollectionId));
+        expect(state.isOpen, false);
+        expect(state.searchTerm, '');
+        expect(state.searchResults, isEmpty);
+        expect(state.selectedGame, isNull);
+        expect(state.images, isEmpty);
+        expect(state.imageCache, isNotEmpty);
+      });
     });
 
     group('searchGames', () {

--- a/test/features/collections/providers/vgmaps_panel_provider_test.dart
+++ b/test/features/collections/providers/vgmaps_panel_provider_test.dart
@@ -172,6 +172,36 @@ void main() {
 
         container.dispose();
       });
+
+      // Mirrors the SteamGridDB regression: provider is keyed by
+      // `collectionId`, so without resetting the URL and any captured
+      // image the previous browsing session leaked into the next canvas
+      // that opened the panel.
+      test('should reset navigation and captured-image state', () {
+        final ProviderContainer container = createContainer();
+        final VgMapsPanelNotifier notifier =
+            container.read(vgMapsPanelProvider(testCollectionId).notifier);
+
+        notifier.openPanel();
+        notifier.setCurrentUrl('https://example.com/some-map');
+        notifier.captureImage(
+          'https://example.com/img.png',
+          width: 800,
+          height: 600,
+        );
+
+        notifier.closePanel();
+
+        final VgMapsPanelState state =
+            container.read(vgMapsPanelProvider(testCollectionId));
+        expect(state.isOpen, false);
+        expect(state.currentUrl, vgMapsHomeUrl);
+        expect(state.capturedImageUrl, isNull);
+        expect(state.capturedImageWidth, isNull);
+        expect(state.capturedImageHeight, isNull);
+
+        container.dispose();
+      });
     });
 
     group('setCurrentUrl', () {


### PR DESCRIPTION
Bugs:
* canvas first-init now copies anime + customMedia through to CanvasItem (both collection canvas via initializeCanvas and per-item canvas via _initializeWithCollectionItem)
* DraggableFab gains initialRight/initialBottom; collection screen pushes it inward on canvas mode so it stops landing on the canvas toolbar column
* SteamGridDB / VgMaps side panels reset their search/browser state on closePanel — provider is keyed by collectionId, so per-item canvases inside the same collection used to leak each other's queries

Refactor:
* extract CanvasItemActions service holding all add/edit dialog plumbing (text/image/link/edit-connection). Internal _showAndApply collapses the seven copies of show → null-check → mounted-check → controller call
* _CanvasViewState sheds ~120 lines

Perf:
* canvas load is now two-phase — phase 1 renders a skeleton (positions + types) as soon as the bare rows are loaded, phase 2 hydrates cover art and titles via the new public CanvasRepository.enrichItems. A _loadGeneration counter discards superseded phase-2 results. Same shape applied to per-item canvas for symmetry.

Tests + housekeeping:
* +1 canvas_repository_test (table-driven media-type propagation)
* +7 new game_canvas_provider_test (same propagation for per-item)
* +2 reset regression tests (steamgriddb + vgmaps panels)
* dartdocs in both panel providers translated to English