### PR TITLE
feat(export): unify mobile PNG save to a folder picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,6 +435,29 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Unify mobile image save to a folder picker across all PNG exports**
+
+  Bulk poster export and tier-list export on Android used to drop the PNG
+  straight into a fixed "Tonkatsu Box" gallery album with no say over the
+  destination. They now open the system folder picker (Storage Access
+  Framework), matching how mood-grid export already behaved. The shared
+  `saveBoundaryAsPng` service is the single save path for all three, and
+  mood-grid export was refactored onto it instead of carrying its own copy.
+  The `gal` dependency and the gallery permissions it required are gone.
+
+  * lib/shared/services/png_export_service.dart (saveBoundaryAsPng): Replace
+    the Android `Gal.putImageBytes` branch with `FilePicker.saveFile` using
+    `FileType.any` plus `bytes` so file_picker writes via SAF; desktop path
+    unchanged.
+  * lib/features/tier_lists/screens/mood_grid_detail_screen.dart
+    (_MoodGridDetailScreenState._exportAsImage): Refactor onto the shared
+    `saveBoundaryAsPng`; drop the inline FilePicker / RenderRepaintBoundary
+    duplication and the now-unused dart:io, dart:ui, file_picker and
+    flutter/services imports.
+  * pubspec.yaml: Remove the `gal` dependency, used only by the old save path.
+  * android/app/src/main/AndroidManifest.xml: Remove `WRITE_EXTERNAL_STORAGE`
+    and `READ_MEDIA_IMAGES`, declared only for `gal` — SAF requires neither.
+
 - **Tier-list detail page is faster on large collections and easier to use on mobile**
 
   Several wins land together. Derived collections on `TierListDetailState`

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
 
     <application
         android:label="Tonkatsu Box"

--- a/lib/features/tier_lists/screens/mood_grid_detail_screen.dart
+++ b/lib/features/tier_lists/screens/mood_grid_detail_screen.dart
@@ -1,16 +1,11 @@
-import 'dart:io';
-import 'dart:ui' as ui;
-
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/mood_grid_cell.dart';
+import '../../../shared/services/png_export_service.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
@@ -375,50 +370,30 @@ class _MoodGridDetailScreenState extends ConsumerState<MoodGridDetailScreen> {
   }
 
   Future<void> _exportAsImage(String gridName, S l) async {
-    try {
-      await WidgetsBinding.instance.endOfFrame;
-      final RenderRepaintBoundary? boundary = _exportKey.currentContext
-          ?.findRenderObject() as RenderRepaintBoundary?;
-      if (boundary == null) return;
-      final ui.Image image = await boundary.toImage(pixelRatio: 2.0);
-      final ByteData? byteData =
-          await image.toByteData(format: ui.ImageByteFormat.png);
-      if (byteData == null) return;
-      final Uint8List pngBytes = byteData.buffer.asUint8List();
+    // Wait for the current frame so the offscreen export view is rendered.
+    await WidgetsBinding.instance.endOfFrame;
 
-      // Windows forbids <>:"/\|?* in file names; sanitize before the picker.
-      final String safeName =
-          gridName.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_').trim();
-      final String fileName = safeName.isEmpty
-          ? 'mood_grid_${widget.gridId}.png'
-          : '$safeName.png';
+    final String safeName = sanitizeFileName(gridName);
+    final String fileName =
+        '${safeName.isEmpty ? 'mood_grid_${widget.gridId}' : safeName}.png';
 
-      final bool mobile = Platform.isAndroid || Platform.isIOS;
-      final String? outputPath = await FilePicker.platform.saveFile(
-        dialogTitle: l.moodGridExportImage,
-        fileName: fileName,
-        // On Android FileType.custom blocks the picker; FileType.any opens SAF.
-        type: mobile ? FileType.any : FileType.custom,
-        allowedExtensions: mobile ? null : <String>['png'],
-        // bytes are required on Android — file_picker writes via SAF itself.
-        bytes: mobile ? pngBytes : null,
-      );
-      if (outputPath == null) return;
+    final BulkExportResult result = await saveBoundaryAsPng(
+      repaintKey: _exportKey,
+      suggestedFileName: fileName,
+      saveDialogTitle: l.moodGridExportImage,
+    );
+    if (!mounted) return;
 
-      // Desktop: file_picker only returns the chosen path; we write the bytes
-      // ourselves. Force a .png extension if the user removed it.
-      if (!mobile) {
-        final String finalPath = outputPath.toLowerCase().endsWith('.png')
-            ? outputPath
-            : '$outputPath.png';
-        await File(finalPath).writeAsBytes(pngBytes);
-      }
-
-      if (!mounted) return;
-      context.showSnack(l.moodGridImageSaved, type: SnackType.success);
-    } on Exception catch (e) {
-      if (!mounted) return;
-      context.showSnack(l.errorPrefix(e.toString()), type: SnackType.error);
+    switch (result.status) {
+      case BulkExportStatus.saved:
+        context.showSnack(l.moodGridImageSaved, type: SnackType.success);
+      case BulkExportStatus.cancelled:
+        break;
+      case BulkExportStatus.failed:
+        context.showSnack(
+          l.errorPrefix(result.error?.toString() ?? ''),
+          type: SnackType.error,
+        );
     }
   }
 }

--- a/lib/shared/services/png_export_service.dart
+++ b/lib/shared/services/png_export_service.dart
@@ -5,7 +5,6 @@ import 'dart:ui' as ui;
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/rendering.dart';
-import 'package:gal/gal.dart';
 
 /// Result of an export attempt.
 enum BulkExportStatus { saved, cancelled, failed }
@@ -38,9 +37,12 @@ class BulkExportResult {
   final Object? error;
 }
 
-/// Renders the widget behind [repaintKey] into a PNG. Desktop opens
-/// [FilePicker.saveFile]; Android writes to the system gallery via
-/// [Gal.putImageBytes] (album "Tonkatsu Box").
+/// Renders the widget behind [repaintKey] into a PNG and lets the user pick
+/// where to save it via [FilePicker.saveFile].
+///
+/// On Android/iOS the picker opens the Storage Access Framework: [FileType.any]
+/// plus [bytes] makes file_picker write the file itself at the chosen location.
+/// On desktop file_picker only returns the path, so we write the bytes here.
 Future<BulkExportResult> saveBoundaryAsPng({
   required GlobalKey repaintKey,
   required String suggestedFileName,
@@ -62,32 +64,28 @@ Future<BulkExportResult> saveBoundaryAsPng({
     }
     final Uint8List pngBytes = byteData.buffer.asUint8List();
 
-    if (Platform.isAndroid) {
-      final bool hasAccess = await Gal.requestAccess();
-      if (!hasAccess) {
-        return const BulkExportResult(BulkExportStatus.cancelled);
-      }
-      final String galName = stripPngExtension(suggestedFileName);
-      await Gal.putImageBytes(
-        pngBytes,
-        album: 'Tonkatsu Box',
-        name: galName,
-      );
-      return BulkExportResult(BulkExportStatus.saved, path: '$galName.png');
-    }
-
+    final bool mobile = Platform.isAndroid || Platform.isIOS;
     final String? outputPath = await FilePicker.platform.saveFile(
       dialogTitle: saveDialogTitle,
       fileName: suggestedFileName,
-      type: FileType.custom,
-      allowedExtensions: <String>['png'],
+      // On Android FileType.custom blocks the picker; FileType.any opens SAF.
+      type: mobile ? FileType.any : FileType.custom,
+      allowedExtensions: mobile ? null : <String>['png'],
+      // bytes are required on mobile — file_picker writes via SAF itself.
+      bytes: mobile ? pngBytes : null,
     );
     if (outputPath == null) {
       return const BulkExportResult(BulkExportStatus.cancelled);
     }
-    final String finalPath = ensurePngExtension(outputPath);
-    await File(finalPath).writeAsBytes(pngBytes);
-    return BulkExportResult(BulkExportStatus.saved, path: finalPath);
+
+    // Desktop: file_picker only returns the chosen path; we write the bytes.
+    if (!mobile) {
+      final String finalPath = ensurePngExtension(outputPath);
+      await File(finalPath).writeAsBytes(pngBytes);
+      return BulkExportResult(BulkExportStatus.saved, path: finalPath);
+    }
+
+    return BulkExportResult(BulkExportStatus.saved, path: outputPath);
   } on Exception catch (e) {
     return BulkExportResult(BulkExportStatus.failed, error: e);
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,14 +261,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  gal:
-    dependency: "direct main"
-    description:
-      name: gal
-      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.2"
   gamepads:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,9 +62,6 @@ dependencies:
   # XML (MyAnimeList import)
   xml: ^6.5.0
 
-  # Gallery
-  gal: ^2.3.0
-
   # URL
   url_launcher: ^6.2.0
 


### PR DESCRIPTION
Bulk poster export and tier-list export on Android dropped the PNG into a fixed "Tonkatsu Box" gallery album via gal, with no choice of destination. They now open the system folder picker (SAF), matching mood-grid export.

The shared saveBoundaryAsPng service is the single save path for all three; mood-grid export was refactored onto it. The gal dependency and the gallery permissions it required (WRITE_EXTERNAL_STORAGE, READ_MEDIA_IMAGES) are gone  SAF needs neither.