### PR TITLE
fix: handle large libraries (SQLite IN limit + AniList import 429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,31 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Fixed
 
+- **Stop imported titles showing as "Unknown" when AniList rate-limits a large import**
+
+  Importing a big `.xcoll` (or AniList list) re-fetches each title's metadata
+  from AniList in batches. A single rate-limit (429) part-way through made the
+  whole anime / manga fetch throw and discard every result, so most titles
+  ended up with no cached metadata and rendered as "Unknown anime" / "Unknown
+  manga" (statuses and notes were intact — only the title/cover was missing).
+  Batches now retry on 429 and keep partial results, so the cache fills in
+  reliably.
+
+  * lib/core/api/anilist/anilist_media_api.dart (AniListMediaApi.getAnimeByIds, AniListMediaApi.getMangaByIds): Per-batch retry on 429, tolerating a failed batch and keeping the partial result instead of throwing; added an `onRateLimit` callback.
+  * lib/core/api/anilist_api.dart (AniListApi.getAnimeByIds, AniListApi.getMangaByIds): Forward `onRateLimit`.
+  * lib/core/services/import_service.dart (ImportService): Surface rate-limit waits via import progress during the anime / manga re-fetch.
+
+- **Stop large collections from crashing on Android (SQLite variable limit)**
+
+  Opening a collection with more than ~999 items of one media type (e.g. a big
+  MyAnimeList import) crashed on Android with "too many SQL variables" — the
+  hydration `IN (...)` query exceeded the platform SQLite bound-parameter
+  limit. Desktop was unaffected (its bundled SQLite allows 32766). Id-list
+  queries are now chunked so any collection size works on every platform.
+
+  * lib/core/database/query_chunk.dart (queryByIdsInChunks, kInClauseChunkSize): New chunked-IN helper (chunk size 900, under the 999 floor).
+  * lib/core/database/dao/manga_dao.dart (MangaDao.getMangaByIds), anime_dao.dart (AnimeDao.getAnimeByIds), movie_dao.dart (MovieDao.getMoviesByTmdbIds), tv_show_dao.dart (TvShowDao.getTvShowsByTmdbIds), visual_novel_dao.dart (VisualNovelDao.getVisualNovelsByNumericIds), custom_media_dao.dart (CustomMediaDao.getByIds), game_dao.dart (GameDao.getGamesByIds, GameDao.getPlatformsByIds), tracker_dao.dart (TrackerDao.getGameDataForGameIds): Run the `IN (...)` lookup through `queryByIdsInChunks`.
+
 - **Stop the gamepad plugin from crashing the app on Windows**
 
   Some Windows users hit a hard crash (access violation `0xc0000005` in

--- a/lib/core/api/anilist/anilist_media_api.dart
+++ b/lib/core/api/anilist/anilist_media_api.dart
@@ -4,6 +4,7 @@ import '../../../shared/models/manga.dart';
 import 'anilist_graphql_client.dart';
 import 'anilist_media_parser.dart';
 import 'anilist_queries.dart';
+import 'anilist_types.dart';
 
 class AniListMediaApi {
   AniListMediaApi(this._client);
@@ -118,20 +119,45 @@ class AniListMediaApi {
     return Anime.fromJson(media);
   }
 
-  Future<List<Manga>> getMangaByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Manga>[];
-    final List<Manga> result = <Manga>[];
-    for (final List<int> batch in aniListBatches(ids)) {
-      result.addAll(await _fetchMangaBatch(batch));
-    }
-    return result;
-  }
+  /// Maximum retries per batch on a 429 before that batch is skipped.
+  static const int _maxRateLimitRetries = 3;
 
-  Future<List<Anime>> getAnimeByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Anime>[];
-    final List<Anime> result = <Anime>[];
+  Future<List<Manga>> getMangaByIds(
+    List<int> ids, {
+    void Function(Duration wait, int attempt)? onRateLimit,
+  }) =>
+      _fetchByIdsResilient<Manga>(ids, _fetchMangaBatch, onRateLimit);
+
+  Future<List<Anime>> getAnimeByIds(
+    List<int> ids, {
+    void Function(Duration wait, int attempt)? onRateLimit,
+  }) =>
+      _fetchByIdsResilient<Anime>(ids, _fetchAnimeBatch, onRateLimit);
+
+  /// Fetches in batches, retrying each batch on a 429 and tolerating failures:
+  /// a batch that keeps rate-limiting or hard-errors is skipped, keeping the
+  /// partial result instead of discarding everything. This is what lets a
+  /// large import cache as much as it can (mirrors the tolerant MAL lookup).
+  Future<List<T>> _fetchByIdsResilient<T>(
+    List<int> ids,
+    Future<List<T>> Function(List<int>) fetchBatch,
+    void Function(Duration wait, int attempt)? onRateLimit,
+  ) async {
+    if (ids.isEmpty) return <T>[];
+    final List<T> result = <T>[];
     for (final List<int> batch in aniListBatches(ids)) {
-      result.addAll(await _fetchAnimeBatch(batch));
+      for (int attempt = 1; attempt <= _maxRateLimitRetries; attempt++) {
+        try {
+          result.addAll(await fetchBatch(batch));
+          break;
+        } on AniListRateLimitException catch (e) {
+          if (attempt >= _maxRateLimitRetries) break;
+          onRateLimit?.call(e.retryAfter, attempt);
+          await Future<void>.delayed(e.retryAfter);
+        } on AniListApiException {
+          break;
+        }
+      }
     }
     return result;
   }

--- a/lib/core/api/anilist_api.dart
+++ b/lib/core/api/anilist_api.dart
@@ -98,11 +98,17 @@ class AniListApi {
 
   Future<Anime?> getAnimeById(int id) => _media.getAnimeById(id);
 
-  Future<List<Manga>> getMangaByIds(List<int> ids) =>
-      _media.getMangaByIds(ids);
+  Future<List<Manga>> getMangaByIds(
+    List<int> ids, {
+    void Function(Duration wait, int attempt)? onRateLimit,
+  }) =>
+      _media.getMangaByIds(ids, onRateLimit: onRateLimit);
 
-  Future<List<Anime>> getAnimeByIds(List<int> ids) =>
-      _media.getAnimeByIds(ids);
+  Future<List<Anime>> getAnimeByIds(
+    List<int> ids, {
+    void Function(Duration wait, int attempt)? onRateLimit,
+  }) =>
+      _media.getAnimeByIds(ids, onRateLimit: onRateLimit);
 
   Future<Map<int, Anime>> getAnimeByMalIds(List<int> malIds) =>
       _mal.getAnimeByMalIds(malIds);

--- a/lib/core/database/dao/anime_dao.dart
+++ b/lib/core/database/dao/anime_dao.dart
@@ -3,6 +3,7 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../../shared/models/anime.dart';
+import '../query_chunk.dart';
 
 /// DAO для таблицы `anime_cache`.
 class AnimeDao {
@@ -51,14 +52,15 @@ class AnimeDao {
 
   /// Получает аниме по списку ID.
   Future<List<Anime>> getAnimeByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Anime>[];
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(ids.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.rawQuery(
-      'SELECT * FROM anime_cache WHERE id IN ($placeholders)',
-      ids,
-    );
-    return rows.map(Anime.fromDb).toList();
+    return queryByIdsInChunks(ids, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.rawQuery(
+        'SELECT * FROM anime_cache WHERE id IN ($placeholders)',
+        chunk,
+      );
+      return rows.map(Anime.fromDb).toList();
+    });
   }
 }

--- a/lib/core/database/dao/custom_media_dao.dart
+++ b/lib/core/database/dao/custom_media_dao.dart
@@ -3,6 +3,7 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../../shared/models/custom_media.dart';
+import '../query_chunk.dart';
 
 /// DAO для таблицы `custom_items`.
 class CustomMediaDao {
@@ -45,15 +46,16 @@ class CustomMediaDao {
 
   /// Получает кастомные элементы по списку ID.
   Future<List<CustomMedia>> getByIds(List<int> ids) async {
-    if (ids.isEmpty) return <CustomMedia>[];
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(ids.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.rawQuery(
-      'SELECT * FROM custom_items WHERE id IN ($placeholders)',
-      ids,
-    );
-    return rows.map(CustomMedia.fromDb).toList();
+    return queryByIdsInChunks(ids, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.rawQuery(
+        'SELECT * FROM custom_items WHERE id IN ($placeholders)',
+        chunk,
+      );
+      return rows.map(CustomMedia.fromDb).toList();
+    });
   }
 
   /// Сохраняет или обновляет кастомный элемент (для импорта).

--- a/lib/core/database/dao/game_dao.dart
+++ b/lib/core/database/dao/game_dao.dart
@@ -4,6 +4,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../../shared/models/game.dart';
 import '../../../shared/models/platform.dart';
+import '../query_chunk.dart';
 
 /// DAO для таблиц `games`, `platforms` и `igdb_genres`.
 class GameDao {
@@ -78,16 +79,17 @@ class GameDao {
   ///
   /// Возвращает только те платформы, которые есть в базе данных.
   Future<List<Platform>> getPlatformsByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Platform>[];
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(ids.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.query(
-      'platforms',
-      where: 'id IN ($placeholders)',
-      whereArgs: ids.cast<Object?>(),
-    );
-    return rows.map(Platform.fromDb).toList();
+    return queryByIdsInChunks(ids, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.query(
+        'platforms',
+        where: 'id IN ($placeholders)',
+        whereArgs: chunk.cast<Object?>(),
+      );
+      return rows.map(Platform.fromDb).toList();
+    });
   }
 
   // ==================== Games ====================
@@ -107,16 +109,17 @@ class GameDao {
 
   /// Возвращает несколько игр по списку ID.
   Future<List<Game>> getGamesByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Game>[];
-
     final Database db = await _getDatabase();
-    final String placeholders = List<String>.filled(ids.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.query(
-      'games',
-      where: 'id IN ($placeholders)',
-      whereArgs: ids.cast<Object?>(),
-    );
-    return rows.map(Game.fromDb).toList();
+    return queryByIdsInChunks(ids, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.query(
+        'games',
+        where: 'id IN ($placeholders)',
+        whereArgs: chunk.cast<Object?>(),
+      );
+      return rows.map(Game.fromDb).toList();
+    });
   }
 
   /// Ищет игры по названию в кеше.

--- a/lib/core/database/dao/manga_dao.dart
+++ b/lib/core/database/dao/manga_dao.dart
@@ -4,6 +4,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../../shared/models/data_source.dart';
 import '../../../shared/models/manga.dart';
+import '../query_chunk.dart';
 
 /// DAO for `manga_cache`. Row identity is the pair `(id, source)`, so the same
 /// numeric `id` from AniList and MangaBaka can coexist.
@@ -53,14 +54,15 @@ class MangaDao {
   /// Returns matches across all sources for the given ids; callers
   /// disambiguate by [Manga.source] (two rows can share a numeric `id`).
   Future<List<Manga>> getMangaByIds(List<int> ids) async {
-    if (ids.isEmpty) return <Manga>[];
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(ids.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.rawQuery(
-      'SELECT * FROM manga_cache WHERE id IN ($placeholders)',
-      ids,
-    );
-    return rows.map(Manga.fromDb).toList();
+    return queryByIdsInChunks(ids, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.rawQuery(
+        'SELECT * FROM manga_cache WHERE id IN ($placeholders)',
+        chunk,
+      );
+      return rows.map(Manga.fromDb).toList();
+    });
   }
 }

--- a/lib/core/database/dao/movie_dao.dart
+++ b/lib/core/database/dao/movie_dao.dart
@@ -3,6 +3,7 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../../shared/models/movie.dart';
+import '../query_chunk.dart';
 
 /// DAO для таблиц `movies_cache` и `tmdb_genres`.
 class MovieDao {
@@ -54,17 +55,17 @@ class MovieDao {
 
   /// Возвращает несколько фильмов по списку TMDB ID.
   Future<List<Movie>> getMoviesByTmdbIds(List<int> tmdbIds) async {
-    if (tmdbIds.isEmpty) return <Movie>[];
-
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(tmdbIds.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.query(
-      'movies_cache',
-      where: 'tmdb_id IN ($placeholders)',
-      whereArgs: tmdbIds.cast<Object?>(),
-    );
-    return rows.map(Movie.fromDb).toList();
+    return queryByIdsInChunks(tmdbIds, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.query(
+        'movies_cache',
+        where: 'tmdb_id IN ($placeholders)',
+        whereArgs: chunk.cast<Object?>(),
+      );
+      return rows.map(Movie.fromDb).toList();
+    });
   }
 
   /// Удаляет все фильмы из кеша.

--- a/lib/core/database/dao/tracker_dao.dart
+++ b/lib/core/database/dao/tracker_dao.dart
@@ -5,6 +5,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../../../shared/models/tracker_achievement.dart';
 import '../../../shared/models/tracker_game_data.dart';
 import '../../../shared/models/tracker_profile.dart';
+import '../query_chunk.dart';
 
 /// DAO для `tracker_profiles`, `tracker_game_data`, `tracker_achievements`.
 class TrackerDao {
@@ -129,15 +130,16 @@ class TrackerDao {
   Future<List<TrackerGameData>> getGameDataForGameIds(
     List<int> gameIds,
   ) async {
-    if (gameIds.isEmpty) return <TrackerGameData>[];
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(gameIds.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.rawQuery(
-      'SELECT * FROM tracker_game_data WHERE game_id IN ($placeholders)',
-      gameIds.map((int id) => id as Object).toList(),
-    );
-    return rows.map(TrackerGameData.fromDb).toList();
+    return queryByIdsInChunks(gameIds, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.rawQuery(
+        'SELECT * FROM tracker_game_data WHERE game_id IN ($placeholders)',
+        chunk,
+      );
+      return rows.map(TrackerGameData.fromDb).toList();
+    });
   }
 
   /// Возвращает все tracker data для игры (от всех трекеров).

--- a/lib/core/database/dao/tv_show_dao.dart
+++ b/lib/core/database/dao/tv_show_dao.dart
@@ -5,6 +5,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
+import '../query_chunk.dart';
 
 /// DAO для таблиц `tv_shows_cache`, `tv_seasons_cache`,
 /// `tv_episodes_cache` и `watched_episodes`.
@@ -59,17 +60,17 @@ class TvShowDao {
 
   /// Возвращает несколько сериалов по списку TMDB ID.
   Future<List<TvShow>> getTvShowsByTmdbIds(List<int> tmdbIds) async {
-    if (tmdbIds.isEmpty) return <TvShow>[];
-
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(tmdbIds.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.query(
-      'tv_shows_cache',
-      where: 'tmdb_id IN ($placeholders)',
-      whereArgs: tmdbIds.cast<Object?>(),
-    );
-    return rows.map(TvShow.fromDb).toList();
+    return queryByIdsInChunks(tmdbIds, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.query(
+        'tv_shows_cache',
+        where: 'tmdb_id IN ($placeholders)',
+        whereArgs: chunk.cast<Object?>(),
+      );
+      return rows.map(TvShow.fromDb).toList();
+    });
   }
 
   /// Удаляет все сериалы из кеша.

--- a/lib/core/database/dao/visual_novel_dao.dart
+++ b/lib/core/database/dao/visual_novel_dao.dart
@@ -3,6 +3,7 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../../shared/models/visual_novel.dart';
+import '../query_chunk.dart';
 
 /// DAO для таблиц `visual_novels_cache` и `vndb_tags`.
 class VisualNovelDao {
@@ -53,15 +54,16 @@ class VisualNovelDao {
   Future<List<VisualNovel>> getVisualNovelsByNumericIds(
     List<int> numericIds,
   ) async {
-    if (numericIds.isEmpty) return <VisualNovel>[];
     final Database db = await _getDatabase();
-    final String placeholders =
-        List<String>.filled(numericIds.length, '?').join(',');
-    final List<Map<String, dynamic>> rows = await db.rawQuery(
-      'SELECT * FROM visual_novels_cache WHERE numeric_id IN ($placeholders)',
-      numericIds,
-    );
-    return rows.map(VisualNovel.fromDb).toList();
+    return queryByIdsInChunks(numericIds, (List<int> chunk) async {
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(',');
+      final List<Map<String, dynamic>> rows = await db.rawQuery(
+        'SELECT * FROM visual_novels_cache WHERE numeric_id IN ($placeholders)',
+        chunk,
+      );
+      return rows.map(VisualNovel.fromDb).toList();
+    });
   }
 
   /// Получает кэшированные теги VNDB.

--- a/lib/core/database/query_chunk.dart
+++ b/lib/core/database/query_chunk.dart
@@ -1,0 +1,28 @@
+/// Maximum number of ids to bind in a single `IN (...)` query.
+///
+/// SQLite's `SQLITE_MAX_VARIABLE_NUMBER` is 32766 on the bundled desktop
+/// (sqflite_common_ffi) build but only 999 on many Android system SQLite
+/// versions. 900 stays safely under that floor so large collections (e.g. a
+/// big MyAnimeList import) don't blow the bound-parameter limit.
+const int kInClauseChunkSize = 900;
+
+/// Runs an id-list query in chunks so the `IN (...)` clause never exceeds the
+/// SQLite bound-parameter limit, concatenating the per-chunk results.
+///
+/// Order is not preserved across chunks — every caller maps results into a
+/// keyed map, so this is fine. Returns immediately for small / empty lists.
+Future<List<T>> queryByIdsInChunks<T>(
+  List<int> ids,
+  Future<List<T>> Function(List<int> chunk) query, {
+  int chunkSize = kInClauseChunkSize,
+}) async {
+  if (ids.isEmpty) return <T>[];
+  if (ids.length <= chunkSize) return query(ids);
+
+  final List<T> out = <T>[];
+  for (int i = 0; i < ids.length; i += chunkSize) {
+    final int end = (i + chunkSize < ids.length) ? i + chunkSize : ids.length;
+    out.addAll(await query(ids.sublist(i, end)));
+  }
+  return out;
+}

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -946,7 +946,18 @@ class ImportService {
       ));
 
       try {
-        mangas = await aniListApi.getMangaByIds(mangaIds);
+        mangas = await aniListApi.getMangaByIds(
+          mangaIds,
+          onRateLimit: (Duration wait, int attempt) => onProgress?.call(
+            ImportProgress(
+              stage: ImportStage.fetchingManga,
+              current: 0,
+              total: mangaIds.length,
+              message: 'Rate limited, waiting ${wait.inSeconds}s '
+                  '(attempt $attempt)...',
+            ),
+          ),
+        );
       } on AniListApiException catch (e) {
         _log.warning('Failed to fetch manga: ${e.message}');
       }
@@ -973,7 +984,18 @@ class ImportService {
       ));
 
       try {
-        animes = await aniListApi.getAnimeByIds(animeIds);
+        animes = await aniListApi.getAnimeByIds(
+          animeIds,
+          onRateLimit: (Duration wait, int attempt) => onProgress?.call(
+            ImportProgress(
+              stage: ImportStage.fetchingAnime,
+              current: 0,
+              total: animeIds.length,
+              message: 'Rate limited, waiting ${wait.inSeconds}s '
+                  '(attempt $attempt)...',
+            ),
+          ),
+        );
       } on AniListApiException catch (e) {
         _log.warning('Failed to fetch anime: ${e.message}');
       }

--- a/test/core/api/anilist_api_test.dart
+++ b/test/core/api/anilist_api_test.dart
@@ -396,7 +396,7 @@ void main() {
         expect(results, hasLength(2));
       });
 
-      test('should handle DioException', () async {
+      test('tolerates a DioException, returning a partial result', () async {
         when(() => mockDio.post<dynamic>(
               any(),
               data: any(named: 'data'),
@@ -405,15 +405,11 @@ void main() {
           requestOptions: RequestOptions(path: ''),
         ));
 
-        try {
-          await api.getMangaByIds(<int>[1]);
-          fail('Should throw');
-        } on AniListApiException catch (e) {
-          expect(e.message, contains('internet'));
-        }
+        // Resilient batching skips the failed batch instead of throwing.
+        expect(await api.getMangaByIds(<int>[1]), isEmpty);
       });
 
-      test('should handle ошибку ответа', () async {
+      test('tolerates an error response, returning a partial result', () async {
         when(() => mockDio.post<dynamic>(
               any(),
               data: any(named: 'data'),
@@ -424,10 +420,7 @@ void main() {
           ),
         );
 
-        expect(
-          () => api.getMangaByIds(<int>[1]),
-          throwsA(isA<AniListApiException>()),
-        );
+        expect(await api.getMangaByIds(<int>[1]), isEmpty);
       });
 
       test('should handle null Page в ответе', () async {
@@ -684,7 +677,7 @@ void main() {
         expect(results, hasLength(2));
       });
 
-      test('should handle DioException', () async {
+      test('tolerates a DioException, returning a partial result', () async {
         when(() => mockDio.post<dynamic>(
               any(),
               data: any(named: 'data'),
@@ -693,12 +686,8 @@ void main() {
           requestOptions: RequestOptions(path: ''),
         ));
 
-        try {
-          await api.getAnimeByIds(<int>[1]);
-          fail('Should throw');
-        } on AniListApiException catch (e) {
-          expect(e.message, contains('internet'));
-        }
+        // Resilient batching skips the failed batch instead of throwing.
+        expect(await api.getAnimeByIds(<int>[1]), isEmpty);
       });
 
       test('should handle null Page в ответе', () async {

--- a/test/core/database/query_chunk_test.dart
+++ b/test/core/database/query_chunk_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/core/database/query_chunk.dart';
+
+void main() {
+  group('queryByIdsInChunks', () {
+    test('returns empty without invoking the query for an empty list',
+        () async {
+      int calls = 0;
+      final List<int> result = await queryByIdsInChunks<int>(
+        <int>[],
+        (List<int> chunk) async {
+          calls++;
+          return chunk;
+        },
+      );
+      expect(result, isEmpty);
+      expect(calls, 0);
+    });
+
+    test('runs a single chunk when ids fit the limit', () async {
+      int calls = 0;
+      final List<int> ids = List<int>.generate(50, (int i) => i);
+      final List<int> result = await queryByIdsInChunks<int>(
+        ids,
+        (List<int> chunk) async {
+          calls++;
+          return chunk;
+        },
+        chunkSize: 100,
+      );
+      expect(calls, 1);
+      expect(result, ids);
+    });
+
+    test('splits into multiple chunks past the limit, covering every id',
+        () async {
+      final List<List<int>> seenChunks = <List<int>>[];
+      final List<int> ids = List<int>.generate(2500, (int i) => i);
+      final List<int> result = await queryByIdsInChunks<int>(
+        ids,
+        (List<int> chunk) async {
+          seenChunks.add(chunk);
+          return chunk;
+        },
+        chunkSize: 900,
+      );
+      // 2500 / 900 → 3 chunks (900 + 900 + 700).
+      expect(seenChunks.length, 3);
+      expect(seenChunks.map((List<int> c) => c.length), <int>[900, 900, 700]);
+      // No chunk exceeds the limit, and the flattened result equals the input.
+      expect(seenChunks.every((List<int> c) => c.length <= 900), isTrue);
+      expect(result, ids);
+    });
+
+    test('default chunk size stays within the SQLite floor (999)', () {
+      expect(kInClauseChunkSize, lessThan(999));
+    });
+  });
+}


### PR DESCRIPTION
- Chunk IN (...) lookups (900 per query) so opening a big collection / the home screen no longer hits Android's 999 bound-parameter SQLite limit. Desktop was unaffected (bundled SQLite allows 32766).

- Retry AniList by-id batches on 429 and keep partial results, so a rate-limited import (e.g. a large .xcoll) no longer discards all metadata and leaves titles as "Unknown".