### PR TITLE
fix(db): single-flight database init to prevent migration race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stop the database from opening twice during startup**
+
+  On cold start several providers may touch the `database` getter
+  before the first `_initDatabase` future has settled. The previous
+  cache-on-completion logic let each caller kick off its own open,
+  and the second one would race `onUpgrade` and crash a non-idempotent
+  migration (e.g. `ALTER TABLE … ADD COLUMN` saw the column already
+  added by the first runner). The getter now single-flights: the
+  first call assigns the in-flight future to `_opening`, every
+  concurrent caller awaits the same future, and `_opening` is cleared
+  on success (after `_database` is set) or on error (so a failed open
+  can be retried).
+
+  * lib/core/database/database_service.dart (DatabaseService.database,
+    DatabaseService._opening): Replace the cache-on-completion getter
+    with a single-flight pattern guarded by `_opening`.
+
 ### Added
 
 - **Refresh a collection item from its source API on demand**

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -117,11 +117,22 @@ class DatabaseService {
   static final Logger _log = Logger('DatabaseService');
 
   Database? _database;
+  Future<Database>? _opening;
 
-  Future<Database> get database async {
-    if (_database != null) return _database!;
-    _database = await _initDatabase();
-    return _database!;
+  /// Single-flight: concurrent first-touch callers share one [_initDatabase]
+  /// future so non-idempotent migrations (e.g. `ALTER TABLE ADD COLUMN`) can't race.
+  Future<Database> get database {
+    final Database? cached = _database;
+    if (cached != null) return Future<Database>.value(cached);
+    return _opening ??= () async {
+      try {
+        final Database db = await _initDatabase();
+        _database = db;
+        return db;
+      } finally {
+        _opening = null;
+      }
+    }();
   }
 
   late final GameDao gameDao = GameDao(() => database);

--- a/lib/core/database/migrations/migration_v37.dart
+++ b/lib/core/database/migrations/migration_v37.dart
@@ -2,13 +2,6 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migration.dart';
 
-/// Migration v37: per-platform tracker_game_data.
-///
-/// The original unique index `(tracker_type, game_id)` collapses a single
-/// IGDB game across platforms — syncing RetroAchievements progress for the
-/// GameCube edition would overwrite the PS2 record. Adding `platform_id`
-/// (nullable) and including it in the unique index lets each platform
-/// variant keep its own row. Existing rows stay with NULL platform_id.
 class MigrationV37 extends Migration {
   @override
   int get version => 37;
@@ -23,9 +16,8 @@ class MigrationV37 extends Migration {
       'ALTER TABLE tracker_game_data ADD COLUMN platform_id INTEGER',
     );
     await db.execute('DROP INDEX IF EXISTS idx_tracker_game_data_unique');
-    // SQLite indexes can include expressions, so wrap platform_id in
-    // COALESCE to give NULL a deterministic key — without it two NULLs
-    // would be treated as distinct and we'd lose the upsert guarantee.
+    // COALESCE pins NULL to -1 so two NULL platform_ids collide on upsert;
+    // bare NULLs are treated as distinct in SQLite unique indexes.
     await db.execute('''
       CREATE UNIQUE INDEX idx_tracker_game_data_unique
       ON tracker_game_data(tracker_type, game_id, COALESCE(platform_id, -1))

--- a/lib/core/database/migrations/migration_v38.dart
+++ b/lib/core/database/migrations/migration_v38.dart
@@ -2,21 +2,6 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migration.dart';
 
-/// Migration v38: backfill `platform_id` on legacy tracker_game_data rows.
-///
-/// v37 added the `platform_id` column but left every existing row with
-/// NULL — the value isn't recoverable from RA without an API round-trip.
-/// We can do better locally: the user's own `collection_items` already
-/// carry the IGDB platform id for the same game. For each NULL tracker
-/// row we look at the matching `collection_items` rows and:
-///
-///   * exactly one distinct platform → set `platform_id` to that;
-///   * zero or >1 distinct platforms → delete the NULL tracker row, since
-///     it can't be unambiguously attributed and would otherwise bleed
-///     across platform installs via the legacy fallback lookup.
-///
-/// Trivial cost (single in-process SQL run) and idempotent — only NULL
-/// rows are touched, so re-running the migration is a no-op.
 class MigrationV38 extends Migration {
   @override
   int get version => 38;
@@ -27,9 +12,8 @@ class MigrationV38 extends Migration {
 
   @override
   Future<void> migrate(Database db) async {
-    // Resolve unambiguous platforms in a single statement: an UPDATE that
-    // joins via subquery and only fires when COUNT(DISTINCT platform_id)
-    // is exactly 1.
+    // Only backfill when collection_items has exactly one platform for the game;
+    // multiple platforms would bleed RA progress across installs.
     await db.execute('''
       UPDATE tracker_game_data
       SET platform_id = (
@@ -49,9 +33,8 @@ class MigrationV38 extends Migration {
         ) = 1
     ''');
 
-    // Anything still NULL is ambiguous (no matching items, or multiple
-    // platforms). Drop the row so the legacy fallback lookup can't leak
-    // it across platform installs of the same IGDB game.
+    // Ambiguous rows get dropped — keeping them would let the legacy fallback
+    // leak progress across platform installs of the same IGDB game.
     final List<Map<String, Object?>> orphans = await db.query(
       'tracker_game_data',
       columns: <String>['tracker_type', 'tracker_game_id'],
@@ -67,8 +50,7 @@ class MigrationV38 extends Migration {
       where: 'platform_id IS NULL',
     );
 
-    // Drop the orphan achievements rows too — they're keyed by
-    // `(tracker_type, tracker_game_id)` and have no parent left.
+    // tracker_achievements has no FK to tracker_game_data, so cascade by hand.
     for (final String key in orphanKeys) {
       final List<String> parts = key.split('|');
       final String type = parts[0];

--- a/lib/core/database/migrations/migration_v39.dart
+++ b/lib/core/database/migrations/migration_v39.dart
@@ -2,8 +2,8 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migration.dart';
 
-/// Cache tables (games/movies/...) stay canonical with API titles; the
-/// per-item rename is stored here so a re-fetch of the API row can't wipe it.
+// override_name lives on collection_items (not cache tables) so an API refetch
+// of the canonical title can't wipe the user's rename.
 class MigrationV39 extends Migration {
   @override
   int get version => 39;

--- a/lib/core/database/migrations/migration_v40.dart
+++ b/lib/core/database/migrations/migration_v40.dart
@@ -2,9 +2,6 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migration.dart';
 
-/// Adds an optional `tag` to wishlist entries so bulk-imported items
-/// (MAL, AniList) can be grouped and removed together; existing rows
-/// stay untagged (NULL).
 class MigrationV40 extends Migration {
   @override
   int get version => 40;

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -544,7 +544,7 @@ abstract class S {
   /// No description provided for @bulkResult.
   ///
   /// In en, this message translates to:
-  /// **'Done: {done} • Skipped: {skipped}'**
+  /// **'Done: {done} • Duplicates: {skipped}'**
   String bulkResult(int done, int skipped);
 
   /// No description provided for @bulkRemoved.


### PR DESCRIPTION
Concurrent first-touch callers no longer each open their own handle and race onUpgrade; the first call assigns the in-flight future to _opening and every other awaits the same one. _opening clears on success (after _database is set) and on error (so a failed open can be retried).

Also trims oversized dartdoc blocks on migrations v37–v40 to short WHY-only comments per project style.

#256 