### PR TITLE
feat(collections): refine item context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Refine the item right-click / long-press context menu**
+
+  Action entries (move, copy, remove, reorder) are now compact single-line rows
+  instead of bulky list tiles. The status switcher became a full-width segmented
+  pill under a "Status" header: the active status is tinted with its color while
+  the rest stay muted, replacing the bordered icon grid.
+
+  * lib/features/collections/widgets/context_menu_item.dart (contextMenuItem): New shared builder for dense icon-and-label menu entries.
+  * lib/features/collections/widgets/status_chip_row.dart (StatusChipRow, statusChipPopupMenuEntries): Redesign the status selector as a segmented pill and add a "Status" header.
+  * lib/features/collections/widgets/collection_items_view.dart (CollectionItemsView), lib/features/home/screens/all_items_screen.dart (_AllItemsScreenState): Build action entries with contextMenuItem.
+
 - **Disambiguate manga by provider across cache, collection, covers and mood grids**
 
   Manga from AniList and MangaBaka can share a numeric id, so manga identity is

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -20,6 +20,7 @@ import '../providers/collection_selection_provider.dart';
 import '../providers/collections_provider.dart';
 import '../extensions/item_display_name.dart';
 import 'collection_table/collection_table_view.dart';
+import 'context_menu_item.dart';
 import 'selectable_poster_card.dart';
 import 'status_chip_row.dart';
 
@@ -540,59 +541,39 @@ class CollectionItemsView extends ConsumerWidget {
       ),
       items: <PopupMenuEntry<String>>[
         if (isManualSort) ...<PopupMenuEntry<String>>[
-          PopupMenuItem<String>(
+          contextMenuItem<String>(
             value: 'moveToTop',
-            child: ListTile(
-              leading: const Icon(Icons.vertical_align_top),
-              title: Text(l.moveToTop),
-              contentPadding: EdgeInsets.zero,
-            ),
+            icon: Icons.vertical_align_top,
+            label: l.moveToTop,
           ),
-          PopupMenuItem<String>(
+          contextMenuItem<String>(
             value: 'moveToBottom',
-            child: ListTile(
-              leading: const Icon(Icons.vertical_align_bottom),
-              title: Text(l.moveToBottom),
-              contentPadding: EdgeInsets.zero,
-            ),
+            icon: Icons.vertical_align_bottom,
+            label: l.moveToBottom,
           ),
           const PopupMenuDivider(),
         ],
         if (onItemMove != null)
-          PopupMenuItem<String>(
+          contextMenuItem<String>(
             value: 'move',
-            child: ListTile(
-              leading: const Icon(Icons.drive_file_move_outlined),
-              title: Text(l.collectionMoveToCollection),
-              contentPadding: EdgeInsets.zero,
-            ),
+            icon: Icons.drive_file_move_outlined,
+            label: l.collectionMoveToCollection,
           ),
         if (onItemClone != null)
-          PopupMenuItem<String>(
+          contextMenuItem<String>(
             value: 'clone',
-            child: ListTile(
-              leading: const Icon(Icons.copy_outlined),
-              title: Text(l.collectionCopyToCollection),
-              contentPadding: EdgeInsets.zero,
-            ),
+            icon: Icons.copy_outlined,
+            label: l.collectionCopyToCollection,
           ),
         if ((onItemMove != null || onItemClone != null) &&
             onItemRemove != null)
           const PopupMenuDivider(),
         if (onItemRemove != null)
-          PopupMenuItem<String>(
+          contextMenuItem<String>(
             value: 'remove',
-            child: ListTile(
-              leading: const Icon(
-                Icons.remove_circle_outline,
-                color: AppColors.error,
-              ),
-              title: Text(
-                l.remove,
-                style: const TextStyle(color: AppColors.error),
-              ),
-              contentPadding: EdgeInsets.zero,
-            ),
+            icon: Icons.remove_circle_outline,
+            label: l.remove,
+            color: AppColors.error,
           ),
         if (canEdit)
           ...statusChipPopupMenuEntries(context: context, item: item),

--- a/lib/features/collections/widgets/context_menu_item.dart
+++ b/lib/features/collections/widgets/context_menu_item.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+
+/// Builds a dense context-menu entry: an icon and a label in a single row.
+///
+/// Replaces the bulky `ListTile` inside a `PopupMenuItem`. [color] tints both
+/// the icon and the text (e.g. [AppColors.error] for destructive actions).
+PopupMenuItem<T> contextMenuItem<T>({
+  required T value,
+  required IconData icon,
+  required String label,
+  Color? color,
+}) {
+  return PopupMenuItem<T>(
+    value: value,
+    height: 42,
+    child: Row(
+      children: <Widget>[
+        Icon(icon, size: 20, color: color ?? AppColors.textSecondary),
+        const SizedBox(width: AppSpacing.md),
+        Flexible(
+          child: Text(
+            label,
+            overflow: TextOverflow.ellipsis,
+            style:
+                TextStyle(fontSize: 14, color: color ?? AppColors.textPrimary),
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/features/collections/widgets/status_chip_row.dart
+++ b/lib/features/collections/widgets/status_chip_row.dart
@@ -1,40 +1,53 @@
-// Полоса кнопок-сегментов для выбора статуса элемента коллекции.
-
 import 'package:flutter/material.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/media_type.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
 
 const String _kStatusMenuPrefix = 'status:';
 
-/// Декодирует значение из `showMenu`, если это выбор статуса через
-/// [statusChipPopupMenuEntries]. Возвращает `null` для обычных пунктов меню.
+/// Decodes a `showMenu` value produced by [statusChipPopupMenuEntries].
+///
+/// Returns `null` for ordinary (non-status) menu entries.
 ItemStatus? tryDecodeStatusMenuValue(String value) {
   if (!value.startsWith(_kStatusMenuPrefix)) return null;
   return ItemStatus.fromString(value.substring(_kStatusMenuPrefix.length));
 }
 
-/// Строит набор `PopupMenuEntry` с разделителем и полосой статусов.
+/// Builds a "Status" header and a [StatusChipRow] for use inside `showMenu`.
 ///
-/// Тап по сегменту закрывает меню через `Navigator.pop` с закодированным
-/// значением — вызывающий код декодирует его через [tryDecodeStatusMenuValue].
+/// Tapping a segment closes the menu via `Navigator.pop` with an encoded value;
+/// the caller decodes it through [tryDecodeStatusMenuValue].
 List<PopupMenuEntry<String>> statusChipPopupMenuEntries({
   required BuildContext context,
   required CollectionItem item,
-  double height = 40,
 }) {
+  final S l = S.of(context);
   return <PopupMenuEntry<String>>[
     const PopupMenuDivider(),
     PopupMenuItem<String>(
       enabled: false,
-      padding: EdgeInsets.zero,
-      height: height,
+      height: 26,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+      child: Text(
+        l.detailStatus.toUpperCase(),
+        style: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.6,
+          color: AppColors.textTertiary,
+        ),
+      ),
+    ),
+    PopupMenuItem<String>(
+      enabled: false,
+      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
       child: StatusChipRow(
         status: item.status,
         mediaType: item.displayMediaType,
-        height: height,
         onChanged: (ItemStatus newStatus) => Navigator.of(context)
             .pop('$_kStatusMenuPrefix${newStatus.value}'),
       ),
@@ -42,49 +55,52 @@ List<PopupMenuEntry<String>> statusChipPopupMenuEntries({
   ];
 }
 
-/// Полоса кнопок-сегментов для выбора статуса (стиль «пианино»).
+/// Segmented status switcher rendered as a single rounded "pill".
 ///
-/// Все статусы отображаются в один ряд с равной шириной, вплотную друг к другу.
-/// Каждый сегмент залит цветом статуса, выбранный — полностью,
-/// невыбранные — приглушённые. Тап на сегмент вызывает [onChanged].
+/// Every status sits in an equal-width segment; the selected one is highlighted
+/// with a soft tint of its status color while the rest stay muted. Tapping a
+/// segment invokes [onChanged].
 class StatusChipRow extends StatelessWidget {
-  /// Создаёт [StatusChipRow].
+  /// Creates a [StatusChipRow].
   const StatusChipRow({
     required this.status,
     required this.mediaType,
     required this.onChanged,
-    this.height = 36,
     super.key,
   });
 
-  /// Текущий выбранный статус.
+  /// Currently selected status.
   final ItemStatus status;
 
-  /// Тип медиа (влияет на метки статусов).
+  /// Media type, which drives the per-status labels.
   final MediaType mediaType;
 
-  /// Callback при изменении статуса.
+  /// Called when a different status segment is tapped.
   final void Function(ItemStatus) onChanged;
-
-  /// Высота сегментов.
-  final double height;
 
   @override
   Widget build(BuildContext context) {
     const List<ItemStatus> statuses = ItemStatus.values;
-    return Row(
-      children: <Widget>[
-        for (final ItemStatus s in statuses)
-          Expanded(
-            child: _StatusSegment(
-              status: s,
-              mediaType: mediaType,
-              isSelected: s == status,
-              height: height,
-              onTap: () => onChanged(s),
+    return Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+        border: Border.all(color: AppColors.surfaceBorder),
+      ),
+      child: Row(
+        children: <Widget>[
+          for (final ItemStatus s in statuses)
+            Expanded(
+              child: _StatusSegment(
+                status: s,
+                mediaType: mediaType,
+                isSelected: s == status,
+                onTap: () => onChanged(s),
+              ),
             ),
-          ),
-      ],
+        ],
+      ),
     );
   }
 }
@@ -94,34 +110,36 @@ class _StatusSegment extends StatelessWidget {
     required this.status,
     required this.mediaType,
     required this.isSelected,
-    required this.height,
     required this.onTap,
   });
 
   final ItemStatus status;
   final MediaType mediaType;
   final bool isSelected;
-  final double height;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final Color statusColor = status.color;
-
     return Tooltip(
       message: status.localizedLabel(S.of(context), mediaType),
+      waitDuration: const Duration(milliseconds: 500),
       child: GestureDetector(
         onTap: onTap,
+        behavior: HitTestBehavior.opaque,
         child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          height: height,
-          color: isSelected ? statusColor : statusColor.withAlpha(30),
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          height: 34,
+          decoration: BoxDecoration(
+            color: isSelected ? statusColor.withAlpha(48) : Colors.transparent,
+            borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+          ),
           alignment: Alignment.center,
           child: Icon(
             status.materialIcon,
-            size: 20,
-            color: isSelected ? Colors.white : statusColor.withAlpha(140),
+            size: 18,
+            color: isSelected ? statusColor : AppColors.textTertiary,
           ),
         ),
       ),

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -27,6 +27,7 @@ import '../../collections/extensions/item_display_name.dart';
 import '../../collections/screens/item_detail_screen.dart';
 import '../../collections/widgets/bulk_action_bar.dart';
 import '../../collections/widgets/selectable_poster_card.dart';
+import '../../collections/widgets/context_menu_item.dart';
 import '../../collections/widgets/status_chip_row.dart';
 import '../providers/all_items_provider.dart';
 
@@ -672,36 +673,22 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         Offset.zero & overlay.size,
       ),
       items: <PopupMenuEntry<String>>[
-        PopupMenuItem<String>(
+        contextMenuItem<String>(
           value: 'move',
-          child: ListTile(
-            leading: const Icon(Icons.drive_file_move_outlined),
-            title: Text(l.collectionMoveToCollection),
-            contentPadding: EdgeInsets.zero,
-          ),
+          icon: Icons.drive_file_move_outlined,
+          label: l.collectionMoveToCollection,
         ),
-        PopupMenuItem<String>(
+        contextMenuItem<String>(
           value: 'clone',
-          child: ListTile(
-            leading: const Icon(Icons.copy_outlined),
-            title: Text(l.collectionCopyToCollection),
-            contentPadding: EdgeInsets.zero,
-          ),
+          icon: Icons.copy_outlined,
+          label: l.collectionCopyToCollection,
         ),
         const PopupMenuDivider(),
-        PopupMenuItem<String>(
+        contextMenuItem<String>(
           value: 'remove',
-          child: ListTile(
-            leading: const Icon(
-              Icons.remove_circle_outline,
-              color: AppColors.error,
-            ),
-            title: Text(
-              l.remove,
-              style: const TextStyle(color: AppColors.error),
-            ),
-            contentPadding: EdgeInsets.zero,
-          ),
+          icon: Icons.remove_circle_outline,
+          label: l.remove,
+          color: AppColors.error,
         ),
         ...statusChipPopupMenuEntries(context: context, item: item),
       ],

--- a/test/features/collections/widgets/collection_items_view_test.dart
+++ b/test/features/collections/widgets/collection_items_view_test.dart
@@ -305,8 +305,8 @@ void main() {
           await gesture.up();
           await tester.pumpAndSettle();
 
-          // Menu shows move/clone/remove + status chip.
-          expect(find.byType(PopupMenuItem<String>), findsNWidgets(4));
+          // Menu shows move/clone/remove + status header + status pill.
+          expect(find.byType(PopupMenuItem<String>), findsNWidgets(5));
 
           expect(moveCalled, isFalse);
           expect(cloneCalled, isFalse);

--- a/test/features/collections/widgets/context_menu_item_test.dart
+++ b/test/features/collections/widgets/context_menu_item_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/collections/widgets/context_menu_item.dart';
+
+void main() {
+  group('contextMenuItem', () {
+    test('should pass the value through to the PopupMenuItem', () {
+      final PopupMenuItem<String> entry = contextMenuItem<String>(
+        value: 'remove',
+        icon: Icons.delete,
+        label: 'Remove',
+      );
+
+      expect(entry.value, 'remove');
+    });
+
+    test('should be enabled so it can be selected', () {
+      final PopupMenuItem<String> entry = contextMenuItem<String>(
+        value: 'move',
+        icon: Icons.drive_file_move_outlined,
+        label: 'Move',
+      );
+
+      expect(entry.enabled, isTrue);
+    });
+  });
+}

--- a/test/features/collections/widgets/status_chip_row_test.dart
+++ b/test/features/collections/widgets/status_chip_row_test.dart
@@ -55,7 +55,7 @@ void main() {
         expect(changedTo, ItemStatus.completed);
       });
 
-      testWidgets('should call onChanged when tapped on уже выбранный',
+      testWidgets('should call onChanged when tapped on the selected segment',
           (WidgetTester tester) async {
         ItemStatus? changedTo;
 
@@ -68,6 +68,23 @@ void main() {
         await tester.tap(find.byIcon(Icons.check_circle));
         expect(changedTo, ItemStatus.completed);
       });
+    });
+  });
+
+  group('tryDecodeStatusMenuValue', () {
+    test('should decode the status when value carries the status prefix', () {
+      expect(
+        tryDecodeStatusMenuValue('status:completed'),
+        ItemStatus.completed,
+      );
+    });
+
+    test('should return null when value is an ordinary menu action', () {
+      expect(tryDecodeStatusMenuValue('remove'), isNull);
+    });
+
+    test('should fall back to notStarted for an unknown status payload', () {
+      expect(tryDecodeStatusMenuValue('status:bogus'), ItemStatus.notStarted);
     });
   });
 }


### PR DESCRIPTION
Compact single-line action entries via a shared contextMenuItem builder, and a full-width segmented pill for the status switcher under a "Status" header (replacing the bordered icon grid).