### PR TITLE
refactor(collections): unify collection dropdowns under CollectionPickerField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,69 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Replace raw collection dropdowns with the shared picker field**
+
+  All places where the user picked one collection from a form
+  (import screens for MAL / AniList / Trakt / Steam /
+  RetroAchievements, in-app `.xcoll` import on the home screen,
+  tier-list creation, browse-collections settings, mood grid
+  picker) now use a single `CollectionPickerField` styled like the
+  rest of the project's inputs. Tapping it opens the same
+  collection-picker dialog used by the bulk "Move/Copy to
+  collection" actions, so list overflow, sorting and search now
+  behave consistently and the dialog no longer spills past the
+  parent dialog edges. The mood-grid case additionally exposes an
+  "All collections" entry via the new `nullLabel` / `nullIcon`
+  options on the picker, which the underlying dialog renders with
+  its own icon so it doesn't blur into the "Without Collection"
+  tile.
+
+  * lib/shared/widgets/collection_picker_field.dart
+    (CollectionPickerField): New. Form-field shell that delegates
+    to `showCollectionPickerDialog`, supports the optional
+    `nullLabel` / `nullSubtitle` / `nullIcon` flow for "any/all"
+    semantics and reactively renders the selected collection's
+    name + author from `collectionsProvider`.
+  * lib/shared/widgets/collection_picker_dialog.dart
+    (showCollectionPickerDialog, _CollectionPickerContent,
+    _CollectionPickerContentState._buildUncategorizedTile,
+    _CollectionPickerContentState._buildLeadingIcon,
+    _CollectionPickerContentState._buildIconBox): Accept optional
+    `uncategorizedLabel` / `uncategorizedSubtitle` /
+    `uncategorizedIcon` overrides and extract `_buildIconBox` so
+    the relabelled tile no longer reuses the default "Uncategorized"
+    subtitle or inbox icon.
+  * lib/features/collections/screens/home_screen.dart,
+    lib/features/settings/content/mal_import_content.dart,
+    lib/features/settings/content/anilist_import_content.dart,
+    lib/features/settings/content/trakt_import_content.dart,
+    lib/features/settings/content/steam_import_content.dart,
+    lib/features/settings/content/ra_import_content.dart,
+    lib/features/settings/content/browse_collections_content.dart,
+    lib/features/tier_lists/widgets/create_tier_list_dialog.dart:
+    Drop the local `DropdownButton` / `DropdownButtonFormField` and
+    its `DropdownMenuItem` wiring; route the selection through
+    `CollectionPickerField`.
+  * lib/features/tier_lists/widgets/mood_grid_item_picker.dart
+    (MoodGridItemPickerState): Same migration, with `nullLabel`
+    set to `l.moodGridPickerAllCollections` so the "All
+    Collections" sentinel keeps its semantics.
+  * test/shared/widgets/collection_picker_field_test.dart: New.
+    Cover hint vs. selected vs. "all" rendering and verify a
+    disabled field swallows taps.
+
+- **Drop the author suffix from the mood-grid watermark**
+
+  Mood-grid exports now read "made by Tonkatsu Box" without the
+  trailing "— $authorName", matching the tier-list watermark.
+
+  * lib/features/tier_lists/widgets/mood_grid_export_view.dart
+    (MoodGridExportView, MoodGridExportView.authorName): Remove
+    the `authorName` field and the conditional suffix.
+  * lib/features/tier_lists/screens/mood_grid_detail_screen.dart:
+    Stop reading `settingsNotifierProvider.authorName` and drop
+    the now-unused `settings_provider` import.
+
 - **Label bulk-move/copy leftovers as "Duplicates" instead of "Skipped"**
 
   A move or copy can only "skip" an item when the target already

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -14,6 +14,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/navigation/search_providers.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../../shared/widgets/draggable_fab.dart';
 import '../../../shared/widgets/shimmer_loading.dart';
 import '../../home/providers/all_items_provider.dart';
@@ -768,22 +769,12 @@ class _ImportTargetDialogState extends State<_ImportTargetDialog> {
                       ),
                     );
                   }
-                  return DropdownButtonFormField<int>(
-                    initialValue: _selectedId,
-                    hint: Text(l.importSelectCollection),
-                    isExpanded: true,
-                    items: collections.map((Collection c) {
-                      return DropdownMenuItem<int>(
-                        value: c.id,
-                        child: Text(
-                          c.name,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      );
-                    }).toList(),
-                    onChanged: (int? value) {
-                      setState(() => _selectedId = value);
-                    },
+                  return CollectionPickerField(
+                    value: _selectedId,
+                    hint: l.importSelectCollection,
+                    title: l.importSelectCollection,
+                    onChanged: (int? id) =>
+                        setState(() => _selectedId = id),
                   );
                 },
                 loading: () =>

--- a/lib/features/settings/content/anilist_import_content.dart
+++ b/lib/features/settings/content/anilist_import_content.dart
@@ -13,6 +13,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -294,21 +295,13 @@ class _AniListImportContentState extends ConsumerState<AniListImportContent> {
                     collections.any(
                       (Collection c) => c.id == _selectedCollectionId,
                     );
-                return DropdownButtonFormField<int>(
-                  initialValue: selectedExists ? _selectedCollectionId : null,
-                  hint: Text(l.aniListImportSelectCollection),
-                  isExpanded: true,
-                  items: collections.map((Collection c) {
-                    return DropdownMenuItem<int>(
-                      value: c.id,
-                      child: Text(c.name, overflow: TextOverflow.ellipsis),
-                    );
-                  }).toList(),
-                  onChanged: _isImporting
-                      ? null
-                      : (int? value) {
-                          setState(() => _selectedCollectionId = value);
-                        },
+                return CollectionPickerField(
+                  value: selectedExists ? _selectedCollectionId : null,
+                  hint: l.aniListImportSelectCollection,
+                  title: l.aniListImportSelectCollection,
+                  enabled: !_isImporting,
+                  onChanged: (int? id) =>
+                      setState(() => _selectedCollectionId = id),
                 );
               },
               loading: () =>

--- a/lib/features/settings/content/browse_collections_content.dart
+++ b/lib/features/settings/content/browse_collections_content.dart
@@ -12,6 +12,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/models/collections_index.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_browser_provider.dart';
@@ -482,20 +483,12 @@ class _ImportTargetDialogState extends ConsumerState<_ImportTargetDialog> {
                         collections.any(
                           (Collection c) => c.id == _selectedId,
                         );
-                    return DropdownButtonFormField<int>(
-                      initialValue: selectedExists ? _selectedId : null,
-                      hint: Text(l.browseCollectionsSelectCollection),
-                      isExpanded: true,
-                      items: collections.map((Collection c) {
-                        return DropdownMenuItem<int>(
-                          value: c.id,
-                          child:
-                              Text(c.name, overflow: TextOverflow.ellipsis),
-                        );
-                      }).toList(),
-                      onChanged: (int? value) {
-                        setState(() => _selectedId = value);
-                      },
+                    return CollectionPickerField(
+                      value: selectedExists ? _selectedId : null,
+                      hint: l.browseCollectionsSelectCollection,
+                      title: l.browseCollectionsSelectCollection,
+                      onChanged: (int? id) =>
+                          setState(() => _selectedId = id),
                     );
                   },
                   loading: () => const Padding(

--- a/lib/features/settings/content/mal_import_content.dart
+++ b/lib/features/settings/content/mal_import_content.dart
@@ -14,6 +14,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -277,21 +278,13 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
                     collections.any(
                       (Collection c) => c.id == _selectedCollectionId,
                     );
-                return DropdownButtonFormField<int>(
-                  initialValue: selectedExists ? _selectedCollectionId : null,
-                  hint: Text(l.malImportSelectCollection),
-                  isExpanded: true,
-                  items: collections.map((Collection c) {
-                    return DropdownMenuItem<int>(
-                      value: c.id,
-                      child: Text(c.name, overflow: TextOverflow.ellipsis),
-                    );
-                  }).toList(),
-                  onChanged: _isImporting
-                      ? null
-                      : (int? value) {
-                          setState(() => _selectedCollectionId = value);
-                        },
+                return CollectionPickerField(
+                  value: selectedExists ? _selectedCollectionId : null,
+                  hint: l.malImportSelectCollection,
+                  title: l.malImportSelectCollection,
+                  enabled: !_isImporting,
+                  onChanged: (int? id) =>
+                      setState(() => _selectedCollectionId = id),
                 );
               },
               loading: () =>

--- a/lib/features/settings/content/ra_import_content.dart
+++ b/lib/features/settings/content/ra_import_content.dart
@@ -15,6 +15,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -303,21 +304,13 @@ class _RaImportContentState extends ConsumerState<RaImportContent> {
                     collections.any(
                       (Collection c) => c.id == _selectedCollectionId,
                     );
-                return DropdownButtonFormField<int>(
-                  initialValue: selectedExists ? _selectedCollectionId : null,
-                  hint: Text(l.raImportSelectCollection),
-                  isExpanded: true,
-                  items: collections.map((Collection c) {
-                    return DropdownMenuItem<int>(
-                      value: c.id,
-                      child: Text(c.name, overflow: TextOverflow.ellipsis),
-                    );
-                  }).toList(),
-                  onChanged: _isImporting
-                      ? null
-                      : (int? value) {
-                          setState(() => _selectedCollectionId = value);
-                        },
+                return CollectionPickerField(
+                  value: selectedExists ? _selectedCollectionId : null,
+                  hint: l.raImportSelectCollection,
+                  title: l.raImportSelectCollection,
+                  enabled: !_isImporting,
+                  onChanged: (int? id) =>
+                      setState(() => _selectedCollectionId = id),
                 );
               },
               loading: () =>

--- a/lib/features/settings/content/steam_import_content.dart
+++ b/lib/features/settings/content/steam_import_content.dart
@@ -15,6 +15,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -327,21 +328,13 @@ class _SteamImportContentState extends ConsumerState<SteamImportContent> {
                     collections.any(
                       (Collection c) => c.id == _selectedCollectionId,
                     );
-                return DropdownButtonFormField<int>(
-                  initialValue: selectedExists ? _selectedCollectionId : null,
-                  hint: Text(l.steamImportSelectCollection),
-                  isExpanded: true,
-                  items: collections.map((Collection c) {
-                    return DropdownMenuItem<int>(
-                      value: c.id,
-                      child: Text(c.name, overflow: TextOverflow.ellipsis),
-                    );
-                  }).toList(),
-                  onChanged: _isImporting
-                      ? null
-                      : (int? value) {
-                          setState(() => _selectedCollectionId = value);
-                        },
+                return CollectionPickerField(
+                  value: selectedExists ? _selectedCollectionId : null,
+                  hint: l.steamImportSelectCollection,
+                  title: l.steamImportSelectCollection,
+                  enabled: !_isImporting,
+                  onChanged: (int? id) =>
+                      setState(() => _selectedCollectionId = id),
                 );
               },
               loading: () =>

--- a/lib/features/settings/content/trakt_import_content.dart
+++ b/lib/features/settings/content/trakt_import_content.dart
@@ -14,6 +14,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -352,19 +353,12 @@ class _TraktImportContentState extends ConsumerState<TraktImportContent> {
                     collections.any(
                       (Collection c) => c.id == _selectedCollectionId,
                     );
-                return DropdownButtonFormField<int>(
-                  initialValue: selectedExists ? _selectedCollectionId : null,
-                  hint: Text(l10n.traktSelectCollection),
-                  isExpanded: true,
-                  items: collections.map((Collection c) {
-                    return DropdownMenuItem<int>(
-                      value: c.id,
-                      child: Text(c.name, overflow: TextOverflow.ellipsis),
-                    );
-                  }).toList(),
-                  onChanged: (int? value) {
-                    setState(() => _selectedCollectionId = value);
-                  },
+                return CollectionPickerField(
+                  value: selectedExists ? _selectedCollectionId : null,
+                  hint: l10n.traktSelectCollection,
+                  title: l10n.traktSelectCollection,
+                  onChanged: (int? id) =>
+                      setState(() => _selectedCollectionId = id),
                 );
               },
               loading: () =>

--- a/lib/features/tier_lists/screens/mood_grid_detail_screen.dart
+++ b/lib/features/tier_lists/screens/mood_grid_detail_screen.dart
@@ -16,7 +16,6 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/draggable_fab.dart';
 import '../../../shared/widgets/sub_screen_title_bar.dart';
-import '../../settings/providers/settings_provider.dart';
 import '../providers/mood_grid_detail_provider.dart';
 import '../providers/mood_grids_provider.dart';
 import '../widgets/mood_grid_export_view.dart';
@@ -50,8 +49,6 @@ class _MoodGridDetailScreenState extends ConsumerState<MoodGridDetailScreen> {
       error: (Object e, StackTrace s) =>
           Center(child: Text(l.errorPrefix(e.toString()))),
       data: (MoodGridDetailState state) {
-        final String authorName =
-            ref.watch(settingsNotifierProvider).authorName;
         return Stack(
           children: <Widget>[
             Column(
@@ -76,7 +73,6 @@ class _MoodGridDetailScreenState extends ConsumerState<MoodGridDetailScreen> {
                           repaintKey: _exportKey,
                           grid: state.grid,
                           cells: state.cells,
-                          authorName: authorName,
                         ),
                       ),
                     ],

--- a/lib/features/tier_lists/widgets/create_tier_list_dialog.dart
+++ b/lib/features/tier_lists/widgets/create_tier_list_dialog.dart
@@ -8,6 +8,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/models/tier_list.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../providers/tier_lists_provider.dart';
 
@@ -147,20 +148,13 @@ class _CreateTierListDialogState
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisSize: MainAxisSize.min,
                         children: <Widget>[
-                          DropdownButton<int>(
-                            isExpanded: true,
+                          CollectionPickerField(
                             value: _selectedCollectionId,
-                            hint: Text(l.tierListScopeCollection),
-                            dropdownColor: AppColors.surface,
-                            items: collections.map((Collection c) {
-                              return DropdownMenuItem<int>(
-                                value: c.id,
-                                child: Text(c.name),
-                              );
-                            }).toList(),
-                            onChanged: (int? value) {
+                            hint: l.tierListScopeCollection,
+                            title: l.tierListScopeCollection,
+                            onChanged: (int? id) {
                               setState(() {
-                                _selectedCollectionId = value;
+                                _selectedCollectionId = id;
                                 _collectionError = null;
                               });
                             },

--- a/lib/features/tier_lists/widgets/mood_grid_export_view.dart
+++ b/lib/features/tier_lists/widgets/mood_grid_export_view.dart
@@ -16,7 +16,6 @@ class MoodGridExportView extends StatelessWidget {
     required this.repaintKey,
     required this.grid,
     required this.cells,
-    this.authorName = '',
     super.key,
   });
 
@@ -28,9 +27,6 @@ class MoodGridExportView extends StatelessWidget {
 
   /// All cells, ordered by position.
   final List<MoodGridCell> cells;
-
-  /// Optional author name shown under the watermark.
-  final String authorName;
 
   static const double _cellWidth = 140;
 
@@ -82,9 +78,7 @@ class MoodGridExportView extends StatelessWidget {
                 Image.asset(AppAssets.logo, width: 16, height: 16),
                 const SizedBox(width: 4),
                 Text(
-                  authorName.isEmpty
-                      ? 'made by Tonkatsu Box'
-                      : 'made by Tonkatsu Box — $authorName',
+                  'made by Tonkatsu Box',
                   style: AppTypography.caption.copyWith(
                     color: AppColors.textTertiary,
                     fontSize: 10,

--- a/lib/features/tier_lists/widgets/mood_grid_item_picker.dart
+++ b/lib/features/tier_lists/widgets/mood_grid_item_picker.dart
@@ -9,6 +9,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/cached_image.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/collections_provider.dart';
 
 /// Result of [showMoodGridItemPicker].
@@ -97,27 +98,14 @@ class _MoodGridItemPickerState extends ConsumerState<_MoodGridItemPicker> {
             ),
             const SizedBox(height: AppSpacing.sm),
             collectionsAsync.when(
-              data: (List<Collection> collections) =>
-                  DropdownButtonFormField<int?>(
-                initialValue: _filterCollectionId,
-                isExpanded: true,
-                decoration: InputDecoration(
-                  labelText: l.moodGridPickerCollection,
-                ),
-                items: <DropdownMenuItem<int?>>[
-                  DropdownMenuItem<int?>(
-                    value: null,
-                    child: Text(l.moodGridPickerAllCollections),
-                  ),
-                  ...collections.map(
-                    (Collection c) => DropdownMenuItem<int?>(
-                      value: c.id,
-                      child: Text(c.name, overflow: TextOverflow.ellipsis),
-                    ),
-                  ),
-                ],
-                onChanged: (int? value) {
-                  _filterCollectionId = value;
+              data: (List<Collection> collections) => CollectionPickerField(
+                value: _filterCollectionId,
+                hint: l.moodGridPickerCollection,
+                title: l.moodGridPickerCollection,
+                nullLabel: l.moodGridPickerAllCollections,
+                leadingIcon: Icons.folder_open_outlined,
+                onChanged: (int? id) {
+                  _filterCollectionId = id;
                   _refreshItems();
                 },
               ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -544,7 +544,7 @@ abstract class S {
   /// No description provided for @bulkResult.
   ///
   /// In en, this message translates to:
-  /// **'Done: {done} • Skipped: {skipped}'**
+  /// **'Done: {done} • Duplicates: {skipped}'**
   String bulkResult(int done, int skipped);
 
   /// No description provided for @bulkRemoved.

--- a/lib/shared/widgets/collection_picker_dialog.dart
+++ b/lib/shared/widgets/collection_picker_dialog.dart
@@ -47,6 +47,9 @@ Future<CollectionChoice?> showCollectionPickerDialog({
   bool showUncategorized = true,
   String? title,
   Set<int?> alreadyInCollectionIds = const <int?>{},
+  String? uncategorizedLabel,
+  String? uncategorizedSubtitle,
+  IconData? uncategorizedIcon,
 }) async {
   final String resolvedTitle = title ?? S.of(context).chooseCollection;
   final AsyncValue<List<Collection>> collectionsAsync =
@@ -75,6 +78,9 @@ Future<CollectionChoice?> showCollectionPickerDialog({
         alreadyInCollectionIds: alreadyInCollectionIds,
         initialSortMode: initialSortMode,
         initialDescending: initialDescending,
+        uncategorizedLabel: uncategorizedLabel,
+        uncategorizedSubtitle: uncategorizedSubtitle,
+        uncategorizedIcon: uncategorizedIcon,
       ),
     ),
   );
@@ -89,6 +95,9 @@ class _CollectionPickerContent extends StatefulWidget {
     required this.alreadyInCollectionIds,
     required this.initialSortMode,
     required this.initialDescending,
+    this.uncategorizedLabel,
+    this.uncategorizedSubtitle,
+    this.uncategorizedIcon,
   });
 
   final String title;
@@ -97,6 +106,9 @@ class _CollectionPickerContent extends StatefulWidget {
   final Set<int?> alreadyInCollectionIds;
   final CollectionListSortMode initialSortMode;
   final bool initialDescending;
+  final String? uncategorizedLabel;
+  final String? uncategorizedSubtitle;
+  final IconData? uncategorizedIcon;
 
   @override
   State<_CollectionPickerContent> createState() =>
@@ -320,11 +332,18 @@ class _CollectionPickerContentState extends State<_CollectionPickerContent> {
   Widget _buildUncategorizedTile(S l) {
     final bool isAlreadyAdded =
         widget.alreadyInCollectionIds.contains(null);
+    final bool customised = widget.uncategorizedLabel != null;
+    final String title = widget.uncategorizedLabel ?? l.withoutCollection;
+    final String? subtitle = widget.uncategorizedSubtitle ??
+        (customised ? null : l.collectionsUncategorized);
     return ListTile(
       enabled: !isAlreadyAdded,
-      leading: _buildLeadingIcon(null, isAlreadyAdded),
-      title: Text(l.withoutCollection),
-      subtitle: Text(l.collectionsUncategorized),
+      leading: _buildIconBox(
+        widget.uncategorizedIcon ?? Icons.inbox_outlined,
+        isAlreadyAdded,
+      ),
+      title: Text(title),
+      subtitle: subtitle == null ? null : Text(subtitle),
       trailing: isAlreadyAdded ? _buildAlreadyAddedBadge(l) : null,
       onTap: isAlreadyAdded
           ? null
@@ -369,12 +388,16 @@ class _CollectionPickerContentState extends State<_CollectionPickerContent> {
   }
 
   Widget _buildLeadingIcon(Collection? collection, bool disabled) {
-    final Color color = disabled ? AppColors.textTertiary : AppColors.brand;
     final IconData icon = collection == null
         ? Icons.inbox_outlined
         : collection.type == CollectionType.own
             ? Icons.folder_rounded
             : Icons.fork_right;
+    return _buildIconBox(icon, disabled);
+  }
+
+  Widget _buildIconBox(IconData icon, bool disabled) {
+    final Color color = disabled ? AppColors.textTertiary : AppColors.brand;
     return Container(
       width: 36,
       height: 36,

--- a/lib/shared/widgets/collection_picker_field.dart
+++ b/lib/shared/widgets/collection_picker_field.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/collections/providers/collections_provider.dart';
+import '../models/collection.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_spacing.dart';
+import '../theme/app_typography.dart';
+import 'collection_picker_dialog.dart';
+
+/// Form-field wrapper around [showCollectionPickerDialog].
+///
+/// Renders a tap-target styled like the project's text fields (filled,
+/// rounded, brand-bordered) showing the picked collection's name. Opening
+/// the field shows the shared collection picker — the same dialog used by
+/// "Move to collection" / "Add to collection" actions, so the visual
+/// language stays in one place.
+class CollectionPickerField extends ConsumerWidget {
+  const CollectionPickerField({
+    required this.value,
+    required this.onChanged,
+    this.label,
+    this.hint,
+    this.title,
+    this.leadingIcon = Icons.folder_outlined,
+    this.excludeCollectionId,
+    this.enabled = true,
+    this.nullLabel,
+    this.nullSubtitle,
+    this.nullIcon = Icons.all_inbox_outlined,
+    super.key,
+  });
+
+  /// Selected collection id. `null` either means nothing is picked or — when
+  /// [nullLabel] is set — that the "any/all" option is currently chosen; the
+  /// field disambiguates with [_summaryForNull].
+  final int? value;
+
+  /// Receives the new collection id. Fires with `null` only when [nullLabel]
+  /// is set and the user picks the "any/all" tile.
+  final ValueChanged<int?> onChanged;
+
+  final String? label;
+  final String? hint;
+  final String? title;
+  final IconData? leadingIcon;
+  final int? excludeCollectionId;
+  final bool enabled;
+
+  /// Label for the optional top tile representing "any/all/no filter". When
+  /// non-null the picker dialog exposes that extra row.
+  final String? nullLabel;
+
+  /// Optional subtitle for the "any/all" tile.
+  final String? nullSubtitle;
+
+  /// Icon for the "any/all" tile in the dialog. Default differs from the
+  /// "without collection" inbox icon so the two cases stay visually distinct.
+  final IconData? nullIcon;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<Collection> collections =
+        ref.watch(collectionsProvider).valueOrNull ?? const <Collection>[];
+    Collection? selected;
+    if (value != null) {
+      for (final Collection c in collections) {
+        if (c.id == value) {
+          selected = c;
+          break;
+        }
+      }
+    }
+
+    final bool hasCollection = selected != null;
+    final bool showsNullSummary = value == null && nullLabel != null;
+    final bool hasSummary = hasCollection || showsNullSummary;
+    final Color border = enabled
+        ? AppColors.surfaceBorder
+        : AppColors.surfaceBorder.withAlpha(120);
+    final Color textColor =
+        hasSummary ? AppColors.textPrimary : AppColors.textTertiary;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: enabled ? () => _open(context, ref) : null,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+        child: Container(
+          decoration: BoxDecoration(
+            color: AppColors.surfaceLight,
+            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+            border: Border.all(color: border),
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm + 2,
+          ),
+          child: Row(
+            children: <Widget>[
+              if (leadingIcon != null) ...<Widget>[
+                Icon(
+                  leadingIcon,
+                  size: 20,
+                  color: AppColors.textSecondary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    if (label != null && label!.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 2),
+                        child: Text(
+                          label!,
+                          style: AppTypography.caption.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                      ),
+                    Text(
+                      hasCollection
+                          ? selected.name
+                          : (showsNullSummary
+                              ? nullLabel!
+                              : (hint ?? '')),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.body.copyWith(color: textColor),
+                    ),
+                    if (hasCollection && selected.author.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 1),
+                        child: Text(
+                          selected.author,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.caption.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                      )
+                    else if (showsNullSummary && nullSubtitle != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 1),
+                        child: Text(
+                          nullSubtitle!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.caption.copyWith(
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.expand_more,
+                color: enabled
+                    ? AppColors.textSecondary
+                    : AppColors.textTertiary,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _open(BuildContext context, WidgetRef ref) async {
+    final CollectionChoice? choice = await showCollectionPickerDialog(
+      context: context,
+      ref: ref,
+      title: title,
+      showUncategorized: nullLabel != null,
+      uncategorizedLabel: nullLabel,
+      uncategorizedSubtitle: nullSubtitle,
+      uncategorizedIcon: nullIcon,
+      excludeCollectionId: excludeCollectionId,
+    );
+    switch (choice) {
+      case ChosenCollection(:final Collection collection):
+        if (collection.id != value) onChanged(collection.id);
+      case WithoutCollection():
+        if (value != null) onChanged(null);
+      case null:
+        break;
+    }
+  }
+}

--- a/test/shared/widgets/collection_picker_field_test.dart
+++ b/test/shared/widgets/collection_picker_field_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/shared/models/collection.dart';
+import 'package:xerabora/shared/widgets/collection_picker_field.dart';
+
+import '../../helpers/test_helpers.dart';
+
+class _StubCollectionsNotifier extends CollectionsNotifier {
+  _StubCollectionsNotifier(this._data);
+
+  final List<Collection> _data;
+
+  @override
+  Future<List<Collection>> build() async => _data;
+}
+
+void main() {
+  final List<Collection> sampleCollections = <Collection>[
+    createTestCollection(id: 10, name: 'My Games', author: 'Alice'),
+    createTestCollection(id: 20, name: 'Watch List', author: 'Bob'),
+  ];
+
+  Future<void> pumpField(
+    WidgetTester tester, {
+    required int? value,
+    String? hint,
+    String? nullLabel,
+    ValueChanged<int?>? onChanged,
+    bool enabled = true,
+  }) {
+    return tester.pumpApp(
+      CollectionPickerField(
+        value: value,
+        hint: hint,
+        nullLabel: nullLabel,
+        enabled: enabled,
+        onChanged: onChanged ?? (_) {},
+      ),
+      wrapInScaffold: true,
+      overrides: <Override>[
+        collectionsProvider.overrideWith(
+          () => _StubCollectionsNotifier(sampleCollections),
+        ),
+      ],
+    );
+  }
+
+  group('CollectionPickerField', () {
+    testWidgets(
+        'should show the hint when value is null and nullLabel is not set',
+        (WidgetTester tester) async {
+      await pumpField(tester, value: null, hint: 'Pick something');
+      expect(find.text('Pick something'), findsOneWidget);
+    });
+
+    testWidgets(
+        'should show the picked collection name and author when value matches',
+        (WidgetTester tester) async {
+      await pumpField(tester, value: 10, hint: 'Pick something');
+      expect(find.text('My Games'), findsOneWidget);
+      expect(find.text('Alice'), findsOneWidget);
+    });
+
+    testWidgets(
+        'should show nullLabel when value is null and nullLabel is set',
+        (WidgetTester tester) async {
+      await pumpField(
+        tester,
+        value: null,
+        hint: 'Pick something',
+        nullLabel: 'All collections',
+      );
+      expect(find.text('All collections'), findsOneWidget);
+      expect(find.text('Pick something'), findsNothing);
+    });
+
+    testWidgets(
+        'should ignore taps when disabled',
+        (WidgetTester tester) async {
+      int callCount = 0;
+      await pumpField(
+        tester,
+        value: null,
+        hint: 'Pick something',
+        enabled: false,
+        onChanged: (_) => callCount++,
+      );
+      await tester.tap(find.text('Pick something'));
+      await tester.pumpAndSettle();
+      expect(callCount, 0);
+      // No dialog opened.
+      expect(find.byType(Dialog), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Replace every raw DropdownButton / DropdownButtonFormField used for picking one collection (import screens for MAL / AniList / Trakt / Steam / RetroAchievements, the in-app .xcoll import on the home screen, tier-list creation, browse-collections settings and the mood grid picker) with a single styled CollectionPickerField. Tapping the field opens the same picker dialog already used by bulk Move/Copy and item-detail flows, so list overflow, sorting and search behave the same everywhere and the popup no longer spills past the parent dialog edges.

The shared dialog gains optional uncategorizedLabel / Subtitle / Icon overrides so callers like the mood-grid picker can surface an "All collections" entry without bleeding the default "Uncategorized" copy or the inbox icon. Drops the "— $authorName" suffix from the mood-grid export watermark to match the tier-list one.