### PR TITLE
feat(bulk): add Select all + dynamic chevron counts, rename Skipped to Duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,77 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     refreshItemFailed): New strings; regenerated
     `app_localizations*.dart`.
 
+### Added
+
+- **Select all visible items from the bulk action bar**
+
+  After picking at least one item, a "Select all" text button appears
+  in the bulk action bar next to the "N selected" counter. Tapping it
+  extends the selection to every item currently visible after search
+  and filters, so a "find then select everything matching" flow
+  becomes one tap instead of clicking each card. The button hides
+  when the visible set is already fully selected or when the host
+  screen doesn't expose a visible-item count.
+
+  * lib/features/collections/widgets/bulk_action_bar.dart
+    (BulkActionBar): Add `visibleCount` and `onSelectAllVisible`
+    parameters; render a `TextButton` between the counter and the
+    existing actions when the callback is set and
+    `visibleCount > items.length`.
+  * lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+    (CollectionBulkActionBar): Accept `CollectionFilters? filters`
+    and `List<CollectionTag> tags`, apply them to the full item list
+    to derive the visible set, and wire the new callback to
+    `CollectionSelectionNotifier.selectAll`.
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState.build): Lift `CollectionFilters` and
+    tags resolution above the bulk action bar so the bar gets the
+    same filtered set as `CollectionItemsView`.
+  * lib/features/home/screens/all_items_screen.dart
+    (AllItemsScreen.build): Compute `visibleItems` via
+    `_applyFilter` once, pass to the bulk action bar with
+    `AllItemsSelectionNotifier.selectAll`, and reuse the same list
+    inside `itemsAsync.when` instead of filtering twice.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (bulkSelectAllVisible):
+    New label string; regenerated `app_localizations*.dart`.
+  * test/features/collections/widgets/bulk_action_bar_test.dart: New.
+    Cover the show/hide branches for the Select all button and
+    confirm the callback fires on tap.
+
+- **Reflect active filters in All Items media-type chevron counts**
+
+  Counts shown next to each chevron on the home screen now drop and
+  rise with the search query, status, platform and tag filters, so
+  it's obvious how many of each type are currently visible. The
+  "Hide empty media types" setting still keys off raw totals — a
+  search that wipes out a category no longer makes the chevron itself
+  disappear, matching how the collection filter bar already worked.
+
+  * lib/features/home/screens/all_items_screen.dart
+    (AllItemsScreen._applyFilter, AllItemsScreen._matchesNonTypeFilters,
+    AllItemsScreen._countByMediaType, AllItemsScreen._rawTotalsByMediaType,
+    AllItemsScreen._buildMediaTypeBar): Split filtering into a shared
+    non-type predicate; chevron labels use a filter-aware count while
+    chevron visibility under `hideEmptyMediaTypeChevrons` uses raw
+    per-type totals.
+  * test/features/home/screens/all_items_screen_test.dart
+    (_FakeSettingsNotifier, "should keep chevrons with non-zero totals
+    visible even when search filters them out"): Add a regression test
+    that drives the search provider to a non-matching query and
+    asserts the Games / Movies chevrons stay mounted.
+
 ### Changed
+
+- **Label bulk-move/copy leftovers as "Duplicates" instead of "Skipped"**
+
+  A move or copy can only "skip" an item when the target already
+  holds the same `(media_type, external_id)` pair (the UNIQUE index
+  rejects the write). The previous wording made the count look like
+  an opaque failure; renaming surfaces the real reason.
+
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (bulkResult): Replace
+    "Skipped" / "Пропущено" with "Duplicates" / "Дубликаты"; sync
+    `app_localizations_en.dart` and `app_localizations_ru.dart`.
 
 - **Split the AniList API god class into layered files**
 

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -175,6 +175,18 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
         ref.watch(collectionStatsProvider(widget.collectionId));
 
     final String searchQuery = ref.watch(collectionsSearchQueryProvider);
+    final List<CollectionTag> tags = widget.collectionId != null
+        ? (ref.watch(collectionTagsProvider(widget.collectionId!))
+                .valueOrNull ??
+            <CollectionTag>[])
+        : <CollectionTag>[];
+    final CollectionFilters activeFilters = CollectionFilters(
+      mediaTypes: _filterTypes,
+      platformIds: _filterPlatformIds,
+      tagIds: _filterTagIds,
+      status: _filterStatus,
+      searchQuery: searchQuery,
+    );
     final S l = S.of(context);
     return CallbackShortcuts(
       bindings: _buildScreenShortcuts(l),
@@ -190,7 +202,11 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
                     : _collection!.name,
               ),
               if (_canEdit && !_isCanvasMode)
-                CollectionBulkActionBar(collectionId: widget.collectionId),
+                CollectionBulkActionBar(
+                  collectionId: widget.collectionId,
+                  filters: activeFilters,
+                  tags: tags,
+                ),
               Expanded(
                 child: _isCanvasMode
                     ? CollectionCanvasLayout(

--- a/lib/features/collections/widgets/bulk_action_bar.dart
+++ b/lib/features/collections/widgets/bulk_action_bar.dart
@@ -33,6 +33,8 @@ class BulkActionBar extends ConsumerWidget {
     required this.items,
     required this.onClearSelection,
     this.collectionId,
+    this.visibleCount,
+    this.onSelectAllVisible,
     super.key,
   });
 
@@ -44,6 +46,13 @@ class BulkActionBar extends ConsumerWidget {
 
   /// ID контекстной коллекции. `null` если бар стоит на All Items.
   final int? collectionId;
+
+  /// Сколько элементов всего видно на экране после фильтров и поиска.
+  /// Используется чтобы скрыть «выделить все видимые», когда уже выделено всё.
+  final int? visibleCount;
+
+  /// Колбэк «выделить все видимые элементы». `null` скрывает кнопку.
+  final VoidCallback? onSelectAllVisible;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -80,6 +89,22 @@ class BulkActionBar extends ConsumerWidget {
                 fontWeight: FontWeight.w600,
               ),
             ),
+            if (onSelectAllVisible != null &&
+                (visibleCount ?? 0) > count) ...<Widget>[
+              const SizedBox(width: AppSpacing.sm),
+              TextButton(
+                onPressed: onSelectAllVisible,
+                style: TextButton.styleFrom(
+                  foregroundColor: AppColors.brand,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.sm,
+                  ),
+                  minimumSize: Size.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: Text(l.bulkSelectAllVisible),
+              ),
+            ],
             const Spacer(),
             _BarAction(
               icon: Icons.drive_file_move_outlined,

--- a/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
@@ -2,14 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../shared/models/collection_item.dart';
+import '../../../../shared/models/collection_tag.dart';
+import '../../helpers/collection_filters.dart';
 import '../../providers/collection_selection_provider.dart';
 import '../../providers/collections_provider.dart';
 import '../bulk_action_bar.dart';
 
 class CollectionBulkActionBar extends ConsumerWidget {
-  const CollectionBulkActionBar({required this.collectionId, super.key});
+  const CollectionBulkActionBar({
+    required this.collectionId,
+    this.filters,
+    this.tags = const <CollectionTag>[],
+    super.key,
+  });
 
   final int? collectionId;
+
+  /// Active screen filters. When provided, the "select all visible" action
+  /// targets `filters.apply(allItems, tags)` instead of the full list.
+  final CollectionFilters? filters;
+  final List<CollectionTag> tags;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -28,9 +40,16 @@ class CollectionBulkActionBar extends ConsumerWidget {
     ];
     if (selectedItems.isEmpty) return const SizedBox.shrink();
 
+    final List<CollectionItem> visible =
+        filters?.apply(all, tags) ?? all;
+
     return BulkActionBar(
       items: selectedItems,
       collectionId: collectionId,
+      visibleCount: visible.length,
+      onSelectAllVisible: () => ref
+          .read(collectionSelectionProvider(collectionId).notifier)
+          .selectAll(visible.map((CollectionItem i) => i.id)),
       onClearSelection: () => ref
           .read(collectionSelectionProvider(collectionId).notifier)
           .clear(),

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -66,6 +66,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     final Set<int> selection = ref.watch(allItemsSelectionProvider);
     final List<CollectionItem> allItems =
         itemsAsync.valueOrNull ?? const <CollectionItem>[];
+    final List<CollectionItem> visibleItems =
+        _applyFilter(allItems, filterStatus, tagsMap, searchQuery);
     final List<CollectionItem> selectedItems = selection.isEmpty
         ? const <CollectionItem>[]
         : <CollectionItem>[
@@ -75,11 +77,15 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
 
     return Column(
       children: <Widget>[
-        _buildMediaTypeBar(itemsAsync, filterStatus),
+        _buildMediaTypeBar(itemsAsync, filterStatus, tagsMap, searchQuery),
         _buildPlatformsRow(),
         if (selectedItems.isNotEmpty)
           BulkActionBar(
             items: selectedItems,
+            visibleCount: visibleItems.length,
+            onSelectAllVisible: () => ref
+                .read(allItemsSelectionProvider.notifier)
+                .selectAll(visibleItems.map((CollectionItem i) => i.id)),
             onClearSelection: () => ref
                 .read(allItemsSelectionProvider.notifier)
                 .clear(),
@@ -87,12 +93,10 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         Expanded(
           child: itemsAsync.when(
             data: (List<CollectionItem> items) {
-              final List<CollectionItem> filtered =
-                  _applyFilter(items, filterStatus, tagsMap, searchQuery);
-              if (filtered.isEmpty) {
+              if (visibleItems.isEmpty) {
                 return _buildEmptyState(items.isEmpty);
               }
-              return _buildGridView(filtered, collectionNames, tagsMap);
+              return _buildGridView(visibleItems, collectionNames, tagsMap);
             },
             loading: () => const Center(child: CircularProgressIndicator()),
             error: (Object error, StackTrace stack) =>
@@ -109,41 +113,37 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     Map<int, CollectionTag> tagsMap,
     String searchQuery,
   ) {
-    List<CollectionItem> result = items;
-    if (_selectedTypes.isNotEmpty) {
-      result = result
-          .where((CollectionItem item) => _selectedTypes.contains(item.mediaType))
-          .toList();
+    final String query = searchQuery.toLowerCase();
+    return items
+        .where((CollectionItem item) =>
+            (_selectedTypes.isEmpty ||
+                _selectedTypes.contains(item.mediaType)) &&
+            _matchesNonTypeFilters(item, filterStatus, tagsMap, query))
+        .toList();
+  }
+
+  bool _matchesNonTypeFilters(
+    CollectionItem item,
+    ItemStatus? filterStatus,
+    Map<int, CollectionTag> tagsMap,
+    String lowerQuery,
+  ) {
+    if (filterStatus != null && item.status != filterStatus) return false;
+    if (_selectedPlatformIds.isNotEmpty &&
+        (item.platformId == null ||
+            !_selectedPlatformIds.contains(item.platformId))) {
+      return false;
     }
-    if (filterStatus != null) {
-      result = result
-          .where((CollectionItem item) => item.status == filterStatus)
-          .toList();
+    if (lowerQuery.isNotEmpty) {
+      final bool match = item.itemName.toLowerCase().contains(lowerQuery) ||
+          (item.tagId != null &&
+              (tagsMap[item.tagId]?.name.toLowerCase().contains(lowerQuery) ??
+                  false)) ||
+          (item.userComment?.toLowerCase().contains(lowerQuery) ?? false) ||
+          (item.authorComment?.toLowerCase().contains(lowerQuery) ?? false);
+      if (!match) return false;
     }
-    if (_selectedPlatformIds.isNotEmpty) {
-      result = result
-          .where(
-            (CollectionItem item) =>
-                item.platformId != null &&
-                _selectedPlatformIds.contains(item.platformId),
-          )
-          .toList();
-    }
-    if (searchQuery.isNotEmpty) {
-      final String query = searchQuery.toLowerCase();
-      result = result
-          .where(
-            (CollectionItem item) =>
-                item.itemName.toLowerCase().contains(query) ||
-                (item.tagId != null &&
-                    (tagsMap[item.tagId]?.name.toLowerCase().contains(query) ??
-                        false)) ||
-                (item.userComment?.toLowerCase().contains(query) ?? false) ||
-                (item.authorComment?.toLowerCase().contains(query) ?? false),
-          )
-          .toList();
-    }
-    return result;
+    return true;
   }
 
   // ==================== Filter UI ====================
@@ -155,9 +155,13 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
   Widget _buildMediaTypeBar(
     AsyncValue<List<CollectionItem>> itemsAsync,
     ItemStatus? filterStatus,
+    Map<int, CollectionTag> tagsMap,
+    String searchQuery,
   ) {
     final List<CollectionItem>? items = itemsAsync.valueOrNull;
-    final Map<MediaType, int> counts = _countByMediaType(items);
+    final Map<MediaType, int> counts =
+        _countByMediaType(items, filterStatus, tagsMap, searchQuery);
+    final Map<MediaType, int> totals = _rawTotalsByMediaType(items);
     final S l = S.of(context);
 
     final List<_MediaTypeEntry> entries = <_MediaTypeEntry>[
@@ -214,7 +218,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         (hideEmpty && items != null)
             ? entries
                 .where((_MediaTypeEntry e) =>
-                    e.count > 0 || _selectedTypes.contains(e.type))
+                    (totals[e.type] ?? 0) > 0 ||
+                    _selectedTypes.contains(e.type))
                 .toList()
             : entries;
 
@@ -339,11 +344,36 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
 
   // ==================== Helpers ====================
 
-  /// Считает количество элементов по типу медиа.
-  static Map<MediaType, int> _countByMediaType(List<CollectionItem>? items) {
+  /// Raw item count per media type, ignoring every filter. Drives chevron
+  /// visibility — search hits should change the chevron label, not make
+  /// non-matching media types disappear when "Hide empty" is on.
+  static Map<MediaType, int> _rawTotalsByMediaType(
+    List<CollectionItem>? items,
+  ) {
+    if (items == null) return const <MediaType, int>{};
+    final Map<MediaType, int> totals = <MediaType, int>{};
+    for (final CollectionItem item in items) {
+      totals[item.mediaType] = (totals[item.mediaType] ?? 0) + 1;
+    }
+    return totals;
+  }
+
+  /// Counts items per media type after applying every active filter except
+  /// the media-type one — so each chevron shows how many would be visible if
+  /// the user picked it.
+  Map<MediaType, int> _countByMediaType(
+    List<CollectionItem>? items,
+    ItemStatus? filterStatus,
+    Map<int, CollectionTag> tagsMap,
+    String searchQuery,
+  ) {
     if (items == null) return <MediaType, int>{};
+    final String lower = searchQuery.toLowerCase();
     final Map<MediaType, int> counts = <MediaType, int>{};
     for (final CollectionItem item in items) {
+      if (!_matchesNonTypeFilters(item, filterStatus, tagsMap, lower)) {
+        continue;
+      }
       counts[item.mediaType] = (counts[item.mediaType] ?? 0) + 1;
     }
     return counts;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -81,6 +81,7 @@
     }
   },
   "bulkClearSelection": "Clear selection",
+  "bulkSelectAllVisible": "Select all",
   "bulkMove": "Move selected to collection",
   "bulkCopy": "Copy selected to collection",
   "bulkChangeStatus": "Change status",
@@ -90,7 +91,7 @@
       "count": {"type": "int"}
     }
   },
-  "bulkResult": "Done: {done} • Skipped: {skipped}",
+  "bulkResult": "Done: {done} • Duplicates: {skipped}",
   "@bulkResult": {
     "placeholders": {
       "done": {"type": "int"},

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -511,6 +511,12 @@ abstract class S {
   /// **'Clear selection'**
   String get bulkClearSelection;
 
+  /// No description provided for @bulkSelectAllVisible.
+  ///
+  /// In en, this message translates to:
+  /// **'Select all'**
+  String get bulkSelectAllVisible;
+
   /// No description provided for @bulkMove.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -224,6 +224,9 @@ class SEn extends S {
   String get bulkClearSelection => 'Clear selection';
 
   @override
+  String get bulkSelectAllVisible => 'Select all';
+
+  @override
   String get bulkMove => 'Move selected to collection';
 
   @override
@@ -245,7 +248,7 @@ class SEn extends S {
 
   @override
   String bulkResult(int done, int skipped) {
-    return 'Done: $done • Skipped: $skipped';
+    return 'Done: $done • Duplicates: $skipped';
   }
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -226,6 +226,9 @@ class SRu extends S {
   String get bulkClearSelection => 'Снять выделение';
 
   @override
+  String get bulkSelectAllVisible => 'Выделить всё';
+
+  @override
   String get bulkMove => 'Переместить выделенные в коллекцию';
 
   @override
@@ -249,7 +252,7 @@ class SRu extends S {
 
   @override
   String bulkResult(int done, int skipped) {
-    return 'Выполнено: $done • Пропущено: $skipped';
+    return 'Выполнено: $done • Дубликаты: $skipped';
   }
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -81,6 +81,7 @@
     }
   },
   "bulkClearSelection": "Снять выделение",
+  "bulkSelectAllVisible": "Выделить всё",
   "bulkMove": "Переместить выделенные в коллекцию",
   "bulkCopy": "Скопировать выделенные в коллекцию",
   "bulkChangeStatus": "Изменить статус",
@@ -90,7 +91,7 @@
       "count": {"type": "int"}
     }
   },
-  "bulkResult": "Выполнено: {done} • Пропущено: {skipped}",
+  "bulkResult": "Выполнено: {done} • Дубликаты: {skipped}",
   "@bulkResult": {
     "placeholders": {
       "done": {"type": "int"},

--- a/test/features/collections/widgets/bulk_action_bar_test.dart
+++ b/test/features/collections/widgets/bulk_action_bar_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/bulk_action_bar.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  group('BulkActionBar select-all action', () {
+    final List<CollectionItem> oneSelected = <CollectionItem>[
+      createTestCollectionItem(id: 1),
+    ];
+
+    Finder selectAllButton() => find.byWidgetPredicate(
+          (Widget w) => w is TextButton && w.onPressed != null,
+        );
+
+    testWidgets(
+        'should show a tappable Select all button when callback is set and '
+        'visibleCount exceeds selection', (WidgetTester tester) async {
+      int taps = 0;
+
+      await tester.pumpApp(
+        BulkActionBar(
+          items: oneSelected,
+          visibleCount: 5,
+          onSelectAllVisible: () => taps++,
+          onClearSelection: () {},
+        ),
+        wrapInScaffold: true,
+      );
+
+      final Finder button = selectAllButton();
+      expect(button, findsOneWidget);
+
+      await tester.tap(button);
+      await tester.pumpAndSettle();
+      expect(taps, 1);
+    });
+
+    testWidgets(
+        'should hide Select all when everything visible is already selected',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        BulkActionBar(
+          items: oneSelected,
+          visibleCount: 1,
+          onSelectAllVisible: () {},
+          onClearSelection: () {},
+        ),
+        wrapInScaffold: true,
+      );
+
+      expect(selectAllButton(), findsNothing);
+    });
+
+    testWidgets(
+        'should hide Select all when no callback is provided',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        BulkActionBar(
+          items: oneSelected,
+          visibleCount: 99,
+          onClearSelection: () {},
+        ),
+        wrapInScaffold: true,
+      );
+
+      expect(selectAllButton(), findsNothing);
+    });
+  });
+}

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:xerabora/shared/models/item_status.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/platform.dart' as model;
 import 'package:xerabora/shared/models/visual_novel.dart';
+import 'package:xerabora/shared/navigation/search_providers.dart';
 
 import '../../../helpers/test_helpers.dart';
 
@@ -420,10 +421,62 @@ void main() {
       expect(find.widgetWithText(ChoiceChip, 'SNES'), findsNothing);
       expect(find.widgetWithText(ChoiceChip, 'GBA'), findsNothing);
     });
+
+    group('chevron counts and visibility under search', () {
+      Widget buildWithHideEmpty() => ProviderScope(
+            overrides: <Override>[
+              collectionRepositoryProvider.overrideWithValue(mockRepo),
+              databaseServiceProvider.overrideWithValue(mockDb),
+              sharedPreferencesProvider.overrideWithValue(prefs),
+              settingsNotifierProvider.overrideWith(
+                () => _FakeSettingsNotifier(hideEmptyMediaTypeChevrons: true),
+              ),
+              currentProfileProvider.overrideWithValue(Profile(
+                id: 'test',
+                name: 'Test',
+                color: '#FF0000',
+                createdAt: DateTime(2025),
+              )),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: S.localizationsDelegates,
+              supportedLocales: S.supportedLocales,
+              home: Scaffold(body: AllItemsScreen()),
+            ),
+          );
+
+      testWidgets(
+          'should keep chevrons with non-zero totals visible even when search '
+          'filters them out', (WidgetTester tester) async {
+        await tester.pumpWidget(buildWithHideEmpty());
+        await tester.pumpAndSettle();
+
+        // Sanity: with the flag on, only types present in data are listed.
+        expect(find.text('Games (2)'), findsOneWidget);
+        expect(find.text('Movies (1)'), findsOneWidget);
+
+        final ProviderContainer container = ProviderScope.containerOf(
+          tester.element(find.byType(AllItemsScreen)),
+        );
+        container.read(homeSearchQueryProvider.notifier).state = 'zzz_no_match';
+        await tester.pumpAndSettle();
+
+        // Counts collapse to 0 across the board, but the chevrons must stay
+        // mounted because the underlying totals are still non-zero.
+        expect(find.textContaining('Games'), findsOneWidget);
+        expect(find.textContaining('Movies'), findsOneWidget);
+      });
+    });
   });
 }
 
 class _FakeSettingsNotifier extends SettingsNotifier {
+  _FakeSettingsNotifier({this.hideEmptyMediaTypeChevrons = false});
+
+  final bool hideEmptyMediaTypeChevrons;
+
   @override
-  SettingsState build() => const SettingsState();
+  SettingsState build() => SettingsState(
+        hideEmptyMediaTypeChevrons: hideEmptyMediaTypeChevrons,
+      );
 }


### PR DESCRIPTION
- BulkActionBar gets a "Select all" text button next to the counter that appears once at least one item is picked and there are still more visible items to grab. Wired for both CollectionScreen and AllItemsScreen — both pass the filtered visible list so the button respects search/status/tag filters.
- All Items media-type chevrons now show filter-aware counts and stop vanishing under "Hide empty media types" when a search drops their match count to zero. Visibility uses raw per-type totals; the label uses the filter-aware count.
- Rename the bulk move/copy result text from "Skipped" to "Duplicates" in en/ru — the only reason a row is skipped is the UNIQUE index on (collection_id, media_type, external_id), so the new label matches the actual cause.