### PR TITLE
refactor(wishlist, custom-item-dialog): split two god classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,61 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Split the wishlist screen god class**
+
+  `_WishlistScreenState` shed its tag-header chrome, item tile, and
+  AlertDialog boilerplate into reusable units under `widgets/`. Four
+  repeated confirm/prompt dialogs collapse to one shared `_confirm`
+  helper in `WishlistDialogs`. The tile's right-click / long-press
+  context menu loses its string-keyed `case 'search' / 'edit' / ...`
+  switch and now dispatches on a typed enum, matching the
+  `_TagMenuChoice` sealed-class pattern that already lived in this
+  file.
+
+  * lib/features/wishlist/screens/wishlist_screen.dart
+    (_WishlistScreenState): 994 LOC → 345. Extract `_promptTagForBulk`,
+    `_promptRenameTag`, `_confirmDeleteTag`, `_confirmClearResolved`,
+    inline delete-item confirm, and bulk-delete confirm to
+    `WishlistDialogs`. Inline `_BulkAction` becomes public
+    `WishlistBulkAction` exported by the header widget. Notifier calls
+    + filter state updates stay on the screen so dialog helpers remain
+    pure.
+  * lib/features/wishlist/widgets/wishlist_dialogs.dart (WishlistDialogs.promptBulkTag,
+    promptRenameTag, confirmDeleteTag, confirmClearResolved,
+    confirmDeleteItem, confirmBulkDelete, _confirm): New. Each returns
+    the user's pick and never touches the wishlist provider.
+  * lib/features/wishlist/widgets/wishlist_tag_header.dart
+    (WishlistTagHeader, WishlistBulkAction, _TagPickerSegment,
+    _BulkActionsSegment, _TagMenuChoice, _TagMenuFilter, _TagMenuRename,
+    _TagMenuDelete): New. Hosts the chevron filter bar + bulk-action
+    dropdown previously inlined.
+  * lib/features/wishlist/widgets/wishlist_tile.dart (WishlistTile,
+    _TileAction): New. Context menu uses a typed `_TileAction` enum.
+
+- **Split the create-custom-item dialog god class**
+
+  `_CreateCustomItemDialogState` (~700 LOC) sheds the cover image
+  preview / picker, the two private dialogs (searchable list and
+  multi-select genre), and the form-result data class into focused
+  files under `widgets/custom_item/`. The dialog's dead "My rating"
+  star section is removed — `_userRating` was collected but never
+  reached `CustomItemData`, so nothing was ever saved.
+
+  * lib/features/collections/widgets/create_custom_item_dialog.dart
+    (_CreateCustomItemDialogState): 1089 LOC → 538. Replace
+    `_buildCoverPreview`, `_buildCoverPlaceholder`, `_pickCoverImage`
+    with `CustomCoverPreview` and `pickCustomCoverImage`. Drop
+    `_userRating` and `_buildRatingSection` (dead code). Re-export
+    `CustomItemData` from its new home so call sites keep working.
+  * lib/features/collections/widgets/custom_item/custom_item_data.dart
+    (CustomItemData), cover_image_picker.dart (pickCustomCoverImage,
+    CustomCoverPreview, CoverPickResult), searchable_list_dialog.dart
+    (SearchableListDialog), multi_select_genre_dialog.dart
+    (MultiSelectGenreDialog): New.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (customItemMyRating):
+    Removed — the rating UI it labelled was deleted as dead code.
+    Regenerated `app_localizations*.dart`.
+
 - **Replace draggable FAB fan menu with a labeled pill stack**
 
   The popup menu attached to every draggable FAB no longer fans small

--- a/lib/features/collections/widgets/create_custom_item_dialog.dart
+++ b/lib/features/collections/widgets/create_custom_item_dialog.dart
@@ -1,13 +1,10 @@
-// Полноэкранная форма создания/редактирования кастомного элемента.
-
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/services/image_cache_service.dart';
 import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/constants/media_type_theme.dart';
 import '../../../shared/models/custom_media.dart';
@@ -16,63 +13,19 @@ import '../../../shared/models/platform.dart' as model;
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import 'custom_item/cover_image_picker.dart';
+import 'custom_item/custom_item_data.dart';
+import 'custom_item/multi_select_genre_dialog.dart';
+import 'custom_item/searchable_list_dialog.dart';
 
-/// Результат формы создания/редактирования кастомного элемента.
-class CustomItemData {
-  /// Создаёт экземпляр [CustomItemData].
-  const CustomItemData({
-    required this.title,
-    required this.mediaType,
-    this.altTitle,
-    this.description,
-    this.year,
-    this.coverUrl,
-    this.localCoverPath,
-    this.genres,
-    this.platform,
-    this.externalUrl,
-  });
+export 'custom_item/custom_item_data.dart' show CustomItemData;
 
-  /// Основное название.
-  final String title;
-
-  /// Альтернативное название (оригинальный язык).
-  final String? altTitle;
-
-  /// Тип медиа.
-  final MediaType mediaType;
-
-  /// Описание.
-  final String? description;
-
-  /// Год выпуска.
-  final int? year;
-
-  /// URL обложки.
-  final String? coverUrl;
-
-  /// Локальный путь к обложке (с ПК).
-  final String? localCoverPath;
-
-  /// Жанры (через запятую).
-  final String? genres;
-
-  /// Платформа (для игр).
-  final String? platform;
-
-  /// Внешний URL.
-  final String? externalUrl;
-}
-
-/// Полноэкранная форма создания/редактирования кастомного элемента.
+/// Full-screen create / edit form for a custom collection item.
 class CreateCustomItemDialog extends ConsumerStatefulWidget {
-  /// Создаёт [CreateCustomItemDialog].
   const CreateCustomItemDialog({this.existing, super.key});
 
-  /// Существующий элемент для редактирования (null = создание нового).
   final CustomMedia? existing;
 
-  /// Открывает полноэкранную форму создания.
   static Future<CustomItemData?> show(BuildContext context) {
     return Navigator.of(context).push<CustomItemData>(
       MaterialPageRoute<CustomItemData>(
@@ -81,7 +34,6 @@ class CreateCustomItemDialog extends ConsumerStatefulWidget {
     );
   }
 
-  /// Открывает полноэкранную форму редактирования.
   static Future<CustomItemData?> edit(
     BuildContext context,
     CustomMedia existing,
@@ -114,9 +66,7 @@ class _CreateCustomItemDialogState
   int? _selectedYear;
   String? _localCoverPath;
   String? _cachedCoverPath;
-  int? _userRating;
 
-  // Справочники для автокомплита
   List<model.Platform> _platforms = <model.Platform>[];
   List<String> _allGenres = <String>[];
   bool _refsLoaded = false;
@@ -224,7 +174,6 @@ class _CreateCustomItemDialogState
 
   Color get _accentColor => MediaTypeTheme.colorFor(_selectedType);
 
-
   @override
   Widget build(BuildContext context) {
     final S l = S.of(context);
@@ -262,8 +211,6 @@ class _CreateCustomItemDialogState
           const SizedBox(height: AppSpacing.md),
           if (!_isEditing) _buildMediaTypeChips(l),
           if (!_isEditing) const SizedBox(height: AppSpacing.md),
-          _buildRatingSection(l),
-          _buildDivider(),
           _buildGenresSection(l),
           const SizedBox(height: AppSpacing.md),
           _buildDescriptionSection(l),
@@ -275,39 +222,21 @@ class _CreateCustomItemDialogState
     );
   }
 
-  Widget _buildDivider() => Padding(
-        padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
-        child: Divider(
-          color: AppColors.surfaceBorder.withAlpha(80),
-          height: 1,
-        ),
-      );
-
-  // ==================== Header ====================
-
   Widget _buildHeader(S l) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        // Обложка (тап для загрузки)
-        GestureDetector(
-          onTap: _pickCoverImage,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
-            child: Container(
-              width: 100,
-              height: 150,
-              color: AppColors.surfaceLight,
-              child: _buildCoverPreview(),
-            ),
-          ),
+        CustomCoverPreview(
+          localPath: _localCoverPath,
+          cachedPath: _cachedCoverPath,
+          url: _coverUrlController.text.trim(),
+          onTap: _pickCover,
         ),
         const SizedBox(width: AppSpacing.md),
         Expanded(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              // Бейдж типа
               Row(
                 children: <Widget>[
                   Icon(
@@ -326,8 +255,6 @@ class _CreateCustomItemDialogState
                 ],
               ),
               const SizedBox(height: AppSpacing.sm),
-
-              // Название
               TextField(
                 controller: _titleController,
                 decoration: InputDecoration(
@@ -347,8 +274,6 @@ class _CreateCustomItemDialogState
                   }
                 },
               ),
-
-              // Альтернативное название
               TextField(
                 controller: _altTitleController,
                 decoration: InputDecoration(
@@ -370,8 +295,6 @@ class _CreateCustomItemDialogState
                 ),
               ),
               const SizedBox(height: AppSpacing.sm),
-
-              // Год + Платформа
               Wrap(
                 spacing: 6,
                 runSpacing: 6,
@@ -389,151 +312,22 @@ class _CreateCustomItemDialogState
     );
   }
 
-  // ==================== Cover ====================
-
-  Widget _buildCoverPreview() {
-    // Локальный файл, только что выбранный пользователем
-    if (_localCoverPath != null) {
-      return Image.file(
-        File(_localCoverPath!),
-        fit: BoxFit.cover,
-        errorBuilder: (_, Object e, StackTrace? s) =>
-            _buildCoverPlaceholder(),
-      );
-    }
-    // Кэшированная обложка (при редактировании)
-    if (_cachedCoverPath != null) {
-      return Image.file(
-        File(_cachedCoverPath!),
-        fit: BoxFit.cover,
-        errorBuilder: (_, Object e, StackTrace? s) =>
-            _buildCoverPlaceholder(),
-      );
-    }
-    // URL обложки (не маркер локальной обложки)
-    final String url = _coverUrlController.text.trim();
-    if (url.isNotEmpty && !CustomMedia.isLocalCover(url)) {
-      return Image.network(
-        url,
-        fit: BoxFit.cover,
-        errorBuilder: (_, Object e, StackTrace? s) =>
-            _buildCoverPlaceholder(),
-      );
-    }
-    return _buildCoverPlaceholder();
-  }
-
-  Widget _buildCoverPlaceholder() {
-    final S l = S.of(context);
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const Icon(
-          Icons.add_photo_alternate_outlined,
-          size: 32,
-          color: AppColors.textTertiary,
-        ),
-        const SizedBox(height: 4),
-        Text(
-          l.customItemAddCover,
-          style: AppTypography.caption.copyWith(
-            color: AppColors.textTertiary,
-          ),
-          textAlign: TextAlign.center,
-        ),
-      ],
+  Future<void> _pickCover() async {
+    final CoverPickResult? result = await pickCustomCoverImage(
+      context,
+      currentUrl: _coverUrlController.text,
     );
-  }
-
-  Future<void> _pickCoverImage() async {
-    final S l = S.of(context);
-    // Показываем выбор: файл или URL
-    final String? choice = await showDialog<String>(
-      context: context,
-      builder: (BuildContext ctx) => SimpleDialog(
-        title: Text(l.customItemCoverSource),
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24),
-            child: Text(
-              l.customItemCoverRatio,
-              style: AppTypography.caption.copyWith(
-                color: AppColors.textTertiary,
-              ),
-            ),
-          ),
-          const SizedBox(height: AppSpacing.xs),
-          SimpleDialogOption(
-            onPressed: () => Navigator.of(ctx).pop('file'),
-            child: ListTile(
-              leading: const Icon(Icons.folder_outlined),
-              title: Text(l.customItemCoverFromFile),
-              contentPadding: EdgeInsets.zero,
-            ),
-          ),
-          SimpleDialogOption(
-            onPressed: () => Navigator.of(ctx).pop('url'),
-            child: ListTile(
-              leading: const Icon(Icons.link),
-              title: Text(l.customItemCoverFromUrl),
-              contentPadding: EdgeInsets.zero,
-            ),
-          ),
-        ],
-      ),
-    );
-
-    if (choice == 'file') {
-      final FilePickerResult? result = await FilePicker.platform.pickFiles(
-        type: FileType.image,
-        allowMultiple: false,
-      );
-      if (result != null && result.files.isNotEmpty) {
-        final String? path = result.files.first.path;
-        if (path != null && mounted) {
-          setState(() {
-            _localCoverPath = path;
-            _coverUrlController.clear();
-          });
-        }
+    if (result == null || !mounted) return;
+    setState(() {
+      if (result.localPath != null) {
+        _localCoverPath = result.localPath;
+        _coverUrlController.clear();
+      } else if (result.url != null) {
+        _coverUrlController.text = result.url!;
+        _localCoverPath = null;
       }
-    } else if (choice == 'url') {
-      if (!mounted) return;
-      final TextEditingController urlCtrl =
-          TextEditingController(text: _coverUrlController.text);
-      final String? url = await showDialog<String>(
-        context: context,
-        builder: (BuildContext ctx) => AlertDialog(
-          title: Text(l.customItemCoverUrl),
-          content: TextField(
-            controller: urlCtrl,
-            decoration: const InputDecoration(hintText: 'https://...'),
-            keyboardType: TextInputType.url,
-            autofocus: true,
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.of(ctx).pop(),
-              child: Text(l.cancel),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(ctx).pop(urlCtrl.text.trim()),
-              child: Text(l.confirm),
-            ),
-          ],
-        ),
-      );
-      urlCtrl.dispose();
-      if (url != null && url.isNotEmpty && mounted) {
-        setState(() {
-          _coverUrlController.text = url;
-          _localCoverPath = null;
-        });
-      }
-    }
+    });
   }
-
-  // ==================== Year Picker ====================
 
   Widget _buildYearChip(S l) {
     return ActionChip(
@@ -562,40 +356,23 @@ class _CreateCustomItemDialogState
     }
   }
 
-  // ==================== Platform Autocomplete ====================
-
   Widget _buildPlatformChip(S l) {
-    if (!_refsLoaded || _platforms.isEmpty) {
-      return ActionChip(
-        avatar: const Icon(Icons.sports_esports, size: 14),
-        label: Text(_platformController.text.isNotEmpty
-            ? _platformController.text
-            : l.customItemPlatform),
-        labelStyle: AppTypography.caption.copyWith(
-          color: _platformController.text.isNotEmpty
-              ? AppColors.textPrimary
-              : AppColors.textTertiary,
-        ),
-        onPressed: null,
-      );
-    }
-
+    final bool hasValue = _platformController.text.isNotEmpty;
+    final VoidCallback? onTap =
+        _refsLoaded && _platforms.isNotEmpty ? _pickPlatform : null;
     return ActionChip(
       avatar: const Icon(Icons.sports_esports, size: 14),
-      label: Text(_platformController.text.isNotEmpty
-          ? _platformController.text
-          : l.customItemPlatform),
+      label: Text(hasValue ? _platformController.text : l.customItemPlatform),
       labelStyle: AppTypography.caption.copyWith(
-        color: _platformController.text.isNotEmpty
-            ? AppColors.textPrimary
-            : AppColors.textTertiary,
+        color: hasValue ? AppColors.textPrimary : AppColors.textTertiary,
       ),
-      onPressed: _pickPlatform,
+      onPressed: onTap,
     );
   }
 
   Future<void> _pickPlatform() async {
-    final String? result = await _showSearchableListDialog(
+    final String? result = await SearchableListDialog.show(
+      context,
       title: S.of(context).customItemPlatform,
       items: _platforms
           .map((model.Platform p) => p.displayName)
@@ -607,8 +384,6 @@ class _CreateCustomItemDialogState
       setState(() => _platformController.text = result);
     }
   }
-
-  // ==================== Genres ====================
 
   Widget _buildGenresSection(S l) {
     return Column(
@@ -655,28 +430,23 @@ class _CreateCustomItemDialogState
   }
 
   Future<void> _pickGenres() async {
-    // Текущие жанры из текстового поля
     final Set<String> current = _genresController.text
         .split(',')
         .map((String s) => s.trim())
         .where((String s) => s.isNotEmpty)
         .toSet();
 
-    final Set<String>? result = await showDialog<Set<String>>(
-      context: context,
-      builder: (BuildContext ctx) => _MultiSelectGenreDialog(
-        title: S.of(context).customItemGenres,
-        items: _allGenres,
-        selected: current,
-      ),
+    final Set<String>? result = await MultiSelectGenreDialog.show(
+      context,
+      title: S.of(context).customItemGenres,
+      items: _allGenres,
+      selected: current,
     );
     if (result != null && mounted) {
       _genresController.text = result.join(', ');
       setState(() {});
     }
   }
-
-  // ==================== Media Type Chips ====================
 
   Widget _buildMediaTypeChips(S l) {
     const List<MediaType> types = <MediaType>[
@@ -719,51 +489,6 @@ class _CreateCustomItemDialogState
     );
   }
 
-  // ==================== Rating ====================
-
-  Widget _buildRatingSection(S l) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Text(
-          l.customItemMyRating,
-          style: AppTypography.bodySmall.copyWith(
-            color: AppColors.textSecondary,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        Row(
-          children: List<Widget>.generate(10, (int index) {
-            final int starValue = index + 1;
-            final bool isFilled =
-                _userRating != null && starValue <= _userRating!;
-            return GestureDetector(
-              onTap: () {
-                setState(() {
-                  _userRating =
-                      _userRating == starValue ? null : starValue;
-                });
-              },
-              child: Padding(
-                padding: const EdgeInsets.only(right: 2),
-                child: Icon(
-                  isFilled
-                      ? Icons.star_rounded
-                      : Icons.star_outline_rounded,
-                  size: 28,
-                  color: isFilled ? _accentColor : AppColors.textTertiary,
-                ),
-              ),
-            );
-          }),
-        ),
-      ],
-    );
-  }
-
-  // ==================== Description ====================
-
   Widget _buildDescriptionSection(S l) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -793,8 +518,6 @@ class _CreateCustomItemDialogState
     );
   }
 
-  // ==================== External URL ====================
-
   Widget _buildExternalUrlSection(S l) {
     return TextField(
       controller: _externalUrlController,
@@ -810,280 +533,6 @@ class _CreateCustomItemDialogState
         fillColor: AppColors.surfaceLight,
       ),
       keyboardType: TextInputType.url,
-    );
-  }
-
-  // ==================== Searchable List Dialog ====================
-
-  Future<String?> _showSearchableListDialog({
-    required String title,
-    required List<String> items,
-    required bool allowCustom,
-    String? currentValue,
-  }) {
-    return showDialog<String>(
-      context: context,
-      builder: (BuildContext ctx) => _SearchableListDialog(
-        title: title,
-        items: items,
-        allowCustom: allowCustom,
-        currentValue: currentValue,
-      ),
-    );
-  }
-}
-
-// ==================== Multi-Select Genre Dialog ====================
-
-class _MultiSelectGenreDialog extends StatefulWidget {
-  const _MultiSelectGenreDialog({
-    required this.title,
-    required this.items,
-    required this.selected,
-  });
-
-  final String title;
-  final List<String> items;
-  final Set<String> selected;
-
-  @override
-  State<_MultiSelectGenreDialog> createState() =>
-      _MultiSelectGenreDialogState();
-}
-
-class _MultiSelectGenreDialogState extends State<_MultiSelectGenreDialog> {
-  final TextEditingController _searchController = TextEditingController();
-  late final Set<String> _selected;
-  List<String> _filtered = <String>[];
-
-  @override
-  void initState() {
-    super.initState();
-    _selected = Set<String>.of(widget.selected);
-    _filtered = widget.items;
-  }
-
-  @override
-  void dispose() {
-    _searchController.dispose();
-    super.dispose();
-  }
-
-  void _filter(String query) {
-    if (query.isEmpty) {
-      _filtered = widget.items;
-    } else {
-      final String lower = query.toLowerCase();
-      _filtered = widget.items
-          .where((String item) => item.toLowerCase().contains(lower))
-          .toList();
-    }
-    setState(() {});
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final S l = S.of(context);
-    return Dialog(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Text(widget.title,
-                  style: Theme.of(context).textTheme.titleMedium),
-              const SizedBox(height: AppSpacing.sm),
-              TextField(
-                controller: _searchController,
-                decoration: InputDecoration(
-                  hintText: l.customItemSearchHint,
-                  prefixIcon: const Icon(Icons.search, size: 20),
-                  isDense: true,
-                ),
-                onChanged: _filter,
-                autofocus: true,
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Flexible(
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: _filtered.length,
-                  itemBuilder: (BuildContext ctx, int index) {
-                    final String item = _filtered[index];
-                    final bool isSelected = _selected.contains(item);
-                    return CheckboxListTile(
-                      title: Text(item, style: AppTypography.bodySmall),
-                      value: isSelected,
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      controlAffinity: ListTileControlAffinity.leading,
-                      onChanged: (bool? value) {
-                        setState(() {
-                          if (value == true) {
-                            _selected.add(item);
-                          } else {
-                            _selected.remove(item);
-                          }
-                        });
-                      },
-                    );
-                  },
-                ),
-              ),
-              const Divider(),
-              OverflowBar(
-                alignment: MainAxisAlignment.end,
-                spacing: AppSpacing.sm,
-                children: <Widget>[
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text(l.cancel),
-                  ),
-                  // Кнопка добавить кастомный жанр
-                  TextButton(
-                    onPressed: () {
-                      final String text = _searchController.text.trim();
-                      if (text.isNotEmpty) {
-                        setState(() => _selected.add(text));
-                        _searchController.clear();
-                        _filter('');
-                      }
-                    },
-                    child: Text(l.customItemUseCustom),
-                  ),
-                  FilledButton(
-                    onPressed: () => Navigator.of(context).pop(_selected),
-                    child: Text(l.confirm),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-// ==================== Searchable List Dialog Widget ====================
-
-class _SearchableListDialog extends StatefulWidget {
-  const _SearchableListDialog({
-    required this.title,
-    required this.items,
-    required this.allowCustom,
-    this.currentValue,
-  });
-
-  final String title;
-  final List<String> items;
-  final bool allowCustom;
-  final String? currentValue;
-
-  @override
-  State<_SearchableListDialog> createState() => _SearchableListDialogState();
-}
-
-class _SearchableListDialogState extends State<_SearchableListDialog> {
-  final TextEditingController _searchController = TextEditingController();
-  List<String> _filtered = <String>[];
-
-  @override
-  void initState() {
-    super.initState();
-    _filtered = widget.items;
-    if (widget.currentValue != null) {
-      _searchController.text = widget.currentValue!;
-      _filter(widget.currentValue!);
-    }
-  }
-
-  @override
-  void dispose() {
-    _searchController.dispose();
-    super.dispose();
-  }
-
-  void _filter(String query) {
-    if (query.isEmpty) {
-      _filtered = widget.items;
-    } else {
-      final String lower = query.toLowerCase();
-      _filtered = widget.items
-          .where((String item) => item.toLowerCase().contains(lower))
-          .toList();
-    }
-    setState(() {});
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final S l = S.of(context);
-    return Dialog(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Text(widget.title,
-                  style: Theme.of(context).textTheme.titleMedium),
-              const SizedBox(height: AppSpacing.sm),
-              TextField(
-                controller: _searchController,
-                decoration: InputDecoration(
-                  hintText: l.customItemSearchHint,
-                  prefixIcon: const Icon(Icons.search, size: 20),
-                  isDense: true,
-                ),
-                onChanged: _filter,
-                autofocus: true,
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Flexible(
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: _filtered.length,
-                  itemBuilder: (BuildContext ctx, int index) {
-                    final String item = _filtered[index];
-                    return ListTile(
-                      title: Text(item, style: AppTypography.bodySmall),
-                      dense: true,
-                      visualDensity: VisualDensity.compact,
-                      onTap: () => Navigator.of(ctx).pop(item),
-                    );
-                  },
-                ),
-              ),
-              if (widget.allowCustom) ...<Widget>[
-                const Divider(),
-                OverflowBar(
-                  alignment: MainAxisAlignment.end,
-                  spacing: AppSpacing.sm,
-                  children: <Widget>[
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: Text(l.cancel),
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        final String text = _searchController.text.trim();
-                        if (text.isNotEmpty) {
-                          Navigator.of(context).pop(text);
-                        }
-                      },
-                      child: Text(l.customItemUseCustom),
-                    ),
-                  ],
-                ),
-              ],
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/features/collections/widgets/custom_item/cover_image_picker.dart
+++ b/lib/features/collections/widgets/custom_item/cover_image_picker.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../../shared/models/custom_media.dart';
+import '../../../../shared/theme/app_colors.dart';
+import '../../../../shared/theme/app_spacing.dart';
+import '../../../../shared/theme/app_typography.dart';
+
+/// Result of [pickCustomCoverImage]. Either a local file path or a URL —
+/// never both, since picking one path clears the other.
+class CoverPickResult {
+  const CoverPickResult.file(this.localPath) : url = null;
+  const CoverPickResult.url(this.url) : localPath = null;
+
+  final String? localPath;
+  final String? url;
+}
+
+/// Asks the user to pick a cover source (local file or URL) and returns
+/// the result, or `null` when the user cancelled.
+Future<CoverPickResult?> pickCustomCoverImage(
+  BuildContext context, {
+  required String currentUrl,
+}) async {
+  final S l = S.of(context);
+  final String? choice = await showDialog<String>(
+    context: context,
+    builder: (BuildContext ctx) => SimpleDialog(
+      title: Text(l.customItemCoverSource),
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Text(
+            l.customItemCoverRatio,
+            style: AppTypography.caption.copyWith(
+              color: AppColors.textTertiary,
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        SimpleDialogOption(
+          onPressed: () => Navigator.of(ctx).pop('file'),
+          child: ListTile(
+            leading: const Icon(Icons.folder_outlined),
+            title: Text(l.customItemCoverFromFile),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        SimpleDialogOption(
+          onPressed: () => Navigator.of(ctx).pop('url'),
+          child: ListTile(
+            leading: const Icon(Icons.link),
+            title: Text(l.customItemCoverFromUrl),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    ),
+  );
+
+  if (choice == 'file') {
+    final FilePickerResult? result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+      allowMultiple: false,
+    );
+    if (result == null || result.files.isEmpty) return null;
+    final String? path = result.files.first.path;
+    if (path == null) return null;
+    return CoverPickResult.file(path);
+  }
+
+  if (choice == 'url') {
+    if (!context.mounted) return null;
+    final TextEditingController urlCtrl =
+        TextEditingController(text: currentUrl);
+    try {
+      final String? url = await showDialog<String>(
+        context: context,
+        builder: (BuildContext ctx) => AlertDialog(
+          title: Text(l.customItemCoverUrl),
+          content: TextField(
+            controller: urlCtrl,
+            decoration: const InputDecoration(hintText: 'https://...'),
+            keyboardType: TextInputType.url,
+            autofocus: true,
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text(l.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(urlCtrl.text.trim()),
+              child: Text(l.confirm),
+            ),
+          ],
+        ),
+      );
+      if (url == null || url.isEmpty) return null;
+      return CoverPickResult.url(url);
+    } finally {
+      urlCtrl.dispose();
+    }
+  }
+
+  return null;
+}
+
+/// Visual preview that picks the best available cover source in order:
+/// freshly picked local file → cached file from previous edit → URL.
+class CustomCoverPreview extends StatelessWidget {
+  const CustomCoverPreview({
+    required this.localPath,
+    required this.cachedPath,
+    required this.url,
+    required this.onTap,
+    super.key,
+  });
+
+  final String? localPath;
+  final String? cachedPath;
+  final String url;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+        child: Container(
+          width: 100,
+          height: 150,
+          color: AppColors.surfaceLight,
+          child: _buildPreview(context),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPreview(BuildContext context) {
+    if (localPath != null) {
+      return Image.file(
+        File(localPath!),
+        fit: BoxFit.cover,
+        errorBuilder: (_, Object e, StackTrace? s) =>
+            _CoverPlaceholder(),
+      );
+    }
+    if (cachedPath != null) {
+      return Image.file(
+        File(cachedPath!),
+        fit: BoxFit.cover,
+        errorBuilder: (_, Object e, StackTrace? s) =>
+            _CoverPlaceholder(),
+      );
+    }
+    if (url.isNotEmpty && !CustomMedia.isLocalCover(url)) {
+      return Image.network(
+        url,
+        fit: BoxFit.cover,
+        errorBuilder: (_, Object e, StackTrace? s) =>
+            _CoverPlaceholder(),
+      );
+    }
+    return _CoverPlaceholder();
+  }
+}
+
+class _CoverPlaceholder extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        const Icon(
+          Icons.add_photo_alternate_outlined,
+          size: 32,
+          color: AppColors.textTertiary,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l.customItemAddCover,
+          style: AppTypography.caption.copyWith(
+            color: AppColors.textTertiary,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/collections/widgets/custom_item/custom_item_data.dart
+++ b/lib/features/collections/widgets/custom_item/custom_item_data.dart
@@ -1,0 +1,28 @@
+import '../../../../shared/models/media_type.dart';
+
+/// Result of the create / edit custom item form.
+class CustomItemData {
+  const CustomItemData({
+    required this.title,
+    required this.mediaType,
+    this.altTitle,
+    this.description,
+    this.year,
+    this.coverUrl,
+    this.localCoverPath,
+    this.genres,
+    this.platform,
+    this.externalUrl,
+  });
+
+  final String title;
+  final String? altTitle;
+  final MediaType mediaType;
+  final String? description;
+  final int? year;
+  final String? coverUrl;
+  final String? localCoverPath;
+  final String? genres;
+  final String? platform;
+  final String? externalUrl;
+}

--- a/lib/features/collections/widgets/custom_item/multi_select_genre_dialog.dart
+++ b/lib/features/collections/widgets/custom_item/multi_select_genre_dialog.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../../shared/theme/app_spacing.dart';
+import '../../../../shared/theme/app_typography.dart';
+
+/// Multi-select dialog with search box for genres (or other tag-style
+/// strings). Returns the picked set, or `null` if the user cancels.
+class MultiSelectGenreDialog extends StatefulWidget {
+  const MultiSelectGenreDialog({
+    required this.title,
+    required this.items,
+    required this.selected,
+    super.key,
+  });
+
+  final String title;
+  final List<String> items;
+  final Set<String> selected;
+
+  static Future<Set<String>?> show(
+    BuildContext context, {
+    required String title,
+    required List<String> items,
+    required Set<String> selected,
+  }) {
+    return showDialog<Set<String>>(
+      context: context,
+      builder: (BuildContext ctx) => MultiSelectGenreDialog(
+        title: title,
+        items: items,
+        selected: selected,
+      ),
+    );
+  }
+
+  @override
+  State<MultiSelectGenreDialog> createState() =>
+      _MultiSelectGenreDialogState();
+}
+
+class _MultiSelectGenreDialogState extends State<MultiSelectGenreDialog> {
+  final TextEditingController _searchController = TextEditingController();
+  late final Set<String> _selected;
+  List<String> _filtered = <String>[];
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = Set<String>.of(widget.selected);
+    _filtered = widget.items;
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _filter(String query) {
+    if (query.isEmpty) {
+      _filtered = widget.items;
+    } else {
+      final String lower = query.toLowerCase();
+      _filtered = widget.items
+          .where((String item) => item.toLowerCase().contains(lower))
+          .toList();
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(widget.title,
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: AppSpacing.sm),
+              TextField(
+                controller: _searchController,
+                decoration: InputDecoration(
+                  hintText: l.customItemSearchHint,
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  isDense: true,
+                ),
+                onChanged: _filter,
+                autofocus: true,
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Flexible(
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: _filtered.length,
+                  itemBuilder: (BuildContext ctx, int index) {
+                    final String item = _filtered[index];
+                    final bool isSelected = _selected.contains(item);
+                    return CheckboxListTile(
+                      title: Text(item, style: AppTypography.bodySmall),
+                      value: isSelected,
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      controlAffinity: ListTileControlAffinity.leading,
+                      onChanged: (bool? value) {
+                        setState(() {
+                          if (value == true) {
+                            _selected.add(item);
+                          } else {
+                            _selected.remove(item);
+                          }
+                        });
+                      },
+                    );
+                  },
+                ),
+              ),
+              const Divider(),
+              OverflowBar(
+                alignment: MainAxisAlignment.end,
+                spacing: AppSpacing.sm,
+                children: <Widget>[
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(l.cancel),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      final String text = _searchController.text.trim();
+                      if (text.isNotEmpty) {
+                        setState(() => _selected.add(text));
+                        _searchController.clear();
+                        _filter('');
+                      }
+                    },
+                    child: Text(l.customItemUseCustom),
+                  ),
+                  FilledButton(
+                    onPressed: () => Navigator.of(context).pop(_selected),
+                    child: Text(l.confirm),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/custom_item/searchable_list_dialog.dart
+++ b/lib/features/collections/widgets/custom_item/searchable_list_dialog.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../../../shared/theme/app_spacing.dart';
+import '../../../../shared/theme/app_typography.dart';
+
+/// Searchable single-select dialog returning the picked string (or the
+/// typed custom value when [allowCustom] is true and the user taps
+/// "use custom").
+class SearchableListDialog extends StatefulWidget {
+  const SearchableListDialog({
+    required this.title,
+    required this.items,
+    required this.allowCustom,
+    this.currentValue,
+    super.key,
+  });
+
+  final String title;
+  final List<String> items;
+  final bool allowCustom;
+  final String? currentValue;
+
+  static Future<String?> show(
+    BuildContext context, {
+    required String title,
+    required List<String> items,
+    required bool allowCustom,
+    String? currentValue,
+  }) {
+    return showDialog<String>(
+      context: context,
+      builder: (BuildContext ctx) => SearchableListDialog(
+        title: title,
+        items: items,
+        allowCustom: allowCustom,
+        currentValue: currentValue,
+      ),
+    );
+  }
+
+  @override
+  State<SearchableListDialog> createState() => _SearchableListDialogState();
+}
+
+class _SearchableListDialogState extends State<SearchableListDialog> {
+  final TextEditingController _searchController = TextEditingController();
+  List<String> _filtered = <String>[];
+
+  @override
+  void initState() {
+    super.initState();
+    _filtered = widget.items;
+    if (widget.currentValue != null) {
+      _searchController.text = widget.currentValue!;
+      _filter(widget.currentValue!);
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _filter(String query) {
+    if (query.isEmpty) {
+      _filtered = widget.items;
+    } else {
+      final String lower = query.toLowerCase();
+      _filtered = widget.items
+          .where((String item) => item.toLowerCase().contains(lower))
+          .toList();
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return Dialog(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400, maxHeight: 500),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(widget.title,
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: AppSpacing.sm),
+              TextField(
+                controller: _searchController,
+                decoration: InputDecoration(
+                  hintText: l.customItemSearchHint,
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  isDense: true,
+                ),
+                onChanged: _filter,
+                autofocus: true,
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Flexible(
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: _filtered.length,
+                  itemBuilder: (BuildContext ctx, int index) {
+                    final String item = _filtered[index];
+                    return ListTile(
+                      title: Text(item, style: AppTypography.bodySmall),
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      onTap: () => Navigator.of(ctx).pop(item),
+                    );
+                  },
+                ),
+              ),
+              if (widget.allowCustom) ...<Widget>[
+                const Divider(),
+                OverflowBar(
+                  alignment: MainAxisAlignment.end,
+                  spacing: AppSpacing.sm,
+                  children: <Widget>[
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: Text(l.cancel),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        final String text = _searchController.text.trim();
+                        if (text.isNotEmpty) {
+                          Navigator.of(context).pop(text);
+                        }
+                      },
+                      child: Text(l.customItemUseCustom),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/wishlist/screens/wishlist_screen.dart
+++ b/lib/features/wishlist/screens/wishlist_screen.dart
@@ -1,37 +1,30 @@
-// Экран вишлиста — заметки для отложенного поиска контента.
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/database/dao/wishlist_dao.dart';
 import '../../../l10n/app_localizations.dart';
-import '../../../shared/constants/media_type_theme.dart';
 import '../../../shared/constants/platform_features.dart';
 import '../../../shared/keyboard/keyboard_shortcuts.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/wishlist_item.dart';
 import '../../../shared/models/wishlist_tag.dart';
-import '../../../shared/widgets/chevron_filter_bar.dart';
 import '../../../shared/navigation/search_providers.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/draggable_fab.dart';
-import '../../../shared/widgets/mini_markdown_text.dart';
 import '../../search/screens/search_screen.dart';
 import '../providers/wishlist_provider.dart';
 import '../widgets/add_wishlist_dialog.dart';
+import '../widgets/wishlist_dialogs.dart';
+import '../widgets/wishlist_tag_header.dart';
+import '../widgets/wishlist_tile.dart';
 
-/// Экран вишлиста.
-///
-/// Показывает список заметок для отложенного поиска контента.
-/// FAB для быстрого добавления, popup menu для действий.
+/// Wishlist screen — notes for deferred content search.
 class WishlistScreen extends ConsumerStatefulWidget {
-  /// Создаёт [WishlistScreen].
   const WishlistScreen({super.key});
 
-  /// Группа хоткеев этого экрана для легенды F1.
   static const ShortcutGroup shortcutGroup = ShortcutGroup(
     title: 'Вишлист',
     entries: <ShortcutEntry>[
@@ -71,25 +64,24 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
                 items,
                 searchQuery: searchQuery,
               );
-
-              // Always show the header when the wishlist isn't empty — the
-              // text-style picker is unobtrusive and stays consistent as
-              // tags appear/disappear during edits.
+              // Keep the header visible whenever the wishlist isn't empty —
+              // the text-style picker stays consistent as tags appear and
+              // disappear during edits.
               final bool showHeader = items.isNotEmpty;
 
               return Column(
                 children: <Widget>[
                   if (showHeader)
-                    _WishlistTagHeader(
+                    WishlistTagHeader(
                       tags: tags,
                       selected: _tagFilter,
                       filteredCount: filtered.length,
                       totalCount: items.length,
                       onChanged: (WishlistTagFilter v) =>
                           setState(() => _tagFilter = v),
-                      onRename: _promptRenameTag,
-                      onDelete: _confirmDeleteTag,
-                      onBulkAction: (_BulkAction a) =>
+                      onRename: _handleRenameTag,
+                      onDelete: _handleDeleteTag,
+                      onBulkAction: (WishlistBulkAction a) =>
                           _runBulkAction(a, filtered),
                     ),
                   Expanded(
@@ -100,16 +92,13 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
                             itemCount: filtered.length,
                             itemBuilder:
                                 (BuildContext context, int index) {
-                              return _WishlistTile(
-                                item: filtered[index],
-                                onTap: () =>
-                                    _searchForItem(context, filtered[index]),
-                                onResolve: () =>
-                                    _toggleResolved(filtered[index]),
-                                onEdit: () =>
-                                    _editItem(context, filtered[index]),
-                                onDelete: () =>
-                                    _deleteItem(context, filtered[index]),
+                              final WishlistItem item = filtered[index];
+                              return WishlistTile(
+                                item: item,
+                                onTap: () => _searchForItem(context, item),
+                                onResolve: () => _toggleResolved(item),
+                                onEdit: () => _editItem(context, item),
+                                onDelete: () => _deleteItem(context, item),
                               );
                             },
                           ),
@@ -199,7 +188,6 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
 
   Widget _buildEmptyState(BuildContext context) {
     final S l = S.of(context);
-
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -232,7 +220,6 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
   Future<void> _addItem(BuildContext context) async {
     final WishlistDialogResult? result = await AddWishlistForm.show(context);
     if (result == null || !mounted) return;
-
     await ref.read(wishlistProvider.notifier).add(
           text: result.text,
           mediaTypeHint: result.mediaTypeHint,
@@ -247,7 +234,6 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
       existing: item,
     );
     if (result == null || !mounted) return;
-
     await ref.read(wishlistProvider.notifier).updateItem(
           item.id,
           text: result.text,
@@ -269,28 +255,10 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
   }
 
   Future<void> _deleteItem(BuildContext context, WishlistItem item) async {
-    final S l = S.of(context);
-    final bool? confirmed = await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(l.wishlistDeleteItem),
-        content: Text(l.wishlistDeletePrompt(item.text)),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l.delete),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && mounted) {
-      await ref.read(wishlistProvider.notifier).delete(item.id);
-    }
+    final bool confirmed =
+        await WishlistDialogs.confirmDeleteItem(context, item.text);
+    if (!confirmed || !mounted) return;
+    await ref.read(wishlistProvider.notifier).delete(item.id);
   }
 
   void _searchForItem(BuildContext context, WishlistItem item) {
@@ -318,677 +286,60 @@ class _WishlistScreenState extends ConsumerState<WishlistScreen> {
   }
 
   Future<void> _runBulkAction(
-    _BulkAction action,
+    WishlistBulkAction action,
     List<WishlistItem> visible,
   ) async {
     if (visible.isEmpty) return;
     final Set<int> ids = visible.map((WishlistItem i) => i.id).toSet();
 
     switch (action) {
-      case _BulkAction.applyTag:
-        final String? tag = await _promptTagForBulk(ids.length);
+      case WishlistBulkAction.applyTag:
+        final String? tag =
+            await WishlistDialogs.promptBulkTag(context, ids.length);
         if (tag == null || !mounted) return;
         await ref.read(wishlistProvider.notifier).applyTagToIds(ids, tag);
-      case _BulkAction.removeTag:
+      case WishlistBulkAction.removeTag:
         await ref.read(wishlistProvider.notifier).applyTagToIds(ids, null);
-      case _BulkAction.delete:
-        final S l = S.of(context);
-        final bool? confirmed = await showDialog<bool>(
-          context: context,
-          builder: (BuildContext context) => AlertDialog(
-            title: Text(l.wishlistBulkDelete),
-            content: Text(l.wishlistBulkDeleteConfirm(ids.length)),
-            actions: <Widget>[
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(false),
-                child: Text(l.cancel),
-              ),
-              FilledButton(
-                onPressed: () => Navigator.of(context).pop(true),
-                child: Text(l.delete),
-              ),
-            ],
-          ),
-        );
-        if (confirmed != true || !mounted) return;
+      case WishlistBulkAction.delete:
+        final bool confirmed =
+            await WishlistDialogs.confirmBulkDelete(context, ids.length);
+        if (!confirmed || !mounted) return;
         await ref.read(wishlistProvider.notifier).deleteIds(ids);
     }
   }
 
-  Future<String?> _promptTagForBulk(int count) async {
-    final S l = S.of(context);
-    final TextEditingController controller = TextEditingController();
-    final String? input = await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(l.wishlistBulkApplyTag),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(l.wishlistBulkApplyTagHint(count)),
-            const SizedBox(height: AppSpacing.sm),
-            TextField(
-              controller: controller,
-              autofocus: true,
-              decoration: InputDecoration(hintText: l.wishlistTagPlaceholder),
-              onSubmitted: (String v) =>
-                  Navigator.of(context).pop(v.trim()),
-            ),
-          ],
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () =>
-                Navigator.of(context).pop(controller.text.trim()),
-            child: Text(l.apply),
-          ),
-        ],
-      ),
-    );
-    if (input == null || input.isEmpty) return null;
-    return input;
-  }
-
-  Future<void> _promptRenameTag(String? currentTag) async {
-    final S l = S.of(context);
-    final TextEditingController controller =
-        TextEditingController(text: currentTag ?? '');
-
-    final String? newTag = await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(l.wishlistTagRename),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: InputDecoration(hintText: l.wishlistTagPlaceholder),
-          onSubmitted: (String value) =>
-              Navigator.of(context).pop(value.trim()),
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () =>
-                Navigator.of(context).pop(controller.text.trim()),
-            child: Text(l.save),
-          ),
-        ],
-      ),
-    );
-
-    if (newTag == null || newTag.isEmpty || newTag == currentTag) return;
-    if (!mounted) return;
-
+  Future<void> _handleRenameTag(String? currentTag) async {
+    final String? newTag =
+        await WishlistDialogs.promptRenameTag(context, currentTag);
+    if (newTag == null || !mounted) return;
     await ref.read(wishlistProvider.notifier).renameTag(currentTag, newTag);
-
     if (mounted) {
       setState(() => _tagFilter = WishlistTagFilter.named(newTag));
     }
   }
 
-  Future<void> _confirmDeleteTag(
-    String? tag,
-    int itemCount,
-  ) async {
-    final S l = S.of(context);
-    final String label = tag ?? l.wishlistTagUntagged;
-
-    final bool? confirmed = await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(l.wishlistTagDelete),
-        content: Text(l.wishlistTagDeleteConfirm(label, itemCount)),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l.delete),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed != true || !mounted) return;
-
+  Future<void> _handleDeleteTag(String? tag, int itemCount) async {
+    final bool confirmed =
+        await WishlistDialogs.confirmDeleteTag(context, tag, itemCount);
+    if (!confirmed || !mounted) return;
     await ref.read(wishlistProvider.notifier).deleteByTag(tag);
-
     if (mounted) {
       setState(() => _tagFilter = const WishlistTagFilter.all());
     }
   }
 
   Future<void> _confirmClearResolved(BuildContext context) async {
-    final S l = S.of(context);
     final int resolvedCount = ref
             .read(wishlistProvider)
             .valueOrNull
             ?.where((WishlistItem item) => item.isResolved)
             .length ??
         0;
-
     if (resolvedCount == 0) return;
 
-    final bool? confirmed = await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(l.wishlistClearResolvedTitle),
-        content: Text(l.wishlistClearResolvedMessage(resolvedCount)),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(l.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(l.clear),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && mounted) {
-      await ref.read(wishlistProvider.notifier).clearResolved();
-    }
-  }
-}
-
-/// Full-width chevron filter bar: two segments (tag picker + bulk actions),
-/// always shown. Same visual language as the collection / search filter bars.
-class _WishlistTagHeader extends StatelessWidget {
-  const _WishlistTagHeader({
-    required this.tags,
-    required this.selected,
-    required this.filteredCount,
-    required this.totalCount,
-    required this.onChanged,
-    required this.onRename,
-    required this.onDelete,
-    required this.onBulkAction,
-  });
-
-  final List<WishlistTagCount> tags;
-  final WishlistTagFilter selected;
-  final int filteredCount;
-  final int totalCount;
-  final ValueChanged<WishlistTagFilter> onChanged;
-  final Future<void> Function(String? tag) onRename;
-  final Future<void> Function(String? tag, int itemCount) onDelete;
-  final Future<void> Function(_BulkAction action) onBulkAction;
-
-  @override
-  Widget build(BuildContext context) {
-    return ColoredBox(
-      color: AppColors.surface,
-      child: SizedBox(
-        height: 40,
-        child: Row(
-          children: <Widget>[
-            Expanded(
-              child: _TagPickerSegment(
-                tags: tags,
-                selected: selected,
-                onChanged: onChanged,
-                onRename: onRename,
-                onDelete: onDelete,
-              ),
-            ),
-            Expanded(
-              child: _BulkActionsSegment(
-                count: filteredCount,
-                onAction: onBulkAction,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _TagPickerSegment extends StatelessWidget {
-  const _TagPickerSegment({
-    required this.tags,
-    required this.selected,
-    required this.onChanged,
-    required this.onRename,
-    required this.onDelete,
-  });
-
-  final List<WishlistTagCount> tags;
-  final WishlistTagFilter selected;
-  final ValueChanged<WishlistTagFilter> onChanged;
-  final Future<void> Function(String? tag) onRename;
-  final Future<void> Function(String? tag, int itemCount) onDelete;
-
-  @override
-  Widget build(BuildContext context) {
-    final S l = S.of(context);
-    final int totalActive =
-        tags.fold(0, (int sum, WishlistTagCount t) => sum + t.activeCount);
-    final int totalAll =
-        tags.fold(0, (int sum, WishlistTagCount t) => sum + t.totalCount);
-
-    final String label = _currentLabel(l);
-    final int count = _currentCount(totalActive);
-    final bool active = selected is! WishlistTagFilterAll;
-
-    return DropdownChevronSegment<_TagMenuChoice>(
-      label: '$label ($count)',
-      icon: Icons.folder_outlined,
-      selected: active,
-      accentColor: AppColors.brand,
-      isFirst: true,
-      isLast: false,
-      menuBuilder: (BuildContext ctx) =>
-          _buildMenu(ctx, totalActive, totalAll),
-      onSelected: (_TagMenuChoice? picked) async {
-        if (picked == null) return;
-        switch (picked) {
-          case _TagMenuFilter(:final WishlistTagFilter filter):
-            onChanged(filter);
-          case _TagMenuRename():
-            if (selected is WishlistTagFilterNamed) {
-              await onRename((selected as WishlistTagFilterNamed).tag);
-            }
-          case _TagMenuDelete():
-            final String? rawTag = switch (selected) {
-              WishlistTagFilterNamed(:final String tag) => tag,
-              _ => null,
-            };
-            final WishlistTagCount bucket = tags.firstWhere(
-              (WishlistTagCount t) => t.tag == rawTag,
-              orElse: () => const WishlistTagCount(
-                tag: null,
-                activeCount: 0,
-                totalCount: 0,
-              ),
-            );
-            await onDelete(rawTag, bucket.totalCount);
-        }
-      },
-    );
-  }
-
-  String _currentLabel(S l) {
-    return switch (selected) {
-      WishlistTagFilterAll() => l.wishlistTagAll,
-      WishlistTagFilterUntagged() => l.wishlistTagUntagged,
-      WishlistTagFilterNamed(:final String tag) => _humanLabel(tag),
-    };
-  }
-
-  int _currentCount(int totalActive) {
-    return switch (selected) {
-      WishlistTagFilterAll() => totalActive,
-      WishlistTagFilterUntagged() => _countFor(null),
-      WishlistTagFilterNamed(:final String tag) => _countFor(tag),
-    };
-  }
-
-  int _countFor(String? tag) {
-    for (final WishlistTagCount t in tags) {
-      if (t.tag == tag) return t.activeCount;
-    }
-    return 0;
-  }
-
-  List<PopupMenuEntry<_TagMenuChoice>> _buildMenu(
-    BuildContext context,
-    int totalActive,
-    int totalAll,
-  ) {
-    final S l = S.of(context);
-    final bool canManage = selected is WishlistTagFilterNamed ||
-        selected is WishlistTagFilterUntagged;
-
-    return <PopupMenuEntry<_TagMenuChoice>>[
-      _tagMenuItem(
-        value: const _TagMenuChoice.filter(WishlistTagFilter.all()),
-        label: l.wishlistTagAll,
-        count: totalActive,
-        total: totalAll,
-        isSelected: selected is WishlistTagFilterAll,
-      ),
-      for (final WishlistTagCount t in tags)
-        _tagMenuItem(
-          value: _TagMenuChoice.filter(t.tag == null
-              ? const WishlistTagFilter.untagged()
-              : WishlistTagFilter.named(t.tag!)),
-          label: t.tag == null ? l.wishlistTagUntagged : _humanLabel(t.tag!),
-          count: t.activeCount,
-          total: t.totalCount,
-          isSelected: _isSelected(t.tag),
-        ),
-      if (canManage) ...<PopupMenuEntry<_TagMenuChoice>>[
-        const PopupMenuDivider(),
-        if (selected is WishlistTagFilterNamed)
-          PopupMenuItem<_TagMenuChoice>(
-            value: const _TagMenuChoice.rename(),
-            child: ListTile(
-              leading: const Icon(Icons.edit),
-              title: Text(l.wishlistTagRename),
-              contentPadding: EdgeInsets.zero,
-              dense: true,
-            ),
-          ),
-        PopupMenuItem<_TagMenuChoice>(
-          value: const _TagMenuChoice.deleteTag(),
-          child: ListTile(
-            leading: const Icon(Icons.delete, color: Colors.red),
-            title: Text(
-              l.wishlistTagDelete,
-              style: const TextStyle(color: Colors.red),
-            ),
-            contentPadding: EdgeInsets.zero,
-            dense: true,
-          ),
-        ),
-      ],
-    ];
-  }
-
-  PopupMenuItem<_TagMenuChoice> _tagMenuItem({
-    required _TagMenuChoice value,
-    required String label,
-    required int count,
-    required int total,
-    required bool isSelected,
-  }) {
-    return PopupMenuItem<_TagMenuChoice>(
-      value: value,
-      child: Row(
-        children: <Widget>[
-          SizedBox(
-            width: 24,
-            child: isSelected
-                ? const Icon(Icons.check, size: 18)
-                : const SizedBox.shrink(),
-          ),
-          Expanded(child: Text(label)),
-          const SizedBox(width: AppSpacing.sm),
-          Text(
-            '$count/$total',
-            style: AppTypography.bodySmall.copyWith(
-              color: AppColors.textTertiary,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  bool _isSelected(String? rowTag) {
-    return switch (selected) {
-      WishlistTagFilterAll() => false,
-      WishlistTagFilterUntagged() => rowTag == null,
-      WishlistTagFilterNamed(:final String tag) => tag == rowTag,
-    };
-  }
-
-  static String _humanLabel(String tag) {
-    final WishlistTagInfo info = parseWishlistTag(tag);
-    if (info.isAutoGenerated) {
-      final DateTime ts = info.timestamp!.toLocal();
-      return '${info.source} — '
-          '${ts.year}-${_two(ts.month)}-${_two(ts.day)} '
-          '${_two(ts.hour)}:${_two(ts.minute)}';
-    }
-    return tag;
-  }
-
-  static String _two(int n) => n < 10 ? '0$n' : '$n';
-}
-
-sealed class _TagMenuChoice {
-  const _TagMenuChoice();
-  const factory _TagMenuChoice.filter(WishlistTagFilter filter) =
-      _TagMenuFilter;
-  const factory _TagMenuChoice.rename() = _TagMenuRename;
-  const factory _TagMenuChoice.deleteTag() = _TagMenuDelete;
-}
-
-final class _TagMenuFilter extends _TagMenuChoice {
-  const _TagMenuFilter(this.filter);
-  final WishlistTagFilter filter;
-}
-
-final class _TagMenuRename extends _TagMenuChoice {
-  const _TagMenuRename();
-}
-
-final class _TagMenuDelete extends _TagMenuChoice {
-  const _TagMenuDelete();
-}
-
-/// Bulk operation surfaced when the visible list is narrower than the full
-/// wishlist (tag filter and/or search query active).
-enum _BulkAction { applyTag, removeTag, delete }
-
-class _BulkActionsSegment extends StatelessWidget {
-  const _BulkActionsSegment({
-    required this.count,
-    required this.onAction,
-  });
-
-  final int count;
-  final Future<void> Function(_BulkAction action) onAction;
-
-  @override
-  Widget build(BuildContext context) {
-    final S l = S.of(context);
-    return DropdownChevronSegment<_BulkAction>(
-      label: l.wishlistBulkActionsButton(count),
-      icon: Icons.checklist,
-      selected: false,
-      accentColor: AppColors.brand,
-      isFirst: false,
-      isLast: true,
-      menuBuilder: (BuildContext ctx) {
-        final S sl = S.of(ctx);
-        return <PopupMenuEntry<_BulkAction>>[
-          PopupMenuItem<_BulkAction>(
-            value: _BulkAction.applyTag,
-            child: ListTile(
-              leading: const Icon(Icons.label),
-              title: Text(sl.wishlistBulkApplyTag),
-              contentPadding: EdgeInsets.zero,
-              dense: true,
-            ),
-          ),
-          PopupMenuItem<_BulkAction>(
-            value: _BulkAction.removeTag,
-            child: ListTile(
-              leading: const Icon(Icons.label_off),
-              title: Text(sl.wishlistBulkRemoveTag),
-              contentPadding: EdgeInsets.zero,
-              dense: true,
-            ),
-          ),
-          const PopupMenuDivider(),
-          PopupMenuItem<_BulkAction>(
-            value: _BulkAction.delete,
-            child: ListTile(
-              leading: const Icon(Icons.delete, color: Colors.red),
-              title: Text(
-                sl.wishlistBulkDelete,
-                style: const TextStyle(color: Colors.red),
-              ),
-              contentPadding: EdgeInsets.zero,
-              dense: true,
-            ),
-          ),
-        ];
-      },
-      onSelected: (_BulkAction? picked) async {
-        if (picked != null) await onAction(picked);
-      },
-    );
-  }
-}
-
-/// FAB с popup-меню: добавить, показать/скрыть resolved, очистить resolved.
-class _WishlistTile extends StatelessWidget {
-  const _WishlistTile({
-    required this.item,
-    required this.onTap,
-    required this.onResolve,
-    required this.onEdit,
-    required this.onDelete,
-  });
-
-  final WishlistItem item;
-  final VoidCallback onTap;
-  final VoidCallback onResolve;
-  final VoidCallback onEdit;
-  final VoidCallback onDelete;
-
-  @override
-  Widget build(BuildContext context) {
-    return Opacity(
-      opacity: item.isResolved ? 0.5 : 1.0,
-      child: GestureDetector(
-        onSecondaryTapUp: (TapUpDetails details) =>
-            _showContextMenu(context, details.globalPosition),
-        child: ListTile(
-          leading: _buildLeadingIcon(),
-          title: Text(
-            item.text,
-            style: item.isResolved
-                ? const TextStyle(decoration: TextDecoration.lineThrough)
-                : null,
-          ),
-          subtitle: _buildSubtitle(context),
-          onLongPress: () => _showContextMenu(
-            context,
-            _centerOfContext(context),
-          ),
-          onTap: onTap,
-        ),
-      ),
-    );
-  }
-
-  Offset _centerOfContext(BuildContext context) {
-    final RenderBox? box = context.findRenderObject() as RenderBox?;
-    if (box == null) return Offset.zero;
-    return box.localToGlobal(box.size.center(Offset.zero));
-  }
-
-  void _showContextMenu(BuildContext context, Offset position) {
-    final S l = S.of(context);
-    final RenderBox overlay =
-        Overlay.of(context).context.findRenderObject()! as RenderBox;
-
-    showMenu<String>(
-      context: context,
-      position: RelativeRect.fromRect(
-        position & const Size(1, 1),
-        Offset.zero & overlay.size,
-      ),
-      items: <PopupMenuEntry<String>>[
-        PopupMenuItem<String>(
-          value: 'search',
-          child: ListTile(
-            leading: const Icon(Icons.search),
-            title: Text(l.search),
-            contentPadding: EdgeInsets.zero,
-            dense: true,
-          ),
-        ),
-        PopupMenuItem<String>(
-          value: 'edit',
-          child: ListTile(
-            leading: const Icon(Icons.edit),
-            title: Text(l.edit),
-            contentPadding: EdgeInsets.zero,
-            dense: true,
-          ),
-        ),
-        PopupMenuItem<String>(
-          value: 'resolve',
-          child: ListTile(
-            leading: Icon(
-              item.isResolved ? Icons.undo : Icons.check_circle_outline,
-            ),
-            title: Text(item.isResolved ? l.wishlistUnresolve : l.wishlistMarkResolved),
-            contentPadding: EdgeInsets.zero,
-            dense: true,
-          ),
-        ),
-        const PopupMenuDivider(),
-        PopupMenuItem<String>(
-          value: 'delete',
-          child: ListTile(
-            leading: const Icon(Icons.delete, color: Colors.red),
-            title: Text(l.delete, style: const TextStyle(color: Colors.red)),
-            contentPadding: EdgeInsets.zero,
-            dense: true,
-          ),
-        ),
-      ],
-    ).then((String? value) {
-      if (value == null) return;
-      switch (value) {
-        case 'search':
-          onTap();
-        case 'edit':
-          onEdit();
-        case 'resolve':
-          onResolve();
-        case 'delete':
-          onDelete();
-      }
-    });
-  }
-
-  Widget _buildLeadingIcon() {
-    if (item.mediaTypeHint != null) {
-      return Icon(
-        MediaTypeTheme.iconFor(item.mediaTypeHint!),
-        color: MediaTypeTheme.colorFor(item.mediaTypeHint!),
-      );
-    }
-    return const Icon(Icons.bookmark_border, color: AppColors.textTertiary);
-  }
-
-  Widget? _buildSubtitle(BuildContext context) {
-    final List<String> parts = <String>[];
-    if (item.hasNote) {
-      parts.add(item.note!);
-    }
-    if (item.mediaTypeHint != null && !item.hasNote) {
-      parts.add(item.mediaTypeHint!.localizedLabel(S.of(context)));
-    }
-
-    if (parts.isEmpty) return null;
-
-    final String subtitle = parts.join(' \u00b7 ');
-
-    // Если есть заметка — рендерим через MiniMarkdownText для поддержки разметки.
-    if (item.hasNote) {
-      return MiniMarkdownText(
-        text: subtitle,
-        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: AppColors.textSecondary,
-            ),
-      );
-    }
-
-    return Text(
-      subtitle,
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-    );
+    final bool confirmed =
+        await WishlistDialogs.confirmClearResolved(context, resolvedCount);
+    if (!confirmed || !mounted) return;
+    await ref.read(wishlistProvider.notifier).clearResolved();
   }
 }

--- a/lib/features/wishlist/widgets/wishlist_dialogs.dart
+++ b/lib/features/wishlist/widgets/wishlist_dialogs.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/app_spacing.dart';
+
+/// Prompts and confirmations used by the wishlist screen. Pure dialogs —
+/// they return the user's choice and never call the wishlist notifier so
+/// the screen keeps the side-effect plumbing in one place.
+class WishlistDialogs {
+  const WishlistDialogs._();
+
+  /// Asks the user for a tag to apply to a bulk selection. Returns null if
+  /// cancelled or the entered text was empty after trimming.
+  static Future<String?> promptBulkTag(
+    BuildContext context,
+    int count,
+  ) async {
+    final S l = S.of(context);
+    final TextEditingController controller = TextEditingController();
+    final String? input = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(l.wishlistBulkApplyTag),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(l.wishlistBulkApplyTagHint(count)),
+            const SizedBox(height: AppSpacing.sm),
+            TextField(
+              controller: controller,
+              autofocus: true,
+              decoration: InputDecoration(hintText: l.wishlistTagPlaceholder),
+              onSubmitted: (String v) =>
+                  Navigator.of(context).pop(v.trim()),
+            ),
+          ],
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(l.cancel),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(context).pop(controller.text.trim()),
+            child: Text(l.apply),
+          ),
+        ],
+      ),
+    );
+    if (input == null || input.isEmpty) return null;
+    return input;
+  }
+
+  /// Asks the user for a new name for [currentTag]. Returns null when the
+  /// user cancelled, entered blank, or kept the original name.
+  static Future<String?> promptRenameTag(
+    BuildContext context,
+    String? currentTag,
+  ) async {
+    final S l = S.of(context);
+    final TextEditingController controller =
+        TextEditingController(text: currentTag ?? '');
+
+    final String? newTag = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(l.wishlistTagRename),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(hintText: l.wishlistTagPlaceholder),
+          onSubmitted: (String value) =>
+              Navigator.of(context).pop(value.trim()),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(l.cancel),
+          ),
+          FilledButton(
+            onPressed: () =>
+                Navigator.of(context).pop(controller.text.trim()),
+            child: Text(l.save),
+          ),
+        ],
+      ),
+    );
+
+    if (newTag == null || newTag.isEmpty || newTag == currentTag) return null;
+    return newTag;
+  }
+
+  /// Confirms deletion of a tag and the [itemCount] items under it.
+  static Future<bool> confirmDeleteTag(
+    BuildContext context,
+    String? tag,
+    int itemCount,
+  ) async {
+    final S l = S.of(context);
+    final String label = tag ?? l.wishlistTagUntagged;
+    return _confirm(
+      context,
+      title: l.wishlistTagDelete,
+      message: l.wishlistTagDeleteConfirm(label, itemCount),
+      confirmLabel: l.delete,
+    );
+  }
+
+  /// Confirms clearing all resolved items.
+  static Future<bool> confirmClearResolved(
+    BuildContext context,
+    int resolvedCount,
+  ) async {
+    final S l = S.of(context);
+    return _confirm(
+      context,
+      title: l.wishlistClearResolvedTitle,
+      message: l.wishlistClearResolvedMessage(resolvedCount),
+      confirmLabel: l.clear,
+    );
+  }
+
+  /// Confirms deletion of a single item.
+  static Future<bool> confirmDeleteItem(
+    BuildContext context,
+    String itemText,
+  ) async {
+    final S l = S.of(context);
+    return _confirm(
+      context,
+      title: l.wishlistDeleteItem,
+      message: l.wishlistDeletePrompt(itemText),
+      confirmLabel: l.delete,
+    );
+  }
+
+  /// Confirms bulk deletion of [count] items.
+  static Future<bool> confirmBulkDelete(
+    BuildContext context,
+    int count,
+  ) async {
+    final S l = S.of(context);
+    return _confirm(
+      context,
+      title: l.wishlistBulkDelete,
+      message: l.wishlistBulkDeleteConfirm(count),
+      confirmLabel: l.delete,
+    );
+  }
+
+  static Future<bool> _confirm(
+    BuildContext context, {
+    required String title,
+    required String message,
+    required String confirmLabel,
+  }) async {
+    final S l = S.of(context);
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+}

--- a/lib/features/wishlist/widgets/wishlist_tag_header.dart
+++ b/lib/features/wishlist/widgets/wishlist_tag_header.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/database/dao/wishlist_dao.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/wishlist_tag.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/chevron_filter_bar.dart';
+
+/// Bulk operation surfaced when a tag/search filter narrows the visible list.
+enum WishlistBulkAction { applyTag, removeTag, delete }
+
+/// Full-width chevron filter bar for the wishlist: tag picker + bulk actions.
+class WishlistTagHeader extends StatelessWidget {
+  const WishlistTagHeader({
+    required this.tags,
+    required this.selected,
+    required this.filteredCount,
+    required this.totalCount,
+    required this.onChanged,
+    required this.onRename,
+    required this.onDelete,
+    required this.onBulkAction,
+    super.key,
+  });
+
+  final List<WishlistTagCount> tags;
+  final WishlistTagFilter selected;
+  final int filteredCount;
+  final int totalCount;
+  final ValueChanged<WishlistTagFilter> onChanged;
+  final Future<void> Function(String? tag) onRename;
+  final Future<void> Function(String? tag, int itemCount) onDelete;
+  final Future<void> Function(WishlistBulkAction action) onBulkAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: AppColors.surface,
+      child: SizedBox(
+        height: 40,
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              child: _TagPickerSegment(
+                tags: tags,
+                selected: selected,
+                onChanged: onChanged,
+                onRename: onRename,
+                onDelete: onDelete,
+              ),
+            ),
+            Expanded(
+              child: _BulkActionsSegment(
+                count: filteredCount,
+                onAction: onBulkAction,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TagPickerSegment extends StatelessWidget {
+  const _TagPickerSegment({
+    required this.tags,
+    required this.selected,
+    required this.onChanged,
+    required this.onRename,
+    required this.onDelete,
+  });
+
+  final List<WishlistTagCount> tags;
+  final WishlistTagFilter selected;
+  final ValueChanged<WishlistTagFilter> onChanged;
+  final Future<void> Function(String? tag) onRename;
+  final Future<void> Function(String? tag, int itemCount) onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    final int totalActive =
+        tags.fold(0, (int sum, WishlistTagCount t) => sum + t.activeCount);
+    final int totalAll =
+        tags.fold(0, (int sum, WishlistTagCount t) => sum + t.totalCount);
+
+    final String label = _currentLabel(l);
+    final int count = _currentCount(totalActive);
+    final bool active = selected is! WishlistTagFilterAll;
+
+    return DropdownChevronSegment<_TagMenuChoice>(
+      label: '$label ($count)',
+      icon: Icons.folder_outlined,
+      selected: active,
+      accentColor: AppColors.brand,
+      isFirst: true,
+      isLast: false,
+      menuBuilder: (BuildContext ctx) =>
+          _buildMenu(ctx, totalActive, totalAll),
+      onSelected: (_TagMenuChoice? picked) async {
+        if (picked == null) return;
+        switch (picked) {
+          case _TagMenuFilter(:final WishlistTagFilter filter):
+            onChanged(filter);
+          case _TagMenuRename():
+            if (selected is WishlistTagFilterNamed) {
+              await onRename((selected as WishlistTagFilterNamed).tag);
+            }
+          case _TagMenuDelete():
+            final String? rawTag = switch (selected) {
+              WishlistTagFilterNamed(:final String tag) => tag,
+              _ => null,
+            };
+            final WishlistTagCount bucket = tags.firstWhere(
+              (WishlistTagCount t) => t.tag == rawTag,
+              orElse: () => const WishlistTagCount(
+                tag: null,
+                activeCount: 0,
+                totalCount: 0,
+              ),
+            );
+            await onDelete(rawTag, bucket.totalCount);
+        }
+      },
+    );
+  }
+
+  String _currentLabel(S l) {
+    return switch (selected) {
+      WishlistTagFilterAll() => l.wishlistTagAll,
+      WishlistTagFilterUntagged() => l.wishlistTagUntagged,
+      WishlistTagFilterNamed(:final String tag) => _humanLabel(tag),
+    };
+  }
+
+  int _currentCount(int totalActive) {
+    return switch (selected) {
+      WishlistTagFilterAll() => totalActive,
+      WishlistTagFilterUntagged() => _countFor(null),
+      WishlistTagFilterNamed(:final String tag) => _countFor(tag),
+    };
+  }
+
+  int _countFor(String? tag) {
+    for (final WishlistTagCount t in tags) {
+      if (t.tag == tag) return t.activeCount;
+    }
+    return 0;
+  }
+
+  List<PopupMenuEntry<_TagMenuChoice>> _buildMenu(
+    BuildContext context,
+    int totalActive,
+    int totalAll,
+  ) {
+    final S l = S.of(context);
+    final bool canManage = selected is WishlistTagFilterNamed ||
+        selected is WishlistTagFilterUntagged;
+
+    return <PopupMenuEntry<_TagMenuChoice>>[
+      _tagMenuItem(
+        value: const _TagMenuChoice.filter(WishlistTagFilter.all()),
+        label: l.wishlistTagAll,
+        count: totalActive,
+        total: totalAll,
+        isSelected: selected is WishlistTagFilterAll,
+      ),
+      for (final WishlistTagCount t in tags)
+        _tagMenuItem(
+          value: _TagMenuChoice.filter(t.tag == null
+              ? const WishlistTagFilter.untagged()
+              : WishlistTagFilter.named(t.tag!)),
+          label: t.tag == null ? l.wishlistTagUntagged : _humanLabel(t.tag!),
+          count: t.activeCount,
+          total: t.totalCount,
+          isSelected: _isSelected(t.tag),
+        ),
+      if (canManage) ...<PopupMenuEntry<_TagMenuChoice>>[
+        const PopupMenuDivider(),
+        if (selected is WishlistTagFilterNamed)
+          PopupMenuItem<_TagMenuChoice>(
+            value: const _TagMenuChoice.rename(),
+            child: ListTile(
+              leading: const Icon(Icons.edit),
+              title: Text(l.wishlistTagRename),
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+            ),
+          ),
+        PopupMenuItem<_TagMenuChoice>(
+          value: const _TagMenuChoice.deleteTag(),
+          child: ListTile(
+            leading: const Icon(Icons.delete, color: Colors.red),
+            title: Text(
+              l.wishlistTagDelete,
+              style: const TextStyle(color: Colors.red),
+            ),
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+          ),
+        ),
+      ],
+    ];
+  }
+
+  PopupMenuItem<_TagMenuChoice> _tagMenuItem({
+    required _TagMenuChoice value,
+    required String label,
+    required int count,
+    required int total,
+    required bool isSelected,
+  }) {
+    return PopupMenuItem<_TagMenuChoice>(
+      value: value,
+      child: Row(
+        children: <Widget>[
+          SizedBox(
+            width: 24,
+            child: isSelected
+                ? const Icon(Icons.check, size: 18)
+                : const SizedBox.shrink(),
+          ),
+          Expanded(child: Text(label)),
+          const SizedBox(width: AppSpacing.sm),
+          Text(
+            '$count/$total',
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textTertiary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _isSelected(String? rowTag) {
+    return switch (selected) {
+      WishlistTagFilterAll() => false,
+      WishlistTagFilterUntagged() => rowTag == null,
+      WishlistTagFilterNamed(:final String tag) => tag == rowTag,
+    };
+  }
+
+  static String _humanLabel(String tag) {
+    final WishlistTagInfo info = parseWishlistTag(tag);
+    if (info.isAutoGenerated) {
+      final DateTime ts = info.timestamp!.toLocal();
+      return '${info.source} — '
+          '${ts.year}-${_two(ts.month)}-${_two(ts.day)} '
+          '${_two(ts.hour)}:${_two(ts.minute)}';
+    }
+    return tag;
+  }
+
+  static String _two(int n) => n < 10 ? '0$n' : '$n';
+}
+
+sealed class _TagMenuChoice {
+  const _TagMenuChoice();
+  const factory _TagMenuChoice.filter(WishlistTagFilter filter) =
+      _TagMenuFilter;
+  const factory _TagMenuChoice.rename() = _TagMenuRename;
+  const factory _TagMenuChoice.deleteTag() = _TagMenuDelete;
+}
+
+final class _TagMenuFilter extends _TagMenuChoice {
+  const _TagMenuFilter(this.filter);
+  final WishlistTagFilter filter;
+}
+
+final class _TagMenuRename extends _TagMenuChoice {
+  const _TagMenuRename();
+}
+
+final class _TagMenuDelete extends _TagMenuChoice {
+  const _TagMenuDelete();
+}
+
+class _BulkActionsSegment extends StatelessWidget {
+  const _BulkActionsSegment({
+    required this.count,
+    required this.onAction,
+  });
+
+  final int count;
+  final Future<void> Function(WishlistBulkAction action) onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return DropdownChevronSegment<WishlistBulkAction>(
+      label: l.wishlistBulkActionsButton(count),
+      icon: Icons.checklist,
+      selected: false,
+      accentColor: AppColors.brand,
+      isFirst: false,
+      isLast: true,
+      menuBuilder: (BuildContext ctx) {
+        final S sl = S.of(ctx);
+        return <PopupMenuEntry<WishlistBulkAction>>[
+          PopupMenuItem<WishlistBulkAction>(
+            value: WishlistBulkAction.applyTag,
+            child: ListTile(
+              leading: const Icon(Icons.label),
+              title: Text(sl.wishlistBulkApplyTag),
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+            ),
+          ),
+          PopupMenuItem<WishlistBulkAction>(
+            value: WishlistBulkAction.removeTag,
+            child: ListTile(
+              leading: const Icon(Icons.label_off),
+              title: Text(sl.wishlistBulkRemoveTag),
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+            ),
+          ),
+          const PopupMenuDivider(),
+          PopupMenuItem<WishlistBulkAction>(
+            value: WishlistBulkAction.delete,
+            child: ListTile(
+              leading: const Icon(Icons.delete, color: Colors.red),
+              title: Text(
+                sl.wishlistBulkDelete,
+                style: const TextStyle(color: Colors.red),
+              ),
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+            ),
+          ),
+        ];
+      },
+      onSelected: (WishlistBulkAction? picked) async {
+        if (picked != null) await onAction(picked);
+      },
+    );
+  }
+}

--- a/lib/features/wishlist/widgets/wishlist_tile.dart
+++ b/lib/features/wishlist/widgets/wishlist_tile.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/constants/media_type_theme.dart';
+import '../../../shared/models/wishlist_item.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/mini_markdown_text.dart';
+
+enum _TileAction { search, edit, resolve, delete }
+
+/// Single wishlist item row with a right-click / long-press context menu.
+class WishlistTile extends StatelessWidget {
+  const WishlistTile({
+    required this.item,
+    required this.onTap,
+    required this.onResolve,
+    required this.onEdit,
+    required this.onDelete,
+    super.key,
+  });
+
+  final WishlistItem item;
+  final VoidCallback onTap;
+  final VoidCallback onResolve;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: item.isResolved ? 0.5 : 1.0,
+      child: GestureDetector(
+        onSecondaryTapUp: (TapUpDetails details) =>
+            _showContextMenu(context, details.globalPosition),
+        child: ListTile(
+          leading: _buildLeadingIcon(),
+          title: Text(
+            item.text,
+            style: item.isResolved
+                ? const TextStyle(decoration: TextDecoration.lineThrough)
+                : null,
+          ),
+          subtitle: _buildSubtitle(context),
+          onLongPress: () => _showContextMenu(
+            context,
+            _centerOfContext(context),
+          ),
+          onTap: onTap,
+        ),
+      ),
+    );
+  }
+
+  Offset _centerOfContext(BuildContext context) {
+    final RenderBox? box = context.findRenderObject() as RenderBox?;
+    if (box == null) return Offset.zero;
+    return box.localToGlobal(box.size.center(Offset.zero));
+  }
+
+  Future<void> _showContextMenu(
+    BuildContext context,
+    Offset position,
+  ) async {
+    final S l = S.of(context);
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+
+    final _TileAction? picked = await showMenu<_TileAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        position & const Size(1, 1),
+        Offset.zero & overlay.size,
+      ),
+      items: <PopupMenuEntry<_TileAction>>[
+        PopupMenuItem<_TileAction>(
+          value: _TileAction.search,
+          child: ListTile(
+            leading: const Icon(Icons.search),
+            title: Text(l.search),
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+          ),
+        ),
+        PopupMenuItem<_TileAction>(
+          value: _TileAction.edit,
+          child: ListTile(
+            leading: const Icon(Icons.edit),
+            title: Text(l.edit),
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+          ),
+        ),
+        PopupMenuItem<_TileAction>(
+          value: _TileAction.resolve,
+          child: ListTile(
+            leading: Icon(
+              item.isResolved ? Icons.undo : Icons.check_circle_outline,
+            ),
+            title: Text(item.isResolved
+                ? l.wishlistUnresolve
+                : l.wishlistMarkResolved),
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<_TileAction>(
+          value: _TileAction.delete,
+          child: ListTile(
+            leading: const Icon(Icons.delete, color: Colors.red),
+            title:
+                Text(l.delete, style: const TextStyle(color: Colors.red)),
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+          ),
+        ),
+      ],
+    );
+
+    if (picked == null) return;
+    switch (picked) {
+      case _TileAction.search:
+        onTap();
+      case _TileAction.edit:
+        onEdit();
+      case _TileAction.resolve:
+        onResolve();
+      case _TileAction.delete:
+        onDelete();
+    }
+  }
+
+  Widget _buildLeadingIcon() {
+    if (item.mediaTypeHint != null) {
+      return Icon(
+        MediaTypeTheme.iconFor(item.mediaTypeHint!),
+        color: MediaTypeTheme.colorFor(item.mediaTypeHint!),
+      );
+    }
+    return const Icon(Icons.bookmark_border, color: AppColors.textTertiary);
+  }
+
+  Widget? _buildSubtitle(BuildContext context) {
+    final List<String> parts = <String>[];
+    if (item.hasNote) {
+      parts.add(item.note!);
+    }
+    if (item.mediaTypeHint != null && !item.hasNote) {
+      parts.add(item.mediaTypeHint!.localizedLabel(S.of(context)));
+    }
+
+    if (parts.isEmpty) return null;
+
+    final String subtitle = parts.join(' · ');
+
+    if (item.hasNote) {
+      return MiniMarkdownText(
+        text: subtitle,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: AppColors.textSecondary,
+            ),
+      );
+    }
+
+    return Text(
+      subtitle,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -485,7 +485,6 @@
   "customItemAltTitleHint": "Original language name",
   "customItemCoverUrl": "Cover image URL",
   "customItemYear": "Year",
-  "customItemMyRating": "My Rating",
   "customItemGenres": "Genres",
   "customItemGenresHint": "e.g. RPG, Action, Puzzle",
   "customItemPlatform": "Platform",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2011,12 +2011,6 @@ abstract class S {
   /// **'Year'**
   String get customItemYear;
 
-  /// No description provided for @customItemMyRating.
-  ///
-  /// In en, this message translates to:
-  /// **'My Rating'**
-  String get customItemMyRating;
-
   /// No description provided for @customItemGenres.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1090,9 +1090,6 @@ class SEn extends S {
   String get customItemYear => 'Year';
 
   @override
-  String get customItemMyRating => 'My Rating';
-
-  @override
   String get customItemGenres => 'Genres';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1107,9 +1107,6 @@ class SRu extends S {
   String get customItemYear => 'Год';
 
   @override
-  String get customItemMyRating => 'Мой рейтинг';
-
-  @override
   String get customItemGenres => 'Жанры';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -423,7 +423,6 @@
   "customItemAltTitleHint": "Название на оригинальном языке",
   "customItemCoverUrl": "URL обложки",
   "customItemYear": "Год",
-  "customItemMyRating": "Мой рейтинг",
   "customItemGenres": "Жанры",
   "customItemGenresHint": "напр. RPG, Экшен, Головоломка",
   "customItemPlatform": "Платформа",


### PR DESCRIPTION
Wishlist screen drops 994 -> 345 LOC by extracting the chevron tag header (with sealed _TagMenuChoice and public WishlistBulkAction), the item tile (now using a typed _TileAction enum instead of string-keyed switch), and four repetitive AlertDialog prompts into a WishlistDialogs helper with a shared _confirm primitive.

Create-custom-item dialog drops 1089 -> 538 LOC by moving the cover preview / picker, the searchable single-select dialog, the multi-select genre dialog, and the CustomItemData form result into widgets/custom_item/. The dead "My rating" star section is removed along with its customItemMyRating ARB key — the value was collected but never reached the form result, so nothing was ever saved.

CustomItemData stays importable from the original path via re-export, so call sites in collection_screen.dart and item_detail_screen.dart are untouched.