### PR TITLE
test: cover backups, collection logic, helpers and reusable widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml"><img src="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <a href="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/hacan359/7ed48e87a6bd59afeb08eaf656fd2adb/raw/tonkatsu-box-coverage.json" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://flutter.dev"><img src="https://img.shields.io/badge/Flutter-3.38+-02569B?logo=flutter&logoColor=white" alt="Flutter 3.38+"></a>
+  <a href="https://flutter.dev"><img src="https://img.shields.io/badge/Flutter-3.44+-02569B?logo=flutter&logoColor=white" alt="Flutter 3.44+"></a>
   <a href="https://discord.gg/JZVNPF7cS2"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
@@ -158,7 +158,7 @@ flutter pub get
 flutter run -d windows  # or linux / android
 ```
 
-Requires Flutter 3.38+. See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
+Requires Flutter 3.44+. See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
 
 ## Community
 

--- a/test/core/api/anilist/anilist_media_parser_test.dart
+++ b/test/core/api/anilist/anilist_media_parser_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/core/api/anilist/anilist_media_parser.dart';
+import 'package:xerabora/shared/models/anime.dart';
+import 'package:xerabora/shared/models/manga.dart';
+
+Map<String, dynamic> _page({
+  List<Map<String, dynamic>> media = const <Map<String, dynamic>>[],
+  bool hasNextPage = false,
+  int lastPage = 1,
+}) =>
+    <String, dynamic>{
+      'Page': <String, dynamic>{
+        'pageInfo': <String, dynamic>{
+          'hasNextPage': hasNextPage,
+          'lastPage': lastPage,
+        },
+        'media': media,
+      },
+    };
+
+void main() {
+  group('AniListMediaParser.animePage', () {
+    test('null data yields empty result', () {
+      final (List<Anime>, bool, int) r = AniListMediaParser.animePage(null);
+      expect(r.$1, isEmpty);
+      expect(r.$2, isFalse);
+      expect(r.$3, 0);
+    });
+
+    test('missing Page node yields empty result', () {
+      final (List<Anime>, bool, int) r =
+          AniListMediaParser.animePage(<String, dynamic>{});
+      expect(r.$1, isEmpty);
+    });
+
+    test('reads pageInfo flags', () {
+      final (List<Anime>, bool, int) r = AniListMediaParser.animePage(
+        _page(hasNextPage: true, lastPage: 5),
+      );
+      expect(r.$1, isEmpty);
+      expect(r.$2, isTrue);
+      expect(r.$3, 5);
+    });
+
+    test('parses media entries into Anime', () {
+      final (List<Anime>, bool, int) r = AniListMediaParser.animePage(
+        _page(media: <Map<String, dynamic>>[
+          <String, dynamic>{'id': 1, 'title': <String, dynamic>{'romaji': 'A'}},
+          <String, dynamic>{'id': 2, 'title': <String, dynamic>{'romaji': 'B'}},
+        ]),
+      );
+      expect(r.$1.map((Anime a) => a.id), <int>[1, 2]);
+    });
+  });
+
+  group('AniListMediaParser.mangaPage', () {
+    test('null data yields empty result', () {
+      final (List<Manga>, bool, int) r = AniListMediaParser.mangaPage(null);
+      expect(r.$1, isEmpty);
+      expect(r.$3, 0);
+    });
+
+    test('parses media entries into Manga', () {
+      final (List<Manga>, bool, int) r = AniListMediaParser.mangaPage(
+        _page(media: <Map<String, dynamic>>[
+          <String, dynamic>{'id': 9, 'title': <String, dynamic>{'romaji': 'M'}},
+        ]),
+      );
+      expect(r.$1.single.id, 9);
+    });
+  });
+
+  group('AniListMediaParser.fuzzyDate', () {
+    test('null map or null year yields null', () {
+      expect(AniListMediaParser.fuzzyDate(null), isNull);
+      expect(
+        AniListMediaParser.fuzzyDate(<String, dynamic>{'year': null}),
+        isNull,
+      );
+    });
+
+    test('year only defaults month and day to 1', () {
+      expect(
+        AniListMediaParser.fuzzyDate(<String, dynamic>{'year': 2020}),
+        DateTime.utc(2020, 1, 1),
+      );
+    });
+
+    test('full fuzzy date is parsed', () {
+      expect(
+        AniListMediaParser.fuzzyDate(
+          <String, dynamic>{'year': 2014, 'month': 6, 'day': 15},
+        ),
+        DateTime.utc(2014, 6, 15),
+      );
+    });
+  });
+}

--- a/test/core/api/anilist/anilist_user_list_api_test.dart
+++ b/test/core/api/anilist/anilist_user_list_api_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/api/anilist/anilist_types.dart';
+import 'package:xerabora/core/api/anilist/anilist_user_list_api.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockAniListGraphQLClient client;
+  late AniListUserListApi api;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    client = MockAniListGraphQLClient();
+    api = AniListUserListApi(client);
+  });
+
+  void stubPost(Map<String, dynamic> body) {
+    when(() => client.post(
+          query: any(named: 'query'),
+          variables: any(named: 'variables'),
+          errorContext: any(named: 'errorContext'),
+        )).thenAnswer((_) async => body);
+  }
+
+  Map<String, dynamic> entry(int id, {bool adult = false, bool noMedia = false}) =>
+      <String, dynamic>{
+        'status': 'CURRENT',
+        'score': 80,
+        'progress': 3,
+        if (!noMedia)
+          'media': <String, dynamic>{
+            'id': id,
+            'title': <String, dynamic>{'romaji': 'T$id'},
+            'isAdult': adult,
+          },
+      };
+
+  Map<String, dynamic> listsBody(List<Map<String, dynamic>> lists) =>
+      <String, dynamic>{
+        'data': <String, dynamic>{
+          'MediaListCollection': <String, dynamic>{'lists': lists},
+        },
+      };
+
+  Map<String, dynamic> oneList(
+    List<Map<String, dynamic>> entries, {
+    bool custom = false,
+  }) =>
+      <String, dynamic>{'isCustomList': custom, 'entries': entries};
+
+  group('argument validation', () {
+    test('rejects non anime/manga types', () {
+      expect(
+        () => api.fetchUserMediaList(userName: 'u', type: MediaType.movie),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an empty user name', () {
+      expect(
+        () => api.fetchUserMediaList(userName: '   ', type: MediaType.anime),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('GraphQL error translation', () {
+    test('"not found" maps to AniListUserNotFoundException', () async {
+      stubPost(<String, dynamic>{
+        'errors': <dynamic>[<String, dynamic>{'message': 'User not found'}],
+      });
+      await expectLater(
+        api.fetchUserMediaList(userName: 'ghost', type: MediaType.anime),
+        throwsA(isA<AniListUserNotFoundException>()),
+      );
+    });
+
+    test('"private" maps to AniListPrivateProfileException', () async {
+      stubPost(<String, dynamic>{
+        'errors': <dynamic>[<String, dynamic>{'message': 'This profile is private'}],
+      });
+      await expectLater(
+        api.fetchUserMediaList(userName: 'secret', type: MediaType.anime),
+        throwsA(isA<AniListPrivateProfileException>()),
+      );
+    });
+
+    test('other errors surface as AniListApiException', () async {
+      stubPost(<String, dynamic>{
+        'errors': <dynamic>[<String, dynamic>{'message': 'rate limited'}],
+      });
+      await expectLater(
+        api.fetchUserMediaList(userName: 'u', type: MediaType.anime),
+        throwsA(isA<AniListApiException>()),
+      );
+    });
+
+    test('a 404 from the client maps to not-found', () async {
+      when(() => client.post(
+            query: any(named: 'query'),
+            variables: any(named: 'variables'),
+            errorContext: any(named: 'errorContext'),
+          )).thenThrow(const AniListApiException('nope', statusCode: 404));
+      await expectLater(
+        api.fetchUserMediaList(userName: 'u', type: MediaType.anime),
+        throwsA(isA<AniListUserNotFoundException>()),
+      );
+    });
+  });
+
+  group('parsing', () {
+    test('null MediaListCollection yields an empty list', () async {
+      stubPost(<String, dynamic>{'data': <String, dynamic>{}});
+      final List<AniListListEntry> r =
+          await api.fetchUserMediaList(userName: 'u', type: MediaType.anime);
+      expect(r, isEmpty);
+    });
+
+    test('parses entries and reports their media ids', () async {
+      stubPost(listsBody(<Map<String, dynamic>>[
+        oneList(<Map<String, dynamic>>[entry(1), entry(2)]),
+      ]));
+      final List<AniListListEntry> r =
+          await api.fetchUserMediaList(userName: 'u', type: MediaType.anime);
+      expect(r.map((AniListListEntry e) => e.mediaId).toSet(), <int>{1, 2});
+    });
+
+    test('deduplicates the same media across lists', () async {
+      stubPost(listsBody(<Map<String, dynamic>>[
+        oneList(<Map<String, dynamic>>[entry(1)]),
+        oneList(<Map<String, dynamic>>[entry(1)]),
+      ]));
+      final List<AniListListEntry> r =
+          await api.fetchUserMediaList(userName: 'u', type: MediaType.anime);
+      expect(r.length, 1);
+    });
+
+    test('skips custom lists, adult entries and entries without media',
+        () async {
+      stubPost(listsBody(<Map<String, dynamic>>[
+        oneList(<Map<String, dynamic>>[entry(10)], custom: true),
+        oneList(<Map<String, dynamic>>[
+          entry(1),
+          entry(2, adult: true),
+          entry(3, noMedia: true),
+        ]),
+      ]));
+      final List<AniListListEntry> r =
+          await api.fetchUserMediaList(userName: 'u', type: MediaType.anime);
+      expect(r.map((AniListListEntry e) => e.mediaId).toSet(), <int>{1});
+    });
+  });
+}

--- a/test/core/api/api_error_extract_test.dart
+++ b/test/core/api/api_error_extract_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/core/api/anilist_api.dart';
+import 'package:xerabora/core/api/api_error_extract.dart';
+import 'package:xerabora/core/api/igdb_api.dart';
+import 'package:xerabora/core/api/ra_api.dart';
+import 'package:xerabora/core/api/steam_api.dart';
+import 'package:xerabora/core/api/steamgriddb_api.dart';
+import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/core/api/vndb_api.dart';
+
+void main() {
+  group('extractApiError', () {
+    test('pulls message and detail from every typed API exception', () {
+      final List<(Exception, String)> cases = <(Exception, String)>[
+        (const TmdbApiException('tmdb', detail: 'd1'), 'tmdb'),
+        (const IgdbApiException('igdb', detail: 'd2'), 'igdb'),
+        (const AniListApiException('anilist', detail: 'd3'), 'anilist'),
+        (const VndbApiException('vndb', detail: 'd4'), 'vndb'),
+        (const SteamGridDbApiException('sgdb', detail: 'd5'), 'sgdb'),
+        (const SteamApiException('steam', detail: 'd6'), 'steam'),
+        (const RaApiException('ra', detail: 'd7'), 'ra'),
+      ];
+
+      for (final (Exception e, String msg) in cases) {
+        final ApiError r = extractApiError(e);
+        expect(r.message, msg);
+        expect(r.detail, isNotNull);
+      }
+    });
+
+    test('keeps a null detail when the exception carries none', () {
+      final ApiError r = extractApiError(const TmdbApiException('boom'));
+      expect(r.message, 'boom');
+      expect(r.detail, isNull);
+    });
+
+    test('falls back to toString for unknown exception types', () {
+      final ApiError r = extractApiError(const FormatException('bad input'));
+      expect(r.detail, isNull);
+      expect(r.message, contains('bad input'));
+    });
+  });
+}

--- a/test/core/services/backup_service_test.dart
+++ b/test/core/services/backup_service_test.dart
@@ -1,0 +1,255 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/services/backup_service.dart';
+import 'package:xerabora/core/services/import_service.dart';
+import 'package:xerabora/core/services/xcoll_file.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('BackupManifest.fromJson', () {
+    test('parses a full manifest', () {
+      final BackupManifest m = BackupManifest.fromJson(<String, dynamic>{
+        'version': 2,
+        'created': '2025-02-02T12:00:00Z',
+        'collections_count': 3,
+        'items_count': 42,
+        'wishlist_count': 5,
+        'includes_config': true,
+        'profile_name': 'Main',
+        'app_version': '1.2.3',
+      });
+
+      expect(m.version, 2);
+      expect(m.collectionsCount, 3);
+      expect(m.itemsCount, 42);
+      expect(m.wishlistCount, 5);
+      expect(m.includesConfig, isTrue);
+      expect(m.profileName, 'Main');
+      expect(m.appVersion, '1.2.3');
+    });
+
+    test('applies defaults for missing fields', () {
+      final BackupManifest m = BackupManifest.fromJson(<String, dynamic>{
+        'created': '2025-02-02T12:00:00Z',
+      });
+
+      expect(m.version, 1);
+      expect(m.collectionsCount, 0);
+      expect(m.itemsCount, 0);
+      expect(m.wishlistCount, 0);
+      expect(m.includesConfig, isFalse);
+      expect(m.profileName, isNull);
+    });
+  });
+
+  group('BackupService restore', () {
+    late MockDatabaseService database;
+    late MockDatabase rawDb;
+    late MockExportService exportService;
+    late MockImportService importService;
+    late MockConfigService configService;
+    late MockCollectionRepository collectionRepo;
+    late MockWishlistRepository wishlistRepo;
+    late Directory tmp;
+    int seq = 0;
+
+    setUpAll(() {
+      registerAllFallbacks();
+      registerFallbackValue(
+        XcollFile(version: 3, name: 'x', author: 'x', created: DateTime(2025)),
+      );
+    });
+
+    setUp(() {
+      database = MockDatabaseService();
+      rawDb = MockDatabase();
+      exportService = MockExportService();
+      importService = MockImportService();
+      configService = MockConfigService();
+      collectionRepo = MockCollectionRepository();
+      wishlistRepo = MockWishlistRepository();
+      tmp = Directory.systemTemp.createTempSync('backup_test');
+
+      // WAL checkpoint at the end of restore.
+      when(() => database.database).thenAnswer((_) async => rawDb);
+      when(() => rawDb.execute(any())).thenAnswer((_) async {});
+    });
+
+    tearDown(() {
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+
+    BackupService makeService() => BackupService(
+          database: database,
+          exportService: exportService,
+          importService: importService,
+          configService: configService,
+          collectionRepo: collectionRepo,
+          wishlistRepo: wishlistRepo,
+        );
+
+    String writeZip(Map<String, String> files) {
+      final Archive archive = Archive();
+      files.forEach((String name, String content) {
+        final List<int> b = utf8.encode(content);
+        archive.addFile(ArchiveFile(name, b.length, b));
+      });
+      final List<int> zip = ZipEncoder().encode(archive);
+      final File f = File('${tmp.path}/backup_${seq++}.zip')
+        ..writeAsBytesSync(zip);
+      return f.path;
+    }
+
+    const String collectionXcoll =
+        '{"version":3,"format":"full","name":"My Coll","author":"me",'
+        '"created":"2025-01-01T00:00:00Z","items":[]}';
+
+    const String manifestJson = '{"version":3,"created":"2025-02-02T12:00:00Z",'
+        '"collections_count":1,"items_count":3,"wishlist_count":2,'
+        '"includes_config":true}';
+
+    const String wishlistJson = '['
+        '{"text":"Dup Game","created_at":1700000000},'
+        '{"text":"New Game","media_type_hint":"game","note":"n",'
+        '"created_at":1700000000,"tag":"t"}'
+        ']';
+
+    void stubImportOk() {
+      when(() => importService.importFromXcoll(any())).thenAnswer(
+        (_) async => ImportResult.success(createTestCollection(), 3),
+      );
+    }
+
+    void stubWishlist() {
+      when(() => wishlistRepo.findUnresolved('Dup Game'))
+          .thenAnswer((_) async => createTestWishlistItem(text: 'Dup Game'));
+      when(() => wishlistRepo.findUnresolved('New Game'))
+          .thenAnswer((_) async => null);
+      when(() => wishlistRepo.add(
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            note: any(named: 'note'),
+            tag: any(named: 'tag'),
+          )).thenAnswer((_) async => createTestWishlistItem(text: 'New Game'));
+    }
+
+    test('readManifest returns the parsed manifest from a ZIP', () async {
+      final String path = writeZip(<String, String>{'manifest.json': manifestJson});
+
+      final BackupManifest? m = await makeService().readManifest(path);
+
+      expect(m, isNotNull);
+      expect(m!.collectionsCount, 1);
+      expect(m.itemsCount, 3);
+      expect(m.includesConfig, isTrue);
+    });
+
+    test('readManifest returns null when manifest is absent', () async {
+      final String path =
+          writeZip(<String, String>{'collections/001_a.xcollx': collectionXcoll});
+
+      expect(await makeService().readManifest(path), isNull);
+    });
+
+    test('readManifest returns null for a non-ZIP file', () async {
+      final File f = File('${tmp.path}/not-a-zip.zip')
+        ..writeAsBytesSync(<int>[1, 2, 3, 4, 5]);
+
+      expect(await makeService().readManifest(f.path), isNull);
+    });
+
+    test('restores collections and dedups wishlist, skips settings by default',
+        () async {
+      stubImportOk();
+      stubWishlist();
+      final String path = writeZip(<String, String>{
+        'manifest.json': manifestJson,
+        'collections/001_my-coll.xcollx': collectionXcoll,
+        'wishlist.json': wishlistJson,
+        'config.json': '{"theme":"dark"}',
+      });
+
+      final RestoreResult r = await makeService().restoreFromBackup(zipPath: path);
+
+      expect(r.success, isTrue);
+      expect(r.collectionsRestored, 1);
+      expect(r.itemsRestored, 3);
+      expect(r.wishlistRestored, 1); // "Dup Game" skipped, "New Game" added
+      expect(r.settingsRestored, isFalse);
+
+      verify(() => importService.importFromXcoll(any())).called(1);
+      verify(() => wishlistRepo.add(
+            text: 'New Game',
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            note: any(named: 'note'),
+            tag: any(named: 'tag'),
+          )).called(1);
+      verifyNever(() => configService.applySettings(any()));
+    });
+
+    test('applies settings only when restoreSettings is true', () async {
+      stubImportOk();
+      stubWishlist();
+      when(() => configService.applySettings(any())).thenAnswer((_) async => 2);
+      final String path = writeZip(<String, String>{
+        'manifest.json': manifestJson,
+        'collections/001_my-coll.xcollx': collectionXcoll,
+        'config.json': '{"theme":"dark"}',
+      });
+
+      final RestoreResult r = await makeService()
+          .restoreFromBackup(zipPath: path, restoreSettings: true);
+
+      expect(r.settingsRestored, isTrue);
+      verify(() => configService.applySettings(any())).called(1);
+    });
+
+    test('does not touch wishlist when restoreWishlist is false', () async {
+      stubImportOk();
+      final String path = writeZip(<String, String>{
+        'manifest.json': manifestJson,
+        'wishlist.json': wishlistJson,
+      });
+
+      final RestoreResult r = await makeService()
+          .restoreFromBackup(zipPath: path, restoreWishlist: false);
+
+      expect(r.wishlistRestored, 0);
+      verifyNever(() => wishlistRepo.findUnresolved(any()));
+      verifyNever(() => wishlistRepo.add(
+            text: any(named: 'text'),
+            mediaTypeHint: any(named: 'mediaTypeHint'),
+            note: any(named: 'note'),
+            tag: any(named: 'tag'),
+          ));
+    });
+
+    test('returns failure when the backup file cannot be read', () async {
+      final RestoreResult r = await makeService()
+          .restoreFromBackup(zipPath: '${tmp.path}/does-not-exist.zip');
+
+      expect(r.success, isFalse);
+    });
+
+    test('a failed collection import does not abort the whole restore',
+        () async {
+      when(() => importService.importFromXcoll(any()))
+          .thenAnswer((_) async => const ImportResult.failure('boom'));
+      final String path = writeZip(<String, String>{
+        'manifest.json': manifestJson,
+        'collections/001_my-coll.xcollx': collectionXcoll,
+      });
+
+      final RestoreResult r = await makeService().restoreFromBackup(zipPath: path);
+
+      expect(r.success, isTrue);
+      expect(r.collectionsRestored, 0); // import failed → not counted
+      expect(r.itemsRestored, 0);
+    });
+  });
+}

--- a/test/core/services/collection_browser_service_test.dart
+++ b/test/core/services/collection_browser_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/core/services/collection_browser_service.dart';
+import 'package:xerabora/features/collections/models/collections_index.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('CollectionBrowserService.fetchIndex', () {
+    late MockDio dio;
+    late CollectionBrowserService service;
+
+    const String indexJson =
+        '{"version":2,"totalCollections":5,"totalItems":100}';
+
+    Response<String> ok(String body) => Response<String>(
+          requestOptions: RequestOptions(path: '/index.json'),
+          data: body,
+          statusCode: 200,
+        );
+
+    setUp(() {
+      dio = MockDio();
+      service = CollectionBrowserService(dio: dio);
+      when(() => dio.get<String>(any()))
+          .thenAnswer((_) async => ok(indexJson));
+    });
+
+    test('parses the fetched index', () async {
+      final CollectionsIndex index = await service.fetchIndex();
+      expect(index.version, 2);
+      expect(index.totalCollections, 5);
+      expect(index.totalItems, 100);
+    });
+
+    test('caches the result across calls', () async {
+      await service.fetchIndex();
+      await service.fetchIndex();
+      verify(() => dio.get<String>(any())).called(1);
+    });
+
+    test('forceRefresh bypasses the cache', () async {
+      await service.fetchIndex();
+      await service.fetchIndex(forceRefresh: true);
+      verify(() => dio.get<String>(any())).called(2);
+    });
+
+    test('clearCache forces a re-fetch', () async {
+      await service.fetchIndex();
+      service.clearCache();
+      await service.fetchIndex();
+      verify(() => dio.get<String>(any())).called(2);
+    });
+
+    test('wraps a DioException in CollectionBrowserException', () async {
+      when(() => dio.get<String>(any())).thenThrow(
+        DioException(requestOptions: RequestOptions(path: '/index.json')),
+      );
+      await expectLater(
+        service.fetchIndex(),
+        throwsA(isA<CollectionBrowserException>()),
+      );
+    });
+  });
+}

--- a/test/features/collections/helpers/collection_filters_test.dart
+++ b/test/features/collections/helpers/collection_filters_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/helpers/collection_filters.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/collection_tag.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  group('CollectionFilters.apply', () {
+    CollectionItem make({
+      int id = 1,
+      MediaType mediaType = MediaType.game,
+      int? platformId,
+      int? tagId,
+      ItemStatus status = ItemStatus.notStarted,
+      String? name,
+      String? userComment,
+      String? authorComment,
+    }) =>
+        createTestCollectionItem(
+          id: id,
+          mediaType: mediaType,
+          externalId: id,
+          platformId: platformId,
+          tagId: tagId,
+          status: status,
+          overrideName: name,
+          userComment: userComment,
+          authorComment: authorComment,
+        );
+
+    final List<CollectionTag> tags = <CollectionTag>[
+      createTestCollectionTag(id: 10, name: 'Favorites'),
+      createTestCollectionTag(id: 20, name: 'Backlog'),
+    ];
+
+    test('no filters returns the list unchanged', () {
+      final List<CollectionItem> items = <CollectionItem>[make(id: 1), make(id: 2)];
+      expect(const CollectionFilters().apply(items, tags), items);
+    });
+
+    test('filters by media type', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, mediaType: MediaType.game),
+        make(id: 2, mediaType: MediaType.movie),
+        make(id: 3, mediaType: MediaType.movie),
+      ];
+      final List<CollectionItem> r = const CollectionFilters(
+        mediaTypes: <MediaType>{MediaType.movie},
+      ).apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[2, 3]);
+    });
+
+    test('filters by platform id, excluding null platforms', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, platformId: 48),
+        make(id: 2, platformId: 6),
+        make(id: 3),
+      ];
+      final List<CollectionItem> r =
+          const CollectionFilters(platformIds: <int>{48}).apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('filters by tag id', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, tagId: 10),
+        make(id: 2, tagId: 20),
+        make(id: 3),
+      ];
+      final List<CollectionItem> r =
+          const CollectionFilters(tagIds: <int>{10}).apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('filters by status', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, status: ItemStatus.completed),
+        make(id: 2, status: ItemStatus.inProgress),
+      ];
+      final List<CollectionItem> r =
+          const CollectionFilters(status: ItemStatus.completed).apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('search matches name case-insensitively', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, name: 'The Legend of Zelda'),
+        make(id: 2, name: 'Halo'),
+      ];
+      final List<CollectionItem> r =
+          const CollectionFilters(searchQuery: 'zelda').apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('search matches by tag name', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, name: 'A', tagId: 10), // tag "Favorites"
+        make(id: 2, name: 'B', tagId: 20), // tag "Backlog"
+      ];
+      final List<CollectionItem> r =
+          const CollectionFilters(searchQuery: 'favor').apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('search matches user and author comments', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, name: 'A', userComment: 'masterpiece'),
+        make(id: 2, name: 'B', authorComment: 'underrated gem'),
+        make(id: 3, name: 'C'),
+      ];
+      expect(
+        const CollectionFilters(searchQuery: 'master')
+            .apply(items, tags)
+            .map((CollectionItem i) => i.id),
+        <int>[1],
+      );
+      expect(
+        const CollectionFilters(searchQuery: 'gem')
+            .apply(items, tags)
+            .map((CollectionItem i) => i.id),
+        <int>[2],
+      );
+    });
+
+    test('combines filters with AND semantics', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, mediaType: MediaType.game, status: ItemStatus.completed),
+        make(id: 2, mediaType: MediaType.game, status: ItemStatus.inProgress),
+        make(id: 3, mediaType: MediaType.movie, status: ItemStatus.completed),
+      ];
+      final List<CollectionItem> r = const CollectionFilters(
+        mediaTypes: <MediaType>{MediaType.game},
+        status: ItemStatus.completed,
+      ).apply(items, tags);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+  });
+}

--- a/test/features/collections/providers/collections_provider_item_fields_test.dart
+++ b/test/features/collections/providers/collections_provider_item_fields_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:xerabora/data/repositories/collection_repository.dart';
+import 'package:xerabora/features/collections/providers/collections_provider.dart';
+import 'package:xerabora/features/settings/providers/settings_provider.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  const int collectionId = 1;
+  late MockCollectionRepository repo;
+  late SharedPreferences prefs;
+
+  setUpAll(registerAllFallbacks);
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    prefs = await SharedPreferences.getInstance();
+    repo = MockCollectionRepository();
+
+    when(() => repo.updateItemUserRating(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => repo.updateItemUserComment(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => repo.updateItemAuthorComment(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => repo.updateItemTimeSpent(any(), any()))
+        .thenAnswer((_) async {});
+  });
+
+  ProviderContainer makeContainer(List<CollectionItem> items) {
+    when(() => repo.getItemsWithData(collectionId))
+        .thenAnswer((_) async => items);
+    final ProviderContainer c = ProviderContainer(
+      overrides: <Override>[
+        collectionRepositoryProvider.overrideWithValue(repo),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  Future<CollectionItemsNotifier> loaded(List<CollectionItem> items) async {
+    final ProviderContainer c = makeContainer(items);
+    c.read(collectionItemsNotifierProvider(collectionId));
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    return c.read(collectionItemsNotifierProvider(collectionId).notifier);
+  }
+
+  CollectionItem item({double? userRating, int timeSpent = 0}) =>
+      createTestCollectionItem(
+        id: 7,
+        mediaType: MediaType.movie,
+        externalId: 550,
+        userRating: userRating,
+      ).copyWith(timeSpentMinutes: timeSpent);
+
+  CollectionItem? readItem(CollectionItemsNotifier n) =>
+      n.state.valueOrNull?.firstWhere((CollectionItem i) => i.id == 7);
+
+  group('updateUserRating', () {
+    test('persists and reflects a fractional rating', () async {
+      final CollectionItemsNotifier n = await loaded(<CollectionItem>[item()]);
+
+      await n.updateUserRating(7, 8.5);
+
+      verify(() => repo.updateItemUserRating(7, 8.5)).called(1);
+      expect(readItem(n)!.userRating, 8.5);
+    });
+
+    test('null clears the rating', () async {
+      final CollectionItemsNotifier n =
+          await loaded(<CollectionItem>[item(userRating: 9)]);
+
+      await n.updateUserRating(7, null);
+
+      verify(() => repo.updateItemUserRating(7, null)).called(1);
+      expect(readItem(n)!.userRating, isNull);
+    });
+  });
+
+  group('comments', () {
+    test('updateUserComment sets and clears', () async {
+      final CollectionItemsNotifier n = await loaded(<CollectionItem>[item()]);
+
+      await n.updateUserComment(7, 'great');
+      expect(readItem(n)!.userComment, 'great');
+      verify(() => repo.updateItemUserComment(7, 'great')).called(1);
+
+      await n.updateUserComment(7, null);
+      expect(readItem(n)!.userComment, isNull);
+    });
+
+    test('updateAuthorComment sets and clears', () async {
+      final CollectionItemsNotifier n = await loaded(<CollectionItem>[item()]);
+
+      await n.updateAuthorComment(7, 'note');
+      expect(readItem(n)!.authorComment, 'note');
+      verify(() => repo.updateItemAuthorComment(7, 'note')).called(1);
+
+      await n.updateAuthorComment(7, null);
+      expect(readItem(n)!.authorComment, isNull);
+    });
+  });
+
+  group('time spent', () {
+    test('addTimeSpent accumulates onto the current value', () async {
+      final CollectionItemsNotifier n =
+          await loaded(<CollectionItem>[item(timeSpent: 30)]);
+
+      await n.addTimeSpent(7, 45);
+
+      verify(() => repo.updateItemTimeSpent(7, 75)).called(1);
+      expect(readItem(n)!.timeSpentMinutes, 75);
+    });
+
+    test('setTimeSpent overwrites the total', () async {
+      final CollectionItemsNotifier n =
+          await loaded(<CollectionItem>[item(timeSpent: 30)]);
+
+      await n.setTimeSpent(7, 120);
+
+      verify(() => repo.updateItemTimeSpent(7, 120)).called(1);
+      expect(readItem(n)!.timeSpentMinutes, 120);
+    });
+  });
+}

--- a/test/features/collections/widgets/item_detail/item_detail_media_config_test.dart
+++ b/test/features/collections/widgets/item_detail/item_detail_media_config_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/item_detail/item_detail_media_config.dart';
+import 'package:xerabora/shared/constants/media_type_theme.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+import '../../../../helpers/test_helpers.dart';
+
+void main() {
+  Future<ItemDetailMediaConfig> buildConfig(
+    WidgetTester tester,
+    CollectionItem item,
+  ) async {
+    late ItemDetailMediaConfig config;
+    await tester.pumpApp(
+      Builder(
+        builder: (BuildContext context) {
+          config = ItemDetailMediaConfig.from(item, context);
+          return const SizedBox();
+        },
+      ),
+    );
+    return config;
+  }
+
+  group('ItemDetailMediaConfig.from', () {
+    testWidgets('game: no trackers, external url and accent resolved',
+        (WidgetTester t) async {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.game,
+        externalId: 100,
+        game: createTestGame(id: 100, externalUrl: 'https://igdb/g'),
+      );
+
+      final ItemDetailMediaConfig c = await buildConfig(t, item);
+
+      expect(c.hasEpisodeTracker, isFalse);
+      expect(c.hasMangaProgress, isFalse);
+      expect(c.hasAnimeProgress, isFalse);
+      expect(c.externalUrl, 'https://igdb/g');
+      expect(c.accentColor, MediaTypeTheme.colorFor(item.displayMediaType));
+      expect(c.coverUrl, item.thumbnailUrl);
+    });
+
+    testWidgets('tv show enables the episode tracker', (WidgetTester t) async {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.tvShow,
+        externalId: 200,
+      );
+
+      final ItemDetailMediaConfig c = await buildConfig(t, item);
+
+      expect(c.hasEpisodeTracker, isTrue);
+      expect(c.hasMangaProgress, isFalse);
+      expect(c.hasAnimeProgress, isFalse);
+    });
+
+    testWidgets('animation tracks episodes only for the TV-show source',
+        (WidgetTester t) async {
+      final ItemDetailMediaConfig tv = await buildConfig(
+        t,
+        createTestCollectionItem(
+          mediaType: MediaType.animation,
+          externalId: 1,
+          platformId: AnimationSource.tvShow,
+        ),
+      );
+      expect(tv.hasEpisodeTracker, isTrue);
+
+      final ItemDetailMediaConfig movie = await buildConfig(
+        t,
+        createTestCollectionItem(
+          mediaType: MediaType.animation,
+          externalId: 2,
+          platformId: AnimationSource.movie,
+        ),
+      );
+      expect(movie.hasEpisodeTracker, isFalse);
+    });
+
+    testWidgets('manga enables only manga progress', (WidgetTester t) async {
+      final ItemDetailMediaConfig c = await buildConfig(
+        t,
+        createTestCollectionItem(mediaType: MediaType.manga, externalId: 5),
+      );
+
+      expect(c.hasMangaProgress, isTrue);
+      expect(c.hasAnimeProgress, isFalse);
+      expect(c.hasEpisodeTracker, isFalse);
+    });
+
+    testWidgets('anime enables only anime progress', (WidgetTester t) async {
+      final ItemDetailMediaConfig c = await buildConfig(
+        t,
+        createTestCollectionItem(mediaType: MediaType.anime, externalId: 6),
+      );
+
+      expect(c.hasAnimeProgress, isTrue);
+      expect(c.hasMangaProgress, isFalse);
+      expect(c.hasEpisodeTracker, isFalse);
+    });
+  });
+}

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -10,6 +10,7 @@ import 'package:xerabora/core/api/kodi_api.dart';
 import 'package:xerabora/core/api/steamgriddb_api.dart';
 import 'package:xerabora/core/services/kodi_sync_service.dart';
 import 'package:xerabora/core/api/tmdb_api.dart';
+import 'package:xerabora/core/api/anilist/anilist_graphql_client.dart';
 import 'package:xerabora/core/api/anilist_api.dart';
 import 'package:xerabora/core/database/dao/anilist_tag_dao.dart';
 import 'package:xerabora/core/api/vndb_api.dart';
@@ -29,7 +30,9 @@ import 'package:xerabora/core/database/dao/tracker_dao.dart';
 import 'package:xerabora/core/database/dao/wishlist_dao.dart';
 import 'package:xerabora/core/database/database_service.dart';
 import 'package:xerabora/core/services/config_service.dart';
+import 'package:xerabora/core/services/export_service.dart';
 import 'package:xerabora/core/services/gamepad_service.dart';
+import 'package:xerabora/core/services/import_service.dart';
 import 'package:xerabora/core/services/image_cache_service.dart';
 import 'package:xerabora/core/services/profile_service.dart';
 import 'package:xerabora/core/api/steam_api.dart';
@@ -81,6 +84,10 @@ class MockDatabaseService extends Mock implements DatabaseService {}
 
 class MockConfigService extends Mock implements ConfigService {}
 
+class MockExportService extends Mock implements ExportService {}
+
+class MockImportService extends Mock implements ImportService {}
+
 class MockGameDao extends Mock implements GameDao {}
 
 class MockMovieDao extends Mock implements MovieDao {}
@@ -118,6 +125,9 @@ class MockSteamGridDbApi extends Mock implements SteamGridDbApi {}
 class MockVndbApi extends Mock implements VndbApi {}
 
 class MockAniListApi extends Mock implements AniListApi {}
+
+class MockAniListGraphQLClient extends Mock
+    implements AniListGraphQLClient {}
 
 class MockAniListTagDao extends Mock implements AniListTagDao {}
 

--- a/test/shared/models/custom_media_test.dart
+++ b/test/shared/models/custom_media_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/custom_media.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+
+void main() {
+  group('CustomMedia.isLocalCover', () {
+    test('true only for the local:// scheme', () {
+      expect(CustomMedia.isLocalCover(CustomMedia.localCoverMarker), isTrue);
+      expect(CustomMedia.isLocalCover('local://anything'), isTrue);
+      expect(CustomMedia.isLocalCover('https://x/cover.jpg'), isFalse);
+      expect(CustomMedia.isLocalCover(null), isFalse);
+      expect(CustomMedia.isLocalCover(''), isFalse);
+    });
+  });
+
+  group('genreList', () {
+    test('splits and trims a comma list', () {
+      const CustomMedia m = CustomMedia(
+        id: 1,
+        title: 't',
+        genres: 'RPG, Action ,  Puzzle',
+      );
+      expect(m.genreList, <String>['RPG', 'Action', 'Puzzle']);
+    });
+
+    test('null genres give a null list', () {
+      const CustomMedia m = CustomMedia(id: 1, title: 't');
+      expect(m.genreList, isNull);
+    });
+  });
+
+  group('db mapping', () {
+    test('fromDb reads displayType and fields', () {
+      final CustomMedia m = CustomMedia.fromDb(<String, dynamic>{
+        'id': 5,
+        'title': 'My Thing',
+        'display_type': 'game',
+        'year': 1999,
+        'platform_name': 'Homebrew',
+      });
+      expect(m.id, 5);
+      expect(m.title, 'My Thing');
+      expect(m.displayType, MediaType.game);
+      expect(m.year, 1999);
+      expect(m.platformName, 'Homebrew');
+    });
+
+    test('fromDb leaves displayType null when absent', () {
+      final CustomMedia m = CustomMedia.fromDb(<String, dynamic>{
+        'id': 1,
+        'title': 't',
+      });
+      expect(m.displayType, isNull);
+    });
+
+    test('toDb serialises displayType to its value', () {
+      const CustomMedia m = CustomMedia(
+        id: 1,
+        title: 't',
+        displayType: MediaType.movie,
+        cachedAt: 123,
+      );
+      final Map<String, dynamic> db = m.toDb();
+      expect(db['display_type'], 'movie');
+      expect(db['cached_at'], 123);
+    });
+
+    test('toDb defaults cached_at to now when not set', () {
+      const CustomMedia m = CustomMedia(id: 1, title: 't');
+      final Object? cachedAt = m.toDb()['cached_at'];
+      expect(cachedAt, isA<int>());
+      expect(cachedAt! as int, greaterThan(0));
+    });
+
+    test('toExport drops cached_at', () {
+      const CustomMedia m = CustomMedia(id: 1, title: 't', cachedAt: 99);
+      expect(m.toExport().containsKey('cached_at'), isFalse);
+      expect(m.toExport()['title'], 't');
+    });
+  });
+
+  group('copyWith', () {
+    test('clear flags null out fields', () {
+      const CustomMedia m = CustomMedia(
+        id: 1,
+        title: 't',
+        displayType: MediaType.game,
+        platformName: 'PC',
+      );
+      final CustomMedia cleared =
+          m.copyWith(clearDisplayType: true, clearPlatformName: true);
+      expect(cleared.displayType, isNull);
+      expect(cleared.platformName, isNull);
+      expect(cleared.title, 't');
+    });
+
+    test('updates a single field', () {
+      const CustomMedia m = CustomMedia(id: 1, title: 'old');
+      expect(m.copyWith(title: 'new').title, 'new');
+    });
+  });
+}

--- a/test/shared/models/tracker_achievement_test.dart
+++ b/test/shared/models/tracker_achievement_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/tracker_achievement.dart';
+import 'package:xerabora/shared/models/tracker_profile.dart';
+
+void main() {
+  group('TrackerAchievement.fromRaJson', () {
+    Map<String, dynamic> raJson({
+      Object? hardcore,
+      Object? normal,
+      String type = 'progression',
+    }) =>
+        <String, dynamic>{
+          'ID': 42,
+          'Title': 'First Blood',
+          'Description': 'Win a fight',
+          'Points': 10,
+          'BadgeName': '12345',
+          'Type': type,
+          'DisplayOrder': 3,
+          'DateEarnedHardcore': ?hardcore,
+          'DateEarned': ?normal,
+        };
+
+    test('unearned when no date present', () {
+      final TrackerAchievement a =
+          TrackerAchievement.fromRaJson(raJson(), trackerGameId: 'g1');
+      expect(a.earned, isFalse);
+      expect(a.earnedAt, isNull);
+      expect(a.achievementId, '42'); // numeric ID stringified
+      expect(a.trackerType, TrackerType.ra);
+    });
+
+    test('earned with a valid date', () {
+      final int expected =
+          DateTime.parse('2023-05-01 12:00:00').millisecondsSinceEpoch ~/ 1000;
+      final TrackerAchievement a = TrackerAchievement.fromRaJson(
+        raJson(hardcore: '2023-05-01 12:00:00'),
+        trackerGameId: 'g1',
+      );
+      expect(a.earned, isTrue);
+      expect(a.earnedAt, expected);
+    });
+
+    test('prefers hardcore date over the normal one', () {
+      final int hardcore =
+          DateTime.parse('2023-05-01 12:00:00').millisecondsSinceEpoch ~/ 1000;
+      final TrackerAchievement a = TrackerAchievement.fromRaJson(
+        raJson(hardcore: '2023-05-01 12:00:00', normal: '2024-01-01 00:00:00'),
+        trackerGameId: 'g1',
+      );
+      expect(a.earnedAt, hardcore);
+    });
+
+    test('blank date string stays unearned', () {
+      final TrackerAchievement a = TrackerAchievement.fromRaJson(
+        raJson(hardcore: ''),
+        trackerGameId: 'g1',
+      );
+      expect(a.earned, isFalse);
+    });
+  });
+
+  group('computed properties', () {
+    TrackerAchievement make({String? badgeName, String? type}) =>
+        TrackerAchievement(
+          id: 1,
+          trackerType: TrackerType.ra,
+          trackerGameId: 'g',
+          achievementId: 'a',
+          title: 't',
+          displayOrder: 0,
+          earned: false,
+          badgeName: badgeName,
+          type: type,
+        );
+
+    test('badge urls are null without a badge name', () {
+      final TrackerAchievement a = make();
+      expect(a.badgeUrl, isNull);
+      expect(a.lockedBadgeUrl, isNull);
+    });
+
+    test('badge urls built from badge name', () {
+      final TrackerAchievement a = make(badgeName: '999');
+      expect(a.badgeUrl, contains('/Badge/999.png'));
+      expect(a.lockedBadgeUrl, contains('/Badge/999_lock.png'));
+    });
+
+    test('type flags', () {
+      expect(make(type: 'missable').isMissable, isTrue);
+      expect(make(type: 'progression').isProgression, isTrue);
+      expect(make(type: 'win_condition').isWinCondition, isTrue);
+      expect(make(type: 'missable').isProgression, isFalse);
+      expect(make().isMissable, isFalse);
+    });
+
+    test('earnedDateTime is null when not earned', () {
+      expect(make().earnedDateTime, isNull);
+    });
+  });
+
+  group('db round-trip', () {
+    test('toDb omits id when zero and maps earned to int', () {
+      const TrackerAchievement a = TrackerAchievement(
+        id: 0,
+        trackerType: TrackerType.ra,
+        trackerGameId: 'g',
+        achievementId: 'a',
+        title: 't',
+        displayOrder: 2,
+        earned: true,
+      );
+      final Map<String, dynamic> db = a.toDb();
+      expect(db.containsKey('id'), isFalse);
+      expect(db['earned'], 1);
+    });
+
+    test('fromDb reads earned int back to bool', () {
+      final TrackerAchievement a = TrackerAchievement.fromDb(<String, dynamic>{
+        'id': 7,
+        'tracker_type': TrackerType.ra.value,
+        'tracker_game_id': 'g',
+        'achievement_id': 'a',
+        'title': 't',
+        'display_order': 1,
+        'earned': 1,
+      });
+      expect(a.id, 7);
+      expect(a.earned, isTrue);
+    });
+  });
+}

--- a/test/shared/models/tracker_profile_test.dart
+++ b/test/shared/models/tracker_profile_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/tracker_profile.dart';
+
+void main() {
+  group('TrackerType.fromString', () {
+    test('maps known values', () {
+      expect(TrackerType.fromString('ra'), TrackerType.ra);
+      expect(TrackerType.fromString('steam'), TrackerType.steam);
+      expect(TrackerType.fromString('trakt'), TrackerType.trakt);
+    });
+
+    test('falls back to ra for unknown values', () {
+      expect(TrackerType.fromString('nope'), TrackerType.ra);
+      expect(TrackerType.fromString(''), TrackerType.ra);
+    });
+  });
+
+  group('TrackerProfile db mapping', () {
+    TrackerProfile profile({
+      int id = 0,
+      Map<String, dynamic>? data,
+    }) =>
+        TrackerProfile(
+          id: id,
+          trackerType: TrackerType.steam,
+          userId: 'u1',
+          displayName: 'Player',
+          createdAt: 1700000000,
+          profileData: data,
+        );
+
+    test('toDb omits id when zero and encodes profile data as JSON', () {
+      final Map<String, dynamic> db =
+          profile(data: <String, dynamic>{'rank': 5}).toDb();
+      expect(db.containsKey('id'), isFalse);
+      expect(db['tracker_type'], 'steam');
+      expect(db['profile_data'], '{"rank":5}');
+    });
+
+    test('toDb leaves profile data null when absent', () {
+      expect(profile().toDb()['profile_data'], isNull);
+    });
+
+    test('fromDb decodes profile data and reads fields', () {
+      final TrackerProfile p = TrackerProfile.fromDb(<String, dynamic>{
+        'id': 3,
+        'tracker_type': 'ra',
+        'user_id': 'bob',
+        'display_name': 'Bob',
+        'created_at': 1700000000,
+        'profile_data': '{"rank":5}',
+      });
+      expect(p.id, 3);
+      expect(p.trackerType, TrackerType.ra);
+      expect(p.profileData, <String, dynamic>{'rank': 5});
+    });
+
+    test('fromDb keeps profile data null when empty', () {
+      final TrackerProfile p = TrackerProfile.fromDb(<String, dynamic>{
+        'id': 1,
+        'tracker_type': 'steam',
+        'user_id': 'u',
+        'display_name': 'd',
+        'created_at': 1,
+        'profile_data': '',
+      });
+      expect(p.profileData, isNull);
+    });
+
+    test('round-trips profile data through toDb -> fromDb', () {
+      const TrackerProfile original = TrackerProfile(
+        id: 9,
+        trackerType: TrackerType.ra,
+        userId: 'u',
+        displayName: 'd',
+        createdAt: 5,
+        profileData: <String, dynamic>{'a': 1, 'b': 'x'},
+      );
+      final TrackerProfile restored = TrackerProfile.fromDb(original.toDb());
+      expect(restored.profileData, original.profileData);
+      expect(restored.trackerType, original.trackerType);
+    });
+  });
+
+  test('copyWith changes only the given field', () {
+    const TrackerProfile p = TrackerProfile(
+      id: 1,
+      trackerType: TrackerType.ra,
+      userId: 'u',
+      displayName: 'd',
+      createdAt: 1,
+    );
+    final TrackerProfile updated = p.copyWith(linkedCollectionId: 42);
+    expect(updated.linkedCollectionId, 42);
+    expect(updated.userId, 'u');
+    expect(updated.trackerType, TrackerType.ra);
+  });
+}

--- a/test/shared/utils/duration_formatter_test.dart
+++ b/test/shared/utils/duration_formatter_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:xerabora/shared/utils/duration_formatter.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  // The exact localized wording is not asserted (that would couple to copy);
+  // instead we verify which bucket is chosen and the computed unit count.
+  group('formatDuration', () {
+    late MockS s;
+
+    setUp(() {
+      s = MockS();
+      when(() => s.durationLessThanDay).thenReturn('LT_DAY');
+      when(() => s.durationOneDay).thenReturn('ONE_DAY');
+      when(() => s.durationDays(any())).thenReturn('DAYS');
+      when(() => s.durationWeeks(any())).thenReturn('WEEKS');
+      when(() => s.durationMonths(any())).thenReturn('MONTHS');
+      when(() => s.durationYears(any())).thenReturn('YEARS');
+    });
+
+    test('0 days -> less than a day', () {
+      expect(formatDuration(Duration.zero, s), 'LT_DAY');
+      verify(() => s.durationLessThanDay).called(1);
+    });
+
+    test('1 day -> single-day form', () {
+      expect(formatDuration(const Duration(days: 1), s), 'ONE_DAY');
+    });
+
+    test('under a week -> days with exact count', () {
+      expect(formatDuration(const Duration(days: 3), s), 'DAYS');
+      verify(() => s.durationDays(3)).called(1);
+    });
+
+    test('a week or more -> weeks, rounded', () {
+      formatDuration(const Duration(days: 14), s);
+      verify(() => s.durationWeeks(2)).called(1);
+
+      formatDuration(const Duration(days: 20), s); // 20/7 = 2.857 -> 3
+      verify(() => s.durationWeeks(3)).called(1);
+    });
+
+    test('a month or more -> months, rounded', () {
+      formatDuration(const Duration(days: 60), s);
+      verify(() => s.durationMonths(2)).called(1);
+    });
+
+    test('a year or more -> years with one decimal', () {
+      formatDuration(const Duration(days: 400), s); // 400/365 = 1.095 -> "1.1"
+      verify(() => s.durationYears('1.1')).called(1);
+    });
+
+    test('boundary: 6 days is still days, 7 days flips to weeks', () {
+      formatDuration(const Duration(days: 6), s);
+      verify(() => s.durationDays(6)).called(1);
+
+      formatDuration(const Duration(days: 7), s);
+      verify(() => s.durationWeeks(1)).called(1);
+    });
+  });
+
+  group('formatCompletionTime', () {
+    test('wraps the formatted duration with the completion prefix', () {
+      final MockS s = MockS();
+      when(() => s.durationWeeks(any())).thenReturn('2 weeks');
+      when(() => s.activityDatesCompletionTime(any()))
+          .thenReturn('Completed in 2 weeks');
+
+      final String result = formatCompletionTime(const Duration(days: 14), s);
+
+      expect(result, 'Completed in 2 weeks');
+      verify(() => s.activityDatesCompletionTime('2 weeks')).called(1);
+    });
+  });
+}

--- a/test/shared/widgets/api_error_display_test.dart
+++ b/test/shared/widgets/api_error_display_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/widgets/api_error_display.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('ApiErrorDisplay', () {
+    testWidgets('shows the message and no copy button without a detail',
+        (WidgetTester t) async {
+      await t.pumpApp(
+        const ApiErrorDisplay(message: 'Network down'),
+        wrapInScaffold: true,
+      );
+
+      expect(find.text('Network down'), findsOneWidget);
+      expect(find.byIcon(Icons.copy), findsNothing);
+    });
+
+    testWidgets('copies the detail when the copy button is tapped',
+        (WidgetTester t) async {
+      String? copied;
+      t.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied = (call.arguments as Map<Object?, Object?>)['text'] as String?;
+          }
+          return null;
+        },
+      );
+      addTearDown(() => t.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await t.pumpApp(
+        const ApiErrorDisplay(message: 'Failed', detail: 'GET /x -> 500'),
+        wrapInScaffold: true,
+      );
+
+      expect(find.byIcon(Icons.copy), findsOneWidget);
+      await t.tap(find.byIcon(Icons.copy));
+      await t.pump();
+
+      expect(copied, 'GET /x -> 500');
+    });
+  });
+}

--- a/test/shared/widgets/chevron_filter_bar_test.dart
+++ b/test/shared/widgets/chevron_filter_bar_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/widgets/chevron_filter_bar.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('StatusDropdownSegment', () {
+    Future<ItemStatus?> pickValue(
+      WidgetTester tester, {
+      required ItemStatus? initial,
+      required String menuValue,
+    }) async {
+      ItemStatus? captured;
+      bool fired = false;
+      await tester.pumpApp(
+        StatusDropdownSegment(
+          status: initial,
+          compact: false,
+          onChanged: (ItemStatus? s) {
+            captured = s;
+            fired = true;
+          },
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      final Finder item = find.byWidgetPredicate(
+        (Widget w) => w is PopupMenuItem<String> && w.value == menuValue,
+      );
+      expect(item, findsOneWidget, reason: 'menu item "$menuValue" missing');
+      await tester.tap(item);
+      await tester.pumpAndSettle();
+
+      expect(fired, isTrue);
+      return captured;
+    }
+
+    testWidgets('selecting a status reports that status', (WidgetTester t) async {
+      final ItemStatus? r = await pickValue(
+        t,
+        initial: null,
+        menuValue: ItemStatus.completed.value,
+      );
+      expect(r, ItemStatus.completed);
+    });
+
+    testWidgets('selecting "All" reports null', (WidgetTester t) async {
+      final ItemStatus? r = await pickValue(
+        t,
+        initial: ItemStatus.completed,
+        menuValue: 'all',
+      );
+      expect(r, isNull);
+    });
+
+    testWidgets('selecting in-progress reports inProgress', (WidgetTester t) async {
+      final ItemStatus? r = await pickValue(
+        t,
+        initial: null,
+        menuValue: ItemStatus.inProgress.value,
+      );
+      expect(r, ItemStatus.inProgress);
+    });
+  });
+}

--- a/test/shared/widgets/copyable_text_test.dart
+++ b/test/shared/widgets/copyable_text_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/widgets/copyable_text.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('CopyableText', () {
+    testWidgets('copies its text to the clipboard on tap', (WidgetTester t) async {
+      String? copied;
+      t.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied = (call.arguments as Map<Object?, Object?>)['text'] as String?;
+          }
+          return null;
+        },
+      );
+      addTearDown(() => t.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await t.pumpApp(
+        const CopyableText(text: 'copy-me', child: Text('shown')),
+        wrapInScaffold: true,
+      );
+      expect(find.text('shown'), findsOneWidget);
+
+      await t.tap(find.byType(CopyableText));
+      await t.pump();
+      expect(copied, 'copy-me');
+
+      // _copy schedules a 1s timer to reset the "copied" state; flush it so
+      // the test doesn't end with a pending timer.
+      await t.pump(const Duration(seconds: 1));
+    });
+  });
+}

--- a/test/shared/widgets/dual_date_picker_dialog_test.dart
+++ b/test/shared/widgets/dual_date_picker_dialog_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/widgets/dual_date_picker_dialog.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('DualDatePickerDialog', () {
+    final DateTime first = DateTime(2020, 1, 1);
+    final DateTime last = DateTime(2025, 12, 31);
+    final DateTime initial = DateTime(2024, 3, 15);
+
+    Future<DateTime?> openAndGet(
+      WidgetTester tester,
+      Future<void> Function(WidgetTester tester) interact,
+    ) async {
+      DateTime? result;
+      bool done = false;
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => ElevatedButton(
+            onPressed: () async {
+              result = await showDualDatePicker(
+                context: context,
+                initialDate: initial,
+                firstDate: first,
+                lastDate: last,
+              );
+              done = true;
+            },
+            child: const Text('open'),
+          ),
+        ),
+        wrapInScaffold: true,
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await interact(tester);
+      await tester.pumpAndSettle();
+      expect(done, isTrue, reason: 'dialog should have been dismissed');
+      return result;
+    }
+
+    bool okEnabled(WidgetTester tester) {
+      final TextButton ok = tester.widget(find.widgetWithText(TextButton, 'OK'));
+      return ok.onPressed != null;
+    }
+
+    testWidgets('confirms the initial date when untouched', (WidgetTester t) async {
+      final DateTime? r =
+          await openAndGet(t, (WidgetTester t) async => t.tap(find.text('OK')));
+      expect(r, DateTime(2024, 3, 15));
+    });
+
+    testWidgets('accepts a valid in-range typed date', (WidgetTester t) async {
+      final DateTime? r = await openAndGet(t, (WidgetTester t) async {
+        await t.enterText(find.byType(TextField), '2024-06-20');
+        await t.pump();
+        await t.tap(find.text('OK'));
+      });
+      expect(r, DateTime(2024, 6, 20));
+    });
+
+    testWidgets('cancel returns null', (WidgetTester t) async {
+      final DateTime? r = await openAndGet(
+        t,
+        (WidgetTester t) async => t.tap(find.text('Cancel')),
+      );
+      expect(r, isNull);
+    });
+
+    testWidgets('disables OK on an invalid format', (WidgetTester t) async {
+      await _open(t, initial, first, last);
+      await t.enterText(find.byType(TextField), 'not-a-date');
+      await t.pump();
+      expect(okEnabled(t), isFalse);
+    });
+
+    testWidgets('disables OK on an out-of-range date', (WidgetTester t) async {
+      await _open(t, initial, first, last);
+      await t.enterText(find.byType(TextField), '2030-01-01');
+      await t.pump();
+      expect(okEnabled(t), isFalse);
+    });
+
+    testWidgets('disables OK on empty input, re-enables when fixed',
+        (WidgetTester t) async {
+      await _open(t, initial, first, last);
+
+      await t.enterText(find.byType(TextField), '');
+      await t.pump();
+      expect(okEnabled(t), isFalse);
+
+      await t.enterText(find.byType(TextField), '2021-05-05');
+      await t.pump();
+      expect(okEnabled(t), isTrue);
+    });
+  });
+}
+
+Future<void> _open(
+  WidgetTester tester,
+  DateTime initial,
+  DateTime first,
+  DateTime last,
+) async {
+  await tester.pumpApp(
+    DualDatePickerDialog(initialDate: initial, firstDate: first, lastDate: last),
+    wrapInScaffold: true,
+  );
+}

--- a/test/shared/widgets/media_progress_row_test.dart
+++ b/test/shared/widgets/media_progress_row_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/shared/widgets/media_progress_row.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('MediaProgressRow', () {
+    Future<void> pump(
+      WidgetTester tester, {
+      required int current,
+      required int? total,
+      VoidCallback? onIncrement,
+      VoidCallback? onEdit,
+    }) {
+      return tester.pumpApp(
+        MediaProgressRow(
+          label: 'Episodes',
+          current: current,
+          total: total,
+          accentColor: const Color(0xFF000000),
+          onIncrement: onIncrement ?? () {},
+          onEdit: onEdit ?? () {},
+        ),
+        wrapInScaffold: true,
+      );
+    }
+
+    testWidgets('shows "current / total" and a progress bar when total is set',
+        (WidgetTester t) async {
+      await pump(t, current: 3, total: 10);
+
+      expect(find.text('3 / 10'), findsOneWidget);
+      final LinearProgressIndicator bar = t.widget(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(bar.value, closeTo(0.3, 1e-9));
+    });
+
+    testWidgets('shows only current and hides the bar when total is null',
+        (WidgetTester t) async {
+      await pump(t, current: 7, total: null);
+
+      expect(find.text('7'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    });
+
+    testWidgets('hides the bar when total is zero', (WidgetTester t) async {
+      await pump(t, current: 0, total: 0);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+    });
+
+    testWidgets('clamps the bar to 1.0 when current exceeds total',
+        (WidgetTester t) async {
+      await pump(t, current: 15, total: 10);
+
+      final LinearProgressIndicator bar = t.widget(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(bar.value, 1.0);
+    });
+
+    testWidgets('fires onIncrement and onEdit', (WidgetTester t) async {
+      int inc = 0;
+      int edit = 0;
+      await pump(
+        t,
+        current: 1,
+        total: 5,
+        onIncrement: () => inc++,
+        onEdit: () => edit++,
+      );
+
+      await t.tap(find.byIcon(Icons.add));
+      expect(inc, 1);
+
+      await t.tap(find.text('1 / 5'));
+      expect(edit, 1);
+    });
+  });
+}


### PR DESCRIPTION
Add focused tests for previously untested high-value code paths (data integrity and reused logic rather than coverage chasing), plus README Flutter badge bump.

* test/core/services/backup_service_test.dart: BackupManifest parsing, readManifest from a real ZIP, restoreFromBackup (collection import, wishlist dedup, settings gated by flag, error handling).
* test/core/services/collection_browser_service_test.dart (CollectionBrowserService.fetchIndex): parsing, in-memory cache, forceRefresh, clearCache, DioException wrapping.
* test/core/api/anilist/anilist_user_list_api_test.dart (AniListUserListApi.fetchUserMediaList): arg validation, GraphQL error translation, dedup and adult/custom-list/no-media filtering.
* test/core/api/anilist/anilist_media_parser_test.dart, api_error_extract_test.dart: page parsing, fuzzy dates, typed-error extract.
* test/features/collections/providers/collections_provider_item_fields_test.dart: updateUserRating / comments / time-spent state logic.
* test/features/collections/helpers/collection_filters_test.dart, item_detail/item_detail_media_config_test.dart: filter chain, item-card config.
* test/shared/widgets: media_progress_row, dual_date_picker_dialog, chevron_filter_bar (status mapping), copyable_text, api_error_display.
* test/shared/utils/duration_formatter_test.dart, test/shared/models/{tracker_achievement,tracker_profile,custom_media}_test.dart.
* test/helpers/mocks.dart: add MockExportService, MockImportService, MockAniListGraphQLClient.
* README.md: Flutter badge 3.38+ -> 3.44+.