### PR TITLE
fix(android): declare url_launcher intents in manifest queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fix external links not opening on Android 11+**
+
+  Buttons and links that should open a browser, mail client or dialer
+  did nothing on Android. Starting with Android 11, apps must declare
+  the intents they want to resolve via `<queries>` in the manifest;
+  the previous manifest only declared `PROCESS_TEXT`, so
+  `url_launcher`'s `canLaunchUrl` / `launchUrl` calls saw zero matching
+  activities for `http` / `https` / `mailto` / `tel` and silently
+  failed. The manifest now declares the standard `VIEW` intents for
+  http and https, `SENDTO` for mailto, and `DIAL` for tel.
+
+  * android/app/src/main/AndroidManifest.xml: Add `VIEW` (http, https),
+    `SENDTO` (mailto), `DIAL` (tel) intents to the `<queries>` block.
+
 ## [0.30.0] - 2026-05-22
 
 ### Fixed

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,5 +46,23 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <category android:name="android.intent.category.BROWSABLE"/>
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SENDTO"/>
+            <data android:scheme="mailto"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.DIAL"/>
+            <data android:scheme="tel"/>
+        </intent>
     </queries>
 </manifest>


### PR DESCRIPTION
Android 11+ package visibility hid http/https/mailto/tel handlers, so launchUrl returned false and external links did nothing. Add the required <queries> entries (with BROWSABLE on http/https) so the system can resolve browsers, mail clients, and the dialer.