### PR TITLE
feat(rating): tap a whole star, fine-tune with -/+ buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Rate by tapping a whole star, fine-tune with −/+ buttons**
+
+  The personal-rating control no longer reads a fractional value from where you
+  tap or drag. Tapping a star now sets a whole number 1–10, and two −/+ buttons
+  next to the stars nudge the value by 0.1 to reach fractional ratings. The
+  buttons are disabled until a rating is set. This applies everywhere the
+  control appears — the item detail screen and the collection table popup.
+
+  * lib/shared/widgets/fractional_star_rating.dart (FractionalStarRating): Tap
+    snaps to a whole integer; drag removed; add −/+ nudge buttons (`step` 0.1,
+    clamped 1.0–10.0, no-op at the bounds) and a private `_NudgeButton`;
+    `naturalWidth` now accounts for the two buttons.
+
 ### Fixed
 
 - **Stop the gamepad plugin from crashing the app on Windows**

--- a/lib/shared/widgets/fractional_star_rating.dart
+++ b/lib/shared/widgets/fractional_star_rating.dart
@@ -2,15 +2,12 @@ import 'package:flutter/material.dart';
 
 import '../theme/app_colors.dart';
 
-/// Tap/drag bar for a fractional personal rating (1.0–10.0, step 0.1).
+/// Star control for a personal rating (1.0–10.0, step 0.1). Inline, no popup.
 ///
-/// Row of 11 cells: a leading dash cell clears the rating to `null`, followed
-/// by 10 stars. Tapping/dragging the stars sets the value by horizontal
-/// position; stars fill partially for fractional values. Inline — no popup.
-///
-/// The fill follows the pointer instantly via internal state; [onChanged] is
-/// emitted on tap and at the end of a drag (not on every drag event), so a
-/// slow persistence layer can't lag the visual.
+/// Row of a leading clear cell (sets the rating to `null`) plus 10 stars;
+/// tapping a star sets a whole integer 1–10. The −/+ buttons nudge the current
+/// value by 0.1 and are disabled while the rating is unset (nothing to nudge —
+/// tap a star first).
 class FractionalStarRating extends StatefulWidget {
   const FractionalStarRating({
     required this.onChanged,
@@ -28,13 +25,17 @@ class FractionalStarRating extends StatefulWidget {
   static const int starCount = 10;
   static const double minRating = 1.0;
   static const double maxRating = 10.0;
+  static const double step = 0.1;
   static const double _gap = 3.0;
 
-  /// Natural (unconstrained) width for a given [starSize]. Useful when the
-  /// widget sits inside an `IntrinsicWidth` (e.g. a popup menu), which cannot
-  /// measure the internal `LayoutBuilder`.
+  static double _buttonWidth(double starSize) => starSize + _gap;
+
+  /// Natural (unconstrained) width for a given [starSize]: clear cell, ten
+  /// stars, and the two nudge buttons. Useful when the widget sits inside an
+  /// `IntrinsicWidth` (e.g. a popup menu), which cannot measure the internal
+  /// `LayoutBuilder`.
   static double naturalWidth(double starSize) =>
-      (starSize + _gap) * (starCount + 1);
+      (starSize + _gap) * (starCount + 1) + 2 * _buttonWidth(starSize);
 
   @override
   State<FractionalStarRating> createState() => _FractionalStarRatingState();
@@ -51,77 +52,133 @@ class _FractionalStarRatingState extends State<FractionalStarRating> {
     }
   }
 
-  double get _cellWidth => widget.starSize + FractionalStarRating._gap;
-
   static double _roundToTenth(double v) => (v * 10).roundToDouble() / 10;
 
-  double? _valueFor(double localX, double cellWidth) {
-    if (localX < cellWidth) return null;
-    final double raw = (localX - cellWidth) / cellWidth;
-    return _roundToTenth(
-      raw.clamp(FractionalStarRating.minRating, FractionalStarRating.maxRating),
-    );
-  }
-
-  void _preview(double localX, double cellWidth) {
-    if (cellWidth <= 0) return;
-    setState(() => _value = _valueFor(localX, cellWidth));
-  }
-
-  void _commit(double localX, double cellWidth) {
-    if (cellWidth <= 0) return;
-    final double? v = _valueFor(localX, cellWidth);
+  void _emit(double? v) {
     setState(() => _value = v);
     widget.onChanged(v);
+  }
+
+  void _handleTap(double localX, double cellWidth) {
+    if (cellWidth <= 0) return;
+    final int index = (localX / cellWidth).floor();
+    if (index <= 0) {
+      _emit(null);
+      return;
+    }
+    _emit(index.clamp(1, FractionalStarRating.starCount).toDouble());
+  }
+
+  void _nudge(double delta) {
+    final double? current = _value;
+    if (current == null) return;
+    final double next = _roundToTenth(
+      (current + delta).clamp(
+        FractionalStarRating.minRating,
+        FractionalStarRating.maxRating,
+      ),
+    );
+    if (next == current) return;
+    _emit(next);
   }
 
   @override
   Widget build(BuildContext context) {
     const int starCount = FractionalStarRating.starCount;
+    final double buttonWidth =
+        FractionalStarRating._buttonWidth(widget.starSize);
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        final double intrinsic = _cellWidth * (starCount + 1);
-        // Shrink to the parent when it is narrower than the natural width,
-        // so the row never overflows; otherwise keep the natural size.
-        final double totalWidth =
-            constraints.maxWidth.isFinite && constraints.maxWidth < intrinsic
-                ? constraints.maxWidth
-                : intrinsic;
-        final double cellWidth = totalWidth / (starCount + 1);
+        final double barNatural =
+            (widget.starSize + FractionalStarRating._gap) * (starCount + 1);
+        final double reserved = 2 * buttonWidth;
+        // Shrink the star bar to the parent when it is too narrow, so the row
+        // never overflows; the nudge buttons keep their natural size.
+        final double barWidth = constraints.maxWidth.isFinite &&
+                constraints.maxWidth - reserved < barNatural
+            ? (constraints.maxWidth - reserved).clamp(0.0, barNatural)
+            : barNatural;
+        final double cellWidth = barWidth / (starCount + 1);
+        final bool hasValue = _value != null;
 
-        return GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTapDown: (TapDownDetails d) =>
-              _preview(d.localPosition.dx, cellWidth),
-          onTapUp: (TapUpDetails d) => _commit(d.localPosition.dx, cellWidth),
-          onHorizontalDragUpdate: (DragUpdateDetails d) =>
-              _preview(d.localPosition.dx, cellWidth),
-          onHorizontalDragEnd: (_) => widget.onChanged(_value),
-          child: SizedBox(
-            width: totalWidth,
-            height: widget.starSize,
-            child: Row(
-              children: <Widget>[
-                _Cell(
-                  width: cellWidth,
-                  child: _ClearCell(
-                    size: widget.starSize,
-                    active: _value == null,
-                  ),
-                ),
-                for (int i = 1; i <= starCount; i++)
-                  _Cell(
-                    width: cellWidth,
-                    child: _PartialStar(
-                      fill: ((_value ?? 0) - (i - 1)).clamp(0.0, 1.0),
-                      size: widget.starSize,
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTapUp: (TapUpDetails d) =>
+                  _handleTap(d.localPosition.dx, cellWidth),
+              child: SizedBox(
+                width: barWidth,
+                height: widget.starSize,
+                child: Row(
+                  children: <Widget>[
+                    _Cell(
+                      width: cellWidth,
+                      child: _ClearCell(
+                        size: widget.starSize,
+                        active: _value == null,
+                      ),
                     ),
-                  ),
-              ],
+                    for (int i = 1; i <= starCount; i++)
+                      _Cell(
+                        width: cellWidth,
+                        child: _PartialStar(
+                          fill: ((_value ?? 0) - (i - 1)).clamp(0.0, 1.0),
+                          size: widget.starSize,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
             ),
-          ),
+            _NudgeButton(
+              icon: Icons.remove,
+              size: widget.starSize,
+              onTap: hasValue ? () => _nudge(-FractionalStarRating.step) : null,
+            ),
+            _NudgeButton(
+              icon: Icons.add,
+              size: widget.starSize,
+              onTap: hasValue ? () => _nudge(FractionalStarRating.step) : null,
+            ),
+          ],
         );
       },
+    );
+  }
+}
+
+/// Square tappable +/- button. Greyed out (and inert) when [onTap] is null.
+class _NudgeButton extends StatelessWidget {
+  const _NudgeButton({
+    required this.icon,
+    required this.size,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final double size;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: FractionalStarRating._buttonWidth(size),
+      height: size,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          customBorder: const CircleBorder(),
+          child: Icon(
+            icon,
+            size: size * 0.8,
+            color:
+                onTap == null ? AppColors.textTertiary : AppColors.ratingStar,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/test/shared/widgets/fractional_star_rating_test.dart
+++ b/test/shared/widgets/fractional_star_rating_test.dart
@@ -4,7 +4,7 @@ import 'package:tonkatsu_box/shared/widgets/fractional_star_rating.dart';
 
 void main() {
   // starSize 24 + gap 3 => cellWidth 27. Leading cell occupies [0, 27),
-  // then 10 stars map [27, 297) onto rating 1.0..10.0.
+  // then 10 stars map [27, 297) onto integers 1..10.
   const double starSize = 24;
   const double cellWidth = starSize + 3;
 
@@ -38,8 +38,7 @@ void main() {
       expect(captured, isNull);
     });
 
-    testWidgets('tap near right edge yields 10.0 (clamped)',
-        (WidgetTester t) async {
+    testWidgets('tap on the last star yields 10.0', (WidgetTester t) async {
       double? captured;
       await t.pumpWidget(build(
         value: null,
@@ -50,8 +49,7 @@ void main() {
       expect(captured, 10.0);
     });
 
-    testWidgets('tap just past leading cell clamps up to 1.0',
-        (WidgetTester t) async {
+    testWidgets('tap on the first star yields 1.0', (WidgetTester t) async {
       double? captured;
       await t.pumpWidget(build(
         value: null,
@@ -62,41 +60,79 @@ void main() {
       expect(captured, 1.0);
     });
 
-    testWidgets('tap mid-bar yields a fractional value on 0.1 grid',
-        (WidgetTester t) async {
+    testWidgets('tap on a star yields a whole integer', (WidgetTester t) async {
       double? captured;
       await t.pumpWidget(build(
         value: null,
         onChanged: (double? v) => captured = v,
       ));
 
-      // x in the 5th star region -> roughly 4.5.
+      // x in the 4th star region -> integer 4.0, never a fraction.
       await t.tapAt(const Offset(cellWidth + cellWidth * 3.5, 10));
-      expect(captured, isNotNull);
-      // Value is rounded to a 0.1 grid.
-      expect((captured! * 10).roundToDouble(), captured! * 10);
-      expect(captured, greaterThanOrEqualTo(1.0));
-      expect(captured, lessThanOrEqualTo(10.0));
+      expect(captured, 4.0);
+    });
+
+    testWidgets('plus button nudges up by 0.1', (WidgetTester t) async {
+      double? captured;
+      await t.pumpWidget(build(
+        value: 7.0,
+        onChanged: (double? v) => captured = v,
+      ));
+
+      await t.tap(find.byIcon(Icons.add));
+      expect(captured, 7.1);
+    });
+
+    testWidgets('minus button nudges down by 0.1', (WidgetTester t) async {
+      double? captured;
+      await t.pumpWidget(build(
+        value: 7.0,
+        onChanged: (double? v) => captured = v,
+      ));
+
+      await t.tap(find.byIcon(Icons.remove));
+      expect(captured, 6.9);
+    });
+
+    testWidgets('nudge buttons do nothing while the rating is unset',
+        (WidgetTester t) async {
+      bool called = false;
+      await t.pumpWidget(build(
+        value: null,
+        onChanged: (double? _) => called = true,
+      ));
+
+      await t.tap(find.byIcon(Icons.add));
+      await t.tap(find.byIcon(Icons.remove));
+      expect(called, isFalse);
+    });
+
+    testWidgets('plus does not re-emit at the maximum', (WidgetTester t) async {
+      bool called = false;
+      await t.pumpWidget(build(
+        value: 10.0,
+        onChanged: (double? _) => called = true,
+      ));
+
+      await t.tap(find.byIcon(Icons.add));
+      expect(called, isFalse);
+    });
+
+    testWidgets('minus does not re-emit at the minimum',
+        (WidgetTester t) async {
+      bool called = false;
+      await t.pumpWidget(build(
+        value: 1.0,
+        onChanged: (double? _) => called = true,
+      ));
+
+      await t.tap(find.byIcon(Icons.remove));
+      expect(called, isFalse);
     });
 
     testWidgets('renders the leading clear cell', (WidgetTester t) async {
       await t.pumpWidget(build(value: 7.5, onChanged: (_) {}));
       expect(find.byIcon(Icons.do_not_disturb_alt), findsOneWidget);
-    });
-
-    testWidgets('a drag emits onChanged once on release, not per move',
-        (WidgetTester t) async {
-      final List<double?> emitted = <double?>[];
-      await t.pumpWidget(build(
-        value: null,
-        onChanged: emitted.add,
-      ));
-
-      await t.drag(find.byType(FractionalStarRating), const Offset(120, 0));
-      await t.pumpAndSettle();
-
-      expect(emitted.length, 1);
-      expect(emitted.single, isNotNull);
     });
 
     testWidgets('does not overflow when the parent is narrower than natural',
@@ -106,7 +142,7 @@ void main() {
           home: Scaffold(
             body: Align(
               alignment: Alignment.topLeft,
-              // Narrower than 11 * (starSize + gap) — the phone case.
+              // Narrower than the natural width — the phone case.
               child: SizedBox(
                 width: 200,
                 child: FractionalStarRating(


### PR DESCRIPTION
The personal-rating control no longer reads a fractional value from the tap/drag position. Tapping a star sets a whole 1-10; two -/+ buttons nudge by 0.1 (clamped 1.0-10.0, no-op at bounds, disabled while unset). Drag removed. Applies everywhere via the shared FractionalStarRating — item detail screen and the collection table popup.