### PR TITLE
feat(search): AniList tag storage, display, exports and search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3663,3 +3663,4 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 - Изменён `SettingsNotifier.clearSettings()` — очищает также SteamGridDB API ключ
 - Изменён `settings_screen.dart` — добавлены секции SteamGridDB API и Developer Tools
 - Обновлены тесты `settings_state_test.dart` и `settings_screen_test.dart` для покрытия новых полей
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,137 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Add AniList tag support across storage, display, search filter and exports**
+
+  Anime and manga now carry their AniList tag list (in addition to genres).
+  Tags are pulled from the API into a new `tags` cache column, shown as a
+  secondary chip row in the search-result details sheet and as a
+  comma-separated chip on the collection item detail screen, and exported
+  via a new `{tags}` token in the text-export template plus the `.xcoll` /
+  `.xcollx` payload. Refresh-from-source backfills tags for items that were
+  added before this change. Search gains an "AniList tag" multi-select
+  filter on the Anime and Manga tabs, served by a SQLite-cached catalog
+  (~600 tags) refreshed weekly. The filter opens a dedicated bottom-sheet
+  picker with live name search, category-grouped collapsible sections,
+  toggles for spoiler and 18+ tags, a manual refresh button, and a
+  selected-count footer with Clear all / Cancel / Apply.
+
+  * lib/shared/models/anilist_tag.dart (AniListTag, AniListTag.fromJson,
+    AniListTag.fromDb, AniListTag.toDb): New model with id, name,
+    category, description, isAdult, isGeneralSpoiler.
+  * lib/shared/models/anime.dart (Anime.tags, Anime.tagsString,
+    Anime.fromJson, Anime.fromDb, Anime.toDb, Anime.copyWith),
+    lib/shared/models/manga.dart (Manga.tags, Manga.tagsString,
+    Manga.fromJson, Manga.fromDb, Manga.toDb, Manga.copyWith): Add a
+    nullable `List<String>` tags field; parse `tags { name }` from
+    GraphQL; JSON-encode in the new SQLite column.
+  * lib/core/database/schema.dart (DatabaseSchema.createAniListTagsTable,
+    DatabaseSchema.createMangaCacheTable,
+    DatabaseSchema.createAnimeCacheTable, DatabaseSchema.createAll):
+    Declare the catalog table and the new `tags` column for fresh
+    installs; register the catalog table in `createAll`.
+  * lib/core/database/migrations/migration_v41.dart (MigrationV41): New —
+    `ALTER TABLE anime_cache / manga_cache ADD COLUMN tags TEXT`.
+  * lib/core/database/migrations/migration_v42.dart (MigrationV42): New —
+    creates the `anilist_tags` catalog table via
+    `DatabaseSchema.createAniListTagsTable`.
+  * lib/core/database/migrations/migration_registry.dart
+    (MigrationRegistry.all): Register MigrationV41 and MigrationV42.
+  * lib/core/database/database_service.dart (DatabaseService.aniListTagDao,
+    aniListTagDaoProvider, OpenDatabaseOptions.version): Expose the new
+    DAO and bump the schema version to 42.
+  * lib/core/database/dao/anilist_tag_dao.dart (AniListTagDao,
+    AniListTagDao.getAll, AniListTagDao.lastUpdatedAt,
+    AniListTagDao.replaceAll): New DAO; `replaceAll` is transactional
+    truncate + batch insert so a partial refresh can't leave a
+    half-updated catalog.
+  * lib/data/repositories/anilist_tags_repository.dart
+    (AniListTagsRepository, AniListTagsRepository.getTags,
+    aniListTagsRepositoryProvider, aniListTagsProvider): New cache
+    layer. A non-empty cache is sticky — refresh only happens via the
+    picker's Refresh button (forceRefresh) or when the cache is empty.
+    On API failure, falls back to the cached set; on empty cache,
+    rethrows.
+  * lib/core/api/anilist/anilist_queries.dart
+    (AniListQueries.tagCollection, AniListQueries.mangaSearch,
+    AniListQueries.animeSearch, AniListQueries.mangaGetById,
+    AniListQueries.mangaGetByIds, AniListQueries.animeGetById,
+    AniListQueries.animeGetByIds, AniListQueries.animeGetByMalIds,
+    AniListQueries.mangaGetByMalIds, AniListQueries.userAnimeList,
+    AniListQueries.userMangaList): Add `tags { name }` to every media
+    query; add `$tags: [String]` + `tag_in: $tags` on search queries;
+    add the standalone `MediaTagCollection` query.
+  * lib/core/api/anilist/anilist_media_api.dart
+    (AniListMediaApi.browseAnime, AniListMediaApi.browseManga,
+    AniListMediaApi.fetchTagCollection),
+    lib/core/api/anilist_api.dart (AniListApi.browseAnime,
+    AniListApi.browseManga, AniListApi.fetchTagCollection): Accept
+    `List<String>? tags`; new top-level `fetchTagCollection` method.
+  * lib/features/search/models/search_source.dart
+    (SearchFilter.openCustomPicker): New optional hook — when present,
+    the filter chevron opens this picker instead of the default
+    dropdown / SearchableFilterDialog.
+  * lib/features/search/widgets/filter_bar.dart
+    (_FilterDropdownChevronState.build),
+    lib/features/search/widgets/filter_sheet.dart
+    (_FilterRowState._openDialog, _FilterRowState.build, _SortTile.build):
+    Honour the custom picker hook (both the chevron bar and the
+    narrow-screen sheet). Filter / sort rows now wrap their ListTile in
+    a transparent Material so ink ripples render over the sheet's
+    DecoratedBox surface.
+  * lib/features/search/filters/anilist_tag_filter.dart
+    (AniListTagFilter, AniListTagFilter.options,
+    AniListTagFilter.openCustomPicker): New SearchFilter; loads options
+    lazily via aniListTagsProvider and points the filter bar at the
+    custom picker.
+  * lib/features/search/widgets/anilist_tag_picker.dart
+    (showAniListTagPicker, _AniListTagPicker,
+    _AniListTagPickerState._refresh, _AniListTagPickerState._buildList,
+    _AniListTagPickerState._groupAndFilter): New bottom-sheet picker
+    with grouped collapsible categories, live search, spoiler / adult
+    toggles, manual refresh, and Apply / Cancel.
+  * lib/features/search/sources/anilist_anime_source.dart
+    (AniListAnimeSource.filters, AniListAnimeSource.fetch),
+    lib/features/search/sources/anilist_manga_source.dart
+    (AniListMangaSource.filters, AniListMangaSource.fetch): Add
+    AniListTagFilter; thread `filterValues['tag']` into the API call.
+  * lib/features/search/widgets/item_details_sheet.dart
+    (ItemDetailsSheet, ItemDetailsSheet.anime, ItemDetailsSheet.manga,
+    ItemDetailsSheet._buildTagChip): Render an outlined-chip row of
+    tags under the genre row for anime / manga results.
+  * lib/features/collections/widgets/item_detail/item_detail_media_config.dart
+    (buildMediaTypeChips): Add a `local_offer_outlined` chip with the
+    first eight tags on anime / manga detail screens.
+  * lib/core/services/text_export_service.dart
+    (TextExportService.availableTokens, TextExportService.formatItem,
+    TextExportService._animeMangaTags): New `{tags}` template token
+    backed by `Anime.tagsString` / `Manga.tagsString`.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (browseFilterTag,
+    tagPickerTitle, tagPickerSearchHint, tagPickerShowSpoilers,
+    tagPickerShowAdult, tagPickerRefresh, tagPickerEmpty,
+    tagPickerSelectedCount, clearAll): New strings for the filter
+    label, picker chrome, and selected-count footer.
+  * test/shared/models/anilist_tag_test.dart,
+    test/core/database/dao/anilist_tag_dao_test.dart,
+    test/data/repositories/anilist_tags_repository_test.dart: New unit
+    suites for the model, DAO truncate-and-insert semantics, and the
+    repository sticky-cache / forceRefresh / fallback / rethrow paths.
+  * test/shared/models/anime_test.dart, test/shared/models/manga_test.dart
+    (group 'tags'): New round-trip suites — fromJson parses `tags { name }`,
+    null / empty handling, toDb / fromDb round-trip, copyWith semantics,
+    tagsString getter.
+  * test/core/services/text_export_service_test.dart: New cases for the
+    `{tags}` token (anime, manga, non anime/manga short-circuit, null
+    tags removed); `availableTokens` assertion extended.
+  * test/features/search/widgets/anilist_tag_picker_test.dart: New
+    widget test — renders without exceptions, spoiler / 18+ toggles
+    reveal hidden tags, search narrows the list, Apply returns the
+    selection, Cancel returns null, initial selection is preserved,
+    Clear all wipes the selection.
+  * test/helpers/mocks.dart (MockAniListTagDao): New mock.
+  * test/features/search/sources/anilist_manga_source_test.dart: Reflect
+    the new filter slot and order.
+
 - **Add anime & manga title-language setting with override-aware rename**
 
   Settings → Appearance gains a new "Anime & manga title language"

--- a/lib/core/api/anilist/anilist_media_api.dart
+++ b/lib/core/api/anilist/anilist_media_api.dart
@@ -1,3 +1,4 @@
+import '../../../shared/models/anilist_tag.dart';
 import '../../../shared/models/anime.dart';
 import '../../../shared/models/manga.dart';
 import 'anilist_graphql_client.dart';
@@ -24,6 +25,7 @@ class AniListMediaApi {
   Future<(List<Manga>, bool hasMore, int totalPages)> browseManga({
     String? query,
     List<String>? genres,
+    List<String>? tags,
     String? format,
     String? status,
     int? startYear,
@@ -40,6 +42,9 @@ class AniListMediaApi {
     if (genres != null && genres.isNotEmpty) {
       variables['genres'] = genres;
     }
+    if (tags != null && tags.isNotEmpty) {
+      variables['tags'] = tags;
+    }
     if (format != null) variables['format'] = format;
     if (status != null) variables['status'] = status;
     _addFuzzyDateRange(variables, startYear, endYear);
@@ -55,6 +60,7 @@ class AniListMediaApi {
   Future<(List<Anime>, bool hasMore, int totalPages)> browseAnime({
     String? query,
     List<String>? genres,
+    List<String>? tags,
     String? status,
     String? format,
     int? startYear,
@@ -70,6 +76,9 @@ class AniListMediaApi {
     }
     if (genres != null && genres.isNotEmpty) {
       variables['genres'] = genres;
+    }
+    if (tags != null && tags.isNotEmpty) {
+      variables['tags'] = tags;
     }
     if (status != null) variables['status'] = status;
     if (format != null) variables['format'] = format;
@@ -155,6 +164,22 @@ class AniListMediaApi {
     final (List<Anime> items, _, _) =
         AniListMediaParser.animePage(_client.unwrapData(body));
     return items;
+  }
+
+  /// Fetches the full tag catalog (~600 entries). Used to build the tag
+  /// filter picker; cache the result in [AniListTagDao].
+  Future<List<AniListTag>> fetchTagCollection() async {
+    final Map<String, dynamic> body = await _client.post(
+      query: AniListQueries.tagCollection,
+      variables: const <String, dynamic>{},
+      errorContext: 'Failed to fetch AniList tag collection',
+    );
+    final Map<String, dynamic>? data = _client.unwrapData(body);
+    final List<dynamic>? list = data?['MediaTagCollection'] as List<dynamic>?;
+    if (list == null) return const <AniListTag>[];
+    return list
+        .map((dynamic e) => AniListTag.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 
   static Map<String, dynamic> _browseVariables({

--- a/lib/core/api/anilist/anilist_queries.dart
+++ b/lib/core/api/anilist/anilist_queries.dart
@@ -13,8 +13,22 @@ Iterable<List<int>> aniListBatches(List<int> ids) sync* {
 class AniListQueries {
   const AniListQueries._();
 
+  static const String tagCollection = '''
+query {
+  MediaTagCollection {
+    id
+    name
+    category
+    description
+    isAdult
+    isGeneralSpoiler
+  }
+}
+''';
+
   static const String mangaSearch = r'''
 query ($page: Int, $perPage: Int, $search: String, $genres: [String],
+       $tags: [String],
        $format: MediaFormat, $status: MediaStatus,
        $startDateGreater: FuzzyDateInt, $startDateLesser: FuzzyDateInt,
        $sort: [MediaSort]) {
@@ -26,6 +40,7 @@ query ($page: Int, $perPage: Int, $search: String, $genres: [String],
       hasNextPage
     }
     media(type: MANGA, search: $search, genre_in: $genres,
+          tag_in: $tags,
           format: $format, status: $status,
           startDate_greater: $startDateGreater,
           startDate_lesser: $startDateLesser,
@@ -36,6 +51,7 @@ query ($page: Int, $perPage: Int, $search: String, $genres: [String],
       bannerImage
       description(asHtml: false)
       genres
+      tags { name }
       averageScore
       status
       startDate { year month day }
@@ -61,6 +77,7 @@ query ($id: Int) {
     coverImage { extraLarge large medium }
     description(asHtml: false)
     genres
+    tags { name }
     averageScore
     status
     startDate { year month day }
@@ -87,6 +104,7 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
       bannerImage
       description(asHtml: false)
       genres
+      tags { name }
       averageScore
       status
       startDate { year month day }
@@ -106,6 +124,7 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
 
   static const String animeSearch = r'''
 query ($page: Int, $perPage: Int, $search: String, $genres: [String],
+       $tags: [String],
        $status: MediaStatus, $format: MediaFormat,
        $startDateGreater: FuzzyDateInt, $startDateLesser: FuzzyDateInt,
        $sort: [MediaSort]) {
@@ -117,6 +136,7 @@ query ($page: Int, $perPage: Int, $search: String, $genres: [String],
       hasNextPage
     }
     media(type: ANIME, search: $search, genre_in: $genres,
+          tag_in: $tags,
           status: $status, format: $format,
           startDate_greater: $startDateGreater,
           startDate_lesser: $startDateLesser,
@@ -127,6 +147,7 @@ query ($page: Int, $perPage: Int, $search: String, $genres: [String],
       bannerImage
       description(asHtml: false)
       genres
+      tags { name }
       averageScore
       status
       startDate { year month day }
@@ -150,6 +171,7 @@ query ($id: Int) {
     bannerImage
     description(asHtml: false)
     genres
+    tags { name }
     averageScore
     status
     startDate { year month day }
@@ -174,6 +196,7 @@ query ($page: Int, $perPage: Int, $malIds: [Int]) {
       bannerImage
       description(asHtml: false)
       genres
+      tags { name }
       averageScore
       status
       startDate { year month day }
@@ -199,6 +222,7 @@ query ($page: Int, $perPage: Int, $malIds: [Int]) {
       bannerImage
       description(asHtml: false)
       genres
+      tags { name }
       averageScore
       status
       startDate { year month day }
@@ -226,6 +250,7 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
       bannerImage
       description(asHtml: false)
       genres
+      tags { name }
       averageScore
       status
       startDate { year month day }
@@ -265,6 +290,7 @@ query ($userName: String) {
           bannerImage
           description(asHtml: false)
           genres
+      tags { name }
           averageScore
           status
           startDate { year month day }
@@ -304,6 +330,7 @@ query ($userName: String) {
           bannerImage
           description(asHtml: false)
           genres
+      tags { name }
           averageScore
           status
           startDate { year month day }

--- a/lib/core/api/anilist_api.dart
+++ b/lib/core/api/anilist_api.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../shared/models/anilist_tag.dart';
 import '../../shared/models/anime.dart';
 import '../../shared/models/manga.dart';
 import '../../shared/models/media_type.dart';
@@ -44,6 +45,7 @@ class AniListApi {
   Future<(List<Manga>, bool hasMore, int totalPages)> browseManga({
     String? query,
     List<String>? genres,
+    List<String>? tags,
     String? format,
     String? status,
     int? startYear,
@@ -55,6 +57,7 @@ class AniListApi {
       _media.browseManga(
         query: query,
         genres: genres,
+        tags: tags,
         format: format,
         status: status,
         startYear: startYear,
@@ -67,6 +70,7 @@ class AniListApi {
   Future<(List<Anime>, bool hasMore, int totalPages)> browseAnime({
     String? query,
     List<String>? genres,
+    List<String>? tags,
     String? status,
     String? format,
     int? startYear,
@@ -78,6 +82,7 @@ class AniListApi {
       _media.browseAnime(
         query: query,
         genres: genres,
+        tags: tags,
         status: status,
         format: format,
         startYear: startYear,
@@ -86,6 +91,8 @@ class AniListApi {
         page: page,
         perPage: perPage,
       );
+
+  Future<List<AniListTag>> fetchTagCollection() => _media.fetchTagCollection();
 
   Future<Manga?> getMangaById(int id) => _media.getMangaById(id);
 

--- a/lib/core/database/dao/anilist_tag_dao.dart
+++ b/lib/core/database/dao/anilist_tag_dao.dart
@@ -1,0 +1,32 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../../../shared/models/anilist_tag.dart';
+
+/// DAO for the `anilist_tags` catalog table.
+class AniListTagDao {
+  const AniListTagDao(this._getDatabase);
+
+  final Future<Database> Function() _getDatabase;
+
+  Future<List<AniListTag>> getAll() async {
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> rows = await db.query(
+      'anilist_tags',
+      orderBy: 'category ASC, name ASC',
+    );
+    return rows.map(AniListTag.fromDb).toList();
+  }
+
+  /// Atomically replaces the catalog — truncate + bulk insert in one tx.
+  Future<void> replaceAll(List<AniListTag> tags) async {
+    final Database db = await _getDatabase();
+    await db.transaction((Transaction txn) async {
+      await txn.delete('anilist_tags');
+      final Batch batch = txn.batch();
+      for (final AniListTag tag in tags) {
+        batch.insert('anilist_tags', tag.toDb());
+      }
+      await batch.commit(noResult: true);
+    });
+  }
+}

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -26,6 +26,7 @@ import '../../shared/models/manga.dart';
 import '../../shared/models/visual_novel.dart';
 import '../../shared/models/wishlist_item.dart';
 import '../../shared/models/wishlist_tag.dart';
+import 'dao/anilist_tag_dao.dart';
 import 'dao/canvas_dao.dart';
 import 'dao/collection_dao.dart';
 import 'dao/custom_media_dao.dart';
@@ -113,6 +114,11 @@ final Provider<TagDao> tagDaoProvider = Provider<TagDao>((Ref ref) {
   return ref.watch(databaseServiceProvider).tagDao;
 });
 
+final Provider<AniListTagDao> aniListTagDaoProvider =
+    Provider<AniListTagDao>((Ref ref) {
+  return ref.watch(databaseServiceProvider).aniListTagDao;
+});
+
 class DatabaseService {
   static final Logger _log = Logger('DatabaseService');
 
@@ -170,6 +176,8 @@ class DatabaseService {
 
   late final TagDao tagDao = TagDao(() => database);
 
+  late final AniListTagDao aniListTagDao = AniListTagDao(() => database);
+
   late final WishlistDao wishlistDao = WishlistDao(() => database);
 
   Future<Database> _initDatabase() async {
@@ -211,7 +219,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 40,
+        version: 42,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -38,6 +38,8 @@ import 'migration_v37.dart';
 import 'migration_v38.dart';
 import 'migration_v39.dart';
 import 'migration_v40.dart';
+import 'migration_v41.dart';
+import 'migration_v42.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
@@ -80,6 +82,8 @@ abstract final class MigrationRegistry {
     MigrationV38(),
     MigrationV39(),
     MigrationV40(),
+    MigrationV41(),
+    MigrationV42(),
   ];
 
   static List<Migration> pending(int oldVersion) {

--- a/lib/core/database/migrations/migration_v41.dart
+++ b/lib/core/database/migrations/migration_v41.dart
@@ -1,0 +1,17 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+class MigrationV41 extends Migration {
+  @override
+  int get version => 41;
+
+  @override
+  String get description => 'Add tags column to anime_cache and manga_cache';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await db.execute('ALTER TABLE anime_cache ADD COLUMN tags TEXT');
+    await db.execute('ALTER TABLE manga_cache ADD COLUMN tags TEXT');
+  }
+}

--- a/lib/core/database/migrations/migration_v42.dart
+++ b/lib/core/database/migrations/migration_v42.dart
@@ -1,0 +1,17 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../schema.dart';
+import 'migration.dart';
+
+class MigrationV42 extends Migration {
+  @override
+  int get version => 42;
+
+  @override
+  String get description => 'Add anilist_tags catalog table';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await DatabaseSchema.createAniListTagsTable(db);
+  }
+}

--- a/lib/core/database/schema.dart
+++ b/lib/core/database/schema.dart
@@ -32,6 +32,7 @@ abstract final class DatabaseSchema {
     await createAnimeCacheTable(db);
     await createMoodGridsTable(db);
     await createMoodGridCellsTable(db);
+    await createAniListTagsTable(db);
   }
 
   static Future<void> createPlatformsTable(Database db) async {
@@ -409,6 +410,7 @@ abstract final class DatabaseSchema {
         format TEXT,
         country_of_origin TEXT,
         genres TEXT,
+        tags TEXT,
         authors TEXT,
         external_url TEXT,
         banner_url TEXT,
@@ -442,12 +444,31 @@ abstract final class DatabaseSchema {
         format TEXT,
         source TEXT,
         genres TEXT,
+        tags TEXT,
         studios TEXT,
         next_airing_episode INTEGER,
         next_airing_at INTEGER,
         external_url TEXT,
         updated_at INTEGER NOT NULL
       )
+    ''');
+  }
+
+  static Future<void> createAniListTagsTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS anilist_tags (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        category TEXT,
+        description TEXT,
+        is_adult INTEGER NOT NULL DEFAULT 0,
+        is_general_spoiler INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE INDEX IF NOT EXISTS idx_anilist_tags_category
+      ON anilist_tags(category)
     ''');
   }
 

--- a/lib/core/services/text_export_service.dart
+++ b/lib/core/services/text_export_service.dart
@@ -1,19 +1,16 @@
-// Сервис шаблонного экспорта коллекции в текст.
-
 import '../../shared/models/collection_item.dart';
 import '../../shared/models/item_status.dart';
 import '../../shared/models/media_type.dart';
 
-/// Сервис для экспорта коллекции в текстовый формат по шаблону.
+/// Template-based text exporter for a collection.
 ///
-/// Поддерживает токены `{name}`, `{year}`, `{rating}`, `{myRating}`,
-/// `{platform}`, `{status}`, `{genres}`, `{notes}`, `{type}`, `{#}`.
-/// Пустые токены и окружающие их разделители автоматически удаляются.
+/// Supports `{name}`, `{year}`, `{rating}`, `{myRating}`, `{platform}`,
+/// `{status}`, `{genres}`, `{tags}`, `{notes}`, `{type}`, `{#}`. Empty tokens
+/// and the surrounding separators are stripped automatically — see
+/// [_removeTokenWithContext].
 class TextExportService {
-  /// Дефолтный шаблон (Quick Copy).
   static const String defaultTemplate = '{name} ({year})';
 
-  /// Доступные токены для UI.
   static const List<String> availableTokens = <String>[
     'name',
     'year',
@@ -22,12 +19,12 @@ class TextExportService {
     'platform',
     'status',
     'genres',
+    'tags',
     'notes',
     'type',
     '#',
   ];
 
-  /// Применяет шаблон ко всем элементам и возвращает текст.
   String applyTemplate(
     String template,
     List<CollectionItem> items, {
@@ -46,17 +43,13 @@ class TextExportService {
     return buffer.toString();
   }
 
-  /// Форматирует один элемент по шаблону.
   String formatItem(
     String template,
     CollectionItem item,
     int index, {
     String animeMangaTitleLanguage = 'romaji',
   }) {
-    // Подставляем значения токенов
     String line = template;
-
-    // Собираем значения для каждого токена
     final Map<String, String?> values = <String, String?>{
       'name': item.displayName(animeMangaTitleLanguage),
       'year': item.releaseYear?.toString(),
@@ -65,12 +58,12 @@ class TextExportService {
       'platform': _platformOrNull(item),
       'status': _statusLabel(item.status),
       'genres': item.genresString,
+      'tags': _animeMangaTags(item),
       'notes': item.userComment,
       'type': _mediaTypeLabel(item.mediaType),
       '#': index.toString(),
     };
 
-    // Заменяем токены с значениями
     for (final MapEntry<String, String?> entry in values.entries) {
       final String token = '{${entry.key}}';
       if (!line.contains(token)) continue;
@@ -78,7 +71,6 @@ class TextExportService {
       if (entry.value != null && entry.value!.isNotEmpty) {
         line = line.replaceAll(token, entry.value!);
       } else {
-        // Токен пустой — удаляем токен + окружающие разделители
         line = _removeTokenWithContext(line, token);
       }
     }
@@ -86,15 +78,10 @@ class TextExportService {
     return line.trim();
   }
 
-  /// Удаляет токен и лишние разделители/скобки вокруг.
-  ///
-  /// Примеры:
-  /// - `"{name} ({year})"` при пустом year → `"{name}"`
-  /// - `"{name} — {rating}"` при пустом rating → `"{name}"`
-  /// - `"{name}, {genres}"` при пустом genres → `"{name}"`
+  /// Strip an empty token together with the surrounding separator / bracket
+  /// so a template like `"{name} ({year})"` collapses to `"{name}"` when
+  /// year is missing instead of leaving an orphaned `"()"`.
   String _removeTokenWithContext(String line, String token) {
-    // Паттерн: разделитель + токен (или токен + разделитель)
-    // Разделители: " — ", " - ", " · ", ", ", " | ", пробел
     final List<String> delimiters = <String>[
       ' — ',
       ' - ',
@@ -104,7 +91,7 @@ class TextExportService {
       ' | ',
     ];
 
-    // Попробуем удалить "разделитель + токен"
+    // Try removing "<separator><token>" or "<token><separator>" first.
     for (final String delim in delimiters) {
       if (line.contains('$delim$token')) {
         return line.replaceAll('$delim$token', '');
@@ -114,26 +101,22 @@ class TextExportService {
       }
     }
 
-    // Скобки: "(...token...)" → ""
     final String escaped = RegExp.escape(token);
     final RegExp parenPattern = RegExp(r'\s*\(' + escaped + r'\)');
     if (parenPattern.hasMatch(line)) {
       return line.replaceAll(parenPattern, '');
     }
 
-    // Квадратные скобки: "[...token...]" → ""
     final RegExp bracketPattern = RegExp(r'\s*\[' + escaped + r'\]');
     if (bracketPattern.hasMatch(line)) {
       return line.replaceAll(bracketPattern, '');
     }
 
-    // Просто удаляем токен
     return line.replaceAll(token, '');
   }
 
   String? _formatApiRating(double? rating) {
     if (rating == null) return null;
-    // Если дробная часть = 0, показываем целое число
     if (rating == rating.roundToDouble()) {
       return rating.toInt().toString();
     }
@@ -180,22 +163,22 @@ class TextExportService {
         return 'Custom';
     }
   }
+
+  String? _animeMangaTags(CollectionItem item) {
+    return switch (item.mediaType) {
+      MediaType.anime => item.anime?.tagsString,
+      MediaType.manga => item.manga?.tagsString,
+      _ => null,
+    };
+  }
 }
 
-/// Режим сортировки для текстового экспорта.
+/// Sort mode for the text exporter.
 enum TextExportSortMode {
-  /// Текущий порядок из коллекции.
+  /// Source order from the collection.
   current,
-
-  /// По названию A→Z.
   name,
-
-  /// По рейтингу (высокий → низкий).
   rating,
-
-  /// По году (новые → старые).
   year,
-
-  /// По дате добавления (новые → старые).
   addedDate,
 }

--- a/lib/data/repositories/anilist_tags_repository.dart
+++ b/lib/data/repositories/anilist_tags_repository.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/api/anilist_api.dart';
+import '../../core/database/dao/anilist_tag_dao.dart';
+import '../../core/database/database_service.dart';
+import '../../shared/models/anilist_tag.dart';
+
+/// Loads the AniList tag catalog with a SQLite-backed cache.
+///
+/// Cache is sticky: a non-empty cache is always returned without hitting the
+/// API. A manual Refresh in the picker calls this with `forceRefresh: true`
+/// — that's the only path that bypasses the cache.
+class AniListTagsRepository {
+  AniListTagsRepository({
+    required AniListApi api,
+    required AniListTagDao dao,
+  })  : _api = api,
+        _dao = dao;
+
+  final AniListApi _api;
+  final AniListTagDao _dao;
+
+  Future<List<AniListTag>> getTags({bool forceRefresh = false}) async {
+    if (!forceRefresh) {
+      final List<AniListTag> cached = await _dao.getAll();
+      if (cached.isNotEmpty) return cached;
+    }
+    try {
+      final List<AniListTag> fresh = await _api.fetchTagCollection();
+      if (fresh.isNotEmpty) {
+        await _dao.replaceAll(fresh);
+        return fresh;
+      }
+    } on Object {
+      final List<AniListTag> cached = await _dao.getAll();
+      if (cached.isNotEmpty) return cached;
+      rethrow;
+    }
+    return _dao.getAll();
+  }
+}
+
+final Provider<AniListTagsRepository> aniListTagsRepositoryProvider =
+    Provider<AniListTagsRepository>((Ref ref) {
+  return AniListTagsRepository(
+    api: ref.watch(aniListApiProvider),
+    dao: ref.watch(aniListTagDaoProvider),
+  );
+});
+
+/// Cached list of AniList tags. Triggers an API fetch on first watch if the
+/// SQLite cache is stale or empty.
+final FutureProvider<List<AniListTag>> aniListTagsProvider =
+    FutureProvider<List<AniListTag>>((Ref ref) async {
+  return ref.watch(aniListTagsRepositoryProvider).getTags();
+});

--- a/lib/features/collections/widgets/item_detail/item_detail_media_config.dart
+++ b/lib/features/collections/widgets/item_detail/item_detail_media_config.dart
@@ -215,6 +215,18 @@ List<MediaDetailChip> _buildChips(CollectionItem item, BuildContext context) {
       text: item.genresString!,
     ));
   }
+  const int maxDisplayedTags = 8;
+  final String? animeMangaTagsString = switch (item.mediaType) {
+    MediaType.anime => item.anime?.tags?.take(maxDisplayedTags).join(', '),
+    MediaType.manga => item.manga?.tags?.take(maxDisplayedTags).join(', '),
+    _ => null,
+  };
+  if (animeMangaTagsString != null && animeMangaTagsString.isNotEmpty) {
+    chips.add(MediaDetailChip(
+      icon: Icons.local_offer_outlined,
+      text: animeMangaTagsString,
+    ));
+  }
   return chips;
 }
 

--- a/lib/features/search/filters/anilist_tag_filter.dart
+++ b/lib/features/search/filters/anilist_tag_filter.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' show WidgetRef;
+
+import '../../../data/repositories/anilist_tags_repository.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/anilist_tag.dart';
+import '../models/search_source.dart';
+import '../widgets/anilist_tag_picker.dart';
+
+/// Multi-select AniList tag filter (~600 entries, served from a SQLite-backed
+/// catalog cache; refreshed weekly).
+///
+/// [forAnime] is used purely for cache-key separation in the filter bar so
+/// anime / manga can keep independent selections.
+class AniListTagFilter extends SearchFilter {
+  AniListTagFilter({this.forAnime = false});
+
+  final bool forAnime;
+
+  @override
+  String get key => 'tag';
+
+  @override
+  String get cacheKey =>
+      forAnime ? '${key}_anilist_anime' : '${key}_anilist_manga';
+
+  @override
+  bool get multiSelect => true;
+
+  @override
+  bool get searchable => true;
+
+  @override
+  String placeholder(S l) => l.browseFilterTag;
+
+  @override
+  FilterOption get allOption => const FilterOption(
+        id: 'any',
+        label: 'All',
+        value: null,
+      );
+
+  @override
+  Future<List<FilterOption>> options(WidgetRef ref, S l) async {
+    final List<AniListTag> tags =
+        await ref.read(aniListTagsProvider.future);
+    return tags
+        .map((AniListTag t) => FilterOption(
+              id: t.id.toString(),
+              label: t.name,
+              value: t.name,
+            ))
+        .toList();
+  }
+
+  @override
+  Future<Object?> Function(BuildContext, WidgetRef, S, Object?)?
+      get openCustomPicker => showAniListTagPicker;
+}

--- a/lib/features/search/models/search_source.dart
+++ b/lib/features/search/models/search_source.dart
@@ -1,17 +1,14 @@
-// Абстракции для поисковых источников данных.
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/media_type.dart';
 
-/// ID жанра Animation в TMDB. Используется для фильтрации анимации.
+/// TMDB's Animation genre id, used to keep animation out of generic
+/// TV / movie searches.
 const int tmdbAnimationGenreId = 16;
 
-/// Вариант фильтра.
 class FilterOption {
-  /// Создаёт [FilterOption].
   const FilterOption({
     required this.id,
     required this.label,
@@ -19,16 +16,11 @@ class FilterOption {
     this.value,
   });
 
-  /// Уникальный идентификатор варианта.
   final String id;
-
-  /// Отображаемое название.
   final String label;
-
-  /// Иконка (опционально).
   final IconData? icon;
 
-  /// Значение для передачи в API.
+  /// Raw value passed to the API for this option.
   final Object? value;
 
   @override
@@ -45,21 +37,16 @@ class FilterOption {
   String toString() => 'FilterOption($id, $label)';
 }
 
-/// Вариант сортировки для Browse mode.
+/// Sort option for Browse mode — `id` doubles as the l10n key.
 class BrowseSortOption {
-  /// Создаёт [BrowseSortOption].
   const BrowseSortOption({
     required this.id,
     required this.apiValue,
   });
 
-  /// Уникальный идентификатор (используется как ключ локализации).
   final String id;
-
-  /// Значение для API запроса.
   final String apiValue;
 
-  /// Локализованное название сортировки.
   String label(S l) => switch (id) {
         'popular' || 'popularity' => l.browseSortPopular,
         'top_rated' || 'rating' || 'score' => l.browseSortTopRated,
@@ -80,45 +67,39 @@ class BrowseSortOption {
   int get hashCode => id.hashCode;
 }
 
-/// Описание одного фильтра.
-///
-/// Каждый фильтр объявляет свой ключ, placeholder и список вариантов.
+/// One filter exposed by a [SearchSource].
 abstract class SearchFilter {
-  /// Уникальный ключ фильтра ("genre", "year", "platform").
+  /// Identifier of the filter ("genre", "year", "platform").
   String get key;
 
-  /// Отображаемое имя когда ничего не выбрано.
+  /// Label shown when no value is selected.
   String placeholder(S l);
 
-  /// Список вариантов (загружается асинхронно).
-  ///
-  /// [l] — объект локализации для переведённых названий опций.
   Future<List<FilterOption>> options(WidgetRef ref, S l);
 
-  /// Ключ для кэширования/сравнения (по умолчанию = [key]).
-  ///
-  /// Переопределяйте, если несколько фильтров имеют одинаковый [key],
-  /// но разные наборы опций (например, жанры Movie vs TV vs IGDB).
+  /// Separate from [key] when several filters share the same key but expose
+  /// different option sets (e.g. genres for Movie vs TV vs IGDB).
   String get cacheKey => key;
 
-  /// Показывать ли поле поиска внутри выпадающего списка.
-  ///
-  /// Включать для фильтров с большим количеством вариантов
-  /// (жанры IGDB, платформы и т.д.).
+  /// True for filters with many options — turns on the in-dropdown search.
   bool get searchable => false;
 
-  /// Поддерживает ли фильтр множественный выбор.
-  ///
-  /// При `true` значение фильтра — `List<Object>` вместо одиночного значения.
+  /// When `true`, the stored value is a `List<Object>`.
   bool get multiSelect => false;
 
-  /// Значение "все" (сброс фильтра).
+  /// "All" (reset) option.
   FilterOption get allOption;
+
+  /// Optional bespoke picker that replaces the default dropdown / searchable
+  /// dialog. Return the new value (or `null` to clear), or leave [Future]
+  /// resolved to a sentinel that the caller ignores. Override only when the
+  /// default UI is insufficient (e.g. needs grouped categories).
+  Future<Object?> Function(BuildContext, WidgetRef, S, Object?)?
+      get openCustomPicker => null;
 }
 
-/// Результат Browse-запроса (Discover с фильтрами).
+/// Result of a Browse / Discover request (a filtered page of media).
 class BrowseResult {
-  /// Создаёт [BrowseResult].
   const BrowseResult({
     required this.items,
     required this.mediaType,
@@ -127,64 +108,41 @@ class BrowseResult {
     this.currentPage = 1,
   });
 
-  /// Список элементов (Game, Movie, TvShow).
   final List<Object> items;
-
-  /// Тип медиа для отображения.
   final MediaType mediaType;
-
-  /// Есть ли ещё страницы.
   final bool hasMore;
-
-  /// Общее количество страниц.
   final int totalPages;
-
-  /// Текущая страница.
   final int currentPage;
 }
 
-/// Описание источника данных для поиска.
-///
-/// Каждый источник объявляет свои фильтры, API-методы
-/// и UI-конфигурацию. Добавление нового источника —
-/// создать реализацию и зарегистрировать в списке.
+/// One data source for the search screen. Each source declares its filter
+/// set, fetch implementation, and UI metadata.
 abstract class SearchSource {
-  /// Уникальный идентификатор.
   String get id;
 
-  /// ID группы источников ('tmdb', 'igdb', 'anilist', 'vndb').
-  ///
-  /// Используется для визуальной группировки в popup выбора источника.
-  /// Источники с одинаковым [groupId] отображаются в одной секции.
+  /// Logical group ('tmdb', 'igdb', 'anilist', 'vndb') used to cluster
+  /// sources in the picker popup.
   String get groupId;
 
-  /// Название группы для отображения ('TMDB', 'IGDB', 'AniList', 'VNDB').
   String get groupName;
-
-  /// Иконка группы для заголовка секции в popup.
   IconData get groupIcon;
 
-  /// Отображаемое имя (локализованное).
+  /// Localised label.
   String label(S l);
 
-  /// Иконка для дропдауна.
   IconData get icon;
 
-  /// Путь к брендовому PNG-ассету (альтернатива [icon] и [groupIcon]).
-  /// Если задан — рендерится вместо Material-иконки.
+  /// Brand PNG asset; rendered instead of [icon] when present.
   String? get iconAsset => null;
 
-  /// Список фильтров, которые поддерживает этот источник.
-  /// Порядок = порядок отображения в фильтр-баре.
+  /// Filters in display order along the filter bar.
   List<SearchFilter> get filters;
 
-  /// Есть ли Browse mode (Discover без поискового запроса).
+  /// Whether the source supports filter-only browse without a text query.
   bool get supportsBrowse;
 
-  /// Загрузить контент: поиск (если [query] задан) или Browse с фильтрами.
-  ///
-  /// Объединяет browse и search в единый метод.
-  /// Каждый source решает как комбинировать [query] с [filterValues].
+  /// Single entry point for both search (when [query] is non-empty) and
+  /// browse (when it isn't). Each source decides how it combines them.
   Future<BrowseResult> fetch(
     Ref ref, {
     String? query,
@@ -193,27 +151,21 @@ abstract class SearchSource {
     required int page,
   });
 
-  /// Виджет Discover feed для режима без фильтров (null = нет Discover).
+  /// Discover feed widget for the no-filters mode. Return null to opt out.
   Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref);
 
-  /// Доступные варианты сортировки.
   List<BrowseSortOption> get sortOptions;
 
-  /// Сортировка по умолчанию.
   BrowseSortOption get defaultSort => sortOptions.first;
 
-  /// Поддерживается ли пользовательская сортировка при текстовом поиске.
-  ///
-  /// Некоторые API (TMDB) не позволяют сортировать результаты поиска.
-  /// По умолчанию `false` — дропдаун сортировки блокируется при поиске.
+  /// Some APIs (TMDB) don't accept sort on search responses — defaulting
+  /// to `false` disables the sort dropdown while a query is active.
   bool get supportsSortDuringSearch => false;
 
-  /// Подсказка для поля поиска (локализованная).
   String searchHint(S l);
 
-  /// MediaType присваиваемый карточкам этого источника при добавлении
-  /// в коллекцию. Совпадает с [BrowseResult.mediaType] и не зависит от
-  /// runtime-типа возвращаемых моделей: TMDB anime tab выдаёт `Movie` и
-  /// `TvShow`, но они классифицируются как [MediaType.animation].
+  /// MediaType stamped onto items added from this source. May differ from
+  /// the runtime type of the fetched model — TMDB's anime tab fetches
+  /// `Movie` / `TvShow` but classifies them as [MediaType.animation].
   MediaType get outputMediaType;
 }

--- a/lib/features/search/sources/anilist_anime_source.dart
+++ b/lib/features/search/sources/anilist_anime_source.dart
@@ -1,5 +1,3 @@
-// Источник данных: аниме из AniList.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,13 +9,13 @@ import '../../../shared/theme/app_assets.dart';
 import '../filters/anilist_anime_format_filter.dart';
 import '../filters/anilist_anime_status_filter.dart';
 import '../filters/anilist_genre_filter.dart';
+import '../filters/anilist_tag_filter.dart';
 import '../filters/year_filter.dart';
 import '../models/search_source.dart';
 
-/// Размер страницы для запросов к AniList API.
 const int _aniListPageSize = 20;
 
-/// Источник данных — аниме из AniList.
+/// SearchSource backed by AniList, anime tab.
 class AniListAnimeSource extends SearchSource {
   @override
   String get id => 'anilist_anime';
@@ -49,6 +47,7 @@ class AniListAnimeSource extends SearchSource {
   @override
   List<SearchFilter> get filters => <SearchFilter>[
         AniListGenreFilter(forAnime: true),
+        AniListTagFilter(forAnime: true),
         AniListAnimeStatusFilter(),
         AniListAnimeFormatFilter(),
         YearFilter(),
@@ -79,10 +78,11 @@ class AniListAnimeSource extends SearchSource {
     final AniListApi api = ref.read(aniListApiProvider);
 
     final List<String>? genres = _readStringList(filterValues['genre']);
+    final List<String>? tags = _readStringList(filterValues['tag']);
     final String? status = filterValues['status'] as String?;
     final String? format = filterValues['format'] as String?;
-    // YearFilter → startDate-диапазон. Надёжно для всех аниме, в т.ч.
-    // старых/отменённых, у которых seasonYear не проставлен.
+    // Year is mapped onto startDate bounds, not seasonYear — the latter
+    // is null for many older or cancelled titles.
     final Object? yearValue = filterValues['year'];
     int? startYear;
     int? endYear;
@@ -102,6 +102,7 @@ class AniListAnimeSource extends SearchSource {
           await api.browseAnime(
         query: query,
         genres: genres,
+        tags: tags,
         status: status,
         format: format,
         startYear: startYear,
@@ -127,7 +128,8 @@ class AniListAnimeSource extends SearchSource {
   Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) => null;
 }
 
-/// Нормализует multi-select значение фильтра в список строк.
+/// Coerce a multi-select filter value (List, single, or null) to
+/// `List&lt;String&gt;`.
 List<String>? _readStringList(Object? value) {
   return switch (value) {
     final List<Object?> list => list.whereType<String>().toList(),

--- a/lib/features/search/sources/anilist_manga_source.dart
+++ b/lib/features/search/sources/anilist_manga_source.dart
@@ -1,5 +1,3 @@
-// Источник данных: манга из AniList.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -10,14 +8,14 @@ import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_assets.dart';
 import '../filters/anilist_genre_filter.dart';
 import '../filters/anilist_manga_status_filter.dart';
+import '../filters/anilist_tag_filter.dart';
 import '../filters/manga_format_filter.dart';
 import '../filters/year_filter.dart';
 import '../models/search_source.dart';
 
-/// Размер страницы для запросов к AniList API.
 const int _aniListPageSize = 20;
 
-/// Источник данных — манга из AniList.
+/// SearchSource backed by AniList, manga tab.
 class AniListMangaSource extends SearchSource {
   @override
   String get id => 'manga';
@@ -49,6 +47,7 @@ class AniListMangaSource extends SearchSource {
   @override
   List<SearchFilter> get filters => <SearchFilter>[
         AniListGenreFilter(),
+        AniListTagFilter(),
         MangaFormatFilter(),
         AniListMangaStatusFilter(),
         YearFilter(),
@@ -79,6 +78,7 @@ class AniListMangaSource extends SearchSource {
     final AniListApi api = ref.read(aniListApiProvider);
 
     final List<String>? genres = _readStringList(filterValues['genre']);
+    final List<String>? tags = _readStringList(filterValues['tag']);
     final String? format = filterValues['format'] as String?;
     final String? status = filterValues['status'] as String?;
     final Object? yearValue = filterValues['year'];
@@ -100,6 +100,7 @@ class AniListMangaSource extends SearchSource {
           await api.browseManga(
         query: query,
         genres: genres,
+        tags: tags,
         format: format,
         status: status,
         startYear: startYear,
@@ -125,7 +126,8 @@ class AniListMangaSource extends SearchSource {
   Widget? buildDiscoverFeed(BuildContext context, WidgetRef ref) => null;
 }
 
-/// Нормализует multi-select значение фильтра в список строк.
+/// Coerce a multi-select filter value (List, single, or null) to
+/// `List&lt;String&gt;`.
 List<String>? _readStringList(Object? value) {
   return switch (value) {
     final List<Object?> list => list.whereType<String>().toList(),

--- a/lib/features/search/widgets/anilist_tag_picker.dart
+++ b/lib/features/search/widgets/anilist_tag_picker.dart
@@ -1,0 +1,315 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../data/repositories/anilist_tags_repository.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/anilist_tag.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+
+/// Opens the AniList tag picker as a modal bottom sheet.
+///
+/// [initialSelection] are tag names (the picker's value type matches the
+/// existing multi-select filter contract: `List<String>`). Returns the new
+/// selection, an empty list to clear, or `null` when the user cancels.
+Future<Object?> showAniListTagPicker(
+  BuildContext context,
+  WidgetRef _,
+  S l,
+  Object? currentValue,
+) {
+  final List<String> initial = switch (currentValue) {
+    final List<Object?> list => list.whereType<String>().toList(),
+    final String single => <String>[single],
+    _ => const <String>[],
+  };
+  return showModalBottomSheet<Object?>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: AppColors.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (BuildContext ctx) => _AniListTagPicker(
+      initialSelection: initial,
+      l: l,
+    ),
+  );
+}
+
+class _AniListTagPicker extends ConsumerStatefulWidget {
+  const _AniListTagPicker({
+    required this.initialSelection,
+    required this.l,
+  });
+
+  final List<String> initialSelection;
+  final S l;
+
+  @override
+  ConsumerState<_AniListTagPicker> createState() => _AniListTagPickerState();
+}
+
+class _AniListTagPickerState extends ConsumerState<_AniListTagPicker> {
+  late final Set<String> _selected = <String>{...widget.initialSelection};
+  final TextEditingController _searchController = TextEditingController();
+  String _query = '';
+  bool _showSpoilers = false;
+  bool _showAdult = false;
+  final Set<String> _collapsedCategories = <String>{};
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _refresh() async {
+    try {
+      await ref
+          .read(aniListTagsRepositoryProvider)
+          .getTags(forceRefresh: true);
+    } on Object {
+      // Refresh failures fall back to the cached set; surfacing the error
+      // here would just spawn a snackbar over the picker.
+    }
+    ref.invalidate(aniListTagsProvider);
+  }
+
+  Map<String, List<AniListTag>> _groupAndFilter(List<AniListTag> all) {
+    final String q = _query.trim().toLowerCase();
+    final Map<String, List<AniListTag>> grouped =
+        <String, List<AniListTag>>{};
+    for (final AniListTag t in all) {
+      if (!_showAdult && t.isAdult) continue;
+      if (!_showSpoilers && t.isGeneralSpoiler) continue;
+      if (q.isNotEmpty && !t.name.toLowerCase().contains(q)) continue;
+      final String cat =
+          (t.category == null || t.category!.isEmpty) ? '—' : t.category!;
+      grouped.putIfAbsent(cat, () => <AniListTag>[]).add(t);
+    }
+    return grouped;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = widget.l;
+    final AsyncValue<List<AniListTag>> tagsAsync =
+        ref.watch(aniListTagsProvider);
+    final Size screen = MediaQuery.sizeOf(context);
+    final double height = screen.height * 0.85;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: height,
+        maxWidth: screen.width,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.sm,
+          AppSpacing.md,
+          AppSpacing.md,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(l.tagPickerTitle, style: AppTypography.h3),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.refresh),
+                  tooltip: l.tagPickerRefresh,
+                  onPressed: _refresh,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            TextField(
+              controller: _searchController,
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search),
+                hintText: l.tagPickerSearchHint,
+              ),
+              onChanged: (String v) => setState(() => _query = v),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                    title: Text(l.tagPickerShowSpoilers,
+                        style: AppTypography.bodySmall),
+                    value: _showSpoilers,
+                    onChanged: (bool v) => setState(() => _showSpoilers = v),
+                  ),
+                ),
+                Expanded(
+                  child: SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                    title: Text(l.tagPickerShowAdult,
+                        style: AppTypography.bodySmall),
+                    value: _showAdult,
+                    onChanged: (bool v) => setState(() => _showAdult = v),
+                  ),
+                ),
+              ],
+            ),
+            const Divider(height: 1),
+            Expanded(child: tagsAsync.when(
+              loading: () =>
+                  const Center(child: CircularProgressIndicator()),
+              error: (Object e, _) => Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppSpacing.md),
+                  child: Text(
+                    e.toString(),
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodySmall
+                        .copyWith(color: AppColors.error),
+                  ),
+                ),
+              ),
+              data: (List<AniListTag> all) => _buildList(all, l),
+            )),
+            const Divider(height: 1),
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.xs),
+              child: Wrap(
+                alignment: WrapAlignment.end,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: AppSpacing.xs,
+                runSpacing: AppSpacing.xs,
+                children: <Widget>[
+                  Text(
+                    l.tagPickerSelectedCount(_selected.length),
+                    style: AppTypography.bodySmall
+                        .copyWith(color: AppColors.textSecondary),
+                  ),
+                  if (_selected.isNotEmpty)
+                    TextButton(
+                      onPressed: () => setState(_selected.clear),
+                      child: Text(l.clearAll),
+                    ),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(l.cancel),
+                  ),
+                  FilledButton(
+                    onPressed: () => Navigator.of(context).pop(
+                      _selected.isEmpty
+                          ? const <String>[]
+                          : _selected.toList(),
+                    ),
+                    child: Text(l.apply),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(List<AniListTag> all, S l) {
+    final Map<String, List<AniListTag>> grouped = _groupAndFilter(all);
+    if (grouped.isEmpty) {
+      return Center(
+        child: Text(
+          l.tagPickerEmpty,
+          style: AppTypography.bodySmall
+              .copyWith(color: AppColors.textSecondary),
+        ),
+      );
+    }
+    final List<String> categories = grouped.keys.toList()..sort();
+    return ListView.builder(
+      itemCount: categories.length,
+      itemBuilder: (BuildContext ctx, int idx) {
+        final String cat = categories[idx];
+        final List<AniListTag> tags = grouped[cat]!;
+        final bool collapsed = _collapsedCategories.contains(cat);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            InkWell(
+              onTap: () => setState(() {
+                if (collapsed) {
+                  _collapsedCategories.remove(cat);
+                } else {
+                  _collapsedCategories.add(cat);
+                }
+              }),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: AppSpacing.xs,
+                  horizontal: AppSpacing.sm,
+                ),
+                child: Row(
+                  children: <Widget>[
+                    Icon(
+                      collapsed ? Icons.chevron_right : Icons.expand_more,
+                      size: 18,
+                      color: AppColors.textSecondary,
+                    ),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        cat,
+                        style: AppTypography.bodySmall.copyWith(
+                          color: AppColors.textSecondary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      tags.length.toString(),
+                      style: AppTypography.caption
+                          .copyWith(color: AppColors.textTertiary),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (!collapsed)
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: AppSpacing.xs,
+                ),
+                child: Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  children: <Widget>[
+                    for (final AniListTag t in tags)
+                      FilterChip(
+                        label: Text(t.name),
+                        selected: _selected.contains(t.name),
+                        onSelected: (bool sel) => setState(() {
+                          if (sel) {
+                            _selected.add(t.name);
+                          } else {
+                            _selected.remove(t.name);
+                          }
+                        }),
+                      ),
+                  ],
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/search/widgets/filter_bar.dart
+++ b/lib/features/search/widgets/filter_bar.dart
@@ -1,9 +1,3 @@
-// Chevron filter bar для экрана поиска.
-//
-// Первый шеврон — выпадающий список источников (цвет по группе).
-// Остальные шевроны — dropdown фильтры + sort текущего источника.
-// Clear кнопка в конце при активных фильтрах.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -19,31 +13,23 @@ import '../utils/filter_ui.dart';
 import 'filter_dropdown.dart';
 import 'filter_sheet.dart';
 
-/// Фикс ширина первого (Source) шеврона — чтобы не «прыгал» остальной ряд
-/// при переключении источника с разной длиной label.
+/// Pinned so the row doesn't jiggle when the source label width changes.
 const double _kSourceWidth = 160;
 
-/// Фикс ширина компактного Customize-шеврона (иконка с Tooltip).
 const double _kCustomizeWidth = 44;
 
-/// Chevron filter bar для Browse mode.
-///
-/// `[Source ▾][Filter1 ▾][Filter2 ▾][Sort ▾][Customize?][×?]`
-/// Всё в одну строку на всю ширину. Customize показывается для TMDB
-/// источников без активного запроса; Clear — при активных фильтрах.
+/// Single-row chevron bar for Browse mode:
+/// `[Source ▾][Filter1 ▾][Filter2 ▾][Sort ▾][Customize?][×?]`.
 class FilterBar extends ConsumerWidget {
-  /// Создаёт [FilterBar].
   const FilterBar({
     this.onBeforeFilterChange,
     this.onDiscoverCustomize,
     super.key,
   });
 
-  /// Вызывается перед применением фильтра.
   final VoidCallback? onBeforeFilterChange;
 
-  /// Открыть «Discover Customize» (TMDB-источники без активного запроса).
-  /// Если `null` — сегмент не показывается.
+  /// Opens Discover Customize (TMDB sources, no active query). Hidden when null.
   final VoidCallback? onDiscoverCustomize;
 
   @override
@@ -54,16 +40,13 @@ class FilterBar extends ConsumerWidget {
     final bool hasSort = source.sortOptions.isNotEmpty;
     final bool hasActiveFilters = browseState.filterValues.values
         .any((Object? v) => v != null);
-    // Discover Customize — это настройка самого фида (фильтры/сортировка),
-    // поэтому активные фильтры его НЕ скрывают. Скрываем только при
-    // текстовом запросе, когда фид превращается в результаты поиска.
+    // Customize controls the feed itself, so active filters do NOT hide it
+    // — only a text query does, since that turns the feed into search results.
     final bool showCustomize = onDiscoverCustomize != null &&
         !browseState.hasSearchQuery &&
         source.groupId == 'tmdb';
     final Color accent = filterAccentForGroup(source.groupId);
 
-    // На узких экранах: Source + кнопка «Фильтры (N)» + (опционально)
-    // Customize-иконка вместо chevron-ряда.
     if (isCompactScreen(context)) {
       return _CompactBar(
         source: source,
@@ -82,8 +65,6 @@ class FilterBar extends ConsumerWidget {
         height: 40,
         child: Row(
           children: <Widget>[
-            // Source dropdown (первый, всегда selected, фикс ширина чтобы
-            // не прыгало при смене источника).
             SizedBox(
               width: _kSourceWidth,
               child: _SourceDropdownChevron(
@@ -95,7 +76,6 @@ class FilterBar extends ConsumerWidget {
                 },
               ),
             ),
-            // Фильтры.
             for (int i = 0; i < filters.length; i++)
               Expanded(
                 child: _FilterDropdownChevron(
@@ -116,7 +96,6 @@ class FilterBar extends ConsumerWidget {
                   },
                 ),
               ),
-            // Sort.
             if (hasSort)
               Expanded(
                 child: _SortDropdownChevron(
@@ -131,8 +110,6 @@ class FilterBar extends ConsumerWidget {
                   },
                 ),
               ),
-            // Discover Customize (TMDB, без активного запроса) —
-            // компактная иконка с Tooltip, не растягивается.
             if (showCustomize)
               SizedBox(
                 width: _kCustomizeWidth,
@@ -148,7 +125,6 @@ class FilterBar extends ConsumerWidget {
                   compact: true,
                 ),
               ),
-            // Clear.
             if (hasActiveFilters)
               _ClearButton(
                 onTap: () =>
@@ -160,7 +136,6 @@ class FilterBar extends ConsumerWidget {
     );
   }
 
-  /// Считает количество активных фильтров (не null, не пустой List).
   static int _countActive(Map<String, Object?> values) {
     int n = 0;
     for (final Object? v in values.values) {
@@ -172,16 +147,7 @@ class FilterBar extends ConsumerWidget {
   }
 }
 
-// =========================================================================
-// Compact bar (узкие экраны)
-// =========================================================================
-
-/// Узкий вариант FilterBar:
-/// `[Source ▾][🎚 Фильтры (N)][⚙ Customize?]`.
-///
-/// Source — chevron того же шейпа что на широких. «Фильтры» открывают
-/// [FilterSheet]. Customize — отдельная иконка для TMDB источников
-/// (Discover Customize не фильтр, поэтому в шит не пускаем).
+/// Narrow-screen variant of [FilterBar]: `[Source ▾][Filters (N)][Customize?]`.
 class _CompactBar extends StatelessWidget {
   const _CompactBar({
     required this.source,
@@ -249,7 +215,7 @@ class _CompactBar extends StatelessWidget {
   }
 }
 
-/// Шеврон-кнопка «🎚 Фильтры (N)» — средний сегмент compact bar.
+/// "Filters (N)" chevron — the middle segment of the compact bar.
 class _FiltersChevronButton extends StatelessWidget {
   const _FiltersChevronButton({
     required this.accent,
@@ -503,6 +469,26 @@ class _FilterDropdownChevronState
     final S l = S.of(context);
 
     final String? sub = _isActive ? widget.filter.placeholder(l) : null;
+
+    final Future<Object?> Function(BuildContext, WidgetRef, S, Object?)?
+        customPicker = widget.filter.openCustomPicker;
+    if (customPicker != null) {
+      return ChevronSegment(
+        label: _getLabel(l),
+        subtitle: sub,
+        icon: Icons.filter_list,
+        selected: _isActive,
+        accentColor: widget.accentColor,
+        isFirst: false,
+        isLast: widget.isLast,
+        onTap: () async {
+          final Object? result =
+              await customPicker(context, ref, l, widget.value);
+          if (!mounted) return;
+          widget.onChanged(result == kFilterResetSentinel ? null : result);
+        },
+      );
+    }
 
     if (widget.filter.searchable) {
       return ChevronSegment(

--- a/lib/features/search/widgets/filter_sheet.dart
+++ b/lib/features/search/widgets/filter_sheet.dart
@@ -1,8 +1,6 @@
-// Bottom sheet с фильтрами/sort/customize для search-экрана на узких экранах.
-//
-// Открывается из FilterBar по тапу на иконку «🎚 Фильтры (N)».
-// Все изменения применяются мгновенно (без кнопки «Применить»), как в
-// chevron-варианте на широких экранах.
+// Narrow-screen filter sheet: same instant-apply semantics as the chevron
+// variant — opening it does not commit a "draft", changes hit the provider
+// straight away.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -17,10 +15,6 @@ import '../providers/browse_provider.dart';
 import '../utils/filter_ui.dart';
 import 'filter_dropdown.dart';
 
-/// Открыть [FilterSheet] как modal bottom sheet.
-///
-/// Возвращает Future, завершающийся при закрытии sheet. Применение фильтров
-/// идёт мгновенно через [browseProvider], поэтому возвращаемого значения нет.
 Future<void> showFilterSheet(BuildContext context) {
   return showModalBottomSheet<void>(
     context: context,
@@ -37,18 +31,14 @@ Future<void> showFilterSheet(BuildContext context) {
   );
 }
 
-/// Содержимое bottom sheet с фильтрами и сортировкой.
-///
-/// Discover Customize здесь нет — это часть интерфейса, а не фильтр,
-/// и живёт отдельной кнопкой в [FilterBar].
+/// Bottom-sheet body holding the filter + sort rows. Discover Customize
+/// lives separately in [FilterBar] — it's chrome, not a filter.
 class FilterSheet extends ConsumerWidget {
-  /// Создаёт [FilterSheet].
   const FilterSheet({
     required this.scrollController,
     super.key,
   });
 
-  /// Контроллер скролла из [DraggableScrollableSheet].
   final ScrollController scrollController;
 
   @override
@@ -80,7 +70,6 @@ class FilterSheet extends ConsumerWidget {
         ),
         child: Stack(
           children: <Widget>[
-            // Цветной glow группы — как «backdrop» для FilterSheet.
             Positioned.fill(
               child: IgnorePointer(
                 child: DecoratedBox(
@@ -99,7 +88,6 @@ class FilterSheet extends ConsumerWidget {
                 ),
               ),
             ),
-            // Затемнение к низу для читаемости.
             Positioned.fill(
               child: IgnorePointer(
                 child: DecoratedBox(
@@ -119,8 +107,6 @@ class FilterSheet extends ConsumerWidget {
               ),
             ),
 
-            // Стеклянная карточка с drag handle внутри (как
-            // item_details_sheet) — единая подложка, всё на стекле.
             SingleChildScrollView(
               controller: scrollController,
               padding: const EdgeInsets.all(AppSpacing.md),
@@ -135,7 +121,6 @@ class FilterSheet extends ConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    // Header: drag handle + Сбросить (как у item_details).
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
                         AppSpacing.lg,
@@ -248,12 +233,8 @@ class FilterSheet extends ConsumerWidget {
   }
 }
 
-// =========================================================================
-// Sort tile (один вариант сортировки)
-// =========================================================================
-
-/// Строка-радиокнопка для выбора сортировки. Кастомная (без [RadioListTile]
-/// чтобы не задействовать deprecated `groupValue`/`onChanged`).
+/// Custom radio row — `RadioListTile` is avoided because `groupValue`
+/// / `onChanged` are deprecated.
 class _SortTile extends StatelessWidget {
   const _SortTile({
     required this.label,
@@ -269,36 +250,34 @@ class _SortTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      leading: Icon(
-        selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
-        size: 18,
-        color: selected ? accent : AppColors.textTertiary,
-      ),
-      title: Text(
-        label,
-        style: AppTypography.body.copyWith(
-          color: selected ? accent : AppColors.textPrimary,
-          fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        leading: Icon(
+          selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+          size: 18,
+          color: selected ? accent : AppColors.textTertiary,
         ),
+        title: Text(
+          label,
+          style: AppTypography.body.copyWith(
+            color: selected ? accent : AppColors.textPrimary,
+            fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+          ),
+        ),
+        dense: true,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+        ),
+        onTap: onTap,
       ),
-      dense: true,
-      contentPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md,
-      ),
-      onTap: onTap,
     );
   }
 }
 
-// =========================================================================
-// Filter row (одна строка фильтра)
-// =========================================================================
-
-/// Строка фильтра в sheet: `Label : current value ›`. Тап → диалог выбора.
-///
-/// Загружает options фильтра асинхронно (через [SearchFilter.options]) для
-/// получения человеко-читаемого label текущего значения.
+/// One filter row in the sheet: `Label : current value ›`. Tap opens the
+/// picker. Options are loaded eagerly so the row can render the human label
+/// for the currently-selected value.
 class _FilterRow extends ConsumerStatefulWidget {
   const _FilterRow({
     required this.filter,
@@ -375,62 +354,69 @@ class _FilterRowState extends ConsumerState<_FilterRow> {
 
   Future<void> _openDialog() async {
     final S l = S.of(context);
-    final Object? result = await showDialog<Object>(
-      context: context,
-      builder: (BuildContext ctx) => SearchableFilterDialog(
-        title: widget.filter.placeholder(l),
-        options: _options,
-        isLoading: _isLoading,
-        currentValue: widget.value,
-        allLabel: l.browseFilterAll,
-        multiSelect: widget.filter.multiSelect,
-      ),
-    );
+    final Future<Object?> Function(BuildContext, WidgetRef, S, Object?)?
+        customPicker = widget.filter.openCustomPicker;
+    final Object? result = customPicker != null
+        ? await customPicker(context, ref, l, widget.value)
+        : await showDialog<Object>(
+            context: context,
+            builder: (BuildContext ctx) => SearchableFilterDialog(
+              title: widget.filter.placeholder(l),
+              options: _options,
+              isLoading: _isLoading,
+              currentValue: widget.value,
+              allLabel: l.browseFilterAll,
+              multiSelect: widget.filter.multiSelect,
+            ),
+          );
     if (result == null) return;
-    // SearchableFilterDialog возвращает sentinel kFilterResetSentinel для All.
+    // SearchableFilterDialog returns the sentinel for the "All" reset.
     widget.onChanged(result == kFilterResetSentinel ? null : result);
   }
 
   @override
   Widget build(BuildContext context) {
     final S l = S.of(context);
-    return ListTile(
-      title: Text(
-        widget.filter.placeholder(l),
-        style: AppTypography.body,
-      ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 160),
-            child: Text(
-              _valueLabel(l),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.end,
-              style: AppTypography.body.copyWith(
-                color: _isActive
-                    ? widget.accent
-                    : AppColors.textSecondary,
-                fontWeight:
-                    _isActive ? FontWeight.w600 : FontWeight.normal,
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        title: Text(
+          widget.filter.placeholder(l),
+          style: AppTypography.body,
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 160),
+              child: Text(
+                _valueLabel(l),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.end,
+                style: AppTypography.body.copyWith(
+                  color: _isActive
+                      ? widget.accent
+                      : AppColors.textSecondary,
+                  fontWeight:
+                      _isActive ? FontWeight.w600 : FontWeight.normal,
+                ),
               ),
             ),
-          ),
-          const SizedBox(width: AppSpacing.xs),
-          const Icon(
-            Icons.chevron_right,
-            size: 18,
-            color: AppColors.textTertiary,
-          ),
-        ],
+            const SizedBox(width: AppSpacing.xs),
+            const Icon(
+              Icons.chevron_right,
+              size: 18,
+              color: AppColors.textTertiary,
+            ),
+          ],
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+        ),
+        dense: true,
+        onTap: _openDialog,
       ),
-      contentPadding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md,
-      ),
-      dense: true,
-      onTap: _openDialog,
     );
   }
 }

--- a/lib/features/search/widgets/item_details_sheet.dart
+++ b/lib/features/search/widgets/item_details_sheet.dart
@@ -34,6 +34,8 @@ class ItemDetailsSheet extends StatelessWidget {
     this.rating,
     this.genres,
     this.maxGenres,
+    this.tags,
+    this.maxTags,
     this.extraInfo,
     this.extraInfoIcon,
     this.subtitle,
@@ -145,6 +147,8 @@ class ItemDetailsSheet extends StatelessWidget {
       rating: manga.formattedRating,
       genres: manga.genres,
       maxGenres: _defaultMaxChips,
+      tags: manga.tags,
+      maxTags: _defaultMaxChips,
       subtitle: displayTitle != manga.title
           ? manga.title
           : (manga.titleEnglish != null && manga.titleEnglish != manga.title
@@ -181,6 +185,8 @@ class ItemDetailsSheet extends StatelessWidget {
       rating: anime.formattedRating,
       genres: anime.genres,
       maxGenres: _defaultMaxChips,
+      tags: anime.tags,
+      maxTags: _defaultMaxChips,
       subtitle: displayTitle != anime.title
           ? anime.title
           : (anime.titleEnglish != null && anime.titleEnglish != anime.title
@@ -246,6 +252,10 @@ class ItemDetailsSheet extends StatelessWidget {
   final String? rating;
   final List<String>? genres;
   final int? maxGenres;
+
+  /// AniList tags for anime/manga (separate from [genres]).
+  final List<String>? tags;
+  final int? maxTags;
   final String? extraInfo;
   final IconData? extraInfoIcon;
   final String? subtitle;
@@ -610,6 +620,16 @@ class ItemDetailsSheet extends StatelessWidget {
                 .toList(),
           ),
         ],
+        if (tags != null && tags!.isNotEmpty) ...<Widget>[
+          const SizedBox(height: AppSpacing.xs),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: (maxTags != null ? tags!.take(maxTags!) : tags!)
+                .map(_buildTagChip)
+                .toList(),
+          ),
+        ],
       ],
     );
   }
@@ -646,6 +666,23 @@ class ItemDetailsSheet extends StatelessWidget {
         genre,
         style: AppTypography.caption.copyWith(
           color: AppColors.textSecondary,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTagChip(String tag) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+        border: Border.all(color: AppColors.surfaceLight),
+      ),
+      child: Text(
+        tag,
+        style: AppTypography.caption.copyWith(
+          color: AppColors.textTertiary,
+          fontSize: 11,
         ),
       ),
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1262,7 +1262,21 @@
   "uncategorizedBannerAction": "Add to Collection",
 
   "browseFilterGenre": "Genre",
+  "browseFilterTag": "Tag",
   "browseFilterYear": "Year",
+  "tagPickerTitle": "Select tags",
+  "tagPickerSearchHint": "Search tags",
+  "tagPickerShowSpoilers": "Show spoiler tags",
+  "tagPickerShowAdult": "Show 18+ tags",
+  "tagPickerRefresh": "Refresh catalog",
+  "tagPickerEmpty": "No tags found",
+  "tagPickerSelectedCount": "{count} selected",
+  "@tagPickerSelectedCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "clearAll": "Clear all",
   "browseFilterPlatform": "Platform",
   "browseFilterFormat": "Format",
   "browseFilterSeason": "Season",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5011,11 +5011,65 @@ abstract class S {
   /// **'Genre'**
   String get browseFilterGenre;
 
+  /// No description provided for @browseFilterTag.
+  ///
+  /// In en, this message translates to:
+  /// **'Tag'**
+  String get browseFilterTag;
+
   /// No description provided for @browseFilterYear.
   ///
   /// In en, this message translates to:
   /// **'Year'**
   String get browseFilterYear;
+
+  /// No description provided for @tagPickerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select tags'**
+  String get tagPickerTitle;
+
+  /// No description provided for @tagPickerSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search tags'**
+  String get tagPickerSearchHint;
+
+  /// No description provided for @tagPickerShowSpoilers.
+  ///
+  /// In en, this message translates to:
+  /// **'Show spoiler tags'**
+  String get tagPickerShowSpoilers;
+
+  /// No description provided for @tagPickerShowAdult.
+  ///
+  /// In en, this message translates to:
+  /// **'Show 18+ tags'**
+  String get tagPickerShowAdult;
+
+  /// No description provided for @tagPickerRefresh.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh catalog'**
+  String get tagPickerRefresh;
+
+  /// No description provided for @tagPickerEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No tags found'**
+  String get tagPickerEmpty;
+
+  /// No description provided for @tagPickerSelectedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} selected'**
+  String tagPickerSelectedCount(int count);
+
+  /// No description provided for @clearAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all'**
+  String get clearAll;
 
   /// No description provided for @browseFilterPlatform.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2774,7 +2774,36 @@ class SEn extends S {
   String get browseFilterGenre => 'Genre';
 
   @override
+  String get browseFilterTag => 'Tag';
+
+  @override
   String get browseFilterYear => 'Year';
+
+  @override
+  String get tagPickerTitle => 'Select tags';
+
+  @override
+  String get tagPickerSearchHint => 'Search tags';
+
+  @override
+  String get tagPickerShowSpoilers => 'Show spoiler tags';
+
+  @override
+  String get tagPickerShowAdult => 'Show 18+ tags';
+
+  @override
+  String get tagPickerRefresh => 'Refresh catalog';
+
+  @override
+  String get tagPickerEmpty => 'No tags found';
+
+  @override
+  String tagPickerSelectedCount(int count) {
+    return '$count selected';
+  }
+
+  @override
+  String get clearAll => 'Clear all';
 
   @override
   String get browseFilterPlatform => 'Platform';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2813,7 +2813,36 @@ class SRu extends S {
   String get browseFilterGenre => 'Жанр';
 
   @override
+  String get browseFilterTag => 'Тэг';
+
+  @override
   String get browseFilterYear => 'Год';
+
+  @override
+  String get tagPickerTitle => 'Выбор тэгов';
+
+  @override
+  String get tagPickerSearchHint => 'Поиск по тэгам';
+
+  @override
+  String get tagPickerShowSpoilers => 'Показать спойлерные';
+
+  @override
+  String get tagPickerShowAdult => 'Показать 18+';
+
+  @override
+  String get tagPickerRefresh => 'Обновить каталог';
+
+  @override
+  String get tagPickerEmpty => 'Тэги не найдены';
+
+  @override
+  String tagPickerSelectedCount(int count) {
+    return 'Выбрано: $count';
+  }
+
+  @override
+  String get clearAll => 'Очистить';
 
   @override
   String get browseFilterPlatform => 'Платформа';

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1033,7 +1033,21 @@
   "uncategorizedBannerAction": "Добавить в коллекцию",
 
   "browseFilterGenre": "Жанр",
+  "browseFilterTag": "Тэг",
   "browseFilterYear": "Год",
+  "tagPickerTitle": "Выбор тэгов",
+  "tagPickerSearchHint": "Поиск по тэгам",
+  "tagPickerShowSpoilers": "Показать спойлерные",
+  "tagPickerShowAdult": "Показать 18+",
+  "tagPickerRefresh": "Обновить каталог",
+  "tagPickerEmpty": "Тэги не найдены",
+  "tagPickerSelectedCount": "Выбрано: {count}",
+  "@tagPickerSelectedCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "clearAll": "Очистить",
   "browseFilterPlatform": "Платформа",
   "browseFilterFormat": "Формат",
   "browseFilterSeason": "Сезон",

--- a/lib/shared/models/anilist_tag.dart
+++ b/lib/shared/models/anilist_tag.dart
@@ -1,0 +1,63 @@
+/// One entry from AniList's `MediaTagCollection`. Per-media tags are stored
+/// by name only in `anime_cache.tags` / `manga_cache.tags`; this is the
+/// structured catalog backing the picker.
+class AniListTag {
+  const AniListTag({
+    required this.id,
+    required this.name,
+    this.category,
+    this.description,
+    this.isAdult = false,
+    this.isGeneralSpoiler = false,
+    this.updatedAt,
+  });
+
+  factory AniListTag.fromJson(Map<String, dynamic> json) => AniListTag(
+        id: json['id'] as int,
+        name: json['name'] as String,
+        category: json['category'] as String?,
+        description: json['description'] as String?,
+        isAdult: json['isAdult'] as bool? ?? false,
+        isGeneralSpoiler: json['isGeneralSpoiler'] as bool? ?? false,
+      );
+
+  factory AniListTag.fromDb(Map<String, dynamic> row) => AniListTag(
+        id: row['id'] as int,
+        name: row['name'] as String,
+        category: row['category'] as String?,
+        description: row['description'] as String?,
+        isAdult: (row['is_adult'] as int) == 1,
+        isGeneralSpoiler: (row['is_general_spoiler'] as int) == 1,
+        updatedAt: row['updated_at'] as int?,
+      );
+
+  final int id;
+  final String name;
+  final String? category;
+  final String? description;
+  final bool isAdult;
+  final bool isGeneralSpoiler;
+  final int? updatedAt;
+
+  Map<String, dynamic> toDb() => <String, dynamic>{
+        'id': id,
+        'name': name,
+        'category': category,
+        'description': description,
+        'is_adult': isAdult ? 1 : 0,
+        'is_general_spoiler': isGeneralSpoiler ? 1 : 0,
+        'updated_at': updatedAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      };
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AniListTag && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'AniListTag(id: $id, name: $name)';
+}

--- a/lib/shared/models/anime.dart
+++ b/lib/shared/models/anime.dart
@@ -2,11 +2,8 @@ import 'dart:convert';
 
 import '../utils/anime_manga_title_language.dart';
 
-/// Модель аниме из AniList GraphQL API.
-///
-/// Представляет аниме с метаданными из AniList.
+/// Anime metadata from the AniList GraphQL API.
 class Anime {
-  /// Создаёт экземпляр [Anime].
   const Anime({
     required this.id,
     required this.title,
@@ -29,6 +26,7 @@ class Anime {
     this.format,
     this.source,
     this.genres,
+    this.tags,
     this.studios,
     this.bannerUrl,
     this.nextAiringEpisode,
@@ -37,27 +35,35 @@ class Anime {
     this.updatedAt,
   });
 
-  /// Создаёт [Anime] из JSON ответа AniList GraphQL API.
   factory Anime.fromJson(Map<String, dynamic> json) {
-    // Title
     final Map<String, dynamic>? titleMap =
         json['title'] as Map<String, dynamic>?;
     final String title = titleMap?['romaji'] as String? ??
         titleMap?['english'] as String? ??
         'Unknown';
 
-    // Cover
     final Map<String, dynamic>? coverMap =
         json['coverImage'] as Map<String, dynamic>?;
 
-    // Start date
     final Map<String, dynamic>? dateMap =
         json['startDate'] as Map<String, dynamic>?;
 
-    // Genres
     final List<dynamic>? genresList = json['genres'] as List<dynamic>?;
 
-    // Studios
+    // AniList tag objects carry category, rank, isMediaSpoiler — we drop
+    // everything except the name since per-media spoiler / category are
+    // looked up from the catalog table when needed.
+    List<String>? tags;
+    final List<dynamic>? tagsList = json['tags'] as List<dynamic>?;
+    if (tagsList != null && tagsList.isNotEmpty) {
+      tags = tagsList
+          .map((dynamic t) =>
+              (t as Map<String, dynamic>)['name'] as String? ?? '')
+          .where((String s) => s.isNotEmpty)
+          .toList();
+      if (tags.isEmpty) tags = null;
+    }
+
     List<String>? studios;
     final Map<String, dynamic>? studiosMap =
         json['studios'] as Map<String, dynamic>?;
@@ -73,7 +79,6 @@ class Anime {
       }
     }
 
-    // Strip HTML from description
     String? description = json['description'] as String?;
     if (description != null) {
       description = _stripHtml(description);
@@ -99,6 +104,7 @@ class Anime {
       format: json['format'] as String?,
       source: json['source'] as String?,
       genres: genresList?.map((dynamic g) => g as String).toList(),
+      tags: tags,
       studios: studios,
       bannerUrl: json['bannerImage'] as String?,
       nextAiringEpisode:
@@ -109,7 +115,6 @@ class Anime {
     );
   }
 
-  /// Создаёт [Anime] из записи базы данных.
   factory Anime.fromDb(Map<String, dynamic> row) {
     List<String>? genres;
     if (row['genres'] != null && (row['genres'] as String).isNotEmpty) {
@@ -130,6 +135,17 @@ class Anime {
             .toList();
       } on FormatException {
         studios = null;
+      }
+    }
+
+    List<String>? tags;
+    if (row['tags'] != null && (row['tags'] as String).isNotEmpty) {
+      try {
+        tags = (jsonDecode(row['tags'] as String) as List<dynamic>)
+            .map((dynamic e) => e as String)
+            .toList();
+      } on FormatException {
+        tags = null;
       }
     }
 
@@ -155,6 +171,7 @@ class Anime {
       format: row['format'] as String?,
       source: row['source'] as String?,
       genres: genres,
+      tags: tags,
       studios: studios,
       bannerUrl: row['banner_url'] as String?,
       nextAiringEpisode: row['next_airing_episode'] as int?,
@@ -183,95 +200,64 @@ class Anime {
         title;
   }
 
-  /// Описание (HTML очищен).
   final String? description;
-
-  /// URL обложки (large).
   final String? coverUrl;
-
-  /// URL обложки (medium, для превью).
   final String? coverUrlMedium;
-
-  /// Средний рейтинг 0-100.
   final int? averageScore;
-
-  /// Средний балл 0-100.
   final int? meanScore;
-
-  /// Ранг популярности.
   final int? popularity;
 
-  /// Статус: FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED, HIATUS.
+  /// One of FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED, HIATUS.
   final String? status;
 
-  /// Сезон: WINTER, SPRING, SUMMER, FALL.
+  /// One of WINTER, SPRING, SUMMER, FALL.
   final String? season;
 
-  /// Год сезона.
   final int? seasonYear;
-
-  /// Год начала.
   final int? startYear;
-
-  /// Месяц начала.
   final int? startMonth;
-
-  /// День начала.
   final int? startDay;
 
-  /// Количество эпизодов (null если ongoing/неизвестно).
+  /// Null when ongoing or unknown.
   final int? episodes;
 
-  /// Длительность эпизода в минутах.
+  /// Per-episode runtime in minutes.
   final int? duration;
 
-  /// Формат: TV, TV_SHORT, MOVIE, SPECIAL, OVA, ONA, MUSIC.
+  /// One of TV, TV_SHORT, MOVIE, SPECIAL, OVA, ONA, MUSIC.
   final String? format;
 
-  /// Исходный материал: ORIGINAL, MANGA, LIGHT_NOVEL, VISUAL_NOVEL, VIDEO_GAME.
+  /// Source material: ORIGINAL, MANGA, LIGHT_NOVEL, VISUAL_NOVEL, VIDEO_GAME.
   final String? source;
 
-  /// Список жанров.
   final List<String>? genres;
 
-  /// Список студий.
+  /// AniList tag names; per-media category / rank / spoiler flags are not
+  /// stored — only the catalog table keeps that metadata.
+  final List<String>? tags;
+
   final List<String>? studios;
-
-  /// URL баннера (для backdrop).
   final String? bannerUrl;
-
-  /// Номер следующего выходящего эпизода (для ongoing).
   final int? nextAiringEpisode;
-
-  /// Unix timestamp выхода следующего эпизода.
   final int? nextAiringAt;
-
-  /// URL страницы на AniList.
   final String? externalUrl;
 
-  /// Время кеширования (Unix timestamp).
+  /// Unix timestamp of when this row was cached.
   final int? updatedAt;
 
-  // ===== Computed =====
-
-  /// Рейтинг в шкале 0-10.
   double? get rating10 =>
       averageScore != null ? averageScore! / 10.0 : null;
 
-  /// Форматированный рейтинг (0-10).
-  String? get formattedRating =>
-      rating10?.toStringAsFixed(1);
+  String? get formattedRating => rating10?.toStringAsFixed(1);
 
-  /// Год релиза.
   int? get releaseYear => seasonYear ?? startYear;
 
-  /// Жанры в виде строки через запятую.
   String? get genresString => genres?.join(', ');
 
-  /// Студии в виде строки через запятую.
+  String? get tagsString => tags?.join(', ');
+
   String? get studiosString => studios?.join(', ');
 
-  /// Человекочитаемая метка формата.
   String? get formatLabel => switch (format) {
         'TV' => 'TV',
         'TV_SHORT' => 'TV Short',
@@ -283,7 +269,6 @@ class Anime {
         _ => format,
       };
 
-  /// Человекочитаемый статус.
   String? get statusLabel => switch (status) {
         'FINISHED' => 'Finished',
         'RELEASING' => 'Airing',
@@ -293,7 +278,6 @@ class Anime {
         _ => status,
       };
 
-  /// Человекочитаемый сезон.
   String? get seasonLabel {
     if (season == null) return null;
     final String seasonName = switch (season) {
@@ -306,15 +290,12 @@ class Anime {
     return seasonYear != null ? '$seasonName $seasonYear' : seasonName;
   }
 
-  /// Строка эпизодов: "24 ep" или "? ep".
   String get episodesString =>
       episodes != null ? '$episodes ep' : '? ep';
 
-  /// Длительность эпизода: "24 min/ep".
   String? get durationString =>
       duration != null ? '$duration min/ep' : null;
 
-  /// Человекочитаемый исходный материал.
   String? get sourceLabel => switch (source) {
         'ORIGINAL' => 'Original',
         'MANGA' => 'Based on Manga',
@@ -325,7 +306,6 @@ class Anime {
         _ => source,
       };
 
-  /// Есть ли информация о следующем эпизоде.
   bool get hasNextAiring =>
       nextAiringEpisode != null && nextAiringAt != null;
 
@@ -341,7 +321,6 @@ class Anime {
   @override
   String toString() => 'Anime(id: $id, title: $title)';
 
-  /// Преобразует в Map для сохранения в базу данных.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'id': id,
@@ -365,6 +344,7 @@ class Anime {
       'format': format,
       'source': source,
       'genres': genres != null ? jsonEncode(genres) : null,
+      'tags': tags != null ? jsonEncode(tags) : null,
       'studios': studios != null ? jsonEncode(studios) : null,
       'banner_url': bannerUrl,
       'next_airing_episode': nextAiringEpisode,
@@ -375,14 +355,13 @@ class Anime {
     };
   }
 
-  /// Преобразует в Map для экспорта коллекции.
+  /// `toDb` minus the cache timestamp, for `.xcoll` / `.xcollx` payloads.
   Map<String, dynamic> toExport() {
     final Map<String, dynamic> data = toDb();
     data.remove('updated_at');
     return data;
   }
 
-  /// Создаёт копию с изменёнными полями.
   Anime copyWith({
     int? id,
     String? title,
@@ -405,6 +384,7 @@ class Anime {
     String? format,
     String? source,
     List<String>? genres,
+    List<String>? tags,
     List<String>? studios,
     String? bannerUrl,
     int? nextAiringEpisode,
@@ -434,6 +414,7 @@ class Anime {
       format: format ?? this.format,
       source: source ?? this.source,
       genres: genres ?? this.genres,
+      tags: tags ?? this.tags,
       studios: studios ?? this.studios,
       bannerUrl: bannerUrl ?? this.bannerUrl,
       nextAiringEpisode: nextAiringEpisode ?? this.nextAiringEpisode,
@@ -445,7 +426,6 @@ class Anime {
 
   static final RegExp _htmlTagPattern = RegExp('<[^>]*>');
 
-  /// Убирает HTML-теги из описания.
   static String? _stripHtml(String? text) {
     if (text == null) return null;
     String clean = text.replaceAll(_htmlTagPattern, '');

--- a/lib/shared/models/manga.dart
+++ b/lib/shared/models/manga.dart
@@ -1,14 +1,9 @@
-// Модель манги из AniList.
-
 import 'dart:convert';
 
 import '../utils/anime_manga_title_language.dart';
 
-/// Модель манги из AniList GraphQL API.
-///
-/// Представляет мангу с метаданными из AniList.
+/// Manga metadata from the AniList GraphQL API.
 class Manga {
-  /// Создаёт экземпляр [Manga].
   const Manga({
     required this.id,
     required this.title,
@@ -29,33 +24,43 @@ class Manga {
     this.format,
     this.countryOfOrigin,
     this.genres,
+    this.tags,
     this.authors,
     this.externalUrl,
     this.updatedAt,
     this.bannerUrl,
   });
 
-  /// Создаёт [Manga] из JSON ответа AniList GraphQL API.
   factory Manga.fromJson(Map<String, dynamic> json) {
-    // Title
     final Map<String, dynamic>? titleMap =
         json['title'] as Map<String, dynamic>?;
     final String title = titleMap?['romaji'] as String? ??
         titleMap?['english'] as String? ??
         'Unknown';
 
-    // Cover
     final Map<String, dynamic>? coverMap =
         json['coverImage'] as Map<String, dynamic>?;
 
-    // Start date
     final Map<String, dynamic>? dateMap =
         json['startDate'] as Map<String, dynamic>?;
 
-    // Genres
     final List<dynamic>? genresList = json['genres'] as List<dynamic>?;
 
-    // Authors from staff edges
+    // AniList tag objects carry category, rank, isMediaSpoiler — we drop
+    // everything except the name since per-media spoiler / category are
+    // looked up from the catalog table when needed.
+    List<String>? tags;
+    final List<dynamic>? tagsList = json['tags'] as List<dynamic>?;
+    if (tagsList != null && tagsList.isNotEmpty) {
+      tags = tagsList
+          .map((dynamic t) =>
+              (t as Map<String, dynamic>)['name'] as String? ?? '')
+          .where((String s) => s.isNotEmpty)
+          .toList();
+      if (tags.isEmpty) tags = null;
+    }
+
+    // Filter staff edges to author-credit roles only (Story, Art, Story & Art).
     List<String>? authors;
     final Map<String, dynamic>? staffMap =
         json['staff'] as Map<String, dynamic>?;
@@ -84,7 +89,6 @@ class Manga {
       }
     }
 
-    // Strip HTML from description
     String? description = json['description'] as String?;
     if (description != null) {
       description = _stripHtml(description);
@@ -109,6 +113,7 @@ class Manga {
       volumes: json['volumes'] as int?,
       format: json['format'] as String?,
       genres: genresList?.map((dynamic g) => g as String).toList(),
+      tags: tags,
       authors: authors,
       externalUrl: 'https://anilist.co/manga/$id',
       updatedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
@@ -116,7 +121,6 @@ class Manga {
     );
   }
 
-  /// Создаёт [Manga] из записи базы данных.
   factory Manga.fromDb(Map<String, dynamic> row) {
     List<String>? genres;
     if (row['genres'] != null && (row['genres'] as String).isNotEmpty) {
@@ -140,6 +144,17 @@ class Manga {
       }
     }
 
+    List<String>? tags;
+    if (row['tags'] != null && (row['tags'] as String).isNotEmpty) {
+      try {
+        tags = (jsonDecode(row['tags'] as String) as List<dynamic>)
+            .map((dynamic e) => e as String)
+            .toList();
+      } on FormatException {
+        tags = null;
+      }
+    }
+
     return Manga(
       id: row['id'] as int,
       title: row['title'] as String,
@@ -160,6 +175,7 @@ class Manga {
       format: row['format'] as String?,
       countryOfOrigin: row['country_of_origin'] as String?,
       genres: genres,
+      tags: tags,
       authors: authors,
       externalUrl: row['external_url'] as String?,
       bannerUrl: row['banner_url'] as String?,
@@ -187,84 +203,61 @@ class Manga {
         title;
   }
 
-  /// Описание (HTML очищен).
   final String? description;
 
-  /// URL обложки (large).
   final String? coverUrl;
-
-  /// URL обложки (medium, для превью).
   final String? coverUrlMedium;
-
-  /// Средний рейтинг 0-100.
   final int? averageScore;
-
-  /// Средний балл 0-100.
   final int? meanScore;
-
-  /// Ранг популярности.
   final int? popularity;
 
-  /// Статус публикации: FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED,
-  /// HIATUS.
+  /// One of FINISHED, RELEASING, NOT_YET_RELEASED, CANCELLED, HIATUS.
   final String? status;
 
-  /// Год начала публикации.
   final int? startYear;
-
-  /// Месяц начала публикации.
   final int? startMonth;
-
-  /// День начала публикации.
   final int? startDay;
 
-  /// Всего глав (null если ongoing/неизвестно).
+  /// Null when ongoing or unknown.
   final int? chapters;
 
-  /// Всего томов (null если ongoing/неизвестно).
+  /// Null when ongoing or unknown.
   final int? volumes;
 
-  /// Формат: MANGA, NOVEL, ONE_SHOT, MANHWA, MANHUA, LIGHT_NOVEL.
+  /// One of MANGA, NOVEL, ONE_SHOT, MANHWA, MANHUA, LIGHT_NOVEL.
   final String? format;
 
-  /// Страна происхождения: JP, KR, CN, TW.
+  /// JP, KR, CN, TW.
   final String? countryOfOrigin;
 
-  /// Список жанров (["Action", "Adventure", "Fantasy"]).
   final List<String>? genres;
 
-  /// Имена авторов.
-  final List<String>? authors;
+  /// AniList tag names; per-media category / rank / spoiler flags are not
+  /// stored — only the catalog table keeps that metadata.
+  final List<String>? tags;
 
-  /// URL страницы на AniList.
+  final List<String>? authors;
   final String? externalUrl;
 
-  /// Время кеширования (Unix timestamp).
+  /// Unix timestamp of when this row was cached.
   final int? updatedAt;
 
-  /// URL баннера (transient, не сохраняется в БД).
+  /// Transient — not persisted (only present on fresh API responses).
   final String? bannerUrl;
 
-  // ===== Computed =====
-
-  /// Рейтинг в шкале 0-10.
   double? get rating10 =>
       averageScore != null ? averageScore! / 10.0 : null;
 
-  /// Форматированный рейтинг (0-10).
-  String? get formattedRating =>
-      rating10?.toStringAsFixed(1);
+  String? get formattedRating => rating10?.toStringAsFixed(1);
 
-  /// Год релиза.
   int? get releaseYear => startYear;
 
-  /// Жанры в виде строки через запятую.
   String? get genresString => genres?.join(', ');
 
-  /// Авторы в виде строки через запятую.
+  String? get tagsString => tags?.join(', ');
+
   String? get authorsString => authors?.join(', ');
 
-  /// Человекочитаемая метка формата.
   String? get formatLabel => switch (format) {
         'MANGA' => 'Manga',
         'NOVEL' => 'Novel',
@@ -275,7 +268,6 @@ class Manga {
         _ => format,
       };
 
-  /// Человекочитаемый статус.
   String? get statusLabel => switch (status) {
         'FINISHED' => 'Finished',
         'RELEASING' => 'Releasing',
@@ -285,7 +277,6 @@ class Manga {
         _ => status,
       };
 
-  /// Строка прогресса: "23 ch · 5 vol" или "? ch" и т.д.
   String get progressString {
     final String ch = chapters != null ? '$chapters ch' : '? ch';
     final String vol = volumes != null ? ' · $volumes vol' : '';
@@ -304,7 +295,6 @@ class Manga {
   @override
   String toString() => 'Manga(id: $id, title: $title)';
 
-  /// Преобразует в Map для сохранения в базу данных.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'id': id,
@@ -326,6 +316,7 @@ class Manga {
       'format': format,
       'country_of_origin': countryOfOrigin,
       'genres': genres != null ? jsonEncode(genres) : null,
+      'tags': tags != null ? jsonEncode(tags) : null,
       'authors': authors != null ? jsonEncode(authors) : null,
       'external_url': externalUrl,
       'banner_url': bannerUrl,
@@ -334,14 +325,13 @@ class Manga {
     };
   }
 
-  /// Преобразует в Map для экспорта коллекции.
+  /// `toDb` minus the cache timestamp, for `.xcoll` / `.xcollx` payloads.
   Map<String, dynamic> toExport() {
     final Map<String, dynamic> data = toDb();
     data.remove('updated_at');
     return data;
   }
 
-  /// Создаёт копию с изменёнными полями.
   Manga copyWith({
     int? id,
     String? title,
@@ -362,6 +352,7 @@ class Manga {
     String? format,
     String? countryOfOrigin,
     List<String>? genres,
+    List<String>? tags,
     List<String>? authors,
     String? externalUrl,
     int? updatedAt,
@@ -387,6 +378,7 @@ class Manga {
       format: format ?? this.format,
       countryOfOrigin: countryOfOrigin ?? this.countryOfOrigin,
       genres: genres ?? this.genres,
+      tags: tags ?? this.tags,
       authors: authors ?? this.authors,
       externalUrl: externalUrl ?? this.externalUrl,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -396,7 +388,6 @@ class Manga {
 
   static final RegExp _htmlTagPattern = RegExp('<[^>]*>');
 
-  /// Убирает HTML-теги из описания.
   static String? _stripHtml(String? text) {
     if (text == null) return null;
     String clean = text.replaceAll(_htmlTagPattern, '');

--- a/test/core/database/dao/anilist_tag_dao_test.dart
+++ b/test/core/database/dao/anilist_tag_dao_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:xerabora/core/database/dao/anilist_tag_dao.dart';
+import 'package:xerabora/core/database/schema.dart';
+import 'package:xerabora/shared/models/anilist_tag.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late Database db;
+  late AniListTagDao dao;
+
+  setUp(() async {
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (Database d, int _) => DatabaseSchema.createAniListTagsTable(d),
+      ),
+    );
+    dao = AniListTagDao(() async => db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('AniListTagDao', () {
+    test('getAll returns empty on fresh table', () async {
+      expect(await dao.getAll(), isEmpty);
+    });
+
+    test('replaceAll inserts rows and getAll returns them sorted', () async {
+      await dao.replaceAll(<AniListTag>[
+        const AniListTag(
+            id: 2, name: 'Magic', category: 'Theme-Other', updatedAt: 100),
+        const AniListTag(
+            id: 1, name: 'School', category: 'Setting', updatedAt: 200),
+      ]);
+
+      final List<AniListTag> all = await dao.getAll();
+      expect(all, hasLength(2));
+      expect(all.first.name, 'School');
+      expect(all.last.name, 'Magic');
+    });
+
+    test('replaceAll wipes previous rows transactionally', () async {
+      await dao.replaceAll(<AniListTag>[
+        const AniListTag(id: 1, name: 'Old', updatedAt: 1),
+      ]);
+      await dao.replaceAll(<AniListTag>[
+        const AniListTag(id: 2, name: 'New', updatedAt: 2),
+      ]);
+      final List<AniListTag> all = await dao.getAll();
+      expect(all, hasLength(1));
+      expect(all.single.name, 'New');
+    });
+
+  });
+}

--- a/test/core/services/text_export_service_test.dart
+++ b/test/core/services/text_export_service_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/core/services/text_export_service.dart';
+import 'package:xerabora/shared/models/anime.dart';
 import 'package:xerabora/shared/models/collection_item.dart';
 import 'package:xerabora/shared/models/game.dart';
 import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/manga.dart';
 import 'package:xerabora/shared/models/media_type.dart';
 import 'package:xerabora/shared/models/movie.dart';
 import 'package:xerabora/shared/models/platform.dart';
@@ -147,6 +149,77 @@ void main() {
         expect(result, equals('Elden Ring — RPG, Action'));
       });
 
+      test('should replace {tags} token for anime', () {
+        final CollectionItem item = CollectionItem(
+          id: 1,
+          collectionId: 1,
+          mediaType: MediaType.anime,
+          externalId: 1,
+          status: ItemStatus.completed,
+          addedAt: DateTime(2024),
+          anime: const Anime(
+            id: 1,
+            title: 'Steins;Gate',
+            tags: <String>['Time Loop', 'Conspiracy'],
+          ),
+        );
+        final String result = _service().formatItem(
+          '{name} — {tags}',
+          item,
+          1,
+        );
+        expect(result, equals('Steins;Gate — Time Loop, Conspiracy'));
+      });
+
+      test('should replace {tags} token for manga', () {
+        final CollectionItem item = CollectionItem(
+          id: 1,
+          collectionId: 1,
+          mediaType: MediaType.manga,
+          externalId: 1,
+          status: ItemStatus.completed,
+          addedAt: DateTime(2024),
+          manga: const Manga(
+            id: 1,
+            title: 'Berserk',
+            tags: <String>['Dark Fantasy', 'Medieval'],
+          ),
+        );
+        final String result = _service().formatItem(
+          '{name} — {tags}',
+          item,
+          1,
+        );
+        expect(result, equals('Berserk — Dark Fantasy, Medieval'));
+      });
+
+      test('should remove {tags} token for non anime/manga', () {
+        final String result = _service().formatItem(
+          '{name}{tags}',
+          _gameItem(),
+          1,
+        );
+        expect(result, equals('Elden Ring'));
+      });
+
+      test('should remove {tags} token when tags are null', () {
+        final CollectionItem item = CollectionItem(
+          id: 1,
+          collectionId: 1,
+          mediaType: MediaType.anime,
+          externalId: 1,
+          status: ItemStatus.completed,
+          addedAt: DateTime(2024),
+          anime: const Anime(id: 1, title: 'Untagged'),
+        );
+        final String result = _service().formatItem(
+          '{name} — {tags}',
+          item,
+          1,
+        );
+        expect(result, equals('Untagged'));
+      });
+
       test('should replace {notes} token', () {
         final String result = _service().formatItem(
           '{name}: {notes}',
@@ -184,7 +257,7 @@ void main() {
       });
     });
 
-    group('cleanup пустых токенов', () {
+    group('empty token cleanup', () {
       test('should remove empty {year} with parentheses', () {
         final String result = _service().formatItem(
           '{name} ({year})',
@@ -305,7 +378,7 @@ void main() {
           TextExportService.availableTokens,
           containsAll(<String>[
             'name', 'year', 'rating', 'myRating', 'platform',
-            'status', 'genres', 'notes', 'type', '#',
+            'status', 'genres', 'tags', 'notes', 'type', '#',
           ]),
         );
       });

--- a/test/data/repositories/anilist_tags_repository_test.dart
+++ b/test/data/repositories/anilist_tags_repository_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/data/repositories/anilist_tags_repository.dart';
+import 'package:xerabora/shared/models/anilist_tag.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  late MockAniListApi api;
+  late MockAniListTagDao dao;
+  late AniListTagsRepository repo;
+
+  const List<AniListTag> apiTags = <AniListTag>[
+    AniListTag(id: 1, name: 'Magic', category: 'Theme'),
+    AniListTag(id: 2, name: 'School', category: 'Setting'),
+  ];
+
+  setUpAll(() {
+    registerFallbackValue(<AniListTag>[]);
+  });
+
+  setUp(() {
+    api = MockAniListApi();
+    dao = MockAniListTagDao();
+    repo = AniListTagsRepository(api: api, dao: dao);
+  });
+
+  group('AniListTagsRepository.getTags', () {
+    test('returns cached when present — no API call', () async {
+      when(dao.getAll).thenAnswer((_) async => apiTags);
+
+      final List<AniListTag> result = await repo.getTags();
+      expect(result, apiTags);
+      verifyNever(() => api.fetchTagCollection());
+    });
+
+    test('fetches from API when cache is empty', () async {
+      when(dao.getAll).thenAnswer((_) async => <AniListTag>[]);
+      when(() => api.fetchTagCollection())
+          .thenAnswer((_) async => apiTags);
+      when(() => dao.replaceAll(any())).thenAnswer((_) async {});
+
+      final List<AniListTag> result = await repo.getTags();
+      expect(result, apiTags);
+      verify(() => api.fetchTagCollection()).called(1);
+      verify(() => dao.replaceAll(apiTags)).called(1);
+    });
+
+    test('forceRefresh bypasses cache and hits API', () async {
+      when(dao.getAll).thenAnswer((_) async => apiTags);
+      when(() => api.fetchTagCollection())
+          .thenAnswer((_) async => apiTags);
+      when(() => dao.replaceAll(any())).thenAnswer((_) async {});
+
+      await repo.getTags(forceRefresh: true);
+      verify(() => api.fetchTagCollection()).called(1);
+    });
+
+    test('API failure with non-empty cache falls back to cache', () async {
+      when(dao.getAll).thenAnswer((_) async => apiTags);
+      when(() => api.fetchTagCollection())
+          .thenThrow(Exception('network down'));
+
+      final List<AniListTag> result = await repo.getTags(forceRefresh: true);
+      expect(result, apiTags);
+      verifyNever(() => dao.replaceAll(any()));
+    });
+
+    test('API failure with empty cache rethrows', () async {
+      when(dao.getAll).thenAnswer((_) async => <AniListTag>[]);
+      when(() => api.fetchTagCollection())
+          .thenThrow(Exception('network down'));
+
+      expect(() => repo.getTags(), throwsException);
+    });
+  });
+}

--- a/test/features/search/sources/anilist_manga_source_test.dart
+++ b/test/features/search/sources/anilist_manga_source_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xerabora/features/search/filters/anilist_genre_filter.dart';
 import 'package:xerabora/features/search/filters/anilist_manga_status_filter.dart';
+import 'package:xerabora/features/search/filters/anilist_tag_filter.dart';
 import 'package:xerabora/features/search/filters/manga_format_filter.dart';
 import 'package:xerabora/features/search/filters/year_filter.dart';
 import 'package:xerabora/features/search/models/search_source.dart';
@@ -34,8 +35,8 @@ void main() {
     });
 
     group('filters', () {
-      test('exposes genre (multi), format, status, year', () {
-        expect(source.filters, hasLength(4));
+      test('exposes genre (multi), tag (multi), format, status, year', () {
+        expect(source.filters, hasLength(5));
       });
 
       test('first filter is AniListGenreFilter (multi-select)', () {
@@ -43,16 +44,21 @@ void main() {
         expect(source.filters[0].multiSelect, isTrue);
       });
 
-      test('second filter is MangaFormatFilter', () {
-        expect(source.filters[1], isA<MangaFormatFilter>());
+      test('second filter is AniListTagFilter (multi-select)', () {
+        expect(source.filters[1], isA<AniListTagFilter>());
+        expect(source.filters[1].multiSelect, isTrue);
       });
 
-      test('third filter is AniListMangaStatusFilter', () {
-        expect(source.filters[2], isA<AniListMangaStatusFilter>());
+      test('third filter is MangaFormatFilter', () {
+        expect(source.filters[2], isA<MangaFormatFilter>());
       });
 
-      test('fourth filter is YearFilter', () {
-        expect(source.filters[3], isA<YearFilter>());
+      test('fourth filter is AniListMangaStatusFilter', () {
+        expect(source.filters[3], isA<AniListMangaStatusFilter>());
+      });
+
+      test('fifth filter is YearFilter', () {
+        expect(source.filters[4], isA<YearFilter>());
       });
     });
 

--- a/test/features/search/widgets/anilist_tag_picker_test.dart
+++ b/test/features/search/widgets/anilist_tag_picker_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/data/repositories/anilist_tags_repository.dart';
+import 'package:xerabora/features/search/widgets/anilist_tag_picker.dart';
+import 'package:xerabora/l10n/app_localizations.dart';
+import 'package:xerabora/shared/models/anilist_tag.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+const List<AniListTag> _tags = <AniListTag>[
+  AniListTag(id: 1, name: 'Time Loop', category: 'Theme-Plot'),
+  AniListTag(id: 2, name: 'School', category: 'Setting'),
+  AniListTag(id: 3, name: 'Ecchi', category: 'Theme', isAdult: true),
+  AniListTag(id: 4, name: 'Plot Twist', category: 'Theme', isGeneralSpoiler: true),
+];
+
+class _Host extends ConsumerWidget {
+  const _Host();
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Builder(
+      builder: (BuildContext ctx) => Scaffold(
+        body: Center(
+          child: ElevatedButton(
+            onPressed: () async {
+              final Object? result = await showAniListTagPicker(
+                ctx,
+                ref,
+                S.of(ctx),
+                _lastResult,
+              );
+              _lastResult = result;
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Object? _lastResult;
+
+void main() {
+  setUp(() => _lastResult = null);
+
+  Future<void> openPicker(WidgetTester tester, {Object? initial}) async {
+    _lastResult = initial;
+    await tester.pumpApp(
+      const _Host(),
+      overrides: <Override>[
+        aniListTagsProvider.overrideWith((Ref _) async => _tags),
+      ],
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('AniListTagPicker', () {
+    testWidgets('renders without exceptions and shows non-adult/non-spoiler tags',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Time Loop'), findsOneWidget);
+      expect(find.text('School'), findsOneWidget);
+      expect(find.text('Ecchi'), findsNothing);
+      expect(find.text('Plot Twist'), findsNothing);
+    });
+
+    testWidgets('Show 18+ toggle reveals adult tags',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      await tester.tap(find.byType(Switch).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ecchi'), findsOneWidget);
+    });
+
+    testWidgets('Show spoiler toggle reveals spoiler tags',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      await tester.tap(find.byType(Switch).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Plot Twist'), findsOneWidget);
+    });
+
+    testWidgets('search filter narrows the list',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      await tester.enterText(find.byType(TextField), 'school');
+      await tester.pumpAndSettle();
+
+      expect(find.text('School'), findsOneWidget);
+      expect(find.text('Time Loop'), findsNothing);
+    });
+
+    testWidgets('Apply returns the picked tags',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      await tester.tap(find.widgetWithText(FilterChip, 'Time Loop'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilterChip, 'School'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      expect(_lastResult, isA<List<String>>());
+      expect(
+        (_lastResult! as List<String>).toSet(),
+        <String>{'Time Loop', 'School'},
+      );
+    });
+
+    testWidgets('Apply with no selection returns empty list',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      expect(_lastResult, isA<List<String>>());
+      expect(_lastResult! as List<String>, isEmpty);
+    });
+
+    testWidgets('Cancel returns null',
+        (WidgetTester tester) async {
+      await openPicker(tester, initial: const <String>['Time Loop']);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(_lastResult, isNull);
+    });
+
+    testWidgets('initial selection is preserved',
+        (WidgetTester tester) async {
+      await openPicker(tester, initial: const <String>['Time Loop']);
+
+      final FilterChip chip = tester.widget<FilterChip>(
+        find.widgetWithText(FilterChip, 'Time Loop'),
+      );
+      expect(chip.selected, isTrue);
+    });
+
+    testWidgets('Clear all removes the selection',
+        (WidgetTester tester) async {
+      await openPicker(tester);
+
+      await tester.tap(find.widgetWithText(FilterChip, 'Time Loop'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Clear all'));
+      await tester.pumpAndSettle();
+
+      final FilterChip chip = tester.widget<FilterChip>(
+        find.widgetWithText(FilterChip, 'Time Loop'),
+      );
+      expect(chip.selected, isFalse);
+    });
+  });
+}

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -11,6 +11,7 @@ import 'package:xerabora/core/api/steamgriddb_api.dart';
 import 'package:xerabora/core/services/kodi_sync_service.dart';
 import 'package:xerabora/core/api/tmdb_api.dart';
 import 'package:xerabora/core/api/anilist_api.dart';
+import 'package:xerabora/core/database/dao/anilist_tag_dao.dart';
 import 'package:xerabora/core/api/vndb_api.dart';
 import 'package:xerabora/core/database/dao/canvas_dao.dart';
 import 'package:xerabora/core/database/dao/collection_dao.dart';
@@ -117,6 +118,8 @@ class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
 class MockVndbApi extends Mock implements VndbApi {}
 
 class MockAniListApi extends Mock implements AniListApi {}
+
+class MockAniListTagDao extends Mock implements AniListTagDao {}
 
 class MockSteamApi extends Mock implements SteamApi {}
 

--- a/test/shared/models/anilist_tag_test.dart
+++ b/test/shared/models/anilist_tag_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/anilist_tag.dart';
+
+void main() {
+  group('AniListTag', () {
+    group('fromJson', () {
+      test('parses full payload', () {
+        final AniListTag tag = AniListTag.fromJson(<String, dynamic>{
+          'id': 42,
+          'name': 'Time Loop',
+          'category': 'Theme-Plot',
+          'description': 'Characters relive events.',
+          'isAdult': false,
+          'isGeneralSpoiler': true,
+        });
+        expect(tag.id, 42);
+        expect(tag.name, 'Time Loop');
+        expect(tag.category, 'Theme-Plot');
+        expect(tag.description, 'Characters relive events.');
+        expect(tag.isAdult, isFalse);
+        expect(tag.isGeneralSpoiler, isTrue);
+      });
+
+      test('defaults isAdult / isGeneralSpoiler to false when missing', () {
+        final AniListTag tag = AniListTag.fromJson(<String, dynamic>{
+          'id': 1,
+          'name': 'Magic',
+        });
+        expect(tag.isAdult, isFalse);
+        expect(tag.isGeneralSpoiler, isFalse);
+        expect(tag.category, isNull);
+      });
+    });
+
+    group('toDb / fromDb round-trip', () {
+      test('preserves all fields and bool encoding', () {
+        const AniListTag original = AniListTag(
+          id: 7,
+          name: 'School',
+          category: 'Setting',
+          description: 'School setting',
+          isAdult: true,
+          isGeneralSpoiler: false,
+          updatedAt: 1234567,
+        );
+        final Map<String, dynamic> row = original.toDb();
+        expect(row['is_adult'], 1);
+        expect(row['is_general_spoiler'], 0);
+        final AniListTag back = AniListTag.fromDb(row);
+        expect(back.id, original.id);
+        expect(back.name, original.name);
+        expect(back.category, original.category);
+        expect(back.description, original.description);
+        expect(back.isAdult, original.isAdult);
+        expect(back.isGeneralSpoiler, original.isGeneralSpoiler);
+        expect(back.updatedAt, original.updatedAt);
+      });
+
+      test('toDb fills updated_at when null', () {
+        const AniListTag tag = AniListTag(id: 1, name: 'X');
+        final Map<String, dynamic> row = tag.toDb();
+        expect(row['updated_at'], isA<int>());
+        expect((row['updated_at'] as int) > 0, isTrue);
+      });
+    });
+
+    group('equality', () {
+      test('equal by id', () {
+        const AniListTag a = AniListTag(id: 1, name: 'A');
+        const AniListTag b = AniListTag(id: 1, name: 'B');
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('different id is not equal', () {
+        const AniListTag a = AniListTag(id: 1, name: 'A');
+        const AniListTag b = AniListTag(id: 2, name: 'A');
+        expect(a, isNot(equals(b)));
+      });
+    });
+  });
+}

--- a/test/shared/models/anime_test.dart
+++ b/test/shared/models/anime_test.dart
@@ -394,5 +394,77 @@ void main() {
         expect(a.titleByLanguage('english'), 'R');
       });
     });
+
+    group('tags', () {
+      test('fromJson parses tags array of {name} objects', () {
+        final Anime anime = Anime.fromJson(<String, dynamic>{
+          'id': 1,
+          'title': <String, dynamic>{'romaji': 'X'},
+          'tags': <Map<String, dynamic>>[
+            <String, dynamic>{'name': 'Time Loop'},
+            <String, dynamic>{'name': 'School'},
+          ],
+        });
+        expect(anime.tags, <String>['Time Loop', 'School']);
+      });
+
+      test('fromJson skips empty / missing names', () {
+        final Anime anime = Anime.fromJson(<String, dynamic>{
+          'id': 1,
+          'title': <String, dynamic>{'romaji': 'X'},
+          'tags': <Map<String, dynamic>>[
+            <String, dynamic>{'name': 'Magic'},
+            <String, dynamic>{'name': ''},
+            <String, dynamic>{},
+          ],
+        });
+        expect(anime.tags, <String>['Magic']);
+      });
+
+      test('fromJson returns null when tags array is missing or empty', () {
+        final Anime missing = Anime.fromJson(<String, dynamic>{
+          'id': 1,
+          'title': <String, dynamic>{'romaji': 'X'},
+        });
+        expect(missing.tags, isNull);
+
+        final Anime empty = Anime.fromJson(<String, dynamic>{
+          'id': 1,
+          'title': <String, dynamic>{'romaji': 'X'},
+          'tags': <dynamic>[],
+        });
+        expect(empty.tags, isNull);
+      });
+
+      test('toDb / fromDb round-trip preserves tags', () {
+        const Anime original =
+            Anime(id: 1, title: 'X', tags: <String>['A', 'B', 'C']);
+        final Map<String, dynamic> row = original.toDb();
+        final Anime back = Anime.fromDb(row);
+        expect(back.tags, original.tags);
+      });
+
+      test('toDb encodes null tags as null', () {
+        const Anime anime = Anime(id: 1, title: 'X');
+        expect(anime.toDb()['tags'], isNull);
+      });
+
+      test('copyWith replaces tags', () {
+        const Anime original = Anime(id: 1, title: 'X', tags: <String>['A']);
+        final Anime updated = original.copyWith(tags: <String>['B', 'C']);
+        expect(updated.tags, <String>['B', 'C']);
+      });
+
+      test('tagsString joins with comma', () {
+        const Anime anime =
+            Anime(id: 1, title: 'X', tags: <String>['A', 'B']);
+        expect(anime.tagsString, 'A, B');
+      });
+
+      test('tagsString returns null when tags is null', () {
+        const Anime anime = Anime(id: 1, title: 'X');
+        expect(anime.tagsString, isNull);
+      });
+    });
   });
 }

--- a/test/shared/models/manga_test.dart
+++ b/test/shared/models/manga_test.dart
@@ -6,7 +6,7 @@ import 'package:xerabora/shared/models/manga.dart';
 void main() {
   group('Manga', () {
     group('fromJson', () {
-      test('должен создать Manga из полного JSON', () {
+      test('should create Manga from full JSON', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 30013,
           'title': <String, dynamic>{
@@ -80,7 +80,7 @@ void main() {
         expect(manga.updatedAt, isNotNull);
       });
 
-      test('должен создать Manga из минимального JSON', () {
+      test('should create Manga from minimal JSON', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{
@@ -113,7 +113,7 @@ void main() {
         expect(manga.externalUrl, 'https://anilist.co/manga/1');
       });
 
-      test('должен использовать english title как fallback', () {
+      test('should use english title as fallback', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{
@@ -126,7 +126,7 @@ void main() {
         expect(manga.title, 'Naruto');
       });
 
-      test('должен использовать Unknown если нет title', () {
+      test('should use Unknown when title is missing', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
         };
@@ -136,7 +136,7 @@ void main() {
         expect(manga.title, 'Unknown');
       });
 
-      test('должен фильтровать авторов по роли', () {
+      test('should filter authors by role', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{'romaji': 'Test'},
@@ -163,7 +163,7 @@ void main() {
         expect(manga.authors, <String>['Author']);
       });
 
-      test('должен вернуть null authors при пустом списке после фильтрации',
+      test('should return null authors when list is empty after filtering',
           () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
@@ -185,7 +185,7 @@ void main() {
         expect(manga.authors, isNull);
       });
 
-      test('должен пропускать авторов с пустым именем', () {
+      test('should skip authors with empty names', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{'romaji': 'Test'},
@@ -212,7 +212,7 @@ void main() {
         expect(manga.authors, isNull);
       });
 
-      test('должен убирать HTML из описания', () {
+      test('should strip HTML from description', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{'romaji': 'Test'},
@@ -225,7 +225,7 @@ void main() {
         expect(manga.description, 'A bold & italic description.');
       });
 
-      test('должен вернуть null description для пустого HTML', () {
+      test('should return null description from empty HTML', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{'romaji': 'Test'},
@@ -237,7 +237,7 @@ void main() {
         expect(manga.description, isNull);
       });
 
-      test('должен декодировать HTML entities', () {
+      test('should decode HTML entities', () {
         final Map<String, dynamic> json = <String, dynamic>{
           'id': 1,
           'title': <String, dynamic>{'romaji': 'Test'},
@@ -251,7 +251,7 @@ void main() {
     });
 
     group('fromDb', () {
-      test('должен создать Manga из записи БД', () {
+      test('should create Manga from DB row', () {
         final Map<String, dynamic> row = <String, dynamic>{
           'id': 30013,
           'title': 'One Punch-Man',
@@ -290,7 +290,7 @@ void main() {
         expect(manga.updatedAt, 1700000000);
       });
 
-      test('должен обработать null JSON строки', () {
+      test('should handle null JSON strings', () {
         final Map<String, dynamic> row = <String, dynamic>{
           'id': 1,
           'title': 'Test',
@@ -322,7 +322,7 @@ void main() {
         expect(manga.authors, isNull);
       });
 
-      test('должен обработать пустые JSON строки', () {
+      test('should handle empty JSON strings', () {
         final Map<String, dynamic> row = <String, dynamic>{
           'id': 1,
           'title': 'Test',
@@ -354,7 +354,7 @@ void main() {
         expect(manga.authors, isNull);
       });
 
-      test('должен обработать повреждённые JSON строки', () {
+      test('should handle malformed JSON strings', () {
         final Map<String, dynamic> row = <String, dynamic>{
           'id': 1,
           'title': 'Test',
@@ -388,7 +388,7 @@ void main() {
     });
 
     group('toDb', () {
-      test('должен сериализовать в Map', () {
+      test('should serialize to Map', () {
         const Manga manga = Manga(
           id: 30013,
           title: 'One Punch-Man',
@@ -426,7 +426,7 @@ void main() {
         expect(db['updated_at'], 1700000000);
       });
 
-      test('должен сериализовать null поля', () {
+      test('should serialize null fields', () {
         const Manga manga = Manga(
           id: 1,
           title: 'Test',
@@ -441,7 +441,7 @@ void main() {
     });
 
     group('toExport', () {
-      test('должен исключить updated_at', () {
+      test('should exclude updated_at', () {
         const Manga manga = Manga(
           id: 30013,
           title: 'One Punch-Man',
@@ -456,7 +456,7 @@ void main() {
     });
 
     group('copyWith', () {
-      test('должен создать копию с изменёнными полями', () {
+      test('should create copy with updated fields', () {
         const Manga original = Manga(
           id: 30013,
           title: 'One Punch-Man',
@@ -470,7 +470,7 @@ void main() {
         expect(copy.averageScore, 84);
       });
 
-      test('должен сохранить все поля при пустом copyWith', () {
+      test('should preserve all fields with empty copyWith', () {
         const Manga original = Manga(
           id: 30013,
           title: 'One Punch-Man',
@@ -490,37 +490,37 @@ void main() {
     });
 
     group('computed getters', () {
-      test('rating10 должен нормализовать к 0-10', () {
+      test('rating10 should normalize to 0-10', () {
         const Manga manga = Manga(id: 1, title: 'T', averageScore: 84);
         expect(manga.rating10, 8.4);
       });
 
-      test('rating10 должен вернуть null при null averageScore', () {
+      test('rating10 should return null when null averageScore', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.rating10, isNull);
       });
 
-      test('formattedRating должен форматировать до 1 знака', () {
+      test('formattedRating should format with 1 decimal', () {
         const Manga manga = Manga(id: 1, title: 'T', averageScore: 85);
         expect(manga.formattedRating, '8.5');
       });
 
-      test('formattedRating должен вернуть null при null averageScore', () {
+      test('formattedRating should return null when null averageScore', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.formattedRating, isNull);
       });
 
-      test('releaseYear должен вернуть startYear', () {
+      test('releaseYear should return startYear', () {
         const Manga manga = Manga(id: 1, title: 'T', startYear: 2012);
         expect(manga.releaseYear, 2012);
       });
 
-      test('releaseYear должен вернуть null при null startYear', () {
+      test('releaseYear should return null when null startYear', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.releaseYear, isNull);
       });
 
-      test('genresString должен объединить жанры через запятую', () {
+      test('genresString should join genres with comma', () {
         const Manga manga = Manga(
           id: 1,
           title: 'T',
@@ -529,12 +529,12 @@ void main() {
         expect(manga.genresString, 'Action, Comedy');
       });
 
-      test('genresString должен вернуть null при null genres', () {
+      test('genresString should return null when null genres', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.genresString, isNull);
       });
 
-      test('authorsString должен объединить авторов через запятую', () {
+      test('authorsString should join authors with comma', () {
         const Manga manga = Manga(
           id: 1,
           title: 'T',
@@ -543,12 +543,12 @@ void main() {
         expect(manga.authorsString, 'ONE, Murata');
       });
 
-      test('authorsString должен вернуть null при null authors', () {
+      test('authorsString should return null when null authors', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.authorsString, isNull);
       });
 
-      test('formatLabel должен вернуть метку для каждого формата', () {
+      test('formatLabel should return the label for each format', () {
         for (final MapEntry<String, String> entry
             in <String, String>{
               'MANGA': 'Manga',
@@ -563,18 +563,18 @@ void main() {
         }
       });
 
-      test('formatLabel должен вернуть raw значение для неизвестного формата',
+      test('formatLabel should return the raw value for an unknown format',
           () {
         const Manga manga = Manga(id: 1, title: 'T', format: 'WEBTOON');
         expect(manga.formatLabel, 'WEBTOON');
       });
 
-      test('formatLabel должен вернуть null при null format', () {
+      test('formatLabel should return null when null format', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.formatLabel, isNull);
       });
 
-      test('statusLabel должен вернуть метку для каждого статуса', () {
+      test('statusLabel should return the label for each status', () {
         for (final MapEntry<String, String> entry
             in <String, String>{
               'FINISHED': 'Finished',
@@ -588,53 +588,53 @@ void main() {
         }
       });
 
-      test('statusLabel должен вернуть raw значение для неизвестного статуса',
+      test('statusLabel should return the raw value for an unknown status',
           () {
         const Manga manga = Manga(id: 1, title: 'T', status: 'UNKNOWN');
         expect(manga.statusLabel, 'UNKNOWN');
       });
 
-      test('statusLabel должен вернуть null при null status', () {
+      test('statusLabel should return null when null status', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.statusLabel, isNull);
       });
 
-      test('progressString должен показать главы и тома', () {
+      test('progressString should show chapters and volumes', () {
         const Manga manga =
             Manga(id: 1, title: 'T', chapters: 200, volumes: 25);
         expect(manga.progressString, '200 ch · 25 vol');
       });
 
-      test('progressString должен показать ? при null chapters', () {
+      test('progressString should show ? when chapters is null', () {
         const Manga manga = Manga(id: 1, title: 'T', volumes: 10);
         expect(manga.progressString, '? ch · 10 vol');
       });
 
-      test('progressString должен не показывать volumes при null', () {
+      test('progressString should skip volumes when null', () {
         const Manga manga = Manga(id: 1, title: 'T', chapters: 50);
         expect(manga.progressString, '50 ch');
       });
 
-      test('progressString должен показать ? ch при null обоих', () {
+      test('progressString should show "? ch" when both are null', () {
         const Manga manga = Manga(id: 1, title: 'T');
         expect(manga.progressString, '? ch');
       });
     });
 
     group('equality', () {
-      test('должен быть равен при одинаковом id', () {
+      test('should be equal for same id', () {
         const Manga a = Manga(id: 30013, title: 'A');
         const Manga b = Manga(id: 30013, title: 'B');
         expect(a, equals(b));
       });
 
-      test('не должен быть равен при разных id', () {
+      test('should not be equal for different ids', () {
         const Manga a = Manga(id: 30013, title: 'A');
         const Manga b = Manga(id: 1, title: 'A');
         expect(a, isNot(equals(b)));
       });
 
-      test('hashCode должен зависеть от id', () {
+      test('hashCode should depend by id', () {
         const Manga a = Manga(id: 30013, title: 'A');
         const Manga b = Manga(id: 30013, title: 'B');
         expect(a.hashCode, equals(b.hashCode));
@@ -642,7 +642,7 @@ void main() {
     });
 
     group('toString', () {
-      test('должен содержать id и title', () {
+      test('should contain id and title', () {
         const Manga manga = Manga(id: 30013, title: 'One Punch-Man');
         expect(manga.toString(), 'Manga(id: 30013, title: One Punch-Man)');
       });
@@ -676,6 +676,48 @@ void main() {
 
       test('unknown lang code falls back to romaji', () {
         expect(full.titleByLanguage('klingon'), 'Romaji Title');
+      });
+    });
+
+    group('tags', () {
+      test('fromJson parses tags array of {name} objects', () {
+        final Manga manga = Manga.fromJson(<String, dynamic>{
+          'id': 1,
+          'title': <String, dynamic>{'romaji': 'X'},
+          'tags': <Map<String, dynamic>>[
+            <String, dynamic>{'name': 'Slice of Life'},
+            <String, dynamic>{'name': 'School'},
+          ],
+        });
+        expect(manga.tags, <String>['Slice of Life', 'School']);
+      });
+
+      test('fromJson returns null when tags missing or empty', () {
+        final Manga missing = Manga.fromJson(<String, dynamic>{
+          'id': 1,
+          'title': <String, dynamic>{'romaji': 'X'},
+        });
+        expect(missing.tags, isNull);
+      });
+
+      test('toDb / fromDb round-trip preserves tags', () {
+        const Manga original =
+            Manga(id: 1, title: 'X', tags: <String>['A', 'B', 'C']);
+        final Map<String, dynamic> row = original.toDb();
+        final Manga back = Manga.fromDb(row);
+        expect(back.tags, original.tags);
+      });
+
+      test('copyWith replaces tags', () {
+        const Manga original = Manga(id: 1, title: 'X', tags: <String>['A']);
+        final Manga updated = original.copyWith(tags: <String>['B', 'C']);
+        expect(updated.tags, <String>['B', 'C']);
+      });
+
+      test('tagsString joins with comma', () {
+        const Manga manga =
+            Manga(id: 1, title: 'X', tags: <String>['A', 'B']);
+        expect(manga.tagsString, 'A, B');
       });
     });
   });


### PR DESCRIPTION
Anime and manga now carry their AniList tag list (in addition to genres). Tags are pulled from the API into a new `tags` cache column, shown as a chip in the item detail screen and the search-result sheet, and exported via the new `{tags}` text-export token plus the `.xcoll` / `.xcollx` payload. Refresh-from-source backfills tags for items added before this change.

Search gains an AniList tag multi-select filter on the Anime and Manga tabs, served by a SQLite-cached catalog (~600 tags). The filter opens a dedicated bottom-sheet picker with live name search, category- grouped collapsible sections, spoiler / 18+ toggles, a manual refresh button, and selected-count footer.