### PR TITLE
Refactor/igdb split god class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,35 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Split IgdbApi god class into layered files under `core/api/igdb/`**
+
+  The 770-line `IgdbApi` is now a thin facade that delegates to four focused
+  sub-APIs (transport+auth, games, platforms, genres) plus a shared types
+  file. Public method signatures, constructor, provider and exception types
+  are preserved 1:1, so all 18 call sites and 9 test files keep working
+  without changes. Same pattern as the earlier AniList split.
+
+  * lib/core/api/igdb_api.dart (IgdbApi): Rewritten as a facade that
+    forwards `setCredentials`, `clearCredentials`, `getAccessToken`,
+    `validateCredentials`, `fetchPlatforms`, `fetchPlatformsByIds`,
+    `searchGames`, `multiSearchGamesByName`, `lookupSteamGames`,
+    `getGameById`, `getGamesByIds`, `getTopGamesByPlatform`, `browseGames`,
+    `fetchGenres`, `dispose`, `onTokenRefreshed` and `maxMultiQueryBatch`
+    to the sub-APIs.
+  * lib/core/api/igdb/igdb_http_client.dart (IgdbHttpClient): New.
+    Owns Dio, credential state, Twitch OAuth (`getAccessToken`,
+    `validateCredentials`), `post` with retry-on-401, `_tryRefreshToken`
+    guarded by `_isRefreshing`, `handleDioException`, `ensureCredentials`.
+  * lib/core/api/igdb/igdb_games_api.dart (IgdbGamesApi): New. Holds
+    `_gameFields`, `maxMultiQueryBatch`, `_multiSearchLimit`,
+    `_steamSource` and all game-domain methods.
+  * lib/core/api/igdb/igdb_platforms_api.dart (IgdbPlatformsApi),
+    igdb_genres_api.dart (IgdbGenresApi),
+    igdb_types.dart (TwitchAuthResult, IgdbApiException,
+    IgdbTokenRefreshedCallback): New, extracted as-is.
+  * lib/core/api/igdb/README.md: New. Documents the layer breakdown and
+    callouts on OAuth refresh, multiquery cap, Steam two-step lookup.
+
 - **Replace raw collection dropdowns with the shared picker field**
 
   All places where the user picked one collection from a form

--- a/lib/core/api/anilist/README.md
+++ b/lib/core/api/anilist/README.md
@@ -1,27 +1,27 @@
 # AniList API
 
-GraphQL-клиент AniList. Публичный endpoint, без авторизации, лимит ~90 req/min.
+GraphQL client for AniList. Public endpoint, no auth, rate-limited at ~90 req/min.
 
 - Docs: https://anilist.gitbook.io/anilist-apiv2-docs
 - Endpoint: `https://graphql.anilist.co`
 
-## Слои
+## Layers
 
-| Файл | Назначение |
+| File | Purpose |
 |---|---|
-| `../anilist_api.dart` | Фасад. Точка входа для остального кода (`aniListApiProvider`). |
-| `anilist_types.dart` | Исключения и data-классы (`AniListListEntry`, `AniListMalLookupResult`). |
-| `anilist_queries.dart` | GraphQL-запросы как `static const`. Поля подобраны под реальное использование. |
-| `anilist_graphql_client.dart` | Dio + маппинг ошибок Dio → `AniListApiException` / `AniListRateLimitException`. |
-| `anilist_media_parser.dart` | Чистые парсеры `Page { media }` и fuzzy-дат. |
-| `anilist_media_api.dart` | Поиск, бровзинг и получение по id для аниме и манги. |
-| `anilist_mal_lookup_api.dart` | MAL id → AniList media. `*Tolerant` варианты переживают rate-limit и сообщают список несрезолвленных id. |
-| `anilist_user_list_api.dart` | `MediaListCollection` — публичные списки пользователя (anime/manga). |
+| `../anilist_api.dart` | Facade. Entry point for the rest of the code (`aniListApiProvider`). |
+| `anilist_types.dart` | Exceptions and data classes (`AniListListEntry`, `AniListMalLookupResult`). |
+| `anilist_queries.dart` | GraphQL queries as `static const`. Fields are pinned to actual usage. |
+| `anilist_graphql_client.dart` | Dio + Dio → `AniListApiException` / `AniListRateLimitException` mapping. |
+| `anilist_media_parser.dart` | Pure parsers for `Page { media }` and fuzzy dates. |
+| `anilist_media_api.dart` | Search, browse and get-by-id for anime and manga. |
+| `anilist_mal_lookup_api.dart` | MAL id → AniList media. `*Tolerant` variants survive rate-limits and report the unresolved ids. |
+| `anilist_user_list_api.dart` | `MediaListCollection` — public user lists (anime/manga). |
 
-## Ключевые моменты
+## Key points
 
-- **Батчинг.** AniList ограничивает `perPage` 50 элементов — см. `aniListMaxPerPage` в `anilist_queries.dart`. Запросы списком id режутся на батчи автоматически.
-- **Rate limit.** HTTP 429 превращается в `AniListRateLimitException` с распарсенным `retryAfter` (`Retry-After` → `X-RateLimit-Reset` → 60s по умолчанию). `*Tolerant`-методы в MAL lookup ждут и повторяют батч до `maxRateLimitRetries` раз, остальные пробрасывают наверх.
-- **GraphQL-ошибки приходят с HTTP 200.** Их разбирает caller через `unwrapData` / `logErrors`. В user-list дополнительно разбираются сообщения `"not found"` / `"private"` → типизированные исключения.
-- **User lists.** Custom lists скипаются (дублируют записи из канонических). `isAdult: true` фильтруется.
-- **Поля в запросах.** В запросах оставлены только поля, которые реально читаются в UI/моделях. Старые колонки БД (`mean_score`, `popularity`, `season`, `season_year`, `country_of_origin`, `next_airing_at`) сохранены для совместимости со старыми записями, но из API больше не приходят.
+- **Batching.** AniList caps `perPage` at 50 — see `aniListMaxPerPage` in `anilist_queries.dart`. Id-list queries are batched automatically.
+- **Rate limit.** HTTP 429 becomes `AniListRateLimitException` with a parsed `retryAfter` (`Retry-After` → `X-RateLimit-Reset` → 60s default). The `*Tolerant` methods in MAL lookup wait and retry the batch up to `maxRateLimitRetries` times; the rest propagate the exception upward.
+- **GraphQL errors come back with HTTP 200.** They're unwrapped by the caller via `unwrapData` / `logErrors`. User-list lookups also classify `"not found"` / `"private"` messages into typed exceptions.
+- **User lists.** Custom lists are skipped (they duplicate entries from the canonical lists). `isAdult: true` entries are filtered out.
+- **Query fields.** Queries only request fields the UI / models actually read. Legacy DB columns (`mean_score`, `popularity`, `season`, `season_year`, `country_of_origin`, `next_airing_at`) are kept for compatibility with old rows but are no longer fetched from the API.

--- a/lib/core/api/igdb/README.md
+++ b/lib/core/api/igdb/README.md
@@ -1,0 +1,27 @@
+# IGDB API
+
+REST-клиент IGDB v4 через Twitch OAuth (Client Credentials).
+
+- Docs: https://api-docs.igdb.com/
+- Twitch OAuth: `https://id.twitch.tv/oauth2/token`
+- IGDB endpoint: `https://api.igdb.com/v4`
+
+## Слои
+
+| Файл | Назначение |
+|---|---|
+| `../igdb_api.dart` | Фасад. Точка входа для остального кода (`igdbApiProvider`). |
+| `igdb_types.dart` | `TwitchAuthResult`, `IgdbApiException`, `IgdbTokenRefreshedCallback`. |
+| `igdb_http_client.dart` | Dio + Twitch OAuth (`getAccessToken`, `validateCredentials`), хранение кредов, auto-refresh на 401, маппинг ошибок Dio → `IgdbApiException`. |
+| `igdb_platforms_api.dart` | `fetchPlatforms` (постранично), `fetchPlatformsByIds`. |
+| `igdb_games_api.dart` | `searchGames`, `multiSearchGamesByName`, `lookupSteamGames`, `getGameById/ById/Ids`, `getTopGamesByPlatform`, `browseGames`. |
+| `igdb_genres_api.dart` | `fetchGenres` для seed справочника. |
+
+## Ключевые моменты
+
+- **OAuth.** Креды хранятся в `IgdbHttpClient`. На 401 один раз пробуется `_tryRefreshToken` (`client_credentials` grant), guard'нутый `_isRefreshing` — параллельные 401 не штормят токен. Свежий токен пробрасывается наружу через `onTokenRefreshed`, чтобы caller успел сохранить в `SharedPreferences`.
+- **Лимит multiquery.** IGDB режет `/multiquery` на 10 sub-queries за запрос — `IgdbGamesApi.maxMultiQueryBatch = 10`. Caller отвечает за батчинг.
+- **Лимит обычных запросов.** IGDB cap 500 записей на запрос; `fetchPlatforms` и `getGamesByIds` режут на батчи сами.
+- **DSL запросов.** IGDB не GraphQL: строится строка вида `fields …; where …; search "…"; limit N; offset M;`. Порядок секций имеет значение, поиск идёт последним.
+- **NULL в unique индексах.** Не относится напрямую к IGDB, но связанная миграция v37 использует `COALESCE(platform_id, -1)` чтобы два NULL не считались разными — см. `migration_v37.dart`.
+- **Steam lookup.** Двухшаговый: `external_games` (`external_game_source = 1`) переводит Steam appId → IGDB game id, потом `getGamesByIds` догружает full payload (deduped).

--- a/lib/core/api/igdb/README.md
+++ b/lib/core/api/igdb/README.md
@@ -1,27 +1,27 @@
 # IGDB API
 
-REST-клиент IGDB v4 через Twitch OAuth (Client Credentials).
+REST client for IGDB v4, authenticated via Twitch OAuth (Client Credentials grant).
 
 - Docs: https://api-docs.igdb.com/
 - Twitch OAuth: `https://id.twitch.tv/oauth2/token`
 - IGDB endpoint: `https://api.igdb.com/v4`
 
-## Слои
+## Layers
 
-| Файл | Назначение |
+| File | Purpose |
 |---|---|
-| `../igdb_api.dart` | Фасад. Точка входа для остального кода (`igdbApiProvider`). |
+| `../igdb_api.dart` | Facade. Entry point for the rest of the code (`igdbApiProvider`). |
 | `igdb_types.dart` | `TwitchAuthResult`, `IgdbApiException`, `IgdbTokenRefreshedCallback`. |
-| `igdb_http_client.dart` | Dio + Twitch OAuth (`getAccessToken`, `validateCredentials`), хранение кредов, auto-refresh на 401, маппинг ошибок Dio → `IgdbApiException`. |
-| `igdb_platforms_api.dart` | `fetchPlatforms` (постранично), `fetchPlatformsByIds`. |
+| `igdb_http_client.dart` | Dio + Twitch OAuth (`getAccessToken`, `validateCredentials`), credential state, auto-refresh on 401, Dio → `IgdbApiException` mapping. |
+| `igdb_platforms_api.dart` | `fetchPlatforms` (paginated), `fetchPlatformsByIds`. |
 | `igdb_games_api.dart` | `searchGames`, `multiSearchGamesByName`, `lookupSteamGames`, `getGameById/ById/Ids`, `getTopGamesByPlatform`, `browseGames`. |
-| `igdb_genres_api.dart` | `fetchGenres` для seed справочника. |
+| `igdb_genres_api.dart` | `fetchGenres` for the lookup-table seed. |
 
-## Ключевые моменты
+## Key points
 
-- **OAuth.** Креды хранятся в `IgdbHttpClient`. На 401 один раз пробуется `_tryRefreshToken` (`client_credentials` grant), guard'нутый `_isRefreshing` — параллельные 401 не штормят токен. Свежий токен пробрасывается наружу через `onTokenRefreshed`, чтобы caller успел сохранить в `SharedPreferences`.
-- **Лимит multiquery.** IGDB режет `/multiquery` на 10 sub-queries за запрос — `IgdbGamesApi.maxMultiQueryBatch = 10`. Caller отвечает за батчинг.
-- **Лимит обычных запросов.** IGDB cap 500 записей на запрос; `fetchPlatforms` и `getGamesByIds` режут на батчи сами.
-- **DSL запросов.** IGDB не GraphQL: строится строка вида `fields …; where …; search "…"; limit N; offset M;`. Порядок секций имеет значение, поиск идёт последним.
-- **NULL в unique индексах.** Не относится напрямую к IGDB, но связанная миграция v37 использует `COALESCE(platform_id, -1)` чтобы два NULL не считались разными — см. `migration_v37.dart`.
-- **Steam lookup.** Двухшаговый: `external_games` (`external_game_source = 1`) переводит Steam appId → IGDB game id, потом `getGamesByIds` догружает full payload (deduped).
+- **OAuth.** Credentials live in `IgdbHttpClient`. On 401 a single `_tryRefreshToken` attempt fires (`client_credentials` grant), guarded by `_isRefreshing` so parallel 401s don't storm the token endpoint. The fresh token is surfaced via `onTokenRefreshed` so the caller can persist it to `SharedPreferences`.
+- **Multiquery cap.** IGDB caps `/multiquery` at 10 sub-queries per request — `IgdbGamesApi.maxMultiQueryBatch = 10`. The caller is responsible for batching.
+- **Per-request cap.** IGDB caps normal endpoints at 500 records per request; `fetchPlatforms` and `getGamesByIds` batch internally.
+- **Query DSL.** IGDB is not GraphQL: requests are strings like `fields …; where …; search "…"; limit N; offset M;`. Section order matters — `search` comes last.
+- **NULL in unique indexes.** Not directly an IGDB concern, but the related migration v37 uses `COALESCE(platform_id, -1)` so two NULLs don't count as distinct — see `migration_v37.dart`.
+- **Steam lookup.** Two-step: `external_games` (`external_game_source = 1`) maps Steam appId → IGDB game id, then `getGamesByIds` pulls the full payload (deduped).

--- a/lib/core/api/igdb/igdb_games_api.dart
+++ b/lib/core/api/igdb/igdb_games_api.dart
@@ -1,0 +1,425 @@
+import 'package:dio/dio.dart';
+
+import '../../../shared/models/game.dart';
+import 'igdb_http_client.dart';
+import 'igdb_types.dart';
+
+class IgdbGamesApi {
+  IgdbGamesApi(this._client);
+
+  final IgdbHttpClient _client;
+
+  static const String _gameFields = '''
+    fields id, name, summary, rating, rating_count, first_release_date,
+           cover.image_id, artworks.image_id, genres.name, platforms, url;
+  ''';
+
+  /// IGDB multiquery cap: 10 sub-queries per request.
+  static const int maxMultiQueryBatch = 10;
+
+  static const int _multiSearchLimit = 20;
+
+  /// IGDB `external_game_source` value for Steam.
+  static const int _steamSource = 1;
+
+  Future<List<Game>> searchGames({
+    required String query,
+    List<int>? genreIds,
+    List<int>? platformIds,
+    List<int>? gameModeIds,
+    int? minRating,
+    int? year,
+    (int, int)? decade,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    _client.ensureCredentials();
+
+    if (query.trim().isEmpty) {
+      return <Game>[];
+    }
+
+    try {
+      final String escapedQuery = query.replaceAll('"', '\\"');
+
+      // IGDB query order: fields -> where -> search -> limit.
+      final StringBuffer body = StringBuffer(_gameFields);
+
+      // IGDB: `field = (a,b)` is ANY-of (OR match).
+      final List<String> conditions = <String>[];
+      if (platformIds != null && platformIds.isNotEmpty) {
+        conditions.add('platforms = (${platformIds.join(",")})');
+      }
+      if (genreIds != null && genreIds.isNotEmpty) {
+        conditions.add('genres = (${genreIds.join(",")})');
+      }
+      if (gameModeIds != null && gameModeIds.isNotEmpty) {
+        conditions.add('game_modes = (${gameModeIds.join(",")})');
+      }
+      if (minRating != null) {
+        conditions.add('rating >= $minRating');
+      }
+      if (year != null) {
+        final int start =
+            DateTime(year).millisecondsSinceEpoch ~/ 1000;
+        final int end =
+            DateTime(year + 1).millisecondsSinceEpoch ~/ 1000;
+        conditions.add(
+          'first_release_date >= $start & first_release_date < $end',
+        );
+      } else if (decade != null) {
+        final int start =
+            DateTime(decade.$1).millisecondsSinceEpoch ~/ 1000;
+        final int end =
+            DateTime(decade.$2 + 1).millisecondsSinceEpoch ~/ 1000;
+        conditions.add(
+          'first_release_date >= $start & first_release_date < $end',
+        );
+      }
+      if (conditions.isNotEmpty) {
+        body.write(' where ${conditions.join(" & ")};');
+      }
+
+      body.write(' search "$escapedQuery"; limit $limit;');
+      if (offset > 0) {
+        body.write(' offset $offset;');
+      }
+
+      final Response<dynamic> response = await _client.post(
+        '/games',
+        data: body.toString(),
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to search games',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> data = response.data as List<dynamic>;
+      return data
+          .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to search games');
+    }
+  }
+
+  Future<Map<int, List<Game>>> multiSearchGamesByName(
+    List<({String name, int? platformId})> queries,
+  ) async {
+    if (queries.isEmpty) return <int, List<Game>>{};
+    _client.ensureCredentials();
+
+    const String fields =
+        'fields id,name,summary,rating,rating_count,first_release_date,'
+        'cover.image_id,genres.name,platforms,url;';
+
+    try {
+      final StringBuffer body = StringBuffer();
+      for (int i = 0; i < queries.length; i++) {
+        final String escaped = queries[i]
+            .name
+            .replaceAll('"', '\\"')
+            .replaceAll('*', '');
+        final String platformFilter = queries[i].platformId != null
+            ? ' & platforms = (${queries[i].platformId})'
+            : '';
+        body.writeln(
+          'query games "q_$i" { $fields '
+          'where name ~ *"$escaped"*$platformFilter; '
+          'limit $_multiSearchLimit; };',
+        );
+      }
+
+      final Response<dynamic> response = await _client.post(
+        '/multiquery',
+        data: body.toString(),
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to multi-search games',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> results = response.data as List<dynamic>;
+      final Map<int, List<Game>> mapped = <int, List<Game>>{};
+
+      for (final dynamic entry in results) {
+        final Map<String, dynamic> item = entry as Map<String, dynamic>;
+        final String name = item['name'] as String;
+        final int? index = int.tryParse(name.replaceFirst('q_', ''));
+        if (index == null) continue;
+
+        final List<dynamic> resultList =
+            (item['result'] as List<dynamic>?) ?? <dynamic>[];
+        mapped[index] = resultList
+            .map((dynamic g) => Game.fromJson(g as Map<String, dynamic>))
+            .toList();
+      }
+
+      for (int i = 0; i < queries.length; i++) {
+        mapped.putIfAbsent(i, () => <Game>[]);
+      }
+
+      return mapped;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to multi-search games');
+    }
+  }
+
+  Future<Map<String, Game>> lookupSteamGames(
+    List<String> steamAppIds,
+  ) async {
+    if (steamAppIds.isEmpty) return <String, Game>{};
+    _client.ensureCredentials();
+
+    try {
+      // Step 1: Steam appId -> IGDB game id via external_games.
+      final Map<String, int> uidToGameId = <String, int>{};
+
+      for (int offset = 0; offset < steamAppIds.length; offset += 500) {
+        final List<String> batch = steamAppIds.sublist(
+          offset,
+          offset + 500 > steamAppIds.length
+              ? steamAppIds.length
+              : offset + 500,
+        );
+        final String uidList = batch.map((String id) => '"$id"').join(',');
+
+        final Response<dynamic> response = await _client.post(
+          '/external_games',
+          data: 'fields game,uid; '
+              'where external_game_source = $_steamSource '
+              '& uid = ($uidList); '
+              'limit 500;',
+        );
+
+        if (response.statusCode != 200 || response.data == null) {
+          throw IgdbApiException(
+            'Failed to lookup Steam games',
+            statusCode: response.statusCode,
+          );
+        }
+
+        final List<dynamic> data = response.data as List<dynamic>;
+        for (final dynamic item in data) {
+          final Map<String, dynamic> map = item as Map<String, dynamic>;
+          final String uid = map['uid'] as String;
+          final int gameId = map['game'] as int;
+          uidToGameId[uid] = gameId;
+        }
+      }
+
+      if (uidToGameId.isEmpty) return <String, Game>{};
+
+      // Step 2: fetch full game data by IGDB id (deduped).
+      final List<Game> games =
+          await getGamesByIds(uidToGameId.values.toSet().toList());
+
+      final Map<int, Game> gamesById = <int, Game>{
+        for (final Game game in games) game.id: game,
+      };
+
+      final Map<String, Game> result = <String, Game>{};
+      for (final MapEntry<String, int> entry in uidToGameId.entries) {
+        final Game? game = gamesById[entry.value];
+        if (game != null) {
+          result[entry.key] = game;
+        }
+      }
+
+      return result;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to lookup Steam games');
+    }
+  }
+
+  Future<Game?> getGameById(int gameId) async {
+    _client.ensureCredentials();
+
+    try {
+      final Response<dynamic> response = await _client.post(
+        '/games',
+        data: '$_gameFields where id = $gameId;',
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to fetch game',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> data = response.data as List<dynamic>;
+      if (data.isEmpty) return null;
+
+      return Game.fromJson(data.first as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch game');
+    }
+  }
+
+  Future<List<Game>> getGamesByIds(List<int> gameIds) async {
+    _client.ensureCredentials();
+
+    if (gameIds.isEmpty) {
+      return <Game>[];
+    }
+
+    try {
+      // IGDB caps a single request at 500 records.
+      final List<Game> allGames = <Game>[];
+
+      for (int i = 0; i < gameIds.length; i += 500) {
+        final List<int> batch = gameIds.sublist(
+          i,
+          i + 500 > gameIds.length ? gameIds.length : i + 500,
+        );
+
+        final String idsString = batch.join(',');
+
+        final Response<dynamic> response = await _client.post(
+          '/games',
+          data: '$_gameFields where id = ($idsString); limit 500;',
+        );
+
+        if (response.statusCode != 200 || response.data == null) {
+          throw IgdbApiException(
+            'Failed to fetch games',
+            statusCode: response.statusCode,
+          );
+        }
+
+        final List<dynamic> data = response.data as List<dynamic>;
+        final List<Game> games = data
+            .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
+            .toList();
+
+        allGames.addAll(games);
+      }
+
+      return allGames;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch games');
+    }
+  }
+
+  Future<List<Game>> getTopGamesByPlatform({
+    required int platformId,
+    int minRatingCount = 20,
+    int limit = 50,
+  }) async {
+    _client.ensureCredentials();
+
+    try {
+      final StringBuffer body = StringBuffer(_gameFields);
+      body.write(
+        ' where platforms = ($platformId)'
+        ' & rating_count >= $minRatingCount'
+        ' & rating != null;',
+      );
+      body.write(' sort rating desc;');
+      body.write(' limit $limit;');
+
+      final Response<dynamic> response = await _client.post(
+        '/games',
+        data: body.toString(),
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to fetch top games',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> data = response.data as List<dynamic>;
+      return data
+          .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch top games');
+    }
+  }
+
+  Future<List<Game>> browseGames({
+    List<int>? genreIds,
+    List<int>? platformIds,
+    List<int>? gameModeIds,
+    int? minRating,
+    int? year,
+    (int, int)? decade,
+    String sortBy = 'rating desc',
+    int limit = 20,
+    int offset = 0,
+    int minRatingCount = 10,
+  }) async {
+    _client.ensureCredentials();
+
+    try {
+      final StringBuffer where =
+          StringBuffer('where rating_count > $minRatingCount');
+
+      if (genreIds != null && genreIds.isNotEmpty) {
+        where.write(' & genres = (${genreIds.join(",")})');
+      }
+      if (platformIds != null && platformIds.isNotEmpty) {
+        where.write(' & platforms = (${platformIds.join(",")})');
+      }
+      if (gameModeIds != null && gameModeIds.isNotEmpty) {
+        where.write(' & game_modes = (${gameModeIds.join(",")})');
+      }
+      if (minRating != null) {
+        where.write(' & rating >= $minRating');
+      }
+      if (year != null) {
+        final int start =
+            DateTime(year).millisecondsSinceEpoch ~/ 1000;
+        final int end =
+            DateTime(year + 1).millisecondsSinceEpoch ~/ 1000;
+        where.write(
+          ' & first_release_date >= $start & first_release_date < $end',
+        );
+      } else if (decade != null) {
+        final int start =
+            DateTime(decade.$1).millisecondsSinceEpoch ~/ 1000;
+        final int end =
+            DateTime(decade.$2 + 1).millisecondsSinceEpoch ~/ 1000;
+        where.write(
+          ' & first_release_date >= $start & first_release_date < $end',
+        );
+      }
+
+      final StringBuffer body = StringBuffer(_gameFields);
+      body.write(' $where;');
+      body.write(' sort $sortBy;');
+      body.write(' limit $limit;');
+      if (offset > 0) {
+        body.write(' offset $offset;');
+      }
+
+      final Response<dynamic> response = await _client.post(
+        '/games',
+        data: body.toString(),
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to browse games',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> data = response.data as List<dynamic>;
+      return data
+          .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to browse games');
+    }
+  }
+}

--- a/lib/core/api/igdb/igdb_genres_api.dart
+++ b/lib/core/api/igdb/igdb_genres_api.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+
+import 'igdb_http_client.dart';
+import 'igdb_types.dart';
+
+class IgdbGenresApi {
+  IgdbGenresApi(this._client);
+
+  final IgdbHttpClient _client;
+
+  Future<List<Map<String, dynamic>>> fetchGenres() async {
+    _client.ensureCredentials();
+
+    try {
+      final Response<dynamic> response = await _client.post(
+        '/genres',
+        data: 'fields id,name; limit 50; sort name asc;',
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to fetch genres',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> data = response.data as List<dynamic>;
+      return data
+          .map((dynamic item) => item as Map<String, dynamic>)
+          .toList();
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch genres');
+    }
+  }
+}

--- a/lib/core/api/igdb/igdb_http_client.dart
+++ b/lib/core/api/igdb/igdb_http_client.dart
@@ -1,0 +1,203 @@
+import 'package:dio/dio.dart';
+import 'package:logging/logging.dart';
+
+import '../api_error_detail.dart';
+import 'igdb_types.dart';
+
+// Twitch OAuth + IGDB v4. Docs: https://api-docs.igdb.com/
+class IgdbHttpClient {
+  IgdbHttpClient({Dio? dio})
+      : _dio = dio ??
+            Dio(BaseOptions(
+              connectTimeout: _timeout,
+              receiveTimeout: _timeout,
+            ));
+
+  static final Logger _log = Logger('IgdbApi');
+
+  static const Duration _timeout = Duration(seconds: 5);
+  static const String _twitchAuthUrl = 'https://id.twitch.tv/oauth2/token';
+  static const String _igdbBaseUrl = 'https://api.igdb.com/v4';
+
+  final Dio _dio;
+
+  String? _clientId;
+  String? _clientSecret;
+  String? _accessToken;
+
+  /// Invoked on auto-refresh so callers can persist the new token.
+  IgdbTokenRefreshedCallback? onTokenRefreshed;
+
+  bool _isRefreshing = false;
+
+  void setCredentials({
+    required String clientId,
+    required String accessToken,
+    String? clientSecret,
+  }) {
+    _clientId = clientId;
+    _clientSecret = clientSecret;
+    _accessToken = accessToken;
+  }
+
+  void clearCredentials() {
+    _clientId = null;
+    _clientSecret = null;
+    _accessToken = null;
+  }
+
+  Future<TwitchAuthResult> getAccessToken({
+    required String clientId,
+    required String clientSecret,
+  }) async {
+    try {
+      final Response<dynamic> response = await _dio.post<dynamic>(
+        _twitchAuthUrl,
+        queryParameters: <String, dynamic>{
+          'client_id': clientId,
+          'client_secret': clientSecret,
+          'grant_type': 'client_credentials',
+        },
+      );
+
+      if (response.statusCode == 200 && response.data != null) {
+        return TwitchAuthResult.fromJson(
+          response.data as Map<String, dynamic>,
+        );
+      }
+
+      throw IgdbApiException(
+        'Failed to get access token',
+        statusCode: response.statusCode,
+      );
+    } on DioException catch (e) {
+      final int? statusCode = e.response?.statusCode;
+      String message = 'Authentication failed';
+
+      if (statusCode == 400 || statusCode == 401) {
+        message = 'Invalid client ID or client secret';
+      } else if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout) {
+        message = 'Connection timeout';
+      } else if (e.type == DioExceptionType.connectionError) {
+        message = 'No internet connection';
+      }
+
+      throw IgdbApiException(
+        message,
+        statusCode: statusCode,
+        detail: buildApiErrorDetail(
+          apiName: 'IGDB Auth',
+          exception: e,
+          userMessage: message,
+        ),
+      );
+    }
+  }
+
+  Future<bool> validateCredentials({
+    required String clientId,
+    required String clientSecret,
+  }) async {
+    try {
+      await getAccessToken(clientId: clientId, clientSecret: clientSecret);
+      return true;
+    } on IgdbApiException {
+      return false;
+    }
+  }
+
+  // On 401, refresh the Twitch token once and retry the request.
+  Future<Response<dynamic>> post(
+    String endpoint, {
+    required String data,
+  }) async {
+    try {
+      return await _dio.post<dynamic>(
+        '$_igdbBaseUrl$endpoint',
+        options: Options(
+          headers: <String, dynamic>{
+            'Client-ID': _clientId,
+            'Authorization': 'Bearer $_accessToken',
+          },
+        ),
+        data: data,
+      );
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401 && await _tryRefreshToken()) {
+        return _dio.post<dynamic>(
+          '$_igdbBaseUrl$endpoint',
+          options: Options(
+            headers: <String, dynamic>{
+              'Client-ID': _clientId,
+              'Authorization': 'Bearer $_accessToken',
+            },
+          ),
+          data: data,
+        );
+      }
+      rethrow;
+    }
+  }
+
+  // Maps Dio errors to user-facing messages; 401 = bad/expired token, 429 = rate limit.
+  IgdbApiException handleDioException(DioException e, String defaultMessage) {
+    final int? statusCode = e.response?.statusCode;
+    String message = defaultMessage;
+
+    if (statusCode == 401) {
+      message = 'Invalid or expired access token';
+    } else if (statusCode == 429) {
+      message = 'Rate limit exceeded. Please try again later';
+    } else if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.receiveTimeout) {
+      message = 'Connection timeout';
+    } else if (e.type == DioExceptionType.connectionError) {
+      message = 'No internet connection';
+    }
+
+    return IgdbApiException(
+      message,
+      statusCode: statusCode,
+      detail: buildApiErrorDetail(
+        apiName: 'IGDB',
+        exception: e,
+        userMessage: message,
+      ),
+    );
+  }
+
+  void ensureCredentials() {
+    if (_clientId == null || _accessToken == null) {
+      throw const IgdbApiException('API credentials not set');
+    }
+  }
+
+  // Guarded by _isRefreshing to avoid concurrent refresh storms on parallel 401s.
+  Future<bool> _tryRefreshToken() async {
+    if (_isRefreshing) return false;
+    if (_clientId == null || _clientSecret == null) return false;
+
+    _isRefreshing = true;
+    try {
+      _log.info('Auto-refreshing IGDB token...');
+      final TwitchAuthResult result = await getAccessToken(
+        clientId: _clientId!,
+        clientSecret: _clientSecret!,
+      );
+      _accessToken = result.accessToken;
+      onTokenRefreshed?.call(result.accessToken, result.expiresAt);
+      _log.info('IGDB token refreshed successfully');
+      return true;
+    } on IgdbApiException catch (e) {
+      _log.warning('IGDB token refresh failed: $e');
+      return false;
+    } finally {
+      _isRefreshing = false;
+    }
+  }
+
+  void dispose() {
+    _dio.close();
+  }
+}

--- a/lib/core/api/igdb/igdb_platforms_api.dart
+++ b/lib/core/api/igdb/igdb_platforms_api.dart
@@ -1,0 +1,81 @@
+import 'package:dio/dio.dart';
+
+import '../../../shared/models/platform.dart';
+import 'igdb_http_client.dart';
+import 'igdb_types.dart';
+
+class IgdbPlatformsApi {
+  IgdbPlatformsApi(this._client);
+
+  final IgdbHttpClient _client;
+
+  Future<List<Platform>> fetchPlatforms() async {
+    _client.ensureCredentials();
+
+    try {
+      final List<Platform> allPlatforms = <Platform>[];
+      int offset = 0;
+      const int limit = 500;
+
+      while (true) {
+        final Response<dynamic> response = await _client.post(
+          '/platforms',
+          data: 'fields id,name,abbreviation; limit $limit; offset $offset;',
+        );
+
+        if (response.statusCode != 200 || response.data == null) {
+          throw IgdbApiException(
+            'Failed to fetch platforms',
+            statusCode: response.statusCode,
+          );
+        }
+
+        final List<dynamic> data = response.data as List<dynamic>;
+        if (data.isEmpty) break;
+
+        final List<Platform> platforms = data
+            .map((dynamic item) =>
+                Platform.fromJson(item as Map<String, dynamic>))
+            .toList();
+
+        allPlatforms.addAll(platforms);
+
+        if (data.length < limit) break;
+        offset += limit;
+      }
+
+      return allPlatforms;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch platforms');
+    }
+  }
+
+  Future<List<Platform>> fetchPlatformsByIds(List<int> ids) async {
+    if (ids.isEmpty) return <Platform>[];
+    _client.ensureCredentials();
+
+    try {
+      final String idList = ids.join(',');
+      final Response<dynamic> response = await _client.post(
+        '/platforms',
+        data:
+            'fields id,name,abbreviation; where id = ($idList); limit 500;',
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        throw IgdbApiException(
+          'Failed to fetch platforms by IDs',
+          statusCode: response.statusCode,
+        );
+      }
+
+      final List<dynamic> data = response.data as List<dynamic>;
+      return data
+          .map((dynamic item) =>
+              Platform.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch platforms by IDs');
+    }
+  }
+}

--- a/lib/core/api/igdb/igdb_types.dart
+++ b/lib/core/api/igdb/igdb_types.dart
@@ -1,0 +1,40 @@
+class TwitchAuthResult {
+  const TwitchAuthResult({
+    required this.accessToken,
+    required this.expiresIn,
+    required this.tokenType,
+  });
+
+  factory TwitchAuthResult.fromJson(Map<String, dynamic> json) {
+    return TwitchAuthResult(
+      accessToken: json['access_token'] as String,
+      expiresIn: json['expires_in'] as int,
+      tokenType: json['token_type'] as String,
+    );
+  }
+
+  final String accessToken;
+  final int expiresIn;
+  final String tokenType;
+
+  /// Unix timestamp when the token expires.
+  int get expiresAt {
+    return DateTime.now().millisecondsSinceEpoch ~/ 1000 + expiresIn;
+  }
+}
+
+class IgdbApiException implements Exception {
+  const IgdbApiException(this.message, {this.statusCode, this.detail});
+
+  final String message;
+  final int? statusCode;
+  final String? detail;
+
+  @override
+  String toString() => 'IgdbApiException: $message (status: $statusCode)';
+}
+
+typedef IgdbTokenRefreshedCallback = void Function(
+  String accessToken,
+  int expiresAt,
+);

--- a/lib/core/api/igdb_api.dart
+++ b/lib/core/api/igdb_api.dart
@@ -1,11 +1,16 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:logging/logging.dart';
 
-import 'api_error_detail.dart';
 import '../services/api_key_initializer.dart';
 import '../../shared/models/game.dart';
 import '../../shared/models/platform.dart';
+import 'igdb/igdb_games_api.dart';
+import 'igdb/igdb_genres_api.dart';
+import 'igdb/igdb_http_client.dart';
+import 'igdb/igdb_platforms_api.dart';
+import 'igdb/igdb_types.dart';
+
+export 'igdb/igdb_types.dart';
 
 // Credentials seeded from apiKeysProvider loaded in main() before runApp().
 final Provider<IgdbApi> igdbApiProvider = Provider<IgdbApi>((Ref ref) {
@@ -21,224 +26,63 @@ final Provider<IgdbApi> igdbApiProvider = Provider<IgdbApi>((Ref ref) {
   return api;
 });
 
-class TwitchAuthResult {
-  const TwitchAuthResult({
-    required this.accessToken,
-    required this.expiresIn,
-    required this.tokenType,
-  });
-
-  factory TwitchAuthResult.fromJson(Map<String, dynamic> json) {
-    return TwitchAuthResult(
-      accessToken: json['access_token'] as String,
-      expiresIn: json['expires_in'] as int,
-      tokenType: json['token_type'] as String,
-    );
-  }
-
-  final String accessToken;
-  final int expiresIn;
-  final String tokenType;
-
-  /// Unix timestamp when the token expires.
-  int get expiresAt {
-    return DateTime.now().millisecondsSinceEpoch ~/ 1000 + expiresIn;
-  }
-}
-
-class IgdbApiException implements Exception {
-  const IgdbApiException(this.message, {this.statusCode, this.detail});
-
-  final String message;
-  final int? statusCode;
-  final String? detail;
-
-  @override
-  String toString() => 'IgdbApiException: $message (status: $statusCode)';
-}
-
-// Twitch OAuth + IGDB v4. Docs: https://api-docs.igdb.com/
-typedef IgdbTokenRefreshedCallback = void Function(
-  String accessToken,
-  int expiresAt,
-);
-
+/// IGDB v4 facade. See `igdb/` for layer breakdown:
+/// `igdb_http_client` (transport+auth), `igdb_games_api`, `igdb_platforms_api`,
+/// `igdb_genres_api`, `igdb_types` (DTOs).
 class IgdbApi {
-  IgdbApi({Dio? dio})
-      : _dio = dio ??
-            Dio(BaseOptions(
-              connectTimeout: _timeout,
-              receiveTimeout: _timeout,
-            ));
+  IgdbApi({Dio? dio}) : _client = IgdbHttpClient(dio: dio) {
+    _games = IgdbGamesApi(_client);
+    _platforms = IgdbPlatformsApi(_client);
+    _genres = IgdbGenresApi(_client);
+  }
 
-  static final Logger _log = Logger('IgdbApi');
+  final IgdbHttpClient _client;
+  late final IgdbGamesApi _games;
+  late final IgdbPlatformsApi _platforms;
+  late final IgdbGenresApi _genres;
 
-  static const Duration _timeout = Duration(seconds: 5);
-  static const String _twitchAuthUrl = 'https://id.twitch.tv/oauth2/token';
-  static const String _igdbBaseUrl = 'https://api.igdb.com/v4';
+  static const int maxMultiQueryBatch = IgdbGamesApi.maxMultiQueryBatch;
 
-  final Dio _dio;
-
-  String? _clientId;
-  String? _clientSecret;
-  String? _accessToken;
-
-  /// Invoked on auto-refresh so callers can persist the new token.
-  IgdbTokenRefreshedCallback? onTokenRefreshed;
-
-  bool _isRefreshing = false;
+  IgdbTokenRefreshedCallback? get onTokenRefreshed => _client.onTokenRefreshed;
+  set onTokenRefreshed(IgdbTokenRefreshedCallback? cb) {
+    _client.onTokenRefreshed = cb;
+  }
 
   void setCredentials({
     required String clientId,
     required String accessToken,
     String? clientSecret,
-  }) {
-    _clientId = clientId;
-    _clientSecret = clientSecret;
-    _accessToken = accessToken;
-  }
+  }) =>
+      _client.setCredentials(
+        clientId: clientId,
+        accessToken: accessToken,
+        clientSecret: clientSecret,
+      );
 
-  void clearCredentials() {
-    _clientId = null;
-    _clientSecret = null;
-    _accessToken = null;
-  }
+  void clearCredentials() => _client.clearCredentials();
 
   Future<TwitchAuthResult> getAccessToken({
     required String clientId,
     required String clientSecret,
-  }) async {
-    try {
-      final Response<dynamic> response = await _dio.post<dynamic>(
-        _twitchAuthUrl,
-        queryParameters: <String, dynamic>{
-          'client_id': clientId,
-          'client_secret': clientSecret,
-          'grant_type': 'client_credentials',
-        },
+  }) =>
+      _client.getAccessToken(
+        clientId: clientId,
+        clientSecret: clientSecret,
       );
-
-      if (response.statusCode == 200 && response.data != null) {
-        return TwitchAuthResult.fromJson(
-          response.data as Map<String, dynamic>,
-        );
-      }
-
-      throw IgdbApiException(
-        'Failed to get access token',
-        statusCode: response.statusCode,
-      );
-    } on DioException catch (e) {
-      final int? statusCode = e.response?.statusCode;
-      String message = 'Authentication failed';
-
-      if (statusCode == 400 || statusCode == 401) {
-        message = 'Invalid client ID or client secret';
-      } else if (e.type == DioExceptionType.connectionTimeout ||
-          e.type == DioExceptionType.receiveTimeout) {
-        message = 'Connection timeout';
-      } else if (e.type == DioExceptionType.connectionError) {
-        message = 'No internet connection';
-      }
-
-      throw IgdbApiException(
-        message,
-        statusCode: statusCode,
-        detail: buildApiErrorDetail(
-          apiName: 'IGDB Auth',
-          exception: e,
-          userMessage: message,
-        ),
-      );
-    }
-  }
 
   Future<bool> validateCredentials({
     required String clientId,
     required String clientSecret,
-  }) async {
-    try {
-      await getAccessToken(clientId: clientId, clientSecret: clientSecret);
-      return true;
-    } on IgdbApiException {
-      return false;
-    }
-  }
-
-  Future<List<Platform>> fetchPlatforms() async {
-    _ensureCredentials();
-
-    try {
-      final List<Platform> allPlatforms = <Platform>[];
-      int offset = 0;
-      const int limit = 500;
-
-      while (true) {
-        final Response<dynamic> response = await _igdbPost(
-          '/platforms',
-          data: 'fields id,name,abbreviation; limit $limit; offset $offset;',
-        );
-
-        if (response.statusCode != 200 || response.data == null) {
-          throw IgdbApiException(
-            'Failed to fetch platforms',
-            statusCode: response.statusCode,
-          );
-        }
-
-        final List<dynamic> data = response.data as List<dynamic>;
-        if (data.isEmpty) break;
-
-        final List<Platform> platforms = data
-            .map((dynamic item) =>
-                Platform.fromJson(item as Map<String, dynamic>))
-            .toList();
-
-        allPlatforms.addAll(platforms);
-
-        if (data.length < limit) break;
-        offset += limit;
-      }
-
-      return allPlatforms;
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to fetch platforms');
-    }
-  }
-
-  Future<List<Platform>> fetchPlatformsByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Platform>[];
-    _ensureCredentials();
-
-    try {
-      final String idList = ids.join(',');
-      final Response<dynamic> response = await _igdbPost(
-        '/platforms',
-        data:
-            'fields id,name,abbreviation; where id = ($idList); limit 500;',
+  }) =>
+      _client.validateCredentials(
+        clientId: clientId,
+        clientSecret: clientSecret,
       );
 
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to fetch platforms by IDs',
-          statusCode: response.statusCode,
-        );
-      }
+  Future<List<Platform>> fetchPlatforms() => _platforms.fetchPlatforms();
 
-      final List<dynamic> data = response.data as List<dynamic>;
-      return data
-          .map((dynamic item) =>
-              Platform.fromJson(item as Map<String, dynamic>))
-          .toList();
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to fetch platforms by IDs');
-    }
-  }
-
-  static const String _gameFields = '''
-    fields id, name, summary, rating, rating_count, first_release_date,
-           cover.image_id, artworks.image_id, genres.name, platforms, url;
-  ''';
+  Future<List<Platform>> fetchPlatformsByIds(List<int> ids) =>
+      _platforms.fetchPlatformsByIds(ids);
 
   Future<List<Game>> searchGames({
     required String query,
@@ -250,352 +94,42 @@ class IgdbApi {
     (int, int)? decade,
     int limit = 20,
     int offset = 0,
-  }) async {
-    _ensureCredentials();
-
-    if (query.trim().isEmpty) {
-      return <Game>[];
-    }
-
-    try {
-      final String escapedQuery = query.replaceAll('"', '\\"');
-
-      // IGDB query order: fields -> where -> search -> limit.
-      final StringBuffer body = StringBuffer(_gameFields);
-
-      // IGDB: `field = (a,b)` is ANY-of (OR match).
-      final List<String> conditions = <String>[];
-      if (platformIds != null && platformIds.isNotEmpty) {
-        conditions.add('platforms = (${platformIds.join(",")})');
-      }
-      if (genreIds != null && genreIds.isNotEmpty) {
-        conditions.add('genres = (${genreIds.join(",")})');
-      }
-      if (gameModeIds != null && gameModeIds.isNotEmpty) {
-        conditions.add('game_modes = (${gameModeIds.join(",")})');
-      }
-      if (minRating != null) {
-        conditions.add('rating >= $minRating');
-      }
-      if (year != null) {
-        final int start =
-            DateTime(year).millisecondsSinceEpoch ~/ 1000;
-        final int end =
-            DateTime(year + 1).millisecondsSinceEpoch ~/ 1000;
-        conditions.add(
-          'first_release_date >= $start & first_release_date < $end',
-        );
-      } else if (decade != null) {
-        final int start =
-            DateTime(decade.$1).millisecondsSinceEpoch ~/ 1000;
-        final int end =
-            DateTime(decade.$2 + 1).millisecondsSinceEpoch ~/ 1000;
-        conditions.add(
-          'first_release_date >= $start & first_release_date < $end',
-        );
-      }
-      if (conditions.isNotEmpty) {
-        body.write(' where ${conditions.join(" & ")};');
-      }
-
-      body.write(' search "$escapedQuery"; limit $limit;');
-      if (offset > 0) {
-        body.write(' offset $offset;');
-      }
-
-      final Response<dynamic> response = await _igdbPost(
-        '/games',
-        data: body.toString(),
+  }) =>
+      _games.searchGames(
+        query: query,
+        genreIds: genreIds,
+        platformIds: platformIds,
+        gameModeIds: gameModeIds,
+        minRating: minRating,
+        year: year,
+        decade: decade,
+        limit: limit,
+        offset: offset,
       );
-
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to search games',
-          statusCode: response.statusCode,
-        );
-      }
-
-      final List<dynamic> data = response.data as List<dynamic>;
-      return data
-          .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
-          .toList();
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to search games');
-    }
-  }
-
-  /// IGDB multiquery cap: 10 sub-queries per request.
-  static const int maxMultiQueryBatch = 10;
-
-  static const int _multiSearchLimit = 20;
 
   Future<Map<int, List<Game>>> multiSearchGamesByName(
     List<({String name, int? platformId})> queries,
-  ) async {
-    if (queries.isEmpty) return <int, List<Game>>{};
-    _ensureCredentials();
+  ) =>
+      _games.multiSearchGamesByName(queries);
 
-    const String fields =
-        'fields id,name,summary,rating,rating_count,first_release_date,'
-        'cover.image_id,genres.name,platforms,url;';
+  Future<Map<String, Game>> lookupSteamGames(List<String> steamAppIds) =>
+      _games.lookupSteamGames(steamAppIds);
 
-    try {
-      final StringBuffer body = StringBuffer();
-      for (int i = 0; i < queries.length; i++) {
-        final String escaped = queries[i]
-            .name
-            .replaceAll('"', '\\"')
-            .replaceAll('*', '');
-        final String platformFilter = queries[i].platformId != null
-            ? ' & platforms = (${queries[i].platformId})'
-            : '';
-        body.writeln(
-          'query games "q_$i" { $fields '
-          'where name ~ *"$escaped"*$platformFilter; '
-          'limit $_multiSearchLimit; };',
-        );
-      }
+  Future<Game?> getGameById(int gameId) => _games.getGameById(gameId);
 
-      final Response<dynamic> response = await _igdbPost(
-        '/multiquery',
-        data: body.toString(),
-      );
-
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to multi-search games',
-          statusCode: response.statusCode,
-        );
-      }
-
-      final List<dynamic> results = response.data as List<dynamic>;
-      final Map<int, List<Game>> mapped = <int, List<Game>>{};
-
-      for (final dynamic entry in results) {
-        final Map<String, dynamic> item = entry as Map<String, dynamic>;
-        final String name = item['name'] as String;
-        final int? index = int.tryParse(name.replaceFirst('q_', ''));
-        if (index == null) continue;
-
-        final List<dynamic> resultList =
-            (item['result'] as List<dynamic>?) ?? <dynamic>[];
-        mapped[index] = resultList
-            .map((dynamic g) => Game.fromJson(g as Map<String, dynamic>))
-            .toList();
-      }
-
-      for (int i = 0; i < queries.length; i++) {
-        mapped.putIfAbsent(i, () => <Game>[]);
-      }
-
-      return mapped;
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to multi-search games');
-    }
-  }
-
-  /// IGDB `external_game_source` value for Steam.
-  static const int _steamSource = 1;
-
-  Future<Map<String, Game>> lookupSteamGames(
-    List<String> steamAppIds,
-  ) async {
-    if (steamAppIds.isEmpty) return <String, Game>{};
-    _ensureCredentials();
-
-    try {
-      // Step 1: Steam appId -> IGDB game id via external_games.
-      final Map<String, int> uidToGameId = <String, int>{};
-
-      for (int offset = 0; offset < steamAppIds.length; offset += 500) {
-        final List<String> batch = steamAppIds.sublist(
-          offset,
-          offset + 500 > steamAppIds.length
-              ? steamAppIds.length
-              : offset + 500,
-        );
-        final String uidList = batch.map((String id) => '"$id"').join(',');
-
-        final Response<dynamic> response = await _igdbPost(
-          '/external_games',
-          data: 'fields game,uid; '
-              'where external_game_source = $_steamSource '
-              '& uid = ($uidList); '
-              'limit 500;',
-        );
-
-        if (response.statusCode != 200 || response.data == null) {
-          throw IgdbApiException(
-            'Failed to lookup Steam games',
-            statusCode: response.statusCode,
-          );
-        }
-
-        final List<dynamic> data = response.data as List<dynamic>;
-        for (final dynamic item in data) {
-          final Map<String, dynamic> map = item as Map<String, dynamic>;
-          final String uid = map['uid'] as String;
-          final int gameId = map['game'] as int;
-          uidToGameId[uid] = gameId;
-        }
-      }
-
-      if (uidToGameId.isEmpty) return <String, Game>{};
-
-      // Step 2: fetch full game data by IGDB id (deduped).
-      final List<Game> games =
-          await getGamesByIds(uidToGameId.values.toSet().toList());
-
-      final Map<int, Game> gamesById = <int, Game>{
-        for (final Game game in games) game.id: game,
-      };
-
-      final Map<String, Game> result = <String, Game>{};
-      for (final MapEntry<String, int> entry in uidToGameId.entries) {
-        final Game? game = gamesById[entry.value];
-        if (game != null) {
-          result[entry.key] = game;
-        }
-      }
-
-      return result;
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to lookup Steam games');
-    }
-  }
-
-  Future<Game?> getGameById(int gameId) async {
-    _ensureCredentials();
-
-    try {
-      final Response<dynamic> response = await _igdbPost(
-        '/games',
-        data: '$_gameFields where id = $gameId;',
-      );
-
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to fetch game',
-          statusCode: response.statusCode,
-        );
-      }
-
-      final List<dynamic> data = response.data as List<dynamic>;
-      if (data.isEmpty) return null;
-
-      return Game.fromJson(data.first as Map<String, dynamic>);
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to fetch game');
-    }
-  }
-
-  Future<List<Game>> getGamesByIds(List<int> gameIds) async {
-    _ensureCredentials();
-
-    if (gameIds.isEmpty) {
-      return <Game>[];
-    }
-
-    try {
-      // IGDB caps a single request at 500 records.
-      final List<Game> allGames = <Game>[];
-
-      for (int i = 0; i < gameIds.length; i += 500) {
-        final List<int> batch = gameIds.sublist(
-          i,
-          i + 500 > gameIds.length ? gameIds.length : i + 500,
-        );
-
-        final String idsString = batch.join(',');
-
-        final Response<dynamic> response = await _igdbPost(
-          '/games',
-          data: '$_gameFields where id = ($idsString); limit 500;',
-        );
-
-        if (response.statusCode != 200 || response.data == null) {
-          throw IgdbApiException(
-            'Failed to fetch games',
-            statusCode: response.statusCode,
-          );
-        }
-
-        final List<dynamic> data = response.data as List<dynamic>;
-        final List<Game> games = data
-            .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
-            .toList();
-
-        allGames.addAll(games);
-      }
-
-      return allGames;
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to fetch games');
-    }
-  }
+  Future<List<Game>> getGamesByIds(List<int> gameIds) =>
+      _games.getGamesByIds(gameIds);
 
   Future<List<Game>> getTopGamesByPlatform({
     required int platformId,
     int minRatingCount = 20,
     int limit = 50,
-  }) async {
-    _ensureCredentials();
-
-    try {
-      final StringBuffer body = StringBuffer(_gameFields);
-      body.write(
-        ' where platforms = ($platformId)'
-        ' & rating_count >= $minRatingCount'
-        ' & rating != null;',
+  }) =>
+      _games.getTopGamesByPlatform(
+        platformId: platformId,
+        minRatingCount: minRatingCount,
+        limit: limit,
       );
-      body.write(' sort rating desc;');
-      body.write(' limit $limit;');
-
-      final Response<dynamic> response = await _igdbPost(
-        '/games',
-        data: body.toString(),
-      );
-
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to fetch top games',
-          statusCode: response.statusCode,
-        );
-      }
-
-      final List<dynamic> data = response.data as List<dynamic>;
-      return data
-          .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
-          .toList();
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to fetch top games');
-    }
-  }
-
-  Future<List<Map<String, dynamic>>> fetchGenres() async {
-    _ensureCredentials();
-
-    try {
-      final Response<dynamic> response = await _igdbPost(
-        '/genres',
-        data: 'fields id,name; limit 50; sort name asc;',
-      );
-
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to fetch genres',
-          statusCode: response.statusCode,
-        );
-      }
-
-      final List<dynamic> data = response.data as List<dynamic>;
-      return data
-          .map((dynamic item) => item as Map<String, dynamic>)
-          .toList();
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to fetch genres');
-    }
-  }
 
   Future<List<Game>> browseGames({
     List<int>? genreIds,
@@ -608,163 +142,21 @@ class IgdbApi {
     int limit = 20,
     int offset = 0,
     int minRatingCount = 10,
-  }) async {
-    _ensureCredentials();
-
-    try {
-      final StringBuffer where =
-          StringBuffer('where rating_count > $minRatingCount');
-
-      if (genreIds != null && genreIds.isNotEmpty) {
-        where.write(' & genres = (${genreIds.join(",")})');
-      }
-      if (platformIds != null && platformIds.isNotEmpty) {
-        where.write(' & platforms = (${platformIds.join(",")})');
-      }
-      if (gameModeIds != null && gameModeIds.isNotEmpty) {
-        where.write(' & game_modes = (${gameModeIds.join(",")})');
-      }
-      if (minRating != null) {
-        where.write(' & rating >= $minRating');
-      }
-      if (year != null) {
-        final int start =
-            DateTime(year).millisecondsSinceEpoch ~/ 1000;
-        final int end =
-            DateTime(year + 1).millisecondsSinceEpoch ~/ 1000;
-        where.write(
-          ' & first_release_date >= $start & first_release_date < $end',
-        );
-      } else if (decade != null) {
-        final int start =
-            DateTime(decade.$1).millisecondsSinceEpoch ~/ 1000;
-        final int end =
-            DateTime(decade.$2 + 1).millisecondsSinceEpoch ~/ 1000;
-        where.write(
-          ' & first_release_date >= $start & first_release_date < $end',
-        );
-      }
-
-      final StringBuffer body = StringBuffer(_gameFields);
-      body.write(' $where;');
-      body.write(' sort $sortBy;');
-      body.write(' limit $limit;');
-      if (offset > 0) {
-        body.write(' offset $offset;');
-      }
-
-      final Response<dynamic> response = await _igdbPost(
-        '/games',
-        data: body.toString(),
+  }) =>
+      _games.browseGames(
+        genreIds: genreIds,
+        platformIds: platformIds,
+        gameModeIds: gameModeIds,
+        minRating: minRating,
+        year: year,
+        decade: decade,
+        sortBy: sortBy,
+        limit: limit,
+        offset: offset,
+        minRatingCount: minRatingCount,
       );
 
-      if (response.statusCode != 200 || response.data == null) {
-        throw IgdbApiException(
-          'Failed to browse games',
-          statusCode: response.statusCode,
-        );
-      }
+  Future<List<Map<String, dynamic>>> fetchGenres() => _genres.fetchGenres();
 
-      final List<dynamic> data = response.data as List<dynamic>;
-      return data
-          .map((dynamic item) => Game.fromJson(item as Map<String, dynamic>))
-          .toList();
-    } on DioException catch (e) {
-      throw _handleDioException(e, 'Failed to browse games');
-    }
-  }
-
-  // Maps Dio errors to user-facing messages; 401 = bad/expired token, 429 = rate limit.
-  IgdbApiException _handleDioException(DioException e, String defaultMessage) {
-    final int? statusCode = e.response?.statusCode;
-    String message = defaultMessage;
-
-    if (statusCode == 401) {
-      message = 'Invalid or expired access token';
-    } else if (statusCode == 429) {
-      message = 'Rate limit exceeded. Please try again later';
-    } else if (e.type == DioExceptionType.connectionTimeout ||
-        e.type == DioExceptionType.receiveTimeout) {
-      message = 'Connection timeout';
-    } else if (e.type == DioExceptionType.connectionError) {
-      message = 'No internet connection';
-    }
-
-    return IgdbApiException(
-      message,
-      statusCode: statusCode,
-      detail: buildApiErrorDetail(
-        apiName: 'IGDB',
-        exception: e,
-        userMessage: message,
-      ),
-    );
-  }
-
-  // On 401, refresh the Twitch token once and retry the request.
-  Future<Response<dynamic>> _igdbPost(
-    String endpoint, {
-    required String data,
-  }) async {
-    try {
-      return await _dio.post<dynamic>(
-        '$_igdbBaseUrl$endpoint',
-        options: Options(
-          headers: <String, dynamic>{
-            'Client-ID': _clientId,
-            'Authorization': 'Bearer $_accessToken',
-          },
-        ),
-        data: data,
-      );
-    } on DioException catch (e) {
-      if (e.response?.statusCode == 401 && await _tryRefreshToken()) {
-        return _dio.post<dynamic>(
-          '$_igdbBaseUrl$endpoint',
-          options: Options(
-            headers: <String, dynamic>{
-              'Client-ID': _clientId,
-              'Authorization': 'Bearer $_accessToken',
-            },
-          ),
-          data: data,
-        );
-      }
-      rethrow;
-    }
-  }
-
-  // Guarded by _isRefreshing to avoid concurrent refresh storms on parallel 401s.
-  Future<bool> _tryRefreshToken() async {
-    if (_isRefreshing) return false;
-    if (_clientId == null || _clientSecret == null) return false;
-
-    _isRefreshing = true;
-    try {
-      _log.info('Auto-refreshing IGDB token...');
-      final TwitchAuthResult result = await getAccessToken(
-        clientId: _clientId!,
-        clientSecret: _clientSecret!,
-      );
-      _accessToken = result.accessToken;
-      onTokenRefreshed?.call(result.accessToken, result.expiresAt);
-      _log.info('IGDB token refreshed successfully');
-      return true;
-    } on IgdbApiException catch (e) {
-      _log.warning('IGDB token refresh failed: $e');
-      return false;
-    } finally {
-      _isRefreshing = false;
-    }
-  }
-
-  void _ensureCredentials() {
-    if (_clientId == null || _accessToken == null) {
-      throw const IgdbApiException('API credentials not set');
-    }
-  }
-
-  void dispose() {
-    _dio.close();
-  }
+  void dispose() => _client.dispose();
 }


### PR DESCRIPTION
770-line IgdbApi becomes a facade over four focused sub-APIs (http client
with Twitch OAuth, games, platforms, genres) plus a shared types file.
Public surface — constructor, provider, methods, exceptions, callback,
maxMultiQueryBatch — is preserved 1:1, so 18 call sites and 9 test files
work without changes. Mirrors the earlier AniList split.