### PR TITLE
ci(coverage): replace Codecov with GitHub-native coverage; fix README download labels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -41,8 +44,44 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Compute coverage summary
+        id: cov
+        run: |
+          LF=$(awk -F: '/^LF:/ {s+=$2} END {print s+0}' coverage/lcov.info)
+          LH=$(awk -F: '/^LH:/ {s+=$2} END {print s+0}' coverage/lcov.info)
+          PCT=$(awk "BEGIN { if ($LF>0) printf \"%.1f\", ($LH/$LF)*100; else print \"0.0\" }")
+          echo "pct=$PCT" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Coverage"
+            echo ""
+            echo "**${PCT}%** of lines covered (${LH}/${LF})."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: romeovs/lcov-reporter-action@v0.4.0
         with:
-          files: coverage/lcov.info
-          fail_ci_if_error: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: coverage/lcov.info
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+
+      # Writes the coverage % to a public Gist; shields.io renders the README
+      # badge from it. Requires repo secret GIST_TOKEN (PAT with `gist` scope)
+      # and the real Gist id below.
+      - name: Update coverage badge
+        if: github.event_name == 'push'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 7ed48e87a6bd59afeb08eaf656fd2adb
+          filename: tonkatsu-box-coverage.json
+          label: coverage
+          message: ${{ steps.cov.outputs.pct }}%
+          valColorRange: ${{ steps.cov.outputs.pct }}
+          minColorRange: 50
+          maxColorRange: 90

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Run tests with coverage
         run: flutter test --coverage
 
+      # Drop generated / non-product code so the percentage reflects real,
+      # testable code (l10n is pure generated strings; debug screens are tools).
+      - name: Strip generated code from coverage
+        run: |
+          sudo apt-get update && sudo apt-get install -y lcov
+          lcov --remove coverage/lcov.info \
+            'lib/l10n/*' '*.g.dart' '*.freezed.dart' '*_debug_screen.dart' \
+            -o coverage/lcov.info --ignore-errors unused
+
       - name: Compute coverage summary
         id: cov
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
           LF=$(awk -F: '/^LF:/ {s+=$2} END {print s+0}' coverage/lcov.info)
           LH=$(awk -F: '/^LH:/ {s+=$2} END {print s+0}' coverage/lcov.info)
           PCT=$(awk "BEGIN { if ($LF>0) printf \"%.1f\", ($LH/$LF)*100; else print \"0.0\" }")
+          echo "Coverage: ${PCT}% of lines (${LH}/${LF})"
           echo "pct=$PCT" >> "$GITHUB_OUTPUT"
           {
             echo "## Coverage"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 <p align="center">
   <a href="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml"><img src="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
+  <a href="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/hacan359/7ed48e87a6bd59afeb08eaf656fd2adb/raw/tonkatsu-box-coverage.json" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://flutter.dev"><img src="https://img.shields.io/badge/Flutter-3.38+-02569B?logo=flutter&logoColor=white" alt="Flutter 3.38+"></a>
   <a href="https://discord.gg/JZVNPF7cS2"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
@@ -80,8 +81,8 @@ Tonkatsu Box is a free, open-source app to organize your media collections. Sear
 
 | Platform | Link |
 |----------|------|
-| Windows | [**Download .exe**](https://github.com/hacan359/tonkatsu_box/releases/latest) |
-| Linux | [**Download .AppImage**](https://github.com/hacan359/tonkatsu_box/releases/latest) |
+| Windows | [**Download .zip**](https://github.com/hacan359/tonkatsu_box/releases/latest) |
+| Linux | [**Download .tar.gz**](https://github.com/hacan359/tonkatsu_box/releases/latest) |
 | Android | [**Download .apk**](https://github.com/hacan359/tonkatsu_box/releases/latest) |
 
 > Linux support is experimental.


### PR DESCRIPTION
* .github/workflows/test.yml: Drop codecov-action; add coverage summary, PR comment (romeovs/lcov-reporter-action), artifact upload, and badge update (schneegans/dynamic-badges-action) to a Gist.
* README.md: Add coverage badge; Windows .exe -> .zip, Linux .AppImage -> .tar.gz.