### PR TITLE
feat(collections): export selected items as poster mosaic PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Export selected items as a poster mosaic PNG from the bulk action bar**
+
+  Selecting items in a collection or on All Items reveals a new image
+  button in the bulk action bar. It opens a dialog with a preview, an
+  auto-picked column count and a slider to override, then saves the
+  full selection as a dense poster grid PNG via FilePicker on desktop
+  or the system gallery on Android (album "Tonkatsu Box"). The
+  watermark row at the bottom matches the tier-list export so every
+  PNG out of the app carries the same signature.
+
+  * lib/features/collections/widgets/bulk_export/bulk_poster_mosaic_view.dart
+    (BulkPosterMosaicView, BulkPosterMosaicView.autoColumns,
+    BulkPosterMosaicView.precachedFiles, _PosterTile): New off-screen
+    `RepaintBoundary` widget; `autoColumns` returns
+    `sqrt(n * 1.5).round().clamp(4, 20)`.
+  * lib/features/collections/widgets/bulk_export/bulk_export_service.dart
+    (saveBoundaryAsPng, BulkExportResult, BulkExportStatus): New —
+    boundary to PNG bytes plus Android Gal / desktop FilePicker save.
+  * lib/features/collections/widgets/bulk_export/bulk_poster_export_dialog.dart
+    (showBulkPosterExportDialog, _BulkPosterExportDialog,
+    _BulkPosterExportDialogState._handleSave,
+    _BulkPosterExportDialogState._precacheCovers,
+    _BulkPosterExportDialogState._precacheOne): New — preview capped
+    at 120 covers, column slider, batched cover precache with
+    progress before the off-screen mosaic is snapshot.
+  * lib/features/collections/widgets/bulk_action_bar.dart (BulkActionBar,
+    BulkActionBar.collectionName, BulkActionBar._handleExportPng):
+    New image button next to the status menu; forwards
+    `collectionName` so the saved file is named after the collection.
+  * lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+    (CollectionBulkActionBar, CollectionBulkActionBar.collectionName):
+    Threads the collection name through.
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState.build): Passes `_collection?.name` (or the
+    uncategorised label) to the bulk bar.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb, lib/l10n/app_localizations.dart,
+    lib/l10n/app_localizations_en.dart, lib/l10n/app_localizations_ru.dart
+    (bulkExportPngTitle, bulkExportPngColumns, bulkExportPngItemsCount,
+    bulkExportPngItemsCountPreview, bulkExportPngPreparing,
+    bulkExportPngSave, bulkExportPngSaved, bulkExportPngFailed): New
+    strings for the dialog, the truncated-preview hint, and snackbars.
+  * test/features/collections/widgets/bulk_export/bulk_poster_mosaic_view_test.dart:
+    New — `autoColumns` formula at the empty / tiny / typical / huge
+    boundaries, plus renders-without-exception on 8 and 50 items.
+
 - **Add AniList tag support across storage, display, search filter and exports**
 
   Anime and manga now carry their AniList tag list (in addition to genres).

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -204,6 +204,9 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
               if (_canEdit && !_isCanvasMode)
                 CollectionBulkActionBar(
                   collectionId: widget.collectionId,
+                  collectionName: _isUncategorized
+                      ? l.collectionsUncategorized
+                      : _collection?.name,
                   filters: activeFilters,
                   tags: tags,
                 ),

--- a/lib/features/collections/widgets/bulk_action_bar.dart
+++ b/lib/features/collections/widgets/bulk_action_bar.dart
@@ -17,6 +17,7 @@ import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
 import '../helpers/bulk_operations.dart';
 import '../providers/collections_provider.dart';
+import 'bulk_export/bulk_poster_export_dialog.dart';
 
 /// Bulk action bar над списком элементов.
 ///
@@ -33,6 +34,7 @@ class BulkActionBar extends ConsumerWidget {
     required this.items,
     required this.onClearSelection,
     this.collectionId,
+    this.collectionName,
     this.visibleCount,
     this.onSelectAllVisible,
     super.key,
@@ -46,6 +48,9 @@ class BulkActionBar extends ConsumerWidget {
 
   /// ID контекстной коллекции. `null` если бар стоит на All Items.
   final int? collectionId;
+
+  /// Имя коллекции — используется как имя файла при экспорте в PNG.
+  final String? collectionName;
 
   /// Сколько элементов всего видно на экране после фильтров и поиска.
   /// Используется чтобы скрыть «выделить все видимые», когда уже выделено всё.
@@ -105,39 +110,55 @@ class BulkActionBar extends ConsumerWidget {
                 child: Text(l.bulkSelectAllVisible),
               ),
             ],
-            const Spacer(),
-            _BarAction(
-              icon: Icons.drive_file_move_outlined,
-              tooltip: l.collectionMoveToCollection,
-              onTap: () => _handleMove(context, ref),
-            ),
-            _BarAction(
-              icon: Icons.copy_outlined,
-              tooltip: l.collectionCopyToCollection,
-              onTap: () => _handleClone(context, ref),
-            ),
-            _StatusMenuAction(
-              onSelected: (ItemStatus s) => _handleStatus(context, ref, s),
-            ),
-            if (isManualSort) ...<Widget>[
-              const _BarDivider(),
-              _BarAction(
-                icon: Icons.vertical_align_top,
-                tooltip: l.moveToTop,
-                onTap: () => _handleMoveToTop(ref),
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                reverse: true,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: <Widget>[
+                    _BarAction(
+                      icon: Icons.drive_file_move_outlined,
+                      tooltip: l.collectionMoveToCollection,
+                      onTap: () => _handleMove(context, ref),
+                    ),
+                    _BarAction(
+                      icon: Icons.copy_outlined,
+                      tooltip: l.collectionCopyToCollection,
+                      onTap: () => _handleClone(context, ref),
+                    ),
+                    _StatusMenuAction(
+                      onSelected: (ItemStatus s) =>
+                          _handleStatus(context, ref, s),
+                    ),
+                    _BarAction(
+                      icon: Icons.image_outlined,
+                      tooltip: l.bulkExportPngTitle,
+                      onTap: () => _handleExportPng(context),
+                    ),
+                    if (isManualSort) ...<Widget>[
+                      const _BarDivider(),
+                      _BarAction(
+                        icon: Icons.vertical_align_top,
+                        tooltip: l.moveToTop,
+                        onTap: () => _handleMoveToTop(ref),
+                      ),
+                      _BarAction(
+                        icon: Icons.vertical_align_bottom,
+                        tooltip: l.moveToBottom,
+                        onTap: () => _handleMoveToBottom(ref),
+                      ),
+                    ],
+                    const _BarDivider(),
+                    _BarAction(
+                      icon: Icons.delete_outline,
+                      tooltip: l.remove,
+                      danger: true,
+                      onTap: () => _handleRemove(context, ref, theme),
+                    ),
+                  ],
+                ),
               ),
-              _BarAction(
-                icon: Icons.vertical_align_bottom,
-                tooltip: l.moveToBottom,
-                onTap: () => _handleMoveToBottom(ref),
-              ),
-            ],
-            const _BarDivider(),
-            _BarAction(
-              icon: Icons.delete_outline,
-              tooltip: l.remove,
-              danger: true,
-              onTap: () => _handleRemove(context, ref, theme),
             ),
           ],
         ),
@@ -259,6 +280,14 @@ class BulkActionBar extends ConsumerWidget {
     context.showSnack(
       l.bulkRemoved(removed),
       type: SnackType.success,
+    );
+  }
+
+  Future<void> _handleExportPng(BuildContext context) {
+    return showBulkPosterExportDialog(
+      context: context,
+      items: items,
+      collectionName: collectionName,
     );
   }
 

--- a/lib/features/collections/widgets/bulk_export/bulk_export_service.dart
+++ b/lib/features/collections/widgets/bulk_export/bulk_export_service.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/rendering.dart';
+import 'package:gal/gal.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Result of an export attempt.
+enum BulkExportStatus { saved, cancelled, failed }
+
+/// Strips characters the system save dialog or `Gal` would reject from a
+/// file name candidate. Public for testing.
+String sanitizeFileName(String name) {
+  return name.replaceAll(RegExp(r'[^\w\- ]'), '_').trim();
+}
+
+/// Appends `.png` to [path] unless it already ends with one (case-insensitive).
+/// Public for testing — covers the case where the user wipes the extension
+/// in the system save dialog.
+String ensurePngExtension(String path) {
+  return path.toLowerCase().endsWith('.png') ? path : '$path.png';
+}
+
+class BulkExportResult {
+  const BulkExportResult(this.status, {this.path, this.error});
+
+  final BulkExportStatus status;
+  final String? path;
+  final Object? error;
+}
+
+/// Renders the widget behind [repaintKey] into a PNG and saves it.
+///
+/// Desktop opens [FilePicker.saveFile]; Android writes to the system gallery
+/// via [Gal] (album: "Tonkatsu Box"). Returns a [BulkExportResult] so the
+/// caller can show a snackbar with the right tone.
+Future<BulkExportResult> saveBoundaryAsPng({
+  required GlobalKey repaintKey,
+  required String suggestedFileName,
+  required String saveDialogTitle,
+  double pixelRatio = 2.0,
+}) async {
+  try {
+    final RenderRepaintBoundary? boundary = repaintKey.currentContext
+        ?.findRenderObject() as RenderRepaintBoundary?;
+    if (boundary == null) {
+      return const BulkExportResult(BulkExportStatus.failed);
+    }
+
+    final ui.Image image = await boundary.toImage(pixelRatio: pixelRatio);
+    final ByteData? byteData =
+        await image.toByteData(format: ui.ImageByteFormat.png);
+    if (byteData == null) {
+      return const BulkExportResult(BulkExportStatus.failed);
+    }
+    final List<int> pngBytes = byteData.buffer.asUint8List();
+
+    if (Platform.isAndroid) {
+      final bool hasAccess = await Gal.requestAccess();
+      if (!hasAccess) {
+        return const BulkExportResult(BulkExportStatus.cancelled);
+      }
+      final Directory tempDir = await getTemporaryDirectory();
+      final String tempPath = '${tempDir.path}/$suggestedFileName';
+      final File temp = File(tempPath);
+      await temp.writeAsBytes(pngBytes);
+      await Gal.putImage(tempPath, album: 'Tonkatsu Box');
+      await temp.delete();
+      return BulkExportResult(BulkExportStatus.saved, path: tempPath);
+    }
+
+    final String? outputPath = await FilePicker.platform.saveFile(
+      dialogTitle: saveDialogTitle,
+      fileName: suggestedFileName,
+      type: FileType.custom,
+      allowedExtensions: <String>['png'],
+    );
+    if (outputPath == null) {
+      return const BulkExportResult(BulkExportStatus.cancelled);
+    }
+    final String finalPath = ensurePngExtension(outputPath);
+    await File(finalPath).writeAsBytes(pngBytes);
+    return BulkExportResult(BulkExportStatus.saved, path: finalPath);
+  } on Exception catch (e) {
+    return BulkExportResult(BulkExportStatus.failed, error: e);
+  }
+}

--- a/lib/features/collections/widgets/bulk_export/bulk_poster_export_dialog.dart
+++ b/lib/features/collections/widgets/bulk_export/bulk_poster_export_dialog.dart
@@ -1,0 +1,343 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/services/image_cache_service.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../../shared/extensions/snackbar_extension.dart';
+import '../../../../shared/models/collection_item.dart';
+import '../../../../shared/theme/app_colors.dart';
+import '../../../../shared/theme/app_spacing.dart';
+import '../../../../shared/theme/app_typography.dart';
+import 'bulk_export_service.dart';
+import 'bulk_poster_mosaic_view.dart';
+
+Future<void> showBulkPosterExportDialog({
+  required BuildContext context,
+  required List<CollectionItem> items,
+  String? collectionName,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (BuildContext ctx) => _BulkPosterExportDialog(
+      items: items,
+      collectionName: collectionName,
+    ),
+  );
+}
+
+class _BulkPosterExportDialog extends ConsumerStatefulWidget {
+  const _BulkPosterExportDialog({
+    required this.items,
+    this.collectionName,
+  });
+
+  final List<CollectionItem> items;
+  final String? collectionName;
+
+  @override
+  ConsumerState<_BulkPosterExportDialog> createState() =>
+      _BulkPosterExportDialogState();
+}
+
+class _BulkPosterExportDialogState
+    extends ConsumerState<_BulkPosterExportDialog> {
+  static const int _previewLimit = 120;
+  static const int _precacheBatchSize = 32;
+
+  final GlobalKey _repaintKey = GlobalKey();
+  final Map<int, File> _precachedFiles = <int, File>{};
+  late int _columns;
+  bool _saving = false;
+  bool _mountFullForExport = false;
+  int _precacheDone = 0;
+  int _precacheTotal = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _columns = BulkPosterMosaicView.autoColumns(widget.items.length);
+  }
+
+  List<CollectionItem> get _previewItems => widget.items.length > _previewLimit
+      ? widget.items.sublist(0, _previewLimit)
+      : widget.items;
+
+  bool get _previewIsTruncated => widget.items.length > _previewLimit;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    final ThemeData theme = Theme.of(context);
+
+    return Stack(
+      children: <Widget>[
+        if (_mountFullForExport)
+          Positioned(
+            left: -100000,
+            top: -100000,
+            child: Material(
+              type: MaterialType.transparency,
+              child: BulkPosterMosaicView(
+                repaintKey: _repaintKey,
+                items: widget.items,
+                columns: _columns,
+                precachedFiles: _precachedFiles,
+              ),
+            ),
+          ),
+        AlertDialog(
+          title: Text(l.bulkExportPngTitle),
+          content: SizedBox(
+            width: 560,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Text(
+                        l.bulkExportPngColumns,
+                        style: AppTypography.bodySmall.copyWith(
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                      Expanded(
+                        child: Slider(
+                          value: _columns.toDouble(),
+                          min: 4,
+                          max: 20,
+                          divisions: 16,
+                          label: '$_columns',
+                          onChanged: _saving
+                              ? null
+                              : (double v) =>
+                                  setState(() => _columns = v.round()),
+                        ),
+                      ),
+                      SizedBox(
+                        width: 28,
+                        child: Text(
+                          '$_columns',
+                          textAlign: TextAlign.end,
+                          style: AppTypography.body.copyWith(
+                            fontFeatures: const <FontFeature>[
+                              FontFeature.tabularFigures(),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  Container(
+                    constraints: const BoxConstraints(maxHeight: 400),
+                    decoration: BoxDecoration(
+                      color: AppColors.background,
+                      border: Border.all(color: AppColors.surfaceBorder),
+                      borderRadius:
+                          BorderRadius.circular(AppSpacing.radiusSm),
+                    ),
+                    padding: const EdgeInsets.all(AppSpacing.sm),
+                    child: FittedBox(
+                      fit: BoxFit.contain,
+                      alignment: Alignment.topCenter,
+                      child: BulkPosterMosaicView(
+                        items: _previewItems,
+                        columns: _columns,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    _previewIsTruncated
+                        ? l.bulkExportPngItemsCountPreview(
+                            widget.items.length, _previewLimit)
+                        : l.bulkExportPngItemsCount(widget.items.length),
+                    style: AppTypography.caption.copyWith(
+                      color: AppColors.textTertiary,
+                    ),
+                  ),
+                  if (_saving && _precacheTotal > 0) ...<Widget>[
+                    const SizedBox(height: AppSpacing.sm),
+                    LinearProgressIndicator(
+                      value: _precacheTotal == 0
+                          ? null
+                          : _precacheDone / _precacheTotal,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      l.bulkExportPngPreparing(_precacheDone, _precacheTotal),
+                      style: AppTypography.caption.copyWith(
+                        color: AppColors.textTertiary,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: _saving ? null : () => Navigator.of(context).pop(),
+              child: Text(l.cancel),
+            ),
+            FilledButton.icon(
+              onPressed: _saving ? null : _handleSave,
+              icon: _saving
+                  ? SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: theme.colorScheme.onPrimary,
+                      ),
+                    )
+                  : const Icon(Icons.save_alt),
+              label: Text(l.bulkExportPngSave),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> _handleSave() async {
+    final S l = S.of(context);
+    setState(() {
+      _saving = true;
+      _precacheDone = 0;
+      _precacheTotal = widget.items.length;
+      _precachedFiles.clear();
+    });
+
+    await _precacheCovers();
+    if (!mounted) return;
+
+    setState(() => _mountFullForExport = true);
+
+    await SchedulerBinding.instance.endOfFrame;
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    await SchedulerBinding.instance.endOfFrame;
+
+    final String baseName = widget.collectionName?.trim().isNotEmpty == true
+        ? widget.collectionName!.trim()
+        : 'collection';
+    final String fileName = '${sanitizeFileName(baseName)}.png';
+
+    final double pixelRatio = widget.items.length > 200 ? 1.0 : 2.0;
+    final BulkExportResult result = await saveBoundaryAsPng(
+      repaintKey: _repaintKey,
+      suggestedFileName: fileName,
+      saveDialogTitle: l.bulkExportPngTitle,
+      pixelRatio: pixelRatio,
+    );
+    if (!mounted) return;
+    setState(() {
+      _saving = false;
+      _mountFullForExport = false;
+      _precacheTotal = 0;
+      _precacheDone = 0;
+    });
+
+    switch (result.status) {
+      case BulkExportStatus.saved:
+        Navigator.of(context).pop();
+        context.showSnack(l.bulkExportPngSaved, type: SnackType.success);
+      case BulkExportStatus.cancelled:
+        break;
+      case BulkExportStatus.failed:
+        context.showSnack(l.bulkExportPngFailed, type: SnackType.error);
+    }
+  }
+
+  Future<void> _precacheCovers() async {
+    final ImageCacheService cache = ref.read(imageCacheServiceProvider);
+    final List<CollectionItem> items = widget.items;
+
+    for (int start = 0; start < items.length; start += _precacheBatchSize) {
+      if (!mounted) return;
+      final int end = (start + _precacheBatchSize).clamp(0, items.length);
+      final List<Future<void>> batch = <Future<void>>[];
+
+      for (int i = start; i < end; i++) {
+        batch.add(_precacheOne(cache, items[i]));
+      }
+      await Future.wait(batch);
+      if (!mounted) return;
+      setState(() => _precacheDone = end);
+    }
+  }
+
+  Future<void> _precacheOne(
+    ImageCacheService cache,
+    CollectionItem item,
+  ) async {
+    final String? url = item.coverUrl ?? item.thumbnailUrl;
+    if (url == null) return;
+    try {
+      ImageResult result = await cache.getImageUri(
+        type: item.imageType,
+        imageId: item.externalId.toString(),
+        remoteUrl: url,
+      );
+      if (!mounted) return;
+
+      if (result.isMissing) {
+        final bool ok = await cache.downloadImage(
+          type: item.imageType,
+          imageId: item.externalId.toString(),
+          remoteUrl: url,
+        );
+        if (!mounted) return;
+        if (ok) {
+          result = await cache.getImageUri(
+            type: item.imageType,
+            imageId: item.externalId.toString(),
+            remoteUrl: url,
+          );
+          if (!mounted) return;
+        }
+      }
+
+      if (result.uri == null) return;
+
+      if (result.isLocal) {
+        final File file = File(result.uri!);
+        if (file.existsSync() && file.lengthSync() > 0) {
+          // Same ImageProvider key as the off-screen tile — otherwise the
+          // tile decodes a second time and skips the warm cache.
+          try {
+            await precacheImage(
+              ResizeImage(FileImage(file), width: 300),
+              context,
+            );
+            if (!mounted) return;
+            _precachedFiles[item.id] = file;
+          } on Exception {
+            // Corrupt cached file — drop it so the next export pulls a fresh
+            // copy. Leave _precachedFiles untouched; the tile falls back to
+            // a placeholder for this run.
+            try {
+              await file.delete();
+            } on FileSystemException {
+              // File already gone or locked — nothing to do.
+            }
+          }
+        }
+      } else {
+        try {
+          await precacheImage(NetworkImage(result.uri!), context);
+        } on Exception {
+          // Remote URL not loadable — tile will render a placeholder.
+        }
+      }
+    } on Exception {
+      // Single cover failing to precache must not abort the whole export.
+    }
+  }
+
+}

--- a/lib/features/collections/widgets/bulk_export/bulk_poster_mosaic_view.dart
+++ b/lib/features/collections/widgets/bulk_export/bulk_poster_mosaic_view.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../../shared/models/collection_item.dart';
+import '../../../../shared/theme/app_assets.dart';
+import '../../../../shared/theme/app_colors.dart';
+import '../../../../shared/theme/app_spacing.dart';
+import '../../../../shared/theme/app_typography.dart';
+import '../../../../shared/widgets/cached_image.dart';
+
+/// Off-screen widget rendered into a PNG via [RepaintBoundary].
+///
+/// Lays out covers in a dense grid (no labels, no headers); the watermark
+/// row at the bottom matches `TierListExportView` so all PNG exports share
+/// one signature.
+class BulkPosterMosaicView extends StatelessWidget {
+  const BulkPosterMosaicView({
+    required this.items,
+    required this.columns,
+    this.repaintKey,
+    this.precachedFiles,
+    super.key,
+  });
+
+  final GlobalKey? repaintKey;
+  final List<CollectionItem> items;
+  final int columns;
+
+  /// When provided, each item id maps to its already-decoded local cover
+  /// file. The tile renders that file synchronously via `Image.file` instead
+  /// of going through `CachedImage` — which still spins up its own
+  /// `FutureBuilder` and would race against `toImage`.
+  final Map<int, File>? precachedFiles;
+
+  static const double _posterWidth = 150;
+  static const double _aspectRatio = 2 / 3;
+  static const double _posterHeight = _posterWidth / _aspectRatio;
+  static const double _gap = 4;
+
+  /// Picks a column count that keeps the canvas roughly square for a portrait
+  /// 2:3 aspect: `cols ≈ sqrt(n * 1.5)`. Clamped so tiny sets don't look like a
+  /// strip and huge sets don't blow up GPU memory at pixelRatio 2.
+  static int autoColumns(int itemCount) {
+    if (itemCount <= 0) return 4;
+    final int cols = math.sqrt(itemCount * 1.5).round();
+    return cols.clamp(4, 20);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final double canvasWidth =
+        columns * _posterWidth + (columns - 1) * _gap + AppSpacing.md * 2;
+
+    return RepaintBoundary(
+      key: repaintKey,
+      child: Container(
+        color: AppColors.background,
+        padding: const EdgeInsets.all(AppSpacing.md),
+        width: canvasWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Wrap(
+              spacing: _gap,
+              runSpacing: _gap,
+              children: <Widget>[
+                for (final CollectionItem item in items)
+                  SizedBox(
+                    width: _posterWidth,
+                    height: _posterHeight,
+                    child: _PosterTile(
+                      item: item,
+                      precachedFile: precachedFiles?[item.id],
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.md),
+            const Divider(height: 1, color: AppColors.surfaceBorder),
+            const SizedBox(height: AppSpacing.sm),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                Image.asset(AppAssets.logo, width: 16, height: 16),
+                const SizedBox(width: 4),
+                Text(
+                  'made by Tonkatsu Box',
+                  style: AppTypography.caption.copyWith(
+                    color: AppColors.textTertiary,
+                    fontSize: 10,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PosterTile extends StatelessWidget {
+  const _PosterTile({required this.item, this.precachedFile});
+
+  final CollectionItem item;
+  final File? precachedFile;
+
+  @override
+  Widget build(BuildContext context) {
+    final String? url = item.coverUrl ?? item.thumbnailUrl;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      child: precachedFile != null
+          ? Image(
+              // Cap decoded resolution at the on-canvas size so the
+              // ImageCache doesn't evict already-loaded covers when the
+              // selection runs into hundreds of items.
+              image: ResizeImage(
+                FileImage(precachedFile!),
+                width: 300,
+              ),
+              fit: BoxFit.cover,
+              errorBuilder:
+                  (BuildContext _, Object _, StackTrace? _) => _placeholder(),
+            )
+          : url == null
+              ? _placeholder()
+              : CachedImage(
+                  imageType: item.imageType,
+                  imageId: item.externalId.toString(),
+                  remoteUrl: url,
+                  fit: BoxFit.cover,
+                  placeholder: _placeholder(),
+                  errorWidget: _placeholder(),
+                ),
+    );
+  }
+
+  Widget _placeholder() {
+    return Container(
+      color: AppColors.surfaceLight,
+      alignment: Alignment.center,
+      child: Icon(
+        item.placeholderIcon,
+        color: AppColors.textSecondary,
+        size: 48,
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
@@ -12,12 +12,14 @@ import '../bulk_action_bar.dart';
 class CollectionBulkActionBar extends ConsumerWidget {
   const CollectionBulkActionBar({
     required this.collectionId,
+    this.collectionName,
     this.filters,
     this.tags = const <CollectionTag>[],
     super.key,
   });
 
   final int? collectionId;
+  final String? collectionName;
 
   /// Active screen filters. When provided, the "select all visible" action
   /// targets `filters.apply(allItems, tags)` instead of the full list.
@@ -53,6 +55,7 @@ class CollectionBulkActionBar extends ConsumerWidget {
     return BulkActionBar(
       items: selectedItems,
       collectionId: collectionId,
+      collectionName: collectionName,
       visibleCount: visible.length,
       onSelectAllVisible: () => ref
           .read(collectionSelectionProvider(collectionId).notifier)

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -110,6 +110,31 @@
       "count": {"type": "int"}
     }
   },
+  "bulkExportPngTitle": "Export as PNG",
+  "bulkExportPngColumns": "Columns",
+  "bulkExportPngItemsCount": "{count, plural, =1{1 item} other{{count} items}}",
+  "@bulkExportPngItemsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkExportPngItemsCountPreview": "{total, plural, =1{1 item} other{{total} items}} ({preview} shown in preview)",
+  "@bulkExportPngItemsCountPreview": {
+    "placeholders": {
+      "total": {"type": "int"},
+      "preview": {"type": "int"}
+    }
+  },
+  "bulkExportPngPreparing": "Preparing covers: {done} / {total}",
+  "@bulkExportPngPreparing": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "bulkExportPngSave": "Save PNG",
+  "bulkExportPngSaved": "Image saved",
+  "bulkExportPngFailed": "Failed to save image",
   "back": "Back",
   "next": "Next",
   "skip": "Skip",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -559,6 +559,54 @@ abstract class S {
   /// **'Status updated for {count, plural, =1{1 item} other{{count} items}}'**
   String bulkStatusUpdated(int count);
 
+  /// No description provided for @bulkExportPngTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Export as PNG'**
+  String get bulkExportPngTitle;
+
+  /// No description provided for @bulkExportPngColumns.
+  ///
+  /// In en, this message translates to:
+  /// **'Columns'**
+  String get bulkExportPngColumns;
+
+  /// No description provided for @bulkExportPngItemsCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 item} other{{count} items}}'**
+  String bulkExportPngItemsCount(int count);
+
+  /// No description provided for @bulkExportPngItemsCountPreview.
+  ///
+  /// In en, this message translates to:
+  /// **'{total, plural, =1{1 item} other{{total} items}} ({preview} shown in preview)'**
+  String bulkExportPngItemsCountPreview(int total, int preview);
+
+  /// No description provided for @bulkExportPngPreparing.
+  ///
+  /// In en, this message translates to:
+  /// **'Preparing covers: {done} / {total}'**
+  String bulkExportPngPreparing(int done, int total);
+
+  /// No description provided for @bulkExportPngSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save PNG'**
+  String get bulkExportPngSave;
+
+  /// No description provided for @bulkExportPngSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Image saved'**
+  String get bulkExportPngSaved;
+
+  /// No description provided for @bulkExportPngFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to save image'**
+  String get bulkExportPngFailed;
+
   /// No description provided for @back.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -268,6 +268,48 @@ class SEn extends S {
   }
 
   @override
+  String get bulkExportPngTitle => 'Export as PNG';
+
+  @override
+  String get bulkExportPngColumns => 'Columns';
+
+  @override
+  String bulkExportPngItemsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items',
+      one: '1 item',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String bulkExportPngItemsCountPreview(int total, int preview) {
+    String _temp0 = intl.Intl.pluralLogic(
+      total,
+      locale: localeName,
+      other: '$total items',
+      one: '1 item',
+    );
+    return '$_temp0 ($preview shown in preview)';
+  }
+
+  @override
+  String bulkExportPngPreparing(int done, int total) {
+    return 'Preparing covers: $done / $total';
+  }
+
+  @override
+  String get bulkExportPngSave => 'Save PNG';
+
+  @override
+  String get bulkExportPngSaved => 'Image saved';
+
+  @override
+  String get bulkExportPngFailed => 'Failed to save image';
+
+  @override
   String get back => 'Back';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -274,6 +274,52 @@ class SRu extends S {
   }
 
   @override
+  String get bulkExportPngTitle => 'Экспорт в PNG';
+
+  @override
+  String get bulkExportPngColumns => 'Колонок';
+
+  @override
+  String bulkExportPngItemsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count элементов',
+      many: '$count элементов',
+      few: '$count элемента',
+      one: '1 элемент',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String bulkExportPngItemsCountPreview(int total, int preview) {
+    String _temp0 = intl.Intl.pluralLogic(
+      total,
+      locale: localeName,
+      other: '$total элементов',
+      many: '$total элементов',
+      few: '$total элемента',
+      one: '1 элемент',
+    );
+    return '$_temp0 (в превью $preview)';
+  }
+
+  @override
+  String bulkExportPngPreparing(int done, int total) {
+    return 'Подготовка обложек: $done / $total';
+  }
+
+  @override
+  String get bulkExportPngSave => 'Сохранить PNG';
+
+  @override
+  String get bulkExportPngSaved => 'Изображение сохранено';
+
+  @override
+  String get bulkExportPngFailed => 'Не удалось сохранить изображение';
+
+  @override
   String get back => 'Назад';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -110,6 +110,31 @@
       "count": {"type": "int"}
     }
   },
+  "bulkExportPngTitle": "Экспорт в PNG",
+  "bulkExportPngColumns": "Колонок",
+  "bulkExportPngItemsCount": "{count, plural, =1{1 элемент} few{{count} элемента} many{{count} элементов} other{{count} элементов}}",
+  "@bulkExportPngItemsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkExportPngItemsCountPreview": "{total, plural, =1{1 элемент} few{{total} элемента} many{{total} элементов} other{{total} элементов}} (в превью {preview})",
+  "@bulkExportPngItemsCountPreview": {
+    "placeholders": {
+      "total": {"type": "int"},
+      "preview": {"type": "int"}
+    }
+  },
+  "bulkExportPngPreparing": "Подготовка обложек: {done} / {total}",
+  "@bulkExportPngPreparing": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "bulkExportPngSave": "Сохранить PNG",
+  "bulkExportPngSaved": "Изображение сохранено",
+  "bulkExportPngFailed": "Не удалось сохранить изображение",
   "back": "Назад",
   "next": "Далее",
   "skip": "Пропустить",

--- a/test/features/collections/widgets/bulk_export/bulk_export_service_test.dart
+++ b/test/features/collections/widgets/bulk_export/bulk_export_service_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/bulk_export/bulk_export_service.dart';
+
+void main() {
+  group('sanitizeFileName', () {
+    test('should keep word chars, hyphens, spaces as-is', () {
+      expect(sanitizeFileName('My Collection 2024'), 'My Collection 2024');
+      expect(sanitizeFileName('top-100'), 'top-100');
+    });
+
+    test('should replace path separators and dots with underscore', () {
+      expect(sanitizeFileName('../etc/passwd'), '___etc_passwd');
+      expect(sanitizeFileName('foo/bar'), 'foo_bar');
+      expect(sanitizeFileName('a.b.c'), 'a_b_c');
+    });
+
+    test('should replace other punctuation', () {
+      expect(sanitizeFileName('A|B?C*'), 'A_B_C_');
+    });
+
+    test('should trim leading and trailing whitespace', () {
+      expect(sanitizeFileName('  padded  '), 'padded');
+    });
+
+    test('should handle Cyrillic by keeping word chars', () {
+      // \w in Dart RegExp matches ASCII word chars only — Cyrillic is replaced.
+      // This documents the current behaviour (callers fall back to "collection"
+      // when sanitization wipes the name to an underscore string).
+      expect(sanitizeFileName('Желаемое'), '________');
+    });
+  });
+
+  group('ensurePngExtension', () {
+    test('should append .png when missing', () {
+      expect(ensurePngExtension('/tmp/foo'), '/tmp/foo.png');
+      expect(ensurePngExtension('image'), 'image.png');
+    });
+
+    test('should keep .png unchanged regardless of case', () {
+      expect(ensurePngExtension('/tmp/foo.png'), '/tmp/foo.png');
+      expect(ensurePngExtension('/tmp/foo.PNG'), '/tmp/foo.PNG');
+      expect(ensurePngExtension('image.Png'), 'image.Png');
+    });
+
+    test('should not strip pre-existing extensions other than png', () {
+      // ".jpg" is not ".png" — we still append rather than replace, since the
+      // user explicitly typed it. This documents current behaviour.
+      expect(ensurePngExtension('image.jpg'), 'image.jpg.png');
+    });
+
+    test('should handle empty and minimal paths', () {
+      expect(ensurePngExtension(''), '.png');
+      expect(ensurePngExtension('.png'), '.png');
+    });
+  });
+}

--- a/test/features/collections/widgets/bulk_export/bulk_poster_mosaic_view_test.dart
+++ b/test/features/collections/widgets/bulk_export/bulk_poster_mosaic_view_test.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xerabora/features/collections/widgets/bulk_export/bulk_poster_mosaic_view.dart';
+import 'package:xerabora/shared/models/collection_item.dart';
+import 'package:xerabora/shared/models/game.dart';
+import 'package:xerabora/shared/models/item_status.dart';
+import 'package:xerabora/shared/models/media_type.dart';
+import 'package:xerabora/shared/widgets/cached_image.dart';
+
+CollectionItem _item(int id, {bool withCover = false}) {
+  return CollectionItem(
+    id: id,
+    collectionId: 1,
+    mediaType: MediaType.game,
+    externalId: 1000 + id,
+    status: ItemStatus.notStarted,
+    addedAt: DateTime(2024),
+    game: Game(
+      id: 1000 + id,
+      name: 'Game $id',
+      coverUrl: withCover ? 'https://example.test/cover_$id.jpg' : null,
+    ),
+  );
+}
+
+void main() {
+  group('BulkPosterMosaicView', () {
+    group('autoColumns', () {
+      test('floors to 4 for empty / tiny sets', () {
+        expect(BulkPosterMosaicView.autoColumns(0), 4);
+        expect(BulkPosterMosaicView.autoColumns(1), 4);
+        expect(BulkPosterMosaicView.autoColumns(5), 4);
+      });
+
+      test('picks ~sqrt(n * 1.5) within bounds', () {
+        expect(BulkPosterMosaicView.autoColumns(20), 5);
+        expect(BulkPosterMosaicView.autoColumns(50), 9);
+        expect(BulkPosterMosaicView.autoColumns(100), 12);
+      });
+
+      test('clamps to 20 for huge sets', () {
+        expect(BulkPosterMosaicView.autoColumns(1000), 20);
+        expect(BulkPosterMosaicView.autoColumns(10000), 20);
+      });
+    });
+
+    testWidgets('renders without exceptions for a small set',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(4000, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final GlobalKey repaintKey = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SingleChildScrollView(
+            child: BulkPosterMosaicView(
+              repaintKey: repaintKey,
+              items: <CollectionItem>[for (int i = 0; i < 8; i++) _item(i)],
+              columns: 4,
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(repaintKey), findsOneWidget);
+    });
+
+    testWidgets('renders without exceptions for a medium set',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(6000, 6000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final GlobalKey repaintKey = GlobalKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SingleChildScrollView(
+            child: BulkPosterMosaicView(
+              repaintKey: repaintKey,
+              items: <CollectionItem>[for (int i = 0; i < 50; i++) _item(i)],
+              columns: BulkPosterMosaicView.autoColumns(50),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('falls back to CachedImage when precachedFiles is null',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(2000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: SingleChildScrollView(
+              child: BulkPosterMosaicView(
+                items: <CollectionItem>[
+                  for (int i = 0; i < 4; i++) _item(i, withCover: true),
+                ],
+                columns: 4,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CachedImage), findsNWidgets(4));
+    });
+
+    testWidgets('renders Image directly when precachedFile is provided',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(2000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final Directory tempDir = Directory.systemTemp.createTempSync(
+        'bulk_export_test_',
+      );
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      final File tempCover = File('${tempDir.path}/cover.png')
+        ..writeAsBytesSync(<int>[
+          // 1×1 transparent PNG.
+          0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+          0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+          0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+          0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+          0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+          0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+          0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+          0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+          0x42, 0x60, 0x82,
+        ]);
+
+      final CollectionItem item = _item(1);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SingleChildScrollView(
+            child: BulkPosterMosaicView(
+              items: <CollectionItem>[item],
+              columns: 4,
+              precachedFiles: <int, File>{item.id: tempCover},
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      // Direct ResizeImage(FileImage) path bypasses CachedImage entirely.
+      expect(find.byType(CachedImage), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Add an image-export action to the bulk action bar in collections and All Items. The dialog shows a preview (capped at 120 covers so big selections open instantly), an auto-picked column slider, and a batched cover-precache step before snapshotting the off-screen mosaic to PNG via FilePicker on desktop or the system gallery on Android. Watermark row matches the tier-list export.