### PR TITLE
Refactor/collection screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,66 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Lazy-render the collection table and react chevron counts to the active status**
+
+  Opening a 500+ item collection in table mode no longer freezes ~500ms:
+  the table body is now a `SliverList.builder` (and `SliverReorderableList`
+  in manual sort) embedded in a shared `CustomScrollView`, so only the
+  rows in the viewport are built. The type chevron bar above the table
+  also reacts to the active status filter — picking "Completed" in the
+  dropdown or cycling the in-table Status column reflects in the per-type
+  counts. Chevrons that were visible before the filter stay visible even
+  if their filtered count is zero, so the bar no longer jumps.
+
+  * lib/features/collections/widgets/collection_table/collection_table_view.dart
+    (CollectionTableView, _CollectionTableViewState._buildSortableSliver,
+    _buildReorderableSliver, initState, didUpdateWidget): Replace
+    `ListView.builder(shrinkWrap, NeverScrollable)` /
+    `ReorderableListView.builder` with `SliverList.builder` /
+    `SliverReorderableList`. Accept `heroHeader` so the collection hero
+    becomes the first sliver, drop the outer `_withHeader(wrapInScroll)`
+    wrapper. Outer horizontal scroll only kicks in when `maxWidth < 864`.
+    Add `onFilterStatusChanged` callback, sync to null on mount and on
+    items-identity change so the parent screen never holds a stale
+    column-header filter.
+  * lib/features/collections/widgets/collection_items_view.dart
+    (CollectionItemsView, onTableFilterStatusChanged): Forward the
+    table's status filter outward; drop `_withHeader` for table mode.
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState._tableFilterStatus,
+    _effectiveStatusForChevrons): Track the table column's status filter
+    separately so the chevron bar reflects it; the dropdown still shows
+    only the dropdown-selected status.
+  * lib/features/collections/widgets/collection_filter_bar.dart
+    (CollectionFilterBar.effectiveStatusForCounts,
+    _CollectionFilterBarState._typeCounts, _totalCountFor): Split
+    "visibility" (uses `CollectionStats` totals) from "displayed count"
+    (filtered by status) so chevrons don't disappear when the filter
+    zeroes a type.
+  * lib/features/collections/widgets/collection_filter_sheet.dart,
+    lib/features/settings/widgets/settings_group.dart: Wrap the
+    decorated body in `Material(type: MaterialType.transparency)` so
+    descendant `ListTile` / `RadioListTile` widgets find a Material
+    ancestor before the styled `DecoratedBox` / `Container`, silencing
+    "ListTile background color or ink splashes may be invisible".
+  * test/features/collections/widgets/collection_table_view_test.dart:
+    Drop the `find.byType(ListView)` assertion (sliver-based view no
+    longer exposes one); rely on `takeException()` for the render-empty
+    check.
+
+- **Widen the collection table Status column**
+
+  Status labels like "Backlog", "Want to watch", "Completed" no longer
+  truncate to the leading icon. The column grows 96 → 140 px in both
+  header and rows; the table's minimum width before horizontal scroll
+  bumps 820 → 864 to keep everything aligned.
+
+  * lib/features/collections/widgets/collection_table/table_header.dart,
+    lib/features/collections/widgets/collection_table/table_row.dart:
+    Status column width 96 → 140.
+  * lib/features/collections/widgets/collection_table/collection_table_view.dart
+    (_CollectionTableViewState._minTableWidth): 820 → 864.
+
 - **Split the collection screen god class and unify the error state**
 
   The 984-line `_CollectionScreenState` shed its FAB tower, the bulk-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,42 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Split the collection screen god class and unify the error state**
+
+  The 984-line `_CollectionScreenState` shed its FAB tower, the bulk-action
+  bar, the error state, the create-tier-list dialog, and the filter logic
+  into reusable units under `widgets/collection_screen/`,
+  `widgets/dialogs/`, and `helpers/`. The string-typed menu dispatch
+  (`'custom_item'`, `'rename'`, …) became a `CollectionMenuAction` enum
+  with an exhaustive switch. The new `CollectionErrorState` widget also
+  replaces the byte-identical `_buildErrorState` that the collections home
+  screen carried, so both screens now share a single retry view.
+
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState._toggleLock, _handleMenuAction): 984 lines → 757.
+    Lock toggle and menu dispatch became named handlers; the FAB builders,
+    bulk-action Consumer, error state, and tier-list dialog moved out.
+  * lib/features/collections/screens/home_screen.dart
+    (_CollectionsHomeScreenState._buildErrorState): Removed — replaced
+    inline with `CollectionErrorState`.
+  * lib/features/collections/widgets/collection_screen/collection_screen_fab.dart
+    (CollectionScreenFab, CollectionMenuAction): New widget owning the
+    main FAB, primary action row, and secondary action list; the menu
+    callback now takes a typed enum instead of a string.
+  * lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+    (CollectionBulkActionBar): New ConsumerWidget that watches selection
+    and items, short-circuits when empty, and renders `BulkActionBar`.
+  * lib/features/collections/widgets/collection_screen/collection_error_state.dart
+    (CollectionErrorState): New shared error view used by both the
+    collection screen and the collections home screen.
+  * lib/features/collections/widgets/dialogs/create_tier_list_dialog.dart
+    (CreateTierListDialog.show): New helper — returns the trimmed name and
+    disposes its `TextEditingController` via `whenComplete`.
+  * lib/features/collections/helpers/collection_filters.dart
+    (CollectionFilters, CollectionFilters.apply): New value type that
+    holds the four filter sets plus the search query; pure function
+    extracted from `_applyFilters`.
+
 - **Split the item detail screen god class and drop the Activity & Progress wrapper**
 
   The 1488-line `_ItemDetailScreenState` shed seven independent widgets into

--- a/lib/features/collections/helpers/collection_filters.dart
+++ b/lib/features/collections/helpers/collection_filters.dart
@@ -1,0 +1,71 @@
+import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/collection_tag.dart';
+import '../../../shared/models/item_status.dart';
+import '../../../shared/models/media_type.dart';
+
+class CollectionFilters {
+  const CollectionFilters({
+    this.mediaTypes = const <MediaType>{},
+    this.platformIds = const <int>{},
+    this.tagIds = const <int>{},
+    this.status,
+    this.searchQuery = '',
+  });
+
+  final Set<MediaType> mediaTypes;
+  final Set<int> platformIds;
+  final Set<int> tagIds;
+  final ItemStatus? status;
+  final String searchQuery;
+
+  List<CollectionItem> apply(
+    List<CollectionItem> items,
+    List<CollectionTag> tags,
+  ) {
+    List<CollectionItem> result = items;
+
+    if (mediaTypes.isNotEmpty) {
+      result = result
+          .where((CollectionItem item) => mediaTypes.contains(item.mediaType))
+          .toList();
+    }
+
+    if (platformIds.isNotEmpty) {
+      result = result
+          .where((CollectionItem item) =>
+              item.platformId != null &&
+              platformIds.contains(item.platformId))
+          .toList();
+    }
+
+    if (tagIds.isNotEmpty) {
+      result = result
+          .where((CollectionItem item) =>
+              item.tagId != null && tagIds.contains(item.tagId))
+          .toList();
+    }
+
+    if (status != null) {
+      result = result
+          .where((CollectionItem item) => item.status == status)
+          .toList();
+    }
+
+    if (searchQuery.isEmpty) return result;
+
+    final String query = searchQuery.toLowerCase();
+    final Map<int, String> tagNames = <int, String>{
+      for (final CollectionTag tag in tags) tag.id: tag.name.toLowerCase(),
+    };
+    return result
+        .where(
+          (CollectionItem item) =>
+              item.itemName.toLowerCase().contains(query) ||
+              (item.tagId != null &&
+                  (tagNames[item.tagId]?.contains(query) ?? false)) ||
+              (item.userComment?.toLowerCase().contains(query) ?? false) ||
+              (item.authorComment?.toLowerCase().contains(query) ?? false),
+        )
+        .toList();
+  }
+}

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -91,7 +91,11 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
   Set<int> _filterTagIds = <int>{};
   bool _groupByTags = false;
   ItemStatus? _filterStatus;
+  ItemStatus? _tableFilterStatus;
   CollectionItem? _focusedItem;
+
+  ItemStatus? get _effectiveStatusForChevrons =>
+      _filterStatus ?? (_isTableMode ? _tableFilterStatus : null);
 
   /// Реальная возможность редактирования с учётом режима просмотра.
   bool get _effectiveIsEditable =>
@@ -306,6 +310,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       filterPlatformIds: _filterPlatformIds,
       filterTagIds: _filterTagIds,
       filterStatus: _filterStatus,
+      effectiveStatusForCounts: _effectiveStatusForChevrons,
       tags: tags,
       searchQuery: searchQuery,
       groupByTags: _groupByTags,
@@ -427,6 +432,9 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             : null,
         onItemFocusChanged: (CollectionItem item, bool hasFocus) {
           setState(() => _focusedItem = hasFocus ? item : null);
+        },
+        onTableFilterStatusChanged: (ItemStatus? status) {
+          setState(() => _tableFilterStatus = status);
         },
       ),
       loading: () => const Center(child: CircularProgressIndicator()),

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -13,9 +13,7 @@ import '../widgets/create_custom_item_dialog.dart';
 import '../../../shared/keyboard/keyboard_shortcuts.dart';
 import '../../../data/repositories/collection_repository.dart';
 import '../../../shared/theme/app_colors.dart';
-import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/navigation/search_providers.dart';
-import '../../../shared/widgets/draggable_fab.dart';
 import '../../../shared/widgets/sub_screen_title_bar.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/models/collection.dart';
@@ -29,11 +27,14 @@ import '../../../shared/constants/platform_features.dart';
 import '../../home/providers/all_items_provider.dart';
 import '../widgets/import_progress_dialog.dart';
 import '../helpers/collection_actions.dart';
+import '../helpers/collection_filters.dart';
 import '../providers/collection_covers_provider.dart';
 import '../providers/collection_tags_provider.dart';
-import '../providers/collection_selection_provider.dart';
 import '../providers/collections_provider.dart';
-import '../widgets/bulk_action_bar.dart';
+import '../widgets/collection_screen/collection_bulk_action_bar.dart';
+import '../widgets/collection_screen/collection_error_state.dart';
+import '../widgets/collection_screen/collection_screen_fab.dart';
+import '../widgets/dialogs/create_tier_list_dialog.dart';
 import '../providers/steamgriddb_panel_provider.dart';
 import '../providers/vgmaps_panel_provider.dart';
 import '../widgets/collection_canvas_layout.dart';
@@ -185,30 +186,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
                     : _collection!.name,
               ),
               if (_canEdit && !_isCanvasMode)
-                Consumer(builder: (BuildContext context, WidgetRef ref, _) {
-                  final Set<int> selection = ref.watch(
-                      collectionSelectionProvider(widget.collectionId));
-                  if (selection.isEmpty) return const SizedBox.shrink();
-                  final List<CollectionItem> all = ref
-                          .watch(collectionItemsNotifierProvider(
-                              widget.collectionId))
-                          .valueOrNull ??
-                      const <CollectionItem>[];
-                  final List<CollectionItem> selectedItems = <CollectionItem>[
-                    for (final CollectionItem i in all)
-                      if (selection.contains(i.id)) i,
-                  ];
-                  if (selectedItems.isEmpty) return const SizedBox.shrink();
-                  return BulkActionBar(
-                    items: selectedItems,
-                    collectionId: widget.collectionId,
-                    onClearSelection: () => ref
-                        .read(collectionSelectionProvider(
-                                widget.collectionId)
-                            .notifier)
-                        .clear(),
-                  );
-                }),
+                CollectionBulkActionBar(collectionId: widget.collectionId),
               Expanded(
                 child: _isCanvasMode
                     ? CollectionCanvasLayout(
@@ -240,12 +218,23 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
               ),
             ],
           ),
-          DraggableFab(
-            key: ValueKey<bool>(_isCanvasMode),
-            mainAction: _buildMainFabAction(l),
-            primaryItems: _buildPrimaryFabItems(l),
-            items: _buildSecondaryFabItems(l),
-            initialRight: _isCanvasMode ? 72 : null,
+          CollectionScreenFab(
+            canEdit: _canEdit,
+            isUncategorized: _isUncategorized,
+            isCollectionEditable: _collection?.isEditable ?? false,
+            isCanvasMode: _isCanvasMode,
+            isTableMode: _isTableMode,
+            isViewModeLocked: _isViewModeLocked,
+            onAddItems: () => CollectionActions.addItems(
+              context: context,
+              ref: ref,
+              collectionId: widget.collectionId,
+            ),
+            onCycleViewMode: _handleCycleViewMode,
+            onToggleLock: _toggleLock,
+            onToggleCanvas: () =>
+                setState(() => _isCanvasMode = !_isCanvasMode),
+            onMenuAction: _handleMenuAction,
           ),
         ],
       ),
@@ -284,119 +273,14 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     };
   }
 
-  /// Основные действия — горизонтальный ряд иконок.
-  DraggableFabItem? _buildMainFabAction(S l) {
-    if (!_canEdit || _isCanvasMode) return null;
-    return DraggableFabItem(
-      icon: Icons.add,
-      label: l.collectionAddItems,
-      onTap: () => CollectionActions.addItems(
-        context: context,
-        ref: ref,
-        collectionId: widget.collectionId,
-      ),
-    );
-  }
-
-  List<DraggableFabItem> _buildPrimaryFabItems(S l) {
-    return <DraggableFabItem>[
-      if (!_isCanvasMode)
-        DraggableFabItem(
-          icon: _isTableMode ? Icons.grid_view : Icons.table_chart_outlined,
-          label: _isTableMode
-              ? l.collectionListViewGrid
-              : l.collectionListViewTable,
-          onTap: _handleCycleViewMode,
-        ),
-      if (_canEdit && _isCanvasMode && kCanvasEnabled && !_isUncategorized)
-        DraggableFabItem(
-          icon: _isViewModeLocked ? Icons.lock : Icons.lock_open,
-          label: _isViewModeLocked
-              ? l.collectionUnlockBoard
-              : l.collectionLockBoard,
-          iconColor: _isViewModeLocked ? AppColors.warning : null,
-          onTap: () {
-            setState(() {
-              _isViewModeLocked = !_isViewModeLocked;
-            });
-            if (_isViewModeLocked) {
-              ref
-                  .read(steamGridDbPanelProvider(widget.collectionId)
-                      .notifier)
-                  .closePanel();
-              ref
-                  .read(vgMapsPanelProvider(widget.collectionId).notifier)
-                  .closePanel();
-            }
-          },
-        ),
-      if (kCanvasEnabled && !_isUncategorized)
-        DraggableFabItem(
-          icon: _isCanvasMode ? Icons.list : Icons.dashboard,
-          label: _isCanvasMode
-              ? l.collectionSwitchToList
-              : l.collectionSwitchToBoard,
-          onTap: () => setState(() => _isCanvasMode = !_isCanvasMode),
-        ),
-    ];
-  }
-
-  /// Остальные действия — вертикальный список.
-  List<DraggableFabItem> _buildSecondaryFabItems(S l) {
-    if (_isUncategorized) return const <DraggableFabItem>[];
-    return <DraggableFabItem>[
-      if (_collection!.isEditable)
-        DraggableFabItem(
-          icon: Icons.add_box_outlined,
-          label: l.customItemCreate,
-          iconColor: AppColors.brand,
-          onTap: () => _handleMenuAction('custom_item'),
-        ),
-      if (_collection!.isEditable)
-        DraggableFabItem(
-          icon: Icons.tune,
-          label: l.collectionEditMenu,
-          onTap: () => _handleMenuAction('rename'),
-        ),
-      DraggableFabItem(
-        icon: Icons.leaderboard,
-        label: l.tierListCreateFromCollection,
-        onTap: () => _handleMenuAction('tier_list'),
-      ),
-      DraggableFabItem(
-        icon: Icons.label_outlined,
-        label: l.tagManage,
-        onTap: () => _handleMenuAction('manage_tags'),
-      ),
-      DraggableFabItem(
-        icon: Icons.content_copy,
-        label: l.copyAsList,
-        onTap: () => _handleMenuAction('copy_as_list'),
-      ),
-      DraggableFabItem(
-        icon: Icons.text_snippet_outlined,
-        label: l.copyAsText,
-        onTap: () => _handleMenuAction('copy_as_text'),
-      ),
-      DraggableFabItem(
-        icon: Icons.file_upload_outlined,
-        label: l.collectionExport,
-        onTap: () => _handleMenuAction('export'),
-      ),
-      if (_collection!.isEditable)
-        DraggableFabItem(
-          icon: Icons.file_download_outlined,
-          label: l.collectionsImportCollection,
-          onTap: () => _handleMenuAction('import'),
-        ),
-      const DraggableFabDivider(),
-      DraggableFabItem(
-        icon: Icons.delete,
-        label: l.delete,
-        iconColor: AppColors.error,
-        onTap: () => _handleMenuAction('delete'),
-      ),
-    ];
+  void _toggleLock() {
+    setState(() => _isViewModeLocked = !_isViewModeLocked);
+    if (_isViewModeLocked) {
+      ref
+          .read(steamGridDbPanelProvider(widget.collectionId).notifier)
+          .closePanel();
+      ref.read(vgMapsPanelProvider(widget.collectionId).notifier).closePanel();
+    }
   }
 
   Widget _buildFilterBar(
@@ -512,10 +396,18 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
           )
         : null;
 
+    final CollectionFilters filters = CollectionFilters(
+      mediaTypes: _filterTypes,
+      platformIds: _filterPlatformIds,
+      tagIds: _filterTagIds,
+      status: _filterStatus,
+      searchQuery: searchQuery,
+    );
+
     final Widget itemsView = itemsAsync.when(
       data: (List<CollectionItem> items) => CollectionItemsView(
         collectionId: widget.collectionId,
-        items: _applyFilters(items, tags),
+        items: filters.apply(items, tags),
         tags: tags,
         filterTagIds: _filterTagIds,
         groupByTags: _groupByTags,
@@ -538,8 +430,12 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
         },
       ),
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (Object error, StackTrace stack) =>
-          _buildErrorState(context, error),
+      error: (Object error, StackTrace stack) => CollectionErrorState(
+        error: error,
+        onRetry: () => ref
+            .read(collectionItemsNotifierProvider(widget.collectionId).notifier)
+            .refresh(),
+      ),
     );
 
     final Widget? tagSidebar =
@@ -580,67 +476,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     );
   }
 
-  /// Применяет фильтры по типу, платформе, тегу и поисковой строке.
-  List<CollectionItem> _applyFilters(
-    List<CollectionItem> items,
-    List<CollectionTag> tags,
-  ) {
-    List<CollectionItem> result = items;
-
-    if (_filterTypes.isNotEmpty) {
-      result = result
-          .where((CollectionItem item) =>
-              _filterTypes.contains(item.mediaType))
-          .toList();
-    }
-
-    if (_filterPlatformIds.isNotEmpty) {
-      result = result
-          .where((CollectionItem item) =>
-              item.platformId != null &&
-              _filterPlatformIds.contains(item.platformId))
-          .toList();
-    }
-
-    if (_filterTagIds.isNotEmpty) {
-      result = result
-          .where((CollectionItem item) =>
-              item.tagId != null && _filterTagIds.contains(item.tagId))
-          .toList();
-    }
-
-    if (_filterStatus != null) {
-      result = result
-          .where((CollectionItem item) => item.status == _filterStatus)
-          .toList();
-    }
-
-    final String textQuery = ref.read(collectionsSearchQueryProvider);
-
-    if (textQuery.isNotEmpty) {
-      final String query = textQuery.toLowerCase();
-      final Map<int, String> tagNames = <int, String>{
-        for (final CollectionTag tag in tags) tag.id: tag.name.toLowerCase(),
-      };
-      result = result
-          .where(
-            (CollectionItem item) =>
-                item.itemName.toLowerCase().contains(query) ||
-                (item.tagId != null &&
-                    (tagNames[item.tagId]?.contains(query) ?? false)) ||
-                (item.userComment?.toLowerCase().contains(query) ?? false) ||
-                (item.authorComment?.toLowerCase().contains(query) ?? false),
-          )
-          .toList();
-    }
-
-    return result;
-  }
-
-  // =========================================================================
-  // Навигация и обработчики действий
-  // =========================================================================
-
   void _showItemDetails(CollectionItem item) {
     final bool isEditable = _canEdit;
     Navigator.of(context).push(
@@ -678,25 +513,25 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     );
   }
 
-  void _handleMenuAction(String action) {
+  void _handleMenuAction(CollectionMenuAction action) {
     switch (action) {
-      case 'custom_item':
+      case CollectionMenuAction.customItem:
         _handleCreateCustomItem();
-      case 'rename':
+      case CollectionMenuAction.rename:
         _handleRename();
-      case 'tier_list':
+      case CollectionMenuAction.tierList:
         _handleCreateTierList();
-      case 'manage_tags':
+      case CollectionMenuAction.manageTags:
         TagManagementDialog.show(context, widget.collectionId!);
-      case 'copy_as_list':
+      case CollectionMenuAction.copyAsList:
         _handleCopyAsList();
-      case 'copy_as_text':
+      case CollectionMenuAction.copyAsText:
         _handleCopyAsText();
-      case 'export':
+      case CollectionMenuAction.export:
         _handleExport();
-      case 'import':
+      case CollectionMenuAction.import:
         _handleImportIntoCollection();
-      case 'delete':
+      case CollectionMenuAction.delete:
         _handleDelete();
     }
   }
@@ -756,37 +591,13 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
 
   Future<void> _handleCreateTierList() async {
     if (_collection == null) return;
-    final S l = S.of(context);
-    final TextEditingController controller =
-        TextEditingController(text: '${_collection!.name} Tier List');
-    final String? name = await showDialog<String>(
-      context: context,
-      builder: (BuildContext ctx) => AlertDialog(
-        title: Text(l.tierListCreateFromCollection),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: InputDecoration(hintText: l.tierListNameHint),
-          onSubmitted: (String value) =>
-              Navigator.of(ctx).pop(value.trim()),
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: Text(l.cancel),
-          ),
-          TextButton(
-            onPressed: () =>
-                Navigator.of(ctx).pop(controller.text.trim()),
-            child: Text(l.create),
-          ),
-        ],
-      ),
+    final String? name = await CreateTierListDialog.show(
+      context,
+      initialName: '${_collection!.name} Tier List',
     );
-    controller.dispose();
     if (name == null || name.isEmpty || !mounted) return;
-
     if (widget.collectionId == null) return;
+
     final TierList tierList = await ref
         .read(collectionTierListsProvider(widget.collectionId!).notifier)
         .create(name);
@@ -943,42 +754,4 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     );
   }
 
-  Widget _buildErrorState(BuildContext context, Object error) {
-    final S l = S.of(context);
-    return Center(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.all(AppSpacing.xl),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            const Icon(
-              Icons.error_outline,
-              size: 64,
-              color: AppColors.error,
-            ),
-            const SizedBox(height: AppSpacing.md),
-            Text(
-              l.collectionsFailedToLoad,
-              style: AppTypography.h3.copyWith(color: AppColors.error),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              error.toString(),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall,
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            FilledButton.icon(
-              onPressed: () => ref
-                  .read(collectionItemsNotifierProvider(widget.collectionId)
-                      .notifier)
-                  .refresh(),
-              icon: const Icon(Icons.refresh),
-              label: Text(l.retry),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -19,6 +19,7 @@ import '../../../shared/widgets/shimmer_loading.dart';
 import '../../home/providers/all_items_provider.dart';
 import '../providers/canvas_provider.dart';
 import '../providers/collection_covers_provider.dart';
+import '../widgets/collection_screen/collection_error_state.dart';
 import '../providers/collections_provider.dart';
 import '../../settings/providers/settings_provider.dart';
 import '../widgets/collection_card.dart';
@@ -82,8 +83,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   searchQuery: searchQuery,
                 ),
             loading: () => _buildLoadingState(),
-            error: (Object error, StackTrace stack) =>
-                _buildErrorState(context, ref, error),
+            error: (Object error, StackTrace stack) => CollectionErrorState(
+              error: error,
+              onRetry: () => ref.invalidate(collectionsProvider),
+            ),
           ),
           DraggableFab(
             mainAction: DraggableFabItem(
@@ -330,42 +333,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               style: AppTypography.body.copyWith(
                 color: AppColors.textSecondary,
               ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildErrorState(BuildContext context, WidgetRef ref, Object error) {
-    final S l = S.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.xl),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Icon(
-              Icons.error_outline,
-              size: 64,
-              color: AppColors.error,
-            ),
-            const SizedBox(height: AppSpacing.md),
-            Text(
-              l.collectionsFailedToLoad,
-              style: AppTypography.h3.copyWith(color: AppColors.error),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              error.toString(),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall,
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            FilledButton.icon(
-              onPressed: () => ref.invalidate(collectionsProvider),
-              icon: const Icon(Icons.refresh),
-              label: Text(l.retry),
             ),
           ],
         ),

--- a/lib/features/collections/widgets/collection_filter_bar.dart
+++ b/lib/features/collections/widgets/collection_filter_bar.dart
@@ -38,6 +38,7 @@ class CollectionFilterBar extends ConsumerStatefulWidget {
     required this.filterPlatformIds,
     required this.filterTagIds,
     required this.filterStatus,
+    this.effectiveStatusForCounts,
     required this.tags,
     this.searchQuery = '',
     required this.onTypeToggled,
@@ -69,6 +70,11 @@ class CollectionFilterBar extends ConsumerStatefulWidget {
 
   /// Фильтр по статусу.
   final ItemStatus? filterStatus;
+
+  /// Status that drives chevron counts when it diverges from [filterStatus]
+  /// (e.g. the table column header cycled a local filter). Falls back to
+  /// [filterStatus] when null.
+  final ItemStatus? effectiveStatusForCounts;
 
   /// Теги коллекции.
   final List<CollectionTag> tags;
@@ -135,7 +141,7 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
         (hideEmpty && stats != null)
             ? entries
                 .where((_TypeEntry e) =>
-                    (e.count ?? 0) > 0 ||
+                    (_totalCountFor(e.type, stats) ?? 0) > 0 ||
                     widget.filterTypes.contains(e.type))
                 .toList()
             : entries;
@@ -395,16 +401,47 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
   }
 
   List<_TypeEntry> _typeEntries(S l, CollectionStats? stats) {
+    final Map<MediaType, int?> counts = _typeCounts(stats);
     return <_TypeEntry>[
-      _TypeEntry(MediaType.game, l.collectionFilterGames, stats?.gameCount),
-      _TypeEntry(MediaType.movie, l.collectionFilterMovies, stats?.movieCount),
-      _TypeEntry(MediaType.tvShow, l.collectionFilterTvShows, stats?.tvShowCount),
-      _TypeEntry(MediaType.animation, l.collectionFilterAnimation, stats?.animationCount),
-      _TypeEntry(MediaType.visualNovel, l.collectionFilterVisualNovels, stats?.visualNovelCount),
-      _TypeEntry(MediaType.manga, l.collectionFilterManga, stats?.mangaCount),
-      _TypeEntry(MediaType.anime, l.mediaTypeAnime, stats?.animeCount),
-      _TypeEntry(MediaType.custom, l.collectionFilterCustom, stats?.customCount),
+      _TypeEntry(MediaType.game, l.collectionFilterGames, counts[MediaType.game]),
+      _TypeEntry(MediaType.movie, l.collectionFilterMovies, counts[MediaType.movie]),
+      _TypeEntry(MediaType.tvShow, l.collectionFilterTvShows, counts[MediaType.tvShow]),
+      _TypeEntry(MediaType.animation, l.collectionFilterAnimation, counts[MediaType.animation]),
+      _TypeEntry(MediaType.visualNovel, l.collectionFilterVisualNovels, counts[MediaType.visualNovel]),
+      _TypeEntry(MediaType.manga, l.collectionFilterManga, counts[MediaType.manga]),
+      _TypeEntry(MediaType.anime, l.mediaTypeAnime, counts[MediaType.anime]),
+      _TypeEntry(MediaType.custom, l.collectionFilterCustom, counts[MediaType.custom]),
     ];
+  }
+
+  Map<MediaType, int?> _typeCounts(CollectionStats? stats) {
+    final ItemStatus? statusFilter =
+        widget.effectiveStatusForCounts ?? widget.filterStatus;
+    if (statusFilter == null) {
+      return <MediaType, int?>{
+        MediaType.game: stats?.gameCount,
+        MediaType.movie: stats?.movieCount,
+        MediaType.tvShow: stats?.tvShowCount,
+        MediaType.animation: stats?.animationCount,
+        MediaType.visualNovel: stats?.visualNovelCount,
+        MediaType.manga: stats?.mangaCount,
+        MediaType.anime: stats?.animeCount,
+        MediaType.custom: stats?.customCount,
+      };
+    }
+    final List<CollectionItem>? items = widget.itemsAsync.valueOrNull;
+    if (items == null) {
+      return const <MediaType, int?>{};
+    }
+    final Map<MediaType, int> tally = <MediaType, int>{
+      for (final MediaType t in MediaType.values) t: 0,
+    };
+    for (final CollectionItem item in items) {
+      if (item.status == statusFilter) {
+        tally[item.mediaType] = tally[item.mediaType]! + 1;
+      }
+    }
+    return tally;
   }
 }
 
@@ -413,4 +450,18 @@ class _TypeEntry {
   final MediaType type;
   final String label;
   final int? count;
+}
+
+int? _totalCountFor(MediaType type, CollectionStats? stats) {
+  if (stats == null) return null;
+  return switch (type) {
+    MediaType.game => stats.gameCount,
+    MediaType.movie => stats.movieCount,
+    MediaType.tvShow => stats.tvShowCount,
+    MediaType.animation => stats.animationCount,
+    MediaType.visualNovel => stats.visualNovelCount,
+    MediaType.manga => stats.mangaCount,
+    MediaType.anime => stats.animeCount,
+    MediaType.custom => stats.customCount,
+  };
 }

--- a/lib/features/collections/widgets/collection_filter_sheet.dart
+++ b/lib/features/collections/widgets/collection_filter_sheet.dart
@@ -202,9 +202,11 @@ class _CollectionFilterSheetState
                     color: AppColors.surfaceBorder.withAlpha(40),
                   ),
                 ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
+                child: Material(
+                  type: MaterialType.transparency,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
                     // Header: drag handle + Сбросить теги (если выбраны).
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
@@ -375,6 +377,7 @@ class _CollectionFilterSheetState
 
                     const SizedBox(height: AppSpacing.md),
                   ],
+                  ),
                 ),
               ),
             ),

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -44,6 +44,7 @@ class CollectionItemsView extends ConsumerWidget {
     this.filterTagIds = const <int>{},
     this.groupByTags = false,
     this.header,
+    this.onTableFilterStatusChanged,
     super.key,
   });
 
@@ -67,6 +68,10 @@ class CollectionItemsView extends ConsumerWidget {
   /// reorder modes pin it above instead — those widgets don't accept slivers.
   final Widget? header;
 
+  /// Mirrors the table's status column filter outward so chevron counts in
+  /// the outer filter bar can react to in-table cycling.
+  final ValueChanged<ItemStatus?>? onTableFilterStatusChanged;
+
   static const double _desktopMaxCardWidth = 170;
 
   @override
@@ -84,10 +89,10 @@ class CollectionItemsView extends ConsumerWidget {
       final Set<int>? selectedIds = canEdit
           ? ref.watch(collectionSelectionProvider(collectionId))
           : null;
-      return _withHeader(
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-          child: CollectionTableView(
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+        child: CollectionTableView(
+          heroHeader: header,
           items: items,
           tags: tags,
           onItemTap: onItemTap,
@@ -148,9 +153,8 @@ class CollectionItemsView extends ConsumerWidget {
                       .reorderItem(oldIndex, newIndex);
                 }
               : null,
-          ),
+          onFilterStatusChanged: onTableFilterStatusChanged,
         ),
-        wrapInScroll: true,
       );
     }
 

--- a/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../shared/models/collection_item.dart';
+import '../../providers/collection_selection_provider.dart';
+import '../../providers/collections_provider.dart';
+import '../bulk_action_bar.dart';
+
+class CollectionBulkActionBar extends ConsumerWidget {
+  const CollectionBulkActionBar({required this.collectionId, super.key});
+
+  final int? collectionId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Set<int> selection = ref.watch(
+      collectionSelectionProvider(collectionId),
+    );
+    if (selection.isEmpty) return const SizedBox.shrink();
+
+    final List<CollectionItem> all = ref
+            .watch(collectionItemsNotifierProvider(collectionId))
+            .valueOrNull ??
+        const <CollectionItem>[];
+    final List<CollectionItem> selectedItems = <CollectionItem>[
+      for (final CollectionItem i in all)
+        if (selection.contains(i.id)) i,
+    ];
+    if (selectedItems.isEmpty) return const SizedBox.shrink();
+
+    return BulkActionBar(
+      items: selectedItems,
+      collectionId: collectionId,
+      onClearSelection: () => ref
+          .read(collectionSelectionProvider(collectionId).notifier)
+          .clear(),
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_screen/collection_error_state.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_error_state.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../../shared/theme/app_colors.dart';
+import '../../../../shared/theme/app_spacing.dart';
+import '../../../../shared/theme/app_typography.dart';
+
+class CollectionErrorState extends StatelessWidget {
+  const CollectionErrorState({
+    required this.error,
+    required this.onRetry,
+    super.key,
+  });
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.error_outline, size: 64, color: AppColors.error),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              l.collectionsFailedToLoad,
+              style: AppTypography.h3.copyWith(color: AppColors.error),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              error.toString(),
+              textAlign: TextAlign.center,
+              style: AppTypography.bodySmall,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            FilledButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: Text(l.retry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_screen/collection_screen_fab.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_screen_fab.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../../shared/constants/platform_features.dart';
+import '../../../../shared/theme/app_colors.dart';
+import '../../../../shared/widgets/draggable_fab.dart';
+
+enum CollectionMenuAction {
+  customItem,
+  rename,
+  tierList,
+  manageTags,
+  copyAsList,
+  copyAsText,
+  export,
+  import,
+  delete,
+}
+
+class CollectionScreenFab extends StatelessWidget {
+  const CollectionScreenFab({
+    required this.canEdit,
+    required this.isUncategorized,
+    required this.isCollectionEditable,
+    required this.isCanvasMode,
+    required this.isTableMode,
+    required this.isViewModeLocked,
+    required this.onAddItems,
+    required this.onCycleViewMode,
+    required this.onToggleLock,
+    required this.onToggleCanvas,
+    required this.onMenuAction,
+    super.key,
+  });
+
+  final bool canEdit;
+  final bool isUncategorized;
+  final bool isCollectionEditable;
+  final bool isCanvasMode;
+  final bool isTableMode;
+  final bool isViewModeLocked;
+  final VoidCallback onAddItems;
+  final VoidCallback onCycleViewMode;
+  final VoidCallback onToggleLock;
+  final VoidCallback onToggleCanvas;
+  final ValueChanged<CollectionMenuAction> onMenuAction;
+
+  DraggableFabItem? _mainAction(S l) {
+    if (!canEdit || isCanvasMode) return null;
+    return DraggableFabItem(
+      icon: Icons.add,
+      label: l.collectionAddItems,
+      onTap: onAddItems,
+    );
+  }
+
+  List<DraggableFabItem> _primaryItems(S l) {
+    return <DraggableFabItem>[
+      if (!isCanvasMode)
+        DraggableFabItem(
+          icon: isTableMode ? Icons.grid_view : Icons.table_chart_outlined,
+          label: isTableMode
+              ? l.collectionListViewGrid
+              : l.collectionListViewTable,
+          onTap: onCycleViewMode,
+        ),
+      if (canEdit && isCanvasMode && kCanvasEnabled && !isUncategorized)
+        DraggableFabItem(
+          icon: isViewModeLocked ? Icons.lock : Icons.lock_open,
+          label: isViewModeLocked
+              ? l.collectionUnlockBoard
+              : l.collectionLockBoard,
+          iconColor: isViewModeLocked ? AppColors.warning : null,
+          onTap: onToggleLock,
+        ),
+      if (kCanvasEnabled && !isUncategorized)
+        DraggableFabItem(
+          icon: isCanvasMode ? Icons.list : Icons.dashboard,
+          label: isCanvasMode
+              ? l.collectionSwitchToList
+              : l.collectionSwitchToBoard,
+          onTap: onToggleCanvas,
+        ),
+    ];
+  }
+
+  List<DraggableFabItem> _secondaryItems(S l) {
+    if (isUncategorized) return const <DraggableFabItem>[];
+    return <DraggableFabItem>[
+      if (isCollectionEditable)
+        DraggableFabItem(
+          icon: Icons.add_box_outlined,
+          label: l.customItemCreate,
+          iconColor: AppColors.brand,
+          onTap: () => onMenuAction(CollectionMenuAction.customItem),
+        ),
+      if (isCollectionEditable)
+        DraggableFabItem(
+          icon: Icons.tune,
+          label: l.collectionEditMenu,
+          onTap: () => onMenuAction(CollectionMenuAction.rename),
+        ),
+      DraggableFabItem(
+        icon: Icons.leaderboard,
+        label: l.tierListCreateFromCollection,
+        onTap: () => onMenuAction(CollectionMenuAction.tierList),
+      ),
+      DraggableFabItem(
+        icon: Icons.label_outlined,
+        label: l.tagManage,
+        onTap: () => onMenuAction(CollectionMenuAction.manageTags),
+      ),
+      DraggableFabItem(
+        icon: Icons.content_copy,
+        label: l.copyAsList,
+        onTap: () => onMenuAction(CollectionMenuAction.copyAsList),
+      ),
+      DraggableFabItem(
+        icon: Icons.text_snippet_outlined,
+        label: l.copyAsText,
+        onTap: () => onMenuAction(CollectionMenuAction.copyAsText),
+      ),
+      DraggableFabItem(
+        icon: Icons.file_upload_outlined,
+        label: l.collectionExport,
+        onTap: () => onMenuAction(CollectionMenuAction.export),
+      ),
+      if (isCollectionEditable)
+        DraggableFabItem(
+          icon: Icons.file_download_outlined,
+          label: l.collectionsImportCollection,
+          onTap: () => onMenuAction(CollectionMenuAction.import),
+        ),
+      const DraggableFabDivider(),
+      DraggableFabItem(
+        icon: Icons.delete,
+        label: l.delete,
+        iconColor: AppColors.error,
+        onTap: () => onMenuAction(CollectionMenuAction.delete),
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return DraggableFab(
+      key: ValueKey<bool>(isCanvasMode),
+      mainAction: _mainAction(l),
+      primaryItems: _primaryItems(l),
+      items: _secondaryItems(l),
+      initialRight: isCanvasMode ? 72 : null,
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_table/collection_table_view.dart
+++ b/lib/features/collections/widgets/collection_table/collection_table_view.dart
@@ -15,12 +15,13 @@ import 'table_row.dart' as table_row;
 export 'table_column.dart' show TableColumn;
 
 /// Manifest-style table view of a collection. When [onReorder] is supplied
-/// the view flips into a [ReorderableListView]: column sort/filter is
-/// disabled and a drag handle appears on every row.
+/// the view flips into a reorderable sliver: column sort/filter is disabled
+/// and a drag handle appears on every row.
 class CollectionTableView extends StatefulWidget {
   const CollectionTableView({
     required this.items,
     required this.onItemTap,
+    this.heroHeader,
     this.onItemSecondaryTap,
     this.tags = const <CollectionTag>[],
     this.onRatingChanged,
@@ -30,11 +31,13 @@ class CollectionTableView extends StatefulWidget {
     this.selectedIds,
     this.onToggleSelect,
     this.onToggleSelectAll,
+    this.onFilterStatusChanged,
     super.key,
   });
 
   final List<CollectionItem> items;
   final ValueChanged<CollectionItem> onItemTap;
+  final Widget? heroHeader;
   final void Function(CollectionItem item, Offset globalPosition)?
       onItemSecondaryTap;
   final List<CollectionTag> tags;
@@ -42,23 +45,22 @@ class CollectionTableView extends StatefulWidget {
   final void Function(int itemId, ItemStatus status, MediaType mediaType)?
       onStatusChanged;
   final void Function(int itemId, int? tagId)? onTagChanged;
-
-  /// When non-null the view becomes a [ReorderableListView] and column-based
-  /// sort/filter is disabled. Indices are reported with the trailing-shift
-  /// already removed (i.e. semantic source→destination).
   final void Function(int oldIndex, int newIndex)? onReorder;
-
-  /// Set of currently selected ids. Together with [onToggleSelect] this drives
-  /// per-row checkboxes and the master tri-state checkbox in the header.
   final Set<int>? selectedIds;
   final void Function(int itemId)? onToggleSelect;
   final void Function(bool selectAll)? onToggleSelectAll;
+
+  /// Notifies the parent when the in-table status column filter cycles, so
+  /// outside chrome (e.g. chevron counts) can mirror the active filter.
+  final ValueChanged<ItemStatus?>? onFilterStatusChanged;
 
   @override
   State<CollectionTableView> createState() => _CollectionTableViewState();
 }
 
 class _CollectionTableViewState extends State<CollectionTableView> {
+  static const double _minTableWidth = 864;
+
   TableColumn _sortColumn = TableColumn.name;
   bool _sortAscending = true;
 
@@ -71,16 +73,30 @@ class _CollectionTableViewState extends State<CollectionTableView> {
   late Map<int, CollectionTag> _cachedTagMap;
 
   @override
+  void initState() {
+    super.initState();
+    if (widget.onFilterStatusChanged != null) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => widget.onFilterStatusChanged?.call(null),
+      );
+    }
+  }
+
+  @override
   void didUpdateWidget(CollectionTableView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // Reset filters when the parent ships a fresh items list — otherwise a
-    // value pointing at a now-missing tag/status would silently hide rows.
     if (!identical(oldWidget.items, widget.items)) {
+      final bool hadStatusFilter = _filterStatus != null;
       _filterStatus = null;
       _filterType = null;
       _filterRating = null;
       _filterTagId = null;
       _filterPlatform = null;
+      if (hadStatusFilter) {
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => widget.onFilterStatusChanged?.call(null),
+        );
+      }
     }
   }
 
@@ -96,62 +112,60 @@ class _CollectionTableViewState extends State<CollectionTableView> {
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
+        final bool needsHorizontalScroll = constraints.maxWidth < _minTableWidth;
         final double tableWidth =
-            constraints.maxWidth < 820 ? 820 : constraints.maxWidth;
-        // Horizontal scroll for narrow windows; the body itself sizes to its
-        // content (shrinkWrap) so a parent vertical scrollable can carry it
-        // alongside an external header (e.g. collection hero).
+            needsHorizontalScroll ? _minTableWidth : constraints.maxWidth;
+
+        final Widget tableHeader = TableHeader(
+          sortColumn: _sortColumn,
+          sortAscending: _sortAscending,
+          onSort: _toggleSort,
+          filterStatus: _filterStatus,
+          filterType: _filterType,
+          filterRating: _filterRating,
+          filterTagId: _filterTagId,
+          filterPlatform: _filterPlatform,
+          tagMap: _cachedTagMap,
+          l: l,
+          isReorderable: isReorderable,
+          selectionState: _selectionStateForVisible(sorted),
+          onToggleSelectAll: widget.onToggleSelectAll,
+        );
+
+        final CustomScrollView scrollView = CustomScrollView(
+          slivers: <Widget>[
+            if (widget.heroHeader != null)
+              SliverToBoxAdapter(child: widget.heroHeader),
+            SliverToBoxAdapter(child: tableHeader),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+              sliver: isReorderable
+                  ? _buildReorderableSliver(sorted)
+                  : _buildSortableSliver(sorted),
+            ),
+          ],
+        );
+
+        if (!needsHorizontalScroll) return scrollView;
+
         return SingleChildScrollView(
           scrollDirection: Axis.horizontal,
-          child: SizedBox(
-            width: tableWidth,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                TableHeader(
-                  sortColumn: _sortColumn,
-                  sortAscending: _sortAscending,
-                  onSort: _toggleSort,
-                  filterStatus: _filterStatus,
-                  filterType: _filterType,
-                  filterRating: _filterRating,
-                  filterTagId: _filterTagId,
-                  filterPlatform: _filterPlatform,
-                  tagMap: _cachedTagMap,
-                  l: l,
-                  isReorderable: isReorderable,
-                  selectionState: _selectionStateForVisible(sorted),
-                  onToggleSelectAll: widget.onToggleSelectAll,
-                ),
-                isReorderable
-                    ? _buildReorderableBody(sorted)
-                    : _buildSortableBody(sorted),
-              ],
-            ),
-          ),
+          child: SizedBox(width: tableWidth, child: scrollView),
         );
       },
     );
   }
 
-  Widget _buildSortableBody(List<CollectionItem> sorted) {
-    return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+  Widget _buildSortableSliver(List<CollectionItem> sorted) {
+    return SliverList.builder(
       itemCount: sorted.length,
-      itemBuilder: (BuildContext context, int index) {
-        return _row(sorted[index], dragIndex: null);
-      },
+      itemBuilder: (BuildContext context, int index) =>
+          _row(sorted[index], dragIndex: null),
     );
   }
 
-  Widget _buildReorderableBody(List<CollectionItem> sorted) {
-    return ReorderableListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-      buildDefaultDragHandles: false,
+  Widget _buildReorderableSliver(List<CollectionItem> sorted) {
+    return SliverReorderableList(
       itemCount: sorted.length,
       proxyDecorator:
           (Widget child, int index, Animation<double> animation) {
@@ -172,9 +186,8 @@ class _CollectionTableViewState extends State<CollectionTableView> {
       onReorderItem: (int oldIndex, int newIndex) {
         widget.onReorder!(oldIndex, newIndex);
       },
-      itemBuilder: (BuildContext context, int index) {
-        return _row(sorted[index], dragIndex: index);
-      },
+      itemBuilder: (BuildContext context, int index) =>
+          _row(sorted[index], dragIndex: index),
     );
   }
 
@@ -184,20 +197,20 @@ class _CollectionTableViewState extends State<CollectionTableView> {
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs / 2),
       child: table_row.TableRow(
         item: item,
-      tag: item.tagId != null ? _cachedTagMap[item.tagId] : null,
-      tags: widget.tags,
-      onTap: () => widget.onItemTap(item),
-      onSecondaryTap: widget.onItemSecondaryTap != null
-          ? (Offset pos) => widget.onItemSecondaryTap!(item, pos)
-          : null,
-      onRatingChanged: widget.onRatingChanged,
-      onStatusChanged: widget.onStatusChanged,
-      onTagChanged: widget.onTagChanged,
-      dragIndex: dragIndex,
-      isSelected: widget.selectedIds?.contains(item.id) ?? false,
-      onToggleSelect: widget.onToggleSelect != null
-          ? () => widget.onToggleSelect!(item.id)
-          : null,
+        tag: item.tagId != null ? _cachedTagMap[item.tagId] : null,
+        tags: widget.tags,
+        onTap: () => widget.onItemTap(item),
+        onSecondaryTap: widget.onItemSecondaryTap != null
+            ? (Offset pos) => widget.onItemSecondaryTap!(item, pos)
+            : null,
+        onRatingChanged: widget.onRatingChanged,
+        onStatusChanged: widget.onStatusChanged,
+        onTagChanged: widget.onTagChanged,
+        dragIndex: dragIndex,
+        isSelected: widget.selectedIds?.contains(item.id) ?? false,
+        onToggleSelect: widget.onToggleSelect != null
+            ? () => widget.onToggleSelect!(item.id)
+            : null,
       ),
     );
   }
@@ -211,6 +224,7 @@ class _CollectionTableViewState extends State<CollectionTableView> {
             widget.items.map((CollectionItem i) => i.status),
             (ItemStatus a, ItemStatus b) => a.index.compareTo(b.index),
           );
+          widget.onFilterStatusChanged?.call(_filterStatus);
         case TableColumn.type:
           _filterType = _cycleFilter<MediaType>(
             _filterType,
@@ -246,8 +260,6 @@ class _CollectionTableViewState extends State<CollectionTableView> {
     });
   }
 
-  /// Cycles a filter through the available unique values in the column:
-  /// null → first → next → ... → null (reset).
   T? _cycleFilter<T>(
     T? current,
     Iterable<T> values,
@@ -315,7 +327,6 @@ class _CollectionTableViewState extends State<CollectionTableView> {
     return _cachedTagMap[item.tagId]?.name ?? '';
   }
 
-  /// Tri-state value for the header master checkbox; null hides it.
   bool? _selectionStateForVisible(List<CollectionItem> visible) {
     final Set<int>? selected = widget.selectedIds;
     if (selected == null || widget.onToggleSelect == null) return null;
@@ -326,7 +337,7 @@ class _CollectionTableViewState extends State<CollectionTableView> {
     }
     if (hit == 0) return false;
     if (hit == visible.length) return true;
-    return null; // partial → tri-state indeterminate
+    return null;
   }
 }
 

--- a/lib/features/collections/widgets/collection_table/table_header.dart
+++ b/lib/features/collections/widgets/collection_table/table_header.dart
@@ -108,7 +108,7 @@ class TableHeader extends StatelessWidget {
                 ? filterStatus!.genericLabel(l)
                 : l.collectionTableStatus,
             TableColumn.status,
-            width: 96,
+            width: 140,
             alignCenter: true,
             isFiltered: filterStatus != null,
           ),

--- a/lib/features/collections/widgets/collection_table/table_row.dart
+++ b/lib/features/collections/widgets/collection_table/table_row.dart
@@ -230,7 +230,7 @@ class _RowContent extends StatelessWidget {
           ),
         ),
         SizedBox(
-          width: 96,
+          width: 140,
           child: StatusCell(
             status: item.status,
             mediaType: item.mediaType,

--- a/lib/features/collections/widgets/dialogs/create_tier_list_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/create_tier_list_dialog.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+class CreateTierListDialog {
+  CreateTierListDialog._();
+
+  static Future<String?> show(BuildContext context, {String? initialName}) {
+    final TextEditingController controller =
+        TextEditingController(text: initialName ?? '');
+    final S l = S.of(context);
+    final Future<String?> result = showDialog<String>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(l.tierListCreateFromCollection),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(hintText: l.tierListNameHint),
+          onSubmitted: (String value) => Navigator.of(ctx).pop(value.trim()),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: Text(l.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
+            child: Text(l.create),
+          ),
+        ],
+      ),
+    );
+    return result.whenComplete(controller.dispose);
+  }
+}

--- a/lib/features/settings/widgets/settings_group.dart
+++ b/lib/features/settings/widgets/settings_group.dart
@@ -98,20 +98,23 @@ class SettingsGroup extends StatelessWidget {
             borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
           ),
           clipBehavior: Clip.antiAlias,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              for (int i = 0; i < children.length; i++) ...<Widget>[
-                if (i > 0)
-                  const Divider(
-                    height: 1,
-                    thickness: 1,
-                    color: AppColors.surfaceBorder,
-                    indent: AppSpacing.md,
-                  ),
-                children[i],
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                for (int i = 0; i < children.length; i++) ...<Widget>[
+                  if (i > 0)
+                    const Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: AppColors.surfaceBorder,
+                      indent: AppSpacing.md,
+                    ),
+                  children[i],
+                ],
               ],
-            ],
+            ),
           ),
         ),
       ],

--- a/test/features/collections/widgets/collection_table_view_test.dart
+++ b/test/features/collections/widgets/collection_table_view_test.dart
@@ -134,7 +134,7 @@ void main() {
         await pumpTableView(tester, items: <CollectionItem>[]);
 
         expect(find.byType(CollectionTableView), findsOneWidget);
-        expect(find.byType(ListView), findsOneWidget);
+        expect(tester.takeException(), isNull);
       });
 
       testWidgets('should display genres when present',


### PR DESCRIPTION
Collection screen state shed 984 → 757 lines across 5 new modules.
 The string-typed menu dispatch became a CollectionMenuAction enum.
 The new CollectionErrorState widget also replaces the byte-identical
_buildErrorState that the collections home screen carried, so both
screens now share a single retry view.

Switch collection table body to SliverList/SliverReorderableList inside a
shared CustomScrollView so only viewport rows build. Chevron counts above
the table react to the active status filter (dropdown or in-table cycle).
Status column widens 96 -> 140 px so labels stop truncating.

