### PR TITLE
feat(releases): manual calendar entries with date and recurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Add any item to the calendar with a date and recurrence**
+
+  A bell on every item's detail screen opens an add dialog (pick a date,
+  pre-filled with the item's future release date, plus a repeat option: once,
+  weekly or monthly). The entry then shows on the Releases calendar. TV shows
+  and anime keep episode tracking; everything else (movies, games, manga, visual
+  novels, custom) uses these manual entries. Past one-time entries are pruned
+  when the calendar opens; recurring entries roll forward up to a year.
+
+  * lib/shared/models/calendar_entry.dart (CalendarEntry), lib/shared/models/calendar_recurrence.dart (CalendarRecurrence): New models.
+  * lib/core/database/migrations/migration_v46.dart (MigrationV46), lib/core/database/migrations/migration_registry.dart, lib/core/database/schema.dart (DatabaseSchema.createCalendarEntriesTable), lib/core/database/database_service.dart (calendarEntryDao, calendarEntryDaoProvider): New `calendar_entries` table; DB version 45 → 46.
+  * lib/core/database/dao/calendar_entry_dao.dart (CalendarEntryDao): isAdded, upsert, remove, getAll, deletePastOnce, deleteOrphaned.
+  * lib/core/database/dao/tracked_release_dao.dart (TrackedReleaseDao.deleteOrphaned): Drop calendar entries / release subscriptions once their item leaves every collection (kept by identity, so not FK-cascaded).
+  * lib/features/collections/providers/collections_provider.dart (CollectionsNotifier.delete, CollectionsNotifier.removeItem, CollectionsNotifier._pruneCalendarOrphans): Prune orphaned calendar entries and refresh the calendar after a collection or item is deleted.
+  * lib/features/releases/widgets/add_to_calendar_dialog.dart (showAddToCalendarDialog, AddToCalendarResult): New date + recurrence dialog.
+  * lib/features/releases/providers/releases_provider.dart (ReleasesNotifier, isCalendarEntryProvider): Merge manual entries into the calendar, expanding recurrence; prune past one-time entries on build. Resolve each entry's title / poster from the hydrated collection item.
+  * lib/core/database/dao/collection_dao.dart (CollectionDao.findCollectionItemWithData): Find an item by identity with its media model joined, so the calendar shows real titles / posters instead of an "Unknown" fallback.
+  * lib/features/releases/models/release_event.dart (ReleaseEvent): season / episode now nullable for manual entries; carries imageType / cacheImageId for poster caching.
+  * lib/features/releases/screens/releases_screen.dart (_ReleasesScreenState._thumb, _ReleasesScreenState._placeholderIcon): Posters use the on-disk image cache instead of a raw network fetch; placeholder icon now matches the media type.
+  * lib/features/collections/screens/item_detail_screen.dart (_ItemDetailScreenState), lib/features/collections/widgets/item_detail/item_detail_app_bar.dart (ItemDetailAppBar): Bell on all media types — episodes for TV / anime, manual calendar entry otherwise.
+  * lib/features/settings/content/database_content.dart (_resetDatabase): Invalidate releasesProvider on database reset so the calendar clears.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (calendarAdd, calendarRemove, calendarAddTitle, calendarDate, calendarRepeat, calendarAddAction, recurrenceOnce, recurrenceWeekly, recurrenceMonthly): New strings.
+
+- **Back up the calendar and episode watch progress**
+
+  Backups now include `tracked_releases` and `calendar_entries` (calendar.json),
+  both keyed by item identity, and `watched_episodes` (watched_episodes.json).
+  Watch progress is stored per show and re-applied on restore to whichever
+  restored collections hold that show.
+
+  * lib/core/services/backup_service.dart (BackupService.createBackup, BackupService.restoreFromBackup): Write / read `calendar.json` and `watched_episodes.json`; backup format version 2 → 3.
+  * lib/core/database/dao/tv_show_dao.dart (TvShowDao.getAllWatchedEpisodes, TvShowDao.markEpisodeWatchedAt): Read all watch progress for backup; restore with an explicit timestamp.
+  * lib/features/settings/screens/settings_screen.dart: Invalidate releasesProvider after restore so the calendar and nav badge refresh without reopening the tab.
+
 - **Add a Releases calendar for tracked TV shows and anime**
 
   A new "Releases" tab (between tier lists and wishlist) shows a

--- a/lib/core/database/dao/calendar_entry_dao.dart
+++ b/lib/core/database/dao/calendar_entry_dao.dart
@@ -1,0 +1,91 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../../../shared/models/calendar_entry.dart';
+import '../../../shared/models/calendar_recurrence.dart';
+import '../../../shared/models/data_source.dart';
+import '../../../shared/models/media_type.dart';
+
+/// DAO for `calendar_entries` — manual calendar entries keyed by
+/// `(external_id, source, media_type)`.
+class CalendarEntryDao {
+  const CalendarEntryDao(this._getDatabase);
+
+  final Future<Database> Function() _getDatabase;
+
+  static const String _where =
+      'external_id = ? AND source = ? AND media_type = ?';
+
+  List<Object?> _key(int externalId, DataSource source, MediaType mediaType) =>
+      <Object?>[externalId, source.name, mediaType.value];
+
+  Future<bool> isAdded(
+    int externalId,
+    DataSource source,
+    MediaType mediaType,
+  ) async {
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> rows = await db.query(
+      'calendar_entries',
+      columns: <String>['external_id'],
+      where: _where,
+      whereArgs: _key(externalId, source, mediaType),
+      limit: 1,
+    );
+    return rows.isNotEmpty;
+  }
+
+  /// Inserts or replaces the entry for its identity.
+  Future<void> upsert(CalendarEntry entry) async {
+    final Database db = await _getDatabase();
+    await db.insert(
+      'calendar_entries',
+      entry.toDb(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> remove(
+    int externalId,
+    DataSource source,
+    MediaType mediaType,
+  ) async {
+    final Database db = await _getDatabase();
+    await db.delete(
+      'calendar_entries',
+      where: _where,
+      whereArgs: _key(externalId, source, mediaType),
+    );
+  }
+
+  Future<List<CalendarEntry>> getAll() async {
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> rows = await db.query('calendar_entries');
+    return rows.map(CalendarEntry.fromDb).toList();
+  }
+
+  /// Removes one-time entries whose date is before [today] — past single
+  /// entries clutter the calendar. Recurring entries roll forward and stay.
+  Future<void> deletePastOnce(DateTime today) async {
+    final Database db = await _getDatabase();
+    await db.delete(
+      'calendar_entries',
+      where: 'recurrence = ? AND start_date < ?',
+      whereArgs: <Object?>[
+        CalendarRecurrence.once.value,
+        CalendarEntry.formatDate(today),
+      ],
+    );
+  }
+
+  /// Drops entries whose item no longer exists in any collection. Matched by
+  /// `(external_id, media_type)` — a still-collected copy keeps it.
+  Future<void> deleteOrphaned() async {
+    final Database db = await _getDatabase();
+    await db.delete(
+      'calendar_entries',
+      where: 'NOT EXISTS (SELECT 1 FROM collection_items ci '
+          'WHERE ci.external_id = calendar_entries.external_id '
+          'AND ci.media_type = calendar_entries.media_type)',
+    );
+  }
+}

--- a/lib/core/database/dao/collection_dao.dart
+++ b/lib/core/database/dao/collection_dao.dart
@@ -293,6 +293,24 @@ class CollectionDao {
     return CollectionItem.fromDb(rows.first);
   }
 
+  /// Like [findCollectionItem] but with the joined media model hydrated, so
+  /// callers get a resolved title / poster instead of an "Unknown" fallback.
+  Future<CollectionItem?> findCollectionItemWithData({
+    required int? collectionId,
+    required MediaType mediaType,
+    required int externalId,
+    int? platformId,
+  }) async {
+    final CollectionItem? item = await findCollectionItem(
+      collectionId: collectionId,
+      mediaType: mediaType,
+      externalId: externalId,
+      platformId: platformId,
+    );
+    if (item == null) return null;
+    return (await _loadJoinedData(<CollectionItem>[item])).first;
+  }
+
   Future<List<CollectionItem>> findAllCollectionItems({
     required MediaType mediaType,
     required int externalId,

--- a/lib/core/database/dao/tracked_release_dao.dart
+++ b/lib/core/database/dao/tracked_release_dao.dart
@@ -90,4 +90,16 @@ class TrackedReleaseDao {
         ),
     };
   }
+
+  /// Drops subscriptions whose item no longer exists in any collection.
+  /// Matched by `(external_id, media_type)` — a still-collected copy keeps it.
+  Future<void> deleteOrphaned() async {
+    final Database db = await _getDatabase();
+    await db.delete(
+      'tracked_releases',
+      where: 'NOT EXISTS (SELECT 1 FROM collection_items ci '
+          'WHERE ci.external_id = tracked_releases.external_id '
+          'AND ci.media_type = tracked_releases.media_type)',
+    );
+  }
 }

--- a/lib/core/database/dao/tv_show_dao.dart
+++ b/lib/core/database/dao/tv_show_dao.dart
@@ -1,4 +1,4 @@
-// DAO для работы с сериалами, сезонами, эпизодами и просмотренными эпизодами.
+// DAO for TV shows, seasons, episodes and watched episodes.
 
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
@@ -7,17 +7,17 @@ import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import '../query_chunk.dart';
 
-/// DAO для таблиц `tv_shows_cache`, `tv_seasons_cache`,
-/// `tv_episodes_cache` и `watched_episodes`.
+/// DAO for the `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache` and
+/// `watched_episodes` tables.
 class TvShowDao {
-  /// Создаёт DAO с функцией получения базы данных.
+  /// Creates the DAO with a database accessor.
   const TvShowDao(this._getDatabase);
 
   final Future<Database> Function() _getDatabase;
 
   // ==================== TV Shows ====================
 
-  /// Возвращает сериал по TMDB ID или null, если не найден.
+  /// Returns the show by TMDB id, or null if not cached.
   Future<TvShow?> getTvShowByTmdbId(int tmdbId) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
@@ -30,7 +30,7 @@ class TvShowDao {
     return TvShow.fromDb(rows.first);
   }
 
-  /// Сохраняет или обновляет сериал в кеше.
+  /// Inserts or updates a show in the cache.
   Future<void> upsertTvShow(TvShow tvShow) async {
     final Database db = await _getDatabase();
     await db.insert(
@@ -40,7 +40,7 @@ class TvShowDao {
     );
   }
 
-  /// Сохраняет список сериалов пакетно.
+  /// Saves a list of shows in a batch.
   Future<void> upsertTvShows(List<TvShow> tvShows) async {
     if (tvShows.isEmpty) return;
 
@@ -58,7 +58,7 @@ class TvShowDao {
     });
   }
 
-  /// Возвращает несколько сериалов по списку TMDB ID.
+  /// Returns several shows by a list of TMDB ids.
   Future<List<TvShow>> getTvShowsByTmdbIds(List<int> tmdbIds) async {
     final Database db = await _getDatabase();
     return queryByIdsInChunks(tmdbIds, (List<int> chunk) async {
@@ -73,7 +73,7 @@ class TvShowDao {
     });
   }
 
-  /// Удаляет все сериалы из кеша.
+  /// Clears all shows from the cache.
   Future<void> clearTvShows() async {
     final Database db = await _getDatabase();
     await db.delete('tv_shows_cache');
@@ -81,7 +81,7 @@ class TvShowDao {
 
   // ==================== TV Seasons ====================
 
-  /// Возвращает сезоны сериала.
+  /// Returns the show's seasons.
   Future<List<TvSeason>> getTvSeasonsByShowId(int tmdbShowId) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
@@ -93,7 +93,7 @@ class TvShowDao {
     return rows.map(TvSeason.fromDb).toList();
   }
 
-  /// Сохраняет сезоны сериала пакетно.
+  /// Saves the show's seasons in a batch.
   Future<void> upsertTvSeasons(List<TvSeason> seasons) async {
     if (seasons.isEmpty) return;
 
@@ -111,7 +111,7 @@ class TvShowDao {
     });
   }
 
-  /// Удаляет все сезоны из кеша.
+  /// Clears all seasons from the cache.
   Future<void> clearTvSeasons() async {
     final Database db = await _getDatabase();
     await db.delete('tv_seasons_cache');
@@ -119,7 +119,7 @@ class TvShowDao {
 
   // ==================== TV Episodes ====================
 
-  /// Возвращает все эпизоды сериала из кеша.
+  /// Returns all cached episodes of a show.
   Future<List<TvEpisode>> getEpisodesByShowId(int showId) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
@@ -131,7 +131,7 @@ class TvShowDao {
     return rows.map(TvEpisode.fromDb).toList();
   }
 
-  /// Возвращает эпизоды сезона сериала из кеша.
+  /// Returns cached episodes of a show's season.
   Future<List<TvEpisode>> getEpisodesByShowAndSeason(
     int showId,
     int seasonNumber,
@@ -146,7 +146,7 @@ class TvShowDao {
     return rows.map(TvEpisode.fromDb).toList();
   }
 
-  /// Сохраняет список эпизодов пакетно (INSERT OR REPLACE).
+  /// Saves a list of episodes in a batch (INSERT OR REPLACE).
   Future<void> upsertEpisodes(List<TvEpisode> episodes) async {
     if (episodes.isEmpty) return;
 
@@ -164,7 +164,7 @@ class TvShowDao {
     });
   }
 
-  /// Удаляет кешированные эпизоды сериала.
+  /// Clears a show's cached episodes.
   Future<void> clearEpisodesByShow(int showId) async {
     final Database db = await _getDatabase();
     await db.delete(
@@ -176,9 +176,9 @@ class TvShowDao {
 
   // ==================== Watched Episodes ====================
 
-  /// Возвращает множество просмотренных эпизодов для сериала в коллекции.
+  /// Watched episodes of a show within a collection.
   ///
-  /// Возвращает Set записей (seasonNumber, episodeNumber).
+  /// Returns a set of (seasonNumber, episodeNumber) records.
   Future<Map<(int, int), DateTime?>> getWatchedEpisodes(
     int collectionId,
     int showId,
@@ -222,7 +222,40 @@ class TvShowDao {
     };
   }
 
-  /// Отмечает эпизод как просмотренный.
+  /// All watched episodes deduped by show/season/episode (collection-agnostic),
+  /// for backup. Keeps the latest `watched_at`.
+  Future<List<Map<String, Object?>>> getAllWatchedEpisodes() async {
+    final Database db = await _getDatabase();
+    return db.rawQuery(
+      'SELECT show_id, season_number, episode_number, '
+      'MAX(watched_at) AS watched_at FROM watched_episodes '
+      'GROUP BY show_id, season_number, episode_number',
+    );
+  }
+
+  /// Marks an episode watched with an explicit timestamp (restore path).
+  Future<void> markEpisodeWatchedAt(
+    int collectionId,
+    int showId,
+    int seasonNumber,
+    int episodeNumber,
+    int? watchedAtMs,
+  ) async {
+    final Database db = await _getDatabase();
+    await db.insert(
+      'watched_episodes',
+      <String, dynamic>{
+        'collection_id': collectionId,
+        'show_id': showId,
+        'season_number': seasonNumber,
+        'episode_number': episodeNumber,
+        'watched_at': watchedAtMs,
+      },
+      conflictAlgorithm: ConflictAlgorithm.ignore,
+    );
+  }
+
+  /// Marks an episode as watched.
   Future<void> markEpisodeWatched(
     int collectionId,
     int showId,
@@ -243,7 +276,7 @@ class TvShowDao {
     );
   }
 
-  /// Снимает отметку просмотра с эпизода.
+  /// Clears the watched mark from an episode.
   Future<void> markEpisodeUnwatched(
     int collectionId,
     int showId,
@@ -259,7 +292,7 @@ class TvShowDao {
     );
   }
 
-  /// Возвращает количество просмотренных эпизодов для сериала в коллекции.
+  /// Returns the watched-episode count for a show within a collection.
   Future<int> getWatchedEpisodeCount(
     int collectionId,
     int showId,
@@ -273,7 +306,7 @@ class TvShowDao {
     return result.first['cnt'] as int;
   }
 
-  /// Отмечает все эпизоды сезона как просмотренные.
+  /// Marks every episode of a season as watched.
   Future<void> markSeasonWatched(
     int collectionId,
     int showId,
@@ -303,7 +336,7 @@ class TvShowDao {
     });
   }
 
-  /// Снимает отметку просмотра со всех эпизодов сезона.
+  /// Clears the watched mark from every episode of a season.
   Future<void> unmarkSeasonWatched(
     int collectionId,
     int showId,

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -42,6 +42,7 @@ import 'dao/mangabaka_tag_dao.dart';
 import 'dao/visual_novel_dao.dart';
 import 'dao/mood_grid_dao.dart';
 import 'dao/tier_list_dao.dart';
+import 'dao/calendar_entry_dao.dart';
 import 'dao/tracked_release_dao.dart';
 import 'dao/tracker_dao.dart';
 import 'dao/wishlist_dao.dart';
@@ -139,6 +140,11 @@ final Provider<TrackedReleaseDao> trackedReleaseDaoProvider =
   return ref.watch(databaseServiceProvider).trackedReleaseDao;
 });
 
+final Provider<CalendarEntryDao> calendarEntryDaoProvider =
+    Provider<CalendarEntryDao>((Ref ref) {
+  return ref.watch(databaseServiceProvider).calendarEntryDao;
+});
+
 class DatabaseService {
   static final Logger _log = Logger('DatabaseService');
 
@@ -208,6 +214,9 @@ class DatabaseService {
   late final TrackedReleaseDao trackedReleaseDao =
       TrackedReleaseDao(() => database);
 
+  late final CalendarEntryDao calendarEntryDao =
+      CalendarEntryDao(() => database);
+
   Future<Database> _initDatabase() async {
     // AppSupport rather than Documents: Documents may sit under OneDrive,
     // which blocks file creation (PathAccessException).
@@ -247,7 +256,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 45,
+        version: 46,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -43,6 +43,7 @@ import 'migration_v42.dart';
 import 'migration_v43.dart';
 import 'migration_v44.dart';
 import 'migration_v45.dart';
+import 'migration_v46.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
@@ -90,6 +91,7 @@ abstract final class MigrationRegistry {
     MigrationV43(),
     MigrationV44(),
     MigrationV45(),
+    MigrationV46(),
   ];
 
   static List<Migration> pending(int oldVersion) {

--- a/lib/core/database/migrations/migration_v46.dart
+++ b/lib/core/database/migrations/migration_v46.dart
@@ -1,0 +1,19 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../schema.dart';
+import 'migration.dart';
+
+/// Adds the `calendar_entries` table for manual calendar entries (any item
+/// with a start date and recurrence).
+class MigrationV46 extends Migration {
+  @override
+  int get version => 46;
+
+  @override
+  String get description => 'Manual calendar entries: calendar_entries table';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await DatabaseSchema.createCalendarEntriesTable(db);
+  }
+}

--- a/lib/core/database/schema.dart
+++ b/lib/core/database/schema.dart
@@ -36,6 +36,7 @@ abstract final class DatabaseSchema {
     await createMangaBakaGenresTable(db);
     await createMangaBakaTagsTable(db);
     await createTrackedReleasesTable(db);
+    await createCalendarEntriesTable(db);
   }
 
   static Future<void> createPlatformsTable(Database db) async {
@@ -222,6 +223,22 @@ abstract final class DatabaseSchema {
         external_id INTEGER NOT NULL,
         source TEXT NOT NULL,
         media_type TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (external_id, source, media_type)
+      )
+    ''');
+  }
+
+  /// Manual calendar entries (any item) with a start date and recurrence.
+  /// Keyed by `(external_id, source, media_type)`, independent of collections.
+  static Future<void> createCalendarEntriesTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE calendar_entries (
+        external_id INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        media_type TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        recurrence TEXT NOT NULL,
         created_at INTEGER NOT NULL,
         PRIMARY KEY (external_id, source, media_type)
       )

--- a/lib/core/services/backup_service.dart
+++ b/lib/core/services/backup_service.dart
@@ -16,8 +16,10 @@ import '../../data/repositories/wishlist_repository.dart';
 import '../../shared/models/collection.dart';
 import '../../shared/models/collection_item.dart';
 import '../../shared/models/media_type.dart';
+import '../../shared/models/calendar_entry.dart';
 import '../../shared/models/mood_grid.dart';
 import '../../shared/models/mood_grid_cell.dart';
+import '../../shared/models/tracked_release.dart';
 import '../../shared/models/wishlist_item.dart';
 import '../../shared/models/tracker_game_data.dart';
 import '../../shared/models/tracker_profile.dart';
@@ -30,7 +32,7 @@ import 'import_service.dart';
 import 'xcoll_file.dart';
 
 /// Версия формата бэкапа.
-const int backupFormatVersion = 2;
+const int backupFormatVersion = 3;
 
 /// Провайдер для сервиса бэкапа.
 final Provider<BackupService> backupServiceProvider =
@@ -410,7 +412,46 @@ class BackupService {
         }
       }
 
-      // 6. Настройки
+      // 6. Calendar — release subscriptions and manual calendar entries.
+      // Both are keyed by item identity, independent of collections.
+      final List<TrackedRelease> trackedReleases =
+          await _database.trackedReleaseDao.getAll();
+      final List<CalendarEntry> calendarEntries =
+          await _database.calendarEntryDao.getAll();
+      if (trackedReleases.isNotEmpty || calendarEntries.isNotEmpty) {
+        final Map<String, dynamic> calendarJson = <String, dynamic>{
+          'tracked_releases': trackedReleases
+              .map((TrackedRelease t) => t.toDb())
+              .toList(),
+          'calendar_entries':
+              calendarEntries.map((CalendarEntry e) => e.toDb()).toList(),
+        };
+        final List<int> calendarBytes = utf8.encode(
+          const JsonEncoder.withIndent('  ').convert(calendarJson),
+        );
+        archive.addFile(ArchiveFile(
+          'calendar.json',
+          calendarBytes.length,
+          calendarBytes,
+        ));
+      }
+
+      // 6b. Watch progress — aggregated by show (collection-agnostic), so it
+      // restores onto whichever collections later hold the show.
+      final List<Map<String, Object?>> watched =
+          await _database.tvShowDao.getAllWatchedEpisodes();
+      if (watched.isNotEmpty) {
+        final List<int> watchedBytes = utf8.encode(
+          const JsonEncoder.withIndent('  ').convert(watched),
+        );
+        archive.addFile(ArchiveFile(
+          'watched_episodes.json',
+          watchedBytes.length,
+          watchedBytes,
+        ));
+      }
+
+      // 7. Настройки
       final Map<String, Object> config = _configService.collectSettings();
       final String configStr =
           const JsonEncoder.withIndent('  ').convert(config);
@@ -533,6 +574,8 @@ class BackupService {
       String? configContent;
       String? trackerContent;
       String? moodGridsContent;
+      String? calendarContent;
+      String? watchedContent;
 
       for (final ArchiveFile file in archive) {
         if (!file.isFile) continue;
@@ -549,6 +592,10 @@ class BackupService {
           trackerContent = content;
         } else if (file.name == 'mood_grids.json') {
           moodGridsContent = content;
+        } else if (file.name == 'calendar.json') {
+          calendarContent = content;
+        } else if (file.name == 'watched_episodes.json') {
+          watchedContent = content;
         }
       }
 
@@ -634,6 +681,24 @@ class BackupService {
           await _restoreMoodGrids(moodGridsContent);
         } catch (e) {
           _log.warning('Failed to restore mood grids', e);
+        }
+      }
+
+      // Calendar — release subscriptions and manual entries, keyed by identity.
+      if (calendarContent != null) {
+        try {
+          await _restoreCalendar(calendarContent);
+        } catch (e) {
+          _log.warning('Failed to restore calendar', e);
+        }
+      }
+
+      // Watch progress — re-applied to the restored collections by show id.
+      if (watchedContent != null) {
+        try {
+          await _restoreWatchedEpisodes(watchedContent);
+        } catch (e) {
+          _log.warning('Failed to restore watched episodes', e);
         }
       }
 
@@ -788,6 +853,69 @@ class BackupService {
             source: cellData.source,
           );
         }
+      }
+    }
+  }
+
+  /// Restores release subscriptions and manual calendar entries. Both are
+  /// keyed by item identity, so re-inserting by identity is enough.
+  Future<void> _restoreCalendar(String jsonContent) async {
+    final Map<String, dynamic> map =
+        jsonDecode(jsonContent) as Map<String, dynamic>;
+
+    final List<dynamic> tracked =
+        (map['tracked_releases'] as List<dynamic>?) ?? <dynamic>[];
+    for (final dynamic raw in tracked) {
+      final TrackedRelease tr =
+          TrackedRelease.fromDb(raw as Map<String, dynamic>);
+      await _database.trackedReleaseDao
+          .subscribe(tr.externalId, tr.source, tr.mediaType);
+    }
+
+    final List<dynamic> entries =
+        (map['calendar_entries'] as List<dynamic>?) ?? <dynamic>[];
+    for (final dynamic raw in entries) {
+      await _database.calendarEntryDao
+          .upsert(CalendarEntry.fromDb(raw as Map<String, dynamic>));
+    }
+  }
+
+  /// Restores watch progress. Backed up by show id (collection-agnostic), so
+  /// each watched episode is re-applied to every restored collection holding
+  /// that TV show or anime.
+  Future<void> _restoreWatchedEpisodes(String jsonContent) async {
+    final List<dynamic> list = jsonDecode(jsonContent) as List<dynamic>;
+    // Episodes of the same show repeat; memoize the lookup per show id.
+    final Map<int, List<CollectionItem>> itemsByShow =
+        <int, List<CollectionItem>>{};
+    for (final dynamic raw in list) {
+      final Map<String, dynamic> m = raw as Map<String, dynamic>;
+      final int showId = m['show_id'] as int;
+      final int season = m['season_number'] as int;
+      final int episode = m['episode_number'] as int;
+      final int? watchedAt = m['watched_at'] as int?;
+
+      final List<CollectionItem> items = itemsByShow[showId] ??=
+          <CollectionItem>[
+        ...await _database.collectionDao.findAllCollectionItems(
+          mediaType: MediaType.tvShow,
+          externalId: showId,
+        ),
+        ...await _database.collectionDao.findAllCollectionItems(
+          mediaType: MediaType.animation,
+          externalId: showId,
+        ),
+      ];
+      for (final CollectionItem item in items) {
+        final int? collectionId = item.collectionId;
+        if (collectionId == null) continue;
+        await _database.tvShowDao.markEpisodeWatchedAt(
+          collectionId,
+          showId,
+          season,
+          episode,
+          watchedAt,
+        );
       }
     }
   }

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -38,6 +38,15 @@ final AsyncNotifierProvider<CollectionsNotifier, List<Collection>>
   CollectionsNotifier.new,
 );
 
+/// Drops calendar entries and release subscriptions whose item left every
+/// collection, then refreshes the calendar. Runs after item / collection
+/// deletion — the entries are keyed by identity, not linked by FK.
+Future<void> _pruneCalendarOrphans(Ref ref) async {
+  await ref.read(calendarEntryDaoProvider).deleteOrphaned();
+  await ref.read(trackedReleaseDaoProvider).deleteOrphaned();
+  ref.invalidate(releasesProvider);
+}
+
 class CollectionsNotifier extends AsyncNotifier<List<Collection>> {
   late CollectionRepository _repository;
 
@@ -124,6 +133,7 @@ class CollectionsNotifier extends AsyncNotifier<List<Collection>> {
     ref.invalidate(collectionStatsProvider(id));
     ref.invalidate(collectionCoversProvider(id));
     ref.invalidate(allItemsNotifierProvider);
+    await _pruneCalendarOrphans(ref);
   }
 
 }
@@ -721,8 +731,7 @@ class CollectionItemsNotifier
     }
     ref.invalidate(uncategorizedItemCountProvider);
     ref.invalidate(allItemsNotifierProvider);
-    // The releases calendar drops shows no longer in any collection.
-    ref.invalidate(releasesProvider);
+    await _pruneCalendarOrphans(ref);
 
     for (final int tierListId in affectedTierListIds) {
       ref.invalidate(tierListDetailProvider(tierListId));

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -10,10 +10,13 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/collection_picker_dialog.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/widgets/screen_app_bar.dart';
+import '../../../core/database/dao/calendar_entry_dao.dart';
 import '../../../core/database/dao/tracked_release_dao.dart';
 import '../../../core/database/database_service.dart';
+import '../../../shared/models/calendar_entry.dart';
 import '../../../shared/models/data_source.dart';
 import '../../releases/providers/releases_provider.dart';
+import '../../releases/widgets/add_to_calendar_dialog.dart';
 import '../../../shared/models/collected_item_info.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/models/collection_item.dart';
@@ -169,8 +172,9 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
     }
   }
 
-  /// Release tracking covers only TMDB-backed TV shows and anime for now.
-  bool _canTrackReleases(CollectionItem item) =>
+  /// TV shows and anime track episodes (TMDB); everything else uses a manual
+  /// calendar entry.
+  bool _isEpisodeType(CollectionItem item) =>
       item.mediaType == MediaType.tvShow ||
       item.mediaType == MediaType.animation;
 
@@ -187,6 +191,68 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
       (externalId: item.externalId, mediaType: item.mediaType),
     ));
     ref.invalidate(releasesProvider);
+  }
+
+  Future<void> _toggleCalendarEntry(CollectionItem item) async {
+    final CalendarEntryDao dao = ref.read(calendarEntryDaoProvider);
+    final DataSource source = item.dataSource;
+    final bool added =
+        await dao.isAdded(item.externalId, source, item.mediaType);
+    if (added) {
+      await dao.remove(item.externalId, source, item.mediaType);
+    } else {
+      if (!mounted) return;
+      final AddToCalendarResult? result = await showAddToCalendarDialog(
+        context,
+        initialDate: _initialCalendarDate(item),
+      );
+      if (result == null || !mounted) return;
+      await dao.upsert(CalendarEntry(
+        externalId: item.externalId,
+        source: source,
+        mediaType: item.mediaType,
+        startDate: result.date,
+        recurrence: result.recurrence,
+        createdAt: DateTime.now(),
+      ));
+    }
+    ref.invalidate(isCalendarEntryProvider(
+      (externalId: item.externalId, source: source, mediaType: item.mediaType),
+    ));
+    ref.invalidate(releasesProvider);
+  }
+
+  /// Pre-selected date for the add dialog: the item's release date if it is in
+  /// the future, otherwise today.
+  DateTime _initialCalendarDate(CollectionItem item) {
+    final DateTime now = DateTime.now();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    final DateTime? release = _releaseDateOf(item);
+    return (release != null && release.isAfter(today)) ? release : today;
+  }
+
+  DateTime? _releaseDateOf(CollectionItem item) {
+    switch (item.mediaType) {
+      case MediaType.game:
+        return item.game?.releaseDate;
+      case MediaType.visualNovel:
+        return DateTime.tryParse(item.visualNovel?.released ?? '');
+      case MediaType.manga:
+        final int? y = item.manga?.startYear;
+        return y != null
+            ? DateTime(y, item.manga?.startMonth ?? 1, item.manga?.startDay ?? 1)
+            : null;
+      case MediaType.anime:
+        final int? y = item.anime?.startYear;
+        return y != null
+            ? DateTime(y, item.anime?.startMonth ?? 1, item.anime?.startDay ?? 1)
+            : null;
+      case MediaType.movie:
+      case MediaType.tvShow:
+      case MediaType.animation:
+      case MediaType.custom:
+        return item.releaseYear != null ? DateTime(item.releaseYear!) : null;
+    }
   }
 
   Future<void> _refreshFromApi(CollectionItem item) async {
@@ -507,16 +573,29 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
           onEditCustom: () => _editCustomItem(item),
           onMenuSelected: (ItemDetailMenuAction action) =>
               _handleMenuAction(action, item),
-          canTrackReleases: _canTrackReleases(item),
-          isTracked: _canTrackReleases(item) &&
-              (ref
+          canTrackReleases: true,
+          isTracked: _isEpisodeType(item)
+              ? ref
                       .watch(isReleaseTrackedProvider((
                         externalId: item.externalId,
                         mediaType: item.mediaType,
                       )))
                       .valueOrNull ??
-                  false),
-          onToggleTracked: () => _toggleTracked(item),
+                  false
+              : ref
+                      .watch(isCalendarEntryProvider((
+                        externalId: item.externalId,
+                        source: item.dataSource,
+                        mediaType: item.mediaType,
+                      )))
+                      .valueOrNull ??
+                  false,
+          onToggleTracked: () => _isEpisodeType(item)
+              ? _toggleTracked(item)
+              : _toggleCalendarEntry(item),
+          trackTooltip: _isEpisodeType(item) ? null : S.of(context).calendarAdd,
+          untrackTooltip:
+              _isEpisodeType(item) ? null : S.of(context).calendarRemove,
         ),
         body: _showCanvas && _hasCanvas
             ? ItemDetailCanvasView(

--- a/lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
+++ b/lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
@@ -24,6 +24,8 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.canTrackReleases = false,
     this.isTracked = false,
     this.onToggleTracked,
+    this.trackTooltip,
+    this.untrackTooltip,
     super.key,
   });
 
@@ -38,14 +40,18 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback onEditCustom;
   final ValueChanged<ItemDetailMenuAction> onMenuSelected;
 
-  /// Whether the release-tracking bell applies to this item (TMDB TV / anime).
+  /// Whether the calendar bell applies to this item.
   final bool canTrackReleases;
 
-  /// Whether the item is currently tracked for releases.
+  /// Whether the item is currently on the calendar (tracked / added).
   final bool isTracked;
 
-  /// Toggles release tracking; required when [canTrackReleases] is true.
+  /// Toggles calendar membership; required when [canTrackReleases] is true.
   final VoidCallback? onToggleTracked;
+
+  /// Bell tooltips; default to the release-tracking wording.
+  final String? trackTooltip;
+  final String? untrackTooltip;
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
@@ -66,7 +72,9 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
               isTracked ? Icons.notifications_active : Icons.notifications_none,
             ),
             color: isTracked ? AppColors.brand : AppColors.textSecondary,
-            tooltip: isTracked ? l.releasesUntrackShow : l.releasesTrackShow,
+            tooltip: isTracked
+                ? (untrackTooltip ?? l.releasesUntrackShow)
+                : (trackTooltip ?? l.releasesTrackShow),
             onPressed: onToggleTracked,
           ),
         if (isEditable && hasCanvas && showCanvas)

--- a/lib/features/releases/models/release_event.dart
+++ b/lib/features/releases/models/release_event.dart
@@ -1,3 +1,4 @@
+import '../../../core/services/image_cache_service.dart';
 import '../../../shared/models/media_type.dart';
 
 /// One aired-or-upcoming episode of a tracked show, placed on the calendar by
@@ -7,12 +8,14 @@ class ReleaseEvent {
     required this.externalId,
     required this.mediaType,
     required this.showTitle,
-    required this.season,
-    required this.episode,
     required this.airDate,
     required this.watched,
     required this.isUpcoming,
+    this.season,
+    this.episode,
     this.posterUrl,
+    this.imageType,
+    this.cacheImageId,
     this.collectionId,
     this.itemId,
   });
@@ -20,12 +23,19 @@ class ReleaseEvent {
   final int externalId;
   final MediaType mediaType;
   final String showTitle;
-  final int season;
-  final int episode;
+
+  /// Season / episode for TV-episode events; null for manual calendar entries.
+  final int? season;
+  final int? episode;
   final DateTime airDate;
   final bool watched;
   final bool isUpcoming;
   final String? posterUrl;
+
+  /// Cache routing for [posterUrl] — the item's own image type and cache key,
+  /// so the poster reuses the on-disk cache instead of refetching.
+  final ImageType? imageType;
+  final String? cacheImageId;
 
   /// A representative collection item for navigation; null if the show is
   /// tracked but no longer in any collection.

--- a/lib/features/releases/providers/releases_provider.dart
+++ b/lib/features/releases/providers/releases_provider.dart
@@ -2,6 +2,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
+import '../../../shared/models/calendar_entry.dart';
+import '../../../shared/models/calendar_recurrence.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/data_source.dart';
 import '../../../shared/models/media_type.dart';
@@ -19,6 +21,18 @@ final AutoDisposeFutureProviderFamily<bool, ({int externalId, MediaType mediaTyp
     return ref
         .watch(trackedReleaseDaoProvider)
         .isTracked(key.externalId, DataSource.tmdb, key.mediaType);
+  },
+);
+
+/// Whether an item has a manual calendar entry, for the detail-screen bell.
+final AutoDisposeFutureProviderFamily<bool,
+        ({int externalId, DataSource source, MediaType mediaType})>
+    isCalendarEntryProvider = FutureProvider.autoDispose.family<bool,
+        ({int externalId, DataSource source, MediaType mediaType})>(
+  (Ref ref, ({int externalId, DataSource source, MediaType mediaType}) key) {
+    return ref
+        .watch(calendarEntryDaoProvider)
+        .isAdded(key.externalId, key.source, key.mediaType);
   },
 );
 
@@ -83,20 +97,89 @@ class ReleasesNotifier extends AsyncNotifier<ReleasesCalendarData> {
     final DateTime now = DateTime.now();
     final DateTime today = DateTime(now.year, now.month, now.day);
 
+    // Tidy past one-time manual entries before reading anything.
+    await db.calendarEntryDao.deletePastOnce(today);
+
     final List<TrackedRelease> tracked = await db.trackedReleaseDao.getAll();
     final List<TrackedRelease> tmdb = tracked
         .where((TrackedRelease t) =>
             t.source == DataSource.tmdb && _supported.contains(t.mediaType))
         .toList();
+    final List<CalendarEntry> manual = await db.calendarEntryDao.getAll();
 
-    final List<List<ReleaseEvent>> perShow = await Future.wait(
-      tmdb.map((TrackedRelease t) => _eventsForShow(db, t, today)),
-    );
+    final List<List<ReleaseEvent>> perShow = await Future.wait(<Future<List<ReleaseEvent>>>[
+      ...tmdb.map((TrackedRelease t) => _eventsForShow(db, t, today)),
+      ...manual.map((CalendarEntry e) => _eventsForEntry(db, e, today)),
+    ]);
 
     return ReleasesCalendarData(
-      trackedCount: tmdb.length,
+      trackedCount: tmdb.length + manual.length,
       events: perShow.expand((List<ReleaseEvent> e) => e).toList(),
     );
+  }
+
+  /// Expands a manual entry into events for its occurrences within a year.
+  Future<List<ReleaseEvent>> _eventsForEntry(
+    DatabaseService db,
+    CalendarEntry entry,
+    DateTime today,
+  ) async {
+    final CollectionItem? item =
+        await db.collectionDao.findCollectionItemWithData(
+      collectionId: null,
+      mediaType: entry.mediaType,
+      externalId: entry.externalId,
+    );
+    if (item == null) return <ReleaseEvent>[];
+
+    return <ReleaseEvent>[
+      for (final DateTime date in _occurrences(entry, today))
+        ReleaseEvent(
+          externalId: entry.externalId,
+          mediaType: entry.mediaType,
+          showTitle: item.itemName,
+          airDate: date,
+          watched: false,
+          isUpcoming: true,
+          posterUrl: item.thumbnailUrl,
+          imageType: item.imageType,
+          cacheImageId: item.coverImageId,
+          collectionId: item.collectionId,
+          itemId: item.id,
+        ),
+    ];
+  }
+
+  /// Occurrence dates for an entry from today up to one year ahead.
+  List<DateTime> _occurrences(CalendarEntry entry, DateTime today) {
+    final DateTime start = DateTime(
+      entry.startDate.year,
+      entry.startDate.month,
+      entry.startDate.day,
+    );
+    final DateTime horizon = today.add(const Duration(days: 365));
+
+    switch (entry.recurrence) {
+      case CalendarRecurrence.once:
+        return start.isBefore(today) ? <DateTime>[] : <DateTime>[start];
+      case CalendarRecurrence.weekly:
+        final List<DateTime> out = <DateTime>[];
+        for (int i = 0; i < 1000; i++) {
+          final DateTime occ = start.add(Duration(days: 7 * i));
+          if (occ.isAfter(horizon)) break;
+          if (!occ.isBefore(today)) out.add(occ);
+        }
+        return out;
+      case CalendarRecurrence.monthly:
+        final List<DateTime> out = <DateTime>[];
+        for (int i = 0; i < 400; i++) {
+          final DateTime occ =
+              DateTime(start.year, start.month + i, start.day);
+          if (occ.isAfter(horizon)) break;
+          if (!occ.isBefore(today)) out.add(occ);
+        }
+        return out;
+    }
   }
 
   Future<List<ReleaseEvent>> _eventsForShow(
@@ -139,6 +222,8 @@ class ReleasesNotifier extends AsyncNotifier<ReleasesCalendarData> {
         watched: false,
         isUpcoming: true,
         posterUrl: show?.posterThumbUrl,
+        imageType: item.imageType,
+        cacheImageId: item.coverImageId,
         collectionId: item.collectionId,
         itemId: item.id,
       ));

--- a/lib/features/releases/screens/releases_screen.dart
+++ b/lib/features/releases/screens/releases_screen.dart
@@ -4,9 +4,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/utils/date_format_preset.dart';
+import '../../../shared/widgets/cached_image.dart';
 import '../../collections/screens/item_detail_screen.dart';
 import '../../settings/providers/settings_provider.dart';
 import '../models/release_event.dart';
@@ -206,7 +208,9 @@ class _ReleasesScreenState extends ConsumerState<ReleasesScreen> {
     return CalendarEventData<Object?>(
       date: e.airDate,
       title: e.showTitle,
-      description: l.releasesEpisode(e.season, e.episode),
+      description: e.season != null
+          ? l.releasesEpisode(e.season!, e.episode!)
+          : null,
       color: _colorFor(e),
       event: e,
     );
@@ -348,7 +352,7 @@ class _ReleasesScreenState extends ConsumerState<ReleasesScreen> {
           child: Row(
             children: <Widget>[
               const SizedBox(width: 4),
-              _thumb(e?.posterUrl, width: 16, height: 22),
+              _thumb(e, width: 16, height: 22),
               const SizedBox(width: 6),
               Expanded(
                 child: Text(
@@ -529,7 +533,7 @@ class _ReleasesScreenState extends ConsumerState<ReleasesScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 _thumb(
-                  e.posterUrl,
+                  e,
                   width: inSheet ? 60 : 46,
                   height: inSheet ? 90 : 69,
                 ),
@@ -552,14 +556,16 @@ class _ReleasesScreenState extends ConsumerState<ReleasesScreen> {
                           decoration: dim ? TextDecoration.lineThrough : null,
                         ),
                       ),
-                      const SizedBox(height: 3),
-                      Text(
-                        l.releasesEpisode(e.season, e.episode),
-                        style: const TextStyle(
-                          fontSize: 13,
-                          color: AppColors.textSecondary,
+                      if (e.season != null) ...<Widget>[
+                        const SizedBox(height: 3),
+                        Text(
+                          l.releasesEpisode(e.season!, e.episode!),
+                          style: const TextStyle(
+                            fontSize: 13,
+                            color: AppColors.textSecondary,
+                          ),
                         ),
-                      ),
+                      ],
                       const SizedBox(height: 6),
                       Row(
                         children: <Widget>[
@@ -644,28 +650,50 @@ class _ReleasesScreenState extends ConsumerState<ReleasesScreen> {
   }
 
 
-  Widget _thumb(String? url, {required double width, required double height}) {
+  Widget _thumb(ReleaseEvent? e, {required double width, required double height}) {
+    final Widget placeholder = ColoredBox(
+      color: AppColors.surface,
+      child: Icon(
+        _placeholderIcon(e?.mediaType),
+        size: 14,
+        color: AppColors.textTertiary,
+      ),
+    );
+    final bool cacheable = e?.posterUrl != null &&
+        e?.imageType != null &&
+        e?.cacheImageId != null;
     return ClipRRect(
       borderRadius: BorderRadius.circular(3),
       child: SizedBox(
         width: width,
         height: height,
-        child: url != null
-            ? Image.network(
-                url,
+        child: cacheable
+            ? CachedImage(
+                imageType: e!.imageType!,
+                imageId: e.cacheImageId!,
+                remoteUrl: e.posterUrl!,
+                width: width,
+                height: height,
                 fit: BoxFit.cover,
-                errorBuilder: (_, _, _) => const ColoredBox(
-                  color: AppColors.surface,
-                  child: Icon(Icons.tv, size: 14, color: AppColors.textTertiary),
-                ),
+                placeholder: placeholder,
+                errorWidget: placeholder,
               )
-            : const ColoredBox(
-                color: AppColors.surface,
-                child: Icon(Icons.tv, size: 14, color: AppColors.textTertiary),
-              ),
+            : placeholder,
       ),
     );
   }
+
+  IconData _placeholderIcon(MediaType? type) => switch (type) {
+        MediaType.game => Icons.videogame_asset,
+        MediaType.movie => Icons.movie_outlined,
+        MediaType.tvShow => Icons.tv_outlined,
+        MediaType.animation => Icons.animation,
+        MediaType.visualNovel => Icons.menu_book,
+        MediaType.manga => Icons.auto_stories,
+        MediaType.anime => Icons.play_circle_outline,
+        MediaType.custom => Icons.dashboard_customize,
+        null => Icons.event,
+      };
 
   Color _colorFor(ReleaseEvent e) {
     if (e.isUpcoming) return AppColors.statusPlanned;

--- a/lib/features/releases/widgets/add_to_calendar_dialog.dart
+++ b/lib/features/releases/widgets/add_to_calendar_dialog.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/calendar_recurrence.dart';
+import '../../../shared/theme/app_spacing.dart';
+
+/// Result of [showAddToCalendarDialog].
+class AddToCalendarResult {
+  const AddToCalendarResult(this.date, this.recurrence);
+
+  final DateTime date;
+  final CalendarRecurrence recurrence;
+}
+
+/// Google-Calendar-style add dialog: pick a date and a repeat option. Returns
+/// null if cancelled. [initialDate] pre-selects the item's future release date.
+Future<AddToCalendarResult?> showAddToCalendarDialog(
+  BuildContext context, {
+  required DateTime initialDate,
+}) {
+  return showDialog<AddToCalendarResult>(
+    context: context,
+    builder: (BuildContext context) =>
+        _AddToCalendarDialog(initialDate: initialDate),
+  );
+}
+
+class _AddToCalendarDialog extends StatefulWidget {
+  const _AddToCalendarDialog({required this.initialDate});
+
+  final DateTime initialDate;
+
+  @override
+  State<_AddToCalendarDialog> createState() => _AddToCalendarDialogState();
+}
+
+class _AddToCalendarDialogState extends State<_AddToCalendarDialog> {
+  late DateTime _date = widget.initialDate;
+  CalendarRecurrence _recurrence = CalendarRecurrence.once;
+
+  Future<void> _pickDate() async {
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: _date,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(_date.year + 10),
+    );
+    if (picked != null) setState(() => _date = picked);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return AlertDialog(
+      title: Text(l.calendarAddTitle),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: const Icon(Icons.event),
+            title: Text(l.calendarDate),
+            subtitle: Text(
+              MaterialLocalizations.of(context).formatMediumDate(_date),
+            ),
+            trailing: TextButton(
+              onPressed: _pickDate,
+              child: Text(MaterialLocalizations.of(context).dateInputLabel),
+            ),
+            onTap: _pickDate,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(l.calendarRepeat),
+          const SizedBox(height: AppSpacing.xs),
+          SegmentedButton<CalendarRecurrence>(
+            showSelectedIcon: false,
+            segments: <ButtonSegment<CalendarRecurrence>>[
+              for (final CalendarRecurrence r in CalendarRecurrence.values)
+                ButtonSegment<CalendarRecurrence>(
+                  value: r,
+                  label: Text(r.localizedLabel(l)),
+                ),
+            ],
+            selected: <CalendarRecurrence>{_recurrence},
+            onSelectionChanged: (Set<CalendarRecurrence> s) =>
+                setState(() => _recurrence = s.first),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.cancel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(
+            AddToCalendarResult(_date, _recurrence),
+          ),
+          child: Text(l.calendarAddAction),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/content/database_content.dart
+++ b/lib/features/settings/content/database_content.dart
@@ -12,6 +12,7 @@ import '../../../shared/theme/app_typography.dart';
 import '../../../shared/navigation/app_shell.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../home/providers/all_items_provider.dart';
+import '../../releases/providers/releases_provider.dart';
 import '../../tier_lists/providers/mood_grids_provider.dart';
 import '../../tier_lists/providers/tier_lists_provider.dart';
 import '../../wishlist/providers/wishlist_provider.dart';
@@ -205,6 +206,7 @@ class DatabaseContent extends ConsumerWidget {
       ref.invalidate(wishlistProvider);
       ref.invalidate(tierListsProvider);
       ref.invalidate(moodGridsProvider);
+      ref.invalidate(releasesProvider);
 
       if (context.mounted) {
         context.showSnack(

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -35,6 +35,7 @@ import 'database_screen.dart';
 import '../../../core/services/backup_service.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../home/providers/all_items_provider.dart';
+import '../../releases/providers/releases_provider.dart';
 import '../../wishlist/providers/wishlist_provider.dart';
 import 'browse_collections_screen.dart';
 import 'anilist_import_screen.dart';
@@ -993,10 +994,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     if (!context.mounted) return;
 
     if (result.success) {
-      // Инвалидируем провайдеры чтобы UI отобразил восстановленные данные
+      // Refresh derived state so the UI reflects the restored data.
       ref.invalidate(collectionsProvider);
       ref.invalidate(allItemsNotifierProvider);
       ref.invalidate(wishlistProvider);
+      ref.invalidate(releasesProvider);
 
       context.showSnack(
         l.restoreSuccess(result.collectionsRestored, result.itemsRestored),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,6 +27,15 @@
       "episode": {"type": "int"}
     }
   },
+  "calendarAdd": "Add to calendar",
+  "calendarRemove": "Remove from calendar",
+  "calendarAddTitle": "Add to calendar",
+  "calendarDate": "Date",
+  "calendarRepeat": "Repeat",
+  "calendarAddAction": "Add",
+  "recurrenceOnce": "Once",
+  "recurrenceWeekly": "Weekly",
+  "recurrenceMonthly": "Monthly",
 
   "statusNotStarted": "Not Started",
   "statusPlaying": "Playing",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -205,6 +205,60 @@ abstract class S {
   /// **'Season {season} · Episode {episode}'**
   String releasesEpisode(int season, int episode);
 
+  /// No description provided for @calendarAdd.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to calendar'**
+  String get calendarAdd;
+
+  /// No description provided for @calendarRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove from calendar'**
+  String get calendarRemove;
+
+  /// No description provided for @calendarAddTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to calendar'**
+  String get calendarAddTitle;
+
+  /// No description provided for @calendarDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Date'**
+  String get calendarDate;
+
+  /// No description provided for @calendarRepeat.
+  ///
+  /// In en, this message translates to:
+  /// **'Repeat'**
+  String get calendarRepeat;
+
+  /// No description provided for @calendarAddAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Add'**
+  String get calendarAddAction;
+
+  /// No description provided for @recurrenceOnce.
+  ///
+  /// In en, this message translates to:
+  /// **'Once'**
+  String get recurrenceOnce;
+
+  /// No description provided for @recurrenceWeekly.
+  ///
+  /// In en, this message translates to:
+  /// **'Weekly'**
+  String get recurrenceWeekly;
+
+  /// No description provided for @recurrenceMonthly.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly'**
+  String get recurrenceMonthly;
+
   /// No description provided for @statusNotStarted.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -66,6 +66,33 @@ class SEn extends S {
   }
 
   @override
+  String get calendarAdd => 'Add to calendar';
+
+  @override
+  String get calendarRemove => 'Remove from calendar';
+
+  @override
+  String get calendarAddTitle => 'Add to calendar';
+
+  @override
+  String get calendarDate => 'Date';
+
+  @override
+  String get calendarRepeat => 'Repeat';
+
+  @override
+  String get calendarAddAction => 'Add';
+
+  @override
+  String get recurrenceOnce => 'Once';
+
+  @override
+  String get recurrenceWeekly => 'Weekly';
+
+  @override
+  String get recurrenceMonthly => 'Monthly';
+
+  @override
   String get statusNotStarted => 'Not Started';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -66,6 +66,33 @@ class SRu extends S {
   }
 
   @override
+  String get calendarAdd => 'Добавить в календарь';
+
+  @override
+  String get calendarRemove => 'Убрать из календаря';
+
+  @override
+  String get calendarAddTitle => 'Добавить в календарь';
+
+  @override
+  String get calendarDate => 'Дата';
+
+  @override
+  String get calendarRepeat => 'Повтор';
+
+  @override
+  String get calendarAddAction => 'Добавить';
+
+  @override
+  String get recurrenceOnce => 'Один раз';
+
+  @override
+  String get recurrenceWeekly => 'Еженедельно';
+
+  @override
+  String get recurrenceMonthly => 'Ежемесячно';
+
+  @override
   String get statusNotStarted => 'Не начато';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -27,6 +27,15 @@
       "episode": {"type": "int"}
     }
   },
+  "calendarAdd": "Добавить в календарь",
+  "calendarRemove": "Убрать из календаря",
+  "calendarAddTitle": "Добавить в календарь",
+  "calendarDate": "Дата",
+  "calendarRepeat": "Повтор",
+  "calendarAddAction": "Добавить",
+  "recurrenceOnce": "Один раз",
+  "recurrenceWeekly": "Еженедельно",
+  "recurrenceMonthly": "Ежемесячно",
 
   "statusNotStarted": "Не начато",
   "statusPlaying": "Играю",

--- a/lib/shared/models/calendar_entry.dart
+++ b/lib/shared/models/calendar_entry.dart
@@ -1,0 +1,54 @@
+import 'calendar_recurrence.dart';
+import 'data_source.dart';
+import 'media_type.dart';
+
+/// A manual calendar entry the user added for any item: a start date and a
+/// recurrence. Identity is `(externalId, source, mediaType)` — one entry per
+/// item, independent of collections.
+class CalendarEntry {
+  const CalendarEntry({
+    required this.externalId,
+    required this.source,
+    required this.mediaType,
+    required this.startDate,
+    required this.recurrence,
+    required this.createdAt,
+  });
+
+  factory CalendarEntry.fromDb(Map<String, dynamic> row) {
+    return CalendarEntry(
+      externalId: row['external_id'] as int,
+      source: DataSource.fromName(row['source'] as String?),
+      mediaType: MediaType.fromString(row['media_type'] as String),
+      startDate: DateTime.parse(row['start_date'] as String),
+      recurrence: CalendarRecurrence.fromValue(row['recurrence'] as String?),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(row['created_at'] as int),
+    );
+  }
+
+  final int externalId;
+  final DataSource source;
+  final MediaType mediaType;
+
+  /// First (or only) occurrence, date-only.
+  final DateTime startDate;
+  final CalendarRecurrence recurrence;
+  final DateTime createdAt;
+
+  /// `YYYY-MM-DD`, stable and lexicographically comparable for SQL.
+  static String formatDate(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'external_id': externalId,
+      'source': source.name,
+      'media_type': mediaType.value,
+      'start_date': formatDate(startDate),
+      'recurrence': recurrence.value,
+      'created_at': createdAt.millisecondsSinceEpoch,
+    };
+  }
+}

--- a/lib/shared/models/calendar_recurrence.dart
+++ b/lib/shared/models/calendar_recurrence.dart
@@ -1,0 +1,26 @@
+import '../../l10n/app_localizations.dart';
+
+/// How a manual calendar entry repeats.
+enum CalendarRecurrence {
+  once('once'),
+  weekly('weekly'),
+  monthly('monthly');
+
+  const CalendarRecurrence(this.value);
+
+  /// Stored value (DB / serialization).
+  final String value;
+
+  static CalendarRecurrence fromValue(String? value) {
+    for (final CalendarRecurrence r in CalendarRecurrence.values) {
+      if (r.value == value) return r;
+    }
+    return CalendarRecurrence.once;
+  }
+
+  String localizedLabel(S l) => switch (this) {
+        CalendarRecurrence.once => l.recurrenceOnce,
+        CalendarRecurrence.weekly => l.recurrenceWeekly,
+        CalendarRecurrence.monthly => l.recurrenceMonthly,
+      };
+}

--- a/lib/shared/navigation/app_bottom_bar.dart
+++ b/lib/shared/navigation/app_bottom_bar.dart
@@ -1,4 +1,4 @@
-// Нижнее меню приложения — горизонтальное, для узких экранов.
+// Bottom navigation bar — horizontal, for narrow screens.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,25 +11,25 @@ import 'nav_destinations.dart';
 import 'nav_icon_button.dart';
 import 'nav_tab.dart';
 
-/// Высота нижнего меню.
+/// Height of the bottom bar.
 const double kAppBottomBarHeight = 64;
 
-/// Нижнее меню приложения (горизонтальное).
+/// Bottom navigation bar (horizontal).
 ///
-/// Используется на узких экранах вместо [AppSidebar]. Settings здесь
-/// нет — она в [AppTopBar].
+/// Used on narrow screens instead of [AppSidebar]. Settings is not here — it
+/// lives in [AppTopBar].
 class AppBottomBar extends ConsumerWidget {
-  /// Создаёт [AppBottomBar].
+  /// Creates an [AppBottomBar].
   const AppBottomBar({
     required this.selectedTab,
     required this.onDestinationSelected,
     super.key,
   });
 
-  /// Активный таб.
+  /// The active tab.
   final NavTab selectedTab;
 
-  /// Колбэк при выборе таба.
+  /// Called when a tab is selected.
   final void Function(NavTab tab) onDestinationSelected;
 
   @override

--- a/lib/shared/navigation/app_shell.dart
+++ b/lib/shared/navigation/app_shell.dart
@@ -1,4 +1,4 @@
-// Основная оболочка приложения: боковое меню + вложенная навигация.
+// Main app shell: side rail + nested per-tab navigation.
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -26,28 +26,28 @@ import 'app_top_bar.dart';
 import 'nav_tab.dart';
 import 'search_providers.dart';
 
-/// Количество основных табов.
+/// Number of primary tabs.
 const int _tabCount = 7;
 
-/// Главная оболочка приложения.
+/// Main app shell.
 ///
-/// Единая для всех платформ (Windows, Android): слева — [AppSidebar] шириной
-/// [kAppSidebarWidth], справа — вложенная навигация каждого таба через
-/// [IndexedStack] + кэшированные [Navigator].
+/// Shared across platforms (Windows, Android): [AppSidebar] of width
+/// [kAppSidebarWidth] on the left, each tab's nested navigation on the right
+/// via [IndexedStack] + cached [Navigator]s.
 ///
-/// Поддержка геймпада:
-/// - D-pad — перемещение фокуса (DirectionalFocusIntent)
-/// - A — активация фокусированного виджета (ActivateIntent)
-/// - LB/RB — переключение между табами
-/// - B — назад (pop внутри таба или переключение на Home)
+/// Gamepad support:
+/// - D-pad — move focus (DirectionalFocusIntent)
+/// - A — activate the focused widget (ActivateIntent)
+/// - LB/RB — switch between tabs
+/// - B — back (pop within the tab, or switch to Home)
 class AppShell extends ConsumerStatefulWidget {
-  /// Создаёт [AppShell].
+  /// Creates an [AppShell].
   ///
-  /// [initialTab] позволяет открыть приложение на конкретном табе
-  /// (например, Settings после Welcome Wizard).
+  /// [initialTab] opens the app on a specific tab (e.g. Settings after the
+  /// Welcome Wizard).
   const AppShell({this.initialTab, super.key});
 
-  /// Начальный таб. Если null — [NavTab.home].
+  /// Starting tab; [NavTab.home] when null.
   final NavTab? initialTab;
 
   @override
@@ -57,29 +57,29 @@ class AppShell extends ConsumerStatefulWidget {
 class _AppShellState extends ConsumerState<AppShell> {
   late int _selectedIndex = widget.initialTab?.index ?? NavTab.home.index;
 
-  /// FocusScopeNode для каждого таба.
+  /// FocusScopeNode per tab.
   final List<FocusScopeNode> _tabFocusScopeNodes = List<FocusScopeNode>.generate(
     _tabCount,
     (int i) => FocusScopeNode(debugLabel: 'tab-$i-scope'),
   );
 
-  /// Табы, которые уже были инициализированы (ленивая инициализация).
+  /// Tabs that have been initialized already (lazy init).
   late final Set<int> _initializedTabs = <int>{
     NavTab.home.index,
     if (widget.initialTab != null) widget.initialTab!.index,
   };
 
-  /// Ключи Navigator для каждого таба.
+  /// Navigator keys per tab.
   final List<GlobalKey<NavigatorState>> _navigatorKeys =
       List<GlobalKey<NavigatorState>>.generate(
     _tabCount,
     (_) => GlobalKey<NavigatorState>(),
   );
 
-  /// Кэшированные Navigator-виджеты.
+  /// Cached Navigator widgets.
   ///
-  /// При смене локали [MaterialApp] перестраивает всё дерево. Без кэша
-  /// каждый ребилд создавал бы новый Navigator и терял историю маршрутов.
+  /// [MaterialApp] rebuilds the whole tree on locale change. Without the cache
+  /// each rebuild would create a new Navigator and lose its route history.
   final List<Widget?> _navigatorWidgets =
       List<Widget?>.filled(_tabCount, null);
 
@@ -179,11 +179,11 @@ class _AppShellState extends ConsumerState<AppShell> {
     );
   }
 
-  /// Перехватывает печатные символы с глобального Focus и перенаправляет
-  /// их в поле поиска [AppTopBar] (type-to-search).
+  /// Captures printable characters from the global Focus and redirects them to
+  /// the [AppTopBar] search field (type-to-search).
   ///
-  /// Срабатывает только на десктопе, только если текущий таб поддерживает
-  /// поиск и фокус не находится внутри другого [EditableText].
+  /// Desktop only, and only when the current tab supports search and focus is
+  /// not already inside another [EditableText].
   KeyEventResult _handleTypeToSearch(FocusNode node, KeyEvent event) {
     if (kIsMobile) return KeyEventResult.ignored;
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
@@ -211,7 +211,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     return KeyEventResult.handled;
   }
 
-  /// Проверяет, находится ли фокус во внешнем [EditableText].
+  /// Whether focus is inside some other [EditableText].
   bool _isAnyEditableTextFocused() {
     final FocusNode? focus = FocusManager.instance.primaryFocus;
     final BuildContext? ctx = focus?.context;
@@ -266,7 +266,7 @@ class _AppShellState extends ConsumerState<AppShell> {
 
   void _onDestinationSelected(int index) {
     if (index == _selectedIndex) {
-      // Повторное нажатие — вернуться к корню таба.
+      // Pressing again returns to the tab root.
       _navigatorKeys[index]
           .currentState
           ?.popUntil((Route<dynamic> route) => route.isFirst);
@@ -274,7 +274,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     }
     _initializedTabs.add(index);
     setState(() => _selectedIndex = index);
-    // Явно фокусируем контент нового таба для геймпада.
+    // Explicitly focus the new tab's content for the gamepad.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final FocusScopeNode scope = _tabFocusScopeNodes[index];
@@ -283,9 +283,9 @@ class _AppShellState extends ConsumerState<AppShell> {
     });
   }
 
-  /// Обработка кнопки «назад» (Android back, Gamepad B).
+  /// Handles the back button (Android back, Gamepad B).
   ///
-  /// Возвращает `true`, если навигация обработана; `false`, если нужно выйти.
+  /// Returns `true` if navigation was handled; `false` if the app should exit.
   bool _handleBack() {
     final NavigatorState? tabNav =
         _navigatorKeys[_selectedIndex].currentState;
@@ -300,7 +300,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     return false;
   }
 
-  /// Возвращает группы хоткеев для текущего таба (для F1 диалога).
+  /// Shortcut groups for the current tab (for the F1 dialog).
   List<ShortcutGroup> _currentScreenShortcutGroups() {
     return switch (NavTab.values[_selectedIndex]) {
       NavTab.home => const <ShortcutGroup>[],
@@ -320,7 +320,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     };
   }
 
-  /// F5 — обновить текущий таб (pop до корня).
+  /// F5 — refresh the current tab (pop to its root).
   void _onRefresh() {
     final NavigatorState? tabNav =
         _navigatorKeys[_selectedIndex].currentState;
@@ -335,7 +335,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     _onDestinationSelected(newIndex);
   }
 
-  /// D-pad → перемещение фокуса через DirectionalFocusIntent.
+  /// D-pad → move focus via DirectionalFocusIntent.
   void _onGamepadNavigate(GamepadAction action) {
     final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
     final BuildContext? focusContext = primaryFocus?.context;
@@ -356,7 +356,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     Actions.maybeInvoke(focusContext, DirectionalFocusIntent(direction));
   }
 
-  /// A кнопка → активация фокусированного виджета.
+  /// A button → activate the focused widget.
   void _onGamepadConfirm() {
     final BuildContext? focusContext =
         FocusManager.instance.primaryFocus?.context;
@@ -365,7 +365,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     Actions.maybeInvoke(focusContext, const ActivateIntent());
   }
 
-  /// Y кнопка → контекстное меню (аналог ПКМ / long press).
+  /// Y button → context menu (like right-click / long press).
   void _onGamepadContextMenu() {
     final FocusNode? primaryFocus = FocusManager.instance.primaryFocus;
     final BuildContext? focusContext = primaryFocus?.context;
@@ -403,7 +403,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     inkWell?.onLongPress?.call();
   }
 
-  /// Left Stick → скролл через синтетический PointerScrollEvent.
+  /// Left stick → scroll via a synthetic PointerScrollEvent.
   void _onGamepadScroll(GamepadAction action) {
     const double scrollAmount = 80.0;
 

--- a/lib/shared/navigation/app_sidebar.dart
+++ b/lib/shared/navigation/app_sidebar.dart
@@ -1,4 +1,4 @@
-// Боковое меню приложения — вертикальное, для широких экранов.
+// Side navigation rail — vertical, for wide screens.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,33 +11,33 @@ import 'nav_destinations.dart';
 import 'nav_icon_button.dart';
 import 'nav_tab.dart';
 
-/// Ширина бокового меню.
+/// Width of the side rail.
 const double kAppSidebarWidth = 64;
 
-/// Максимальная высота одной кнопки таба. На узких/низких экранах кнопки
-/// сжимаются пропорционально, не выходя за пределы доступной высоты.
+/// Maximum height of one tab button. On short screens the buttons shrink
+/// proportionally to stay within the available height.
 const double _kItemHeight = 56;
 
-/// Минимальная высота кнопки таба — ниже этого иконка становится трудночитаемой.
+/// Minimum tab-button height — below this the icon becomes hard to read.
 const double _kItemHeightMin = 36;
 
-/// Боковое меню приложения (вертикальное).
+/// Side navigation rail (vertical).
 ///
-/// Содержит только иконки (без подписей и логотипа), располагает кнопки
-/// вертикально по центру и подсвечивает активный пункт анимированным
-/// [LiquidIndicator]. Settings здесь нет — она в [AppTopBar].
+/// Icons only (no labels or logo); centers the buttons vertically and
+/// highlights the active item with an animated [LiquidIndicator]. Settings is
+/// not here — it lives in [AppTopBar].
 class AppSidebar extends ConsumerWidget {
-  /// Создаёт [AppSidebar].
+  /// Creates an [AppSidebar].
   const AppSidebar({
     required this.selectedTab,
     required this.onDestinationSelected,
     super.key,
   });
 
-  /// Активный таб.
+  /// The active tab.
   final NavTab selectedTab;
 
-  /// Колбэк при выборе таба.
+  /// Called when a tab is selected.
   final void Function(NavTab tab) onDestinationSelected;
 
   @override
@@ -70,8 +70,8 @@ class AppSidebar extends ConsumerWidget {
             ),
             LayoutBuilder(
               builder: (BuildContext ctx, BoxConstraints c) {
-                // Сжимаем высоту кнопок если экран ниже идеала, но не меньше
-                // минимума — иначе иконки сольются.
+                // Shrink button height when the screen is shorter than ideal,
+                // but never below the minimum or the icons blur together.
                 final double itemHeight = (c.maxHeight / destinations.length)
                     .clamp(_kItemHeightMin, _kItemHeight);
                 final double totalHeight = itemHeight * destinations.length;

--- a/lib/shared/navigation/nav_destinations.dart
+++ b/lib/shared/navigation/nav_destinations.dart
@@ -1,6 +1,6 @@
-// Построение списка пунктов навигации для бокового и нижнего меню.
+// Builds the navigation destinations for the side and bottom menus.
 //
-// Settings сюда не входит — она вынесена в шестерёнку в [AppTopBar].
+// Settings is not included here — it lives behind the gear in [AppTopBar].
 
 import 'package:flutter/material.dart';
 
@@ -8,10 +8,10 @@ import '../../l10n/app_localizations.dart';
 import 'nav_icon_button.dart';
 import 'nav_tab.dart';
 
-/// Формирует упорядоченный список [NavDestination] для меню.
+/// Builds the ordered list of [NavDestination]s for the menu.
 ///
-/// Порядок идентичен для [AppSidebar] и [AppBottomBar]. Settings
-/// отсутствует — она открывается через шестерёнку в [AppTopBar].
+/// The order is identical for [AppSidebar] and [AppBottomBar]. Settings is
+/// absent — it opens via the gear in [AppTopBar].
 List<NavDestination> buildNavDestinations({
   required BuildContext context,
   required int wishlistCount,

--- a/lib/shared/navigation/nav_tab.dart
+++ b/lib/shared/navigation/nav_tab.dart
@@ -1,28 +1,28 @@
-// Перечисление главных табов навигации приложения.
+// Main navigation tabs of the app.
 
-/// Индексы вкладок основной навигации.
+/// Tab indices for the primary navigation.
 ///
-/// Используется [AppShell] для переключения табов и внешними экранами
-/// (например, [WelcomeScreen]) — для указания стартового таба.
+/// Used by [AppShell] to switch tabs and by external screens (e.g.
+/// [WelcomeScreen]) to set the starting tab.
 enum NavTab {
-  /// Домашний экран (все элементы).
+  /// Home screen (all items).
   home,
 
-  /// Коллекции.
+  /// Collections.
   collections,
 
-  /// Тир-листы.
+  /// Tier lists.
   tierLists,
 
-  /// Релизы (новые серии отслеживаемых сериалов).
+  /// Releases (new episodes of tracked shows).
   releases,
 
-  /// Вишлист (заметки для поиска).
+  /// Wishlist (search notes).
   wishlist,
 
-  /// Поиск.
+  /// Search.
   search,
 
-  /// Настройки.
+  /// Settings.
   settings,
 }

--- a/lib/shared/navigation/search_providers.dart
+++ b/lib/shared/navigation/search_providers.dart
@@ -1,10 +1,9 @@
-// Провайдеры контекстного поиска для глобального [AppTopBar].
+// Contextual search providers for the global [AppTopBar].
 //
-// На каждый таб, поддерживающий поиск, заводится отдельный
-// [StateProvider] с query — это даёт per-tab сохранение ввода.
-// [searchContextFor] возвращает описание контекста текущего таба
-// (какой провайдер слушать, какой hint показывать), либо null —
-// когда таб поиск не поддерживает.
+// Each search-capable tab has its own query [StateProvider], which keeps the
+// input per tab. [searchContextFor] returns the current tab's search context
+// (which provider to listen to, which hint to show), or null when the tab does
+// not support search.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,35 +11,34 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../l10n/app_localizations.dart';
 import 'nav_tab.dart';
 
-/// Query поиска для Home (All Items) таба.
+/// Search query for the Home (All Items) tab.
 final StateProvider<String> homeSearchQueryProvider =
     StateProvider<String>((Ref ref) => '');
 
-/// Query поиска для Wishlist таба.
+/// Search query for the Wishlist tab.
 final StateProvider<String> wishlistSearchQueryProvider =
     StateProvider<String>((Ref ref) => '');
 
-/// Query поиска для Tier Lists таба.
+/// Search query for the Tier Lists tab.
 final StateProvider<String> tierListsSearchQueryProvider =
     StateProvider<String>((Ref ref) => '');
 
-/// Query поиска для Collections таба.
+/// Search query for the Collections tab.
 final StateProvider<String> collectionsSearchQueryProvider =
     StateProvider<String>((Ref ref) => '');
 
-/// Query поиска для Search таба (API поиск IGDB/TMDB).
+/// Search query for the Search tab (IGDB/TMDB API search).
 final StateProvider<String> searchTabQueryProvider =
     StateProvider<String>((Ref ref) => '');
 
-/// Query поиска для Settings таба.
+/// Search query for the Settings tab.
 final StateProvider<String> settingsSearchQueryProvider =
     StateProvider<String>((Ref ref) => '');
 
-/// Общий [FocusNode] для TextField в [AppTopBar].
+/// Shared [FocusNode] for the [AppTopBar] text field.
 ///
-/// Живёт на уровне приложения: используется [AppTopBar] для поля ввода
-/// и [AppShell] для программной фокусировки при type-to-search
-/// (начал печатать — фокус в шапку).
+/// Lives at app level: used by [AppTopBar] for the input and by [AppShell]
+/// to focus programmatically on type-to-search (start typing — focus the bar).
 final Provider<FocusNode> appTopBarFocusProvider = Provider<FocusNode>((
   Ref ref,
 ) {
@@ -49,23 +47,23 @@ final Provider<FocusNode> appTopBarFocusProvider = Provider<FocusNode>((
   return node;
 });
 
-/// Описание контекста поиска для одного таба.
+/// Describes the search context for one tab.
 class SearchContext {
-  /// Создаёт [SearchContext].
+  /// Creates a [SearchContext].
   const SearchContext({
     required this.queryProvider,
     required this.hint,
   });
 
-  /// Куда пишется и откуда читается текущий query.
+  /// Where the current query is read from and written to.
   final StateProvider<String> queryProvider;
 
-  /// Placeholder в поле поиска для этого таба.
+  /// Placeholder shown in the search field for this tab.
   final String hint;
 }
 
-/// Возвращает контекст поиска для [tab] или `null`, если таб поиск
-/// пока не поддерживает (подключим в следующих этапах).
+/// Returns the search context for [tab], or `null` if the tab does not
+/// support search yet.
 SearchContext? searchContextFor(NavTab tab, BuildContext context) {
   final S loc = S.of(context);
   switch (tab) {

--- a/test/core/database/dao/calendar_entry_dao_test.dart
+++ b/test/core/database/dao/calendar_entry_dao_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/dao/calendar_entry_dao.dart';
+import 'package:tonkatsu_box/core/database/schema.dart';
+import 'package:tonkatsu_box/shared/models/calendar_entry.dart';
+import 'package:tonkatsu_box/shared/models/calendar_recurrence.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  late Database db;
+  late CalendarEntryDao dao;
+
+  CalendarEntry entry({
+    int externalId = 1,
+    DataSource source = DataSource.tmdb,
+    MediaType mediaType = MediaType.movie,
+    required DateTime startDate,
+    CalendarRecurrence recurrence = CalendarRecurrence.once,
+  }) =>
+      CalendarEntry(
+        externalId: externalId,
+        source: source,
+        mediaType: mediaType,
+        startDate: startDate,
+        recurrence: recurrence,
+        createdAt: DateTime(2024),
+      );
+
+  setUp(() async {
+    db = await factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 1,
+        onCreate: (Database db, int _) async {
+          await DatabaseSchema.createCalendarEntriesTable(db);
+          await DatabaseSchema.createCollectionItemsTable(db);
+        },
+      ),
+    );
+    dao = CalendarEntryDao(() async => db);
+  });
+
+  tearDown(() async => db.close());
+
+  group('CalendarEntryDao', () {
+    test('should report added after upsert', () async {
+      await dao.upsert(entry(startDate: DateTime(2026, 6, 1)));
+
+      expect(
+        await dao.isAdded(1, DataSource.tmdb, MediaType.movie),
+        isTrue,
+      );
+    });
+
+    test('should not collide across providers sharing an id', () async {
+      await dao.upsert(entry(
+        externalId: 5,
+        source: DataSource.anilist,
+        mediaType: MediaType.manga,
+        startDate: DateTime(2026, 6, 1),
+      ));
+
+      expect(
+        await dao.isAdded(5, DataSource.mangabaka, MediaType.manga),
+        isFalse,
+      );
+    });
+
+    test('should remove an entry', () async {
+      await dao.upsert(entry(startDate: DateTime(2026, 6, 1)));
+      await dao.remove(1, DataSource.tmdb, MediaType.movie);
+
+      expect(
+        await dao.isAdded(1, DataSource.tmdb, MediaType.movie),
+        isFalse,
+      );
+    });
+
+    test('should round-trip recurrence and date through getAll', () async {
+      await dao.upsert(entry(
+        startDate: DateTime(2026, 7, 15),
+        recurrence: CalendarRecurrence.weekly,
+      ));
+
+      final CalendarEntry stored = (await dao.getAll()).single;
+      expect(stored.recurrence, CalendarRecurrence.weekly);
+      expect(stored.startDate, DateTime(2026, 7, 15));
+    });
+
+    test('should delete past one-time entries but keep recurring ones',
+        () async {
+      final DateTime today = DateTime(2026, 6, 2);
+      await dao.upsert(entry(
+        externalId: 1,
+        startDate: DateTime(2026, 5, 1), // past one-time → removed
+      ));
+      await dao.upsert(entry(
+        externalId: 2,
+        startDate: DateTime(2026, 5, 1), // past but weekly → kept
+        recurrence: CalendarRecurrence.weekly,
+      ));
+      await dao.upsert(entry(
+        externalId: 3,
+        startDate: DateTime(2026, 7, 1), // future one-time → kept
+      ));
+
+      await dao.deletePastOnce(today);
+
+      final Set<int> ids =
+          (await dao.getAll()).map((CalendarEntry e) => e.externalId).toSet();
+      expect(ids, <int>{2, 3});
+    });
+
+    test('deleteOrphaned drops entries whose item left all collections',
+        () async {
+      await dao.upsert(entry(externalId: 1, startDate: DateTime(2026, 6, 1)));
+      await dao.upsert(entry(externalId: 2, startDate: DateTime(2026, 6, 1)));
+      await db.insert('collection_items', <String, Object?>{
+        'external_id': 1,
+        'media_type': MediaType.movie.value,
+        'added_at': 0,
+        'sort_order': 0,
+      });
+
+      await dao.deleteOrphaned();
+
+      final Set<int> ids =
+          (await dao.getAll()).map((CalendarEntry e) => e.externalId).toSet();
+      expect(ids, <int>{1});
+    });
+  });
+}

--- a/test/core/database/dao/tracked_release_dao_test.dart
+++ b/test/core/database/dao/tracked_release_dao_test.dart
@@ -18,8 +18,10 @@ void main() {
       inMemoryDatabasePath,
       options: OpenDatabaseOptions(
         version: 1,
-        onCreate: (Database db, int _) =>
-            DatabaseSchema.createTrackedReleasesTable(db),
+        onCreate: (Database db, int _) async {
+          await DatabaseSchema.createTrackedReleasesTable(db);
+          await DatabaseSchema.createCollectionItemsTable(db);
+        },
       ),
     );
     dao = TrackedReleaseDao(() async => db);
@@ -82,6 +84,24 @@ void main() {
         await dao.getTrackedKeys(),
         contains((7, 'tmdb', 'tv_show')),
       );
+    });
+
+    test('deleteOrphaned drops subscriptions whose item left all collections',
+        () async {
+      await dao.subscribe(1, DataSource.tmdb, MediaType.tvShow);
+      await dao.subscribe(2, DataSource.tmdb, MediaType.tvShow);
+      await db.insert('collection_items', <String, Object?>{
+        'external_id': 1,
+        'media_type': MediaType.tvShow.value,
+        'added_at': 0,
+        'sort_order': 0,
+      });
+
+      await dao.deleteOrphaned();
+
+      final Set<int> ids =
+          (await dao.getAll()).map((TrackedRelease r) => r.externalId).toSet();
+      expect(ids, <int>{1});
     });
   });
 }

--- a/test/core/database/dao/tv_show_dao_test.dart
+++ b/test/core/database/dao/tv_show_dao_test.dart
@@ -394,6 +394,52 @@ void main() {
       });
     });
 
+    group('getAllWatchedEpisodes', () {
+      test('returns deduped rows for backup', () async {
+        when(() => mockDb.rawQuery(any())).thenAnswer(
+          (_) async => <Map<String, Object?>>[
+            <String, Object?>{
+              'show_id': 200,
+              'season_number': 1,
+              'episode_number': 1,
+              'watched_at': 1705320000000,
+            },
+          ],
+        );
+
+        final List<Map<String, Object?>> rows =
+            await dao.getAllWatchedEpisodes();
+
+        expect(rows.single['show_id'], 200);
+      });
+    });
+
+    group('markEpisodeWatchedAt', () {
+      test('inserts with the explicit watched_at timestamp', () async {
+        when(() => mockDb.insert(
+              'watched_episodes',
+              any(),
+              conflictAlgorithm: ConflictAlgorithm.ignore,
+            )).thenAnswer((_) async => 1);
+
+        await dao.markEpisodeWatchedAt(1, 200, 2, 3, 1705320000000);
+
+        final VerificationResult captured = verify(
+          () => mockDb.insert(
+            'watched_episodes',
+            captureAny(),
+            conflictAlgorithm: ConflictAlgorithm.ignore,
+          ),
+        );
+        captured.called(1);
+        final Map<String, dynamic> data =
+            captured.captured.first as Map<String, dynamic>;
+        expect(data['watched_at'], 1705320000000);
+        expect(data['collection_id'], 1);
+        expect(data['show_id'], 200);
+      });
+    });
+
     group('markEpisodeWatched', () {
       test('inserts with ignore conflict', () async {
         when(

--- a/test/core/database/migrations/migration_v46_test.dart
+++ b/test/core/database/migrations/migration_v46_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v46.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  Future<Database> openOldDb() async {
+    return factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: 45),
+    );
+  }
+
+  group('MigrationV46', () {
+    test('should create the calendar_entries table', () async {
+      final Database db = await openOldDb();
+      await MigrationV46().migrate(db);
+
+      final List<Map<String, dynamic>> tables = await db.query(
+        'sqlite_master',
+        where: "type = 'table' AND name = 'calendar_entries'",
+      );
+
+      expect(tables, isNotEmpty);
+      await db.close();
+    });
+
+    test('should let the same id coexist across providers', () async {
+      final Database db = await openOldDb();
+      await MigrationV46().migrate(db);
+
+      await db.insert('calendar_entries', <String, Object?>{
+        'external_id': 10,
+        'source': 'anilist',
+        'media_type': 'manga',
+        'start_date': '2026-07-01',
+        'recurrence': 'weekly',
+        'created_at': 1,
+      });
+      await db.insert('calendar_entries', <String, Object?>{
+        'external_id': 10,
+        'source': 'mangabaka',
+        'media_type': 'manga',
+        'start_date': '2026-07-01',
+        'recurrence': 'once',
+        'created_at': 1,
+      });
+
+      expect((await db.query('calendar_entries')).length, 2);
+      await db.close();
+    });
+  });
+}

--- a/test/core/services/backup_service_test.dart
+++ b/test/core/services/backup_service_test.dart
@@ -7,6 +7,11 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/services/backup_service.dart';
 import 'package:tonkatsu_box/core/services/import_service.dart';
 import 'package:tonkatsu_box/core/services/xcoll_file.dart';
+import 'package:tonkatsu_box/shared/models/calendar_entry.dart';
+import 'package:tonkatsu_box/shared/models/calendar_recurrence.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
 
 import '../../helpers/test_helpers.dart';
 
@@ -63,6 +68,15 @@ void main() {
       registerFallbackValue(
         XcollFile(version: 3, name: 'x', author: 'x', created: DateTime(2025)),
       );
+      registerFallbackValue(DataSource.tmdb);
+      registerFallbackValue(CalendarEntry(
+        externalId: 0,
+        source: DataSource.tmdb,
+        mediaType: MediaType.movie,
+        startDate: DateTime(2025),
+        recurrence: CalendarRecurrence.once,
+        createdAt: DateTime(2025),
+      ));
     });
 
     setUp(() {
@@ -250,6 +264,121 @@ void main() {
       expect(r.success, isTrue);
       expect(r.collectionsRestored, 0); // import failed → not counted
       expect(r.itemsRestored, 0);
+    });
+
+    test('restores tracked releases and calendar entries from calendar.json',
+        () async {
+      final MockTrackedReleaseDao trackedDao = MockTrackedReleaseDao();
+      final MockCalendarEntryDao calendarDao = MockCalendarEntryDao();
+      when(() => database.trackedReleaseDao).thenReturn(trackedDao);
+      when(() => database.calendarEntryDao).thenReturn(calendarDao);
+      when(() => trackedDao.subscribe(any(), any(), any()))
+          .thenAnswer((_) async {});
+      when(() => calendarDao.upsert(any())).thenAnswer((_) async {});
+
+      const String calendarJson =
+          '{"tracked_releases":[{"external_id":1,"source":"tmdb",'
+          '"media_type":"tv_show","created_at":1}],'
+          '"calendar_entries":[{"external_id":2,"source":"igdb",'
+          '"media_type":"game","start_date":"2026-07-01",'
+          '"recurrence":"weekly","created_at":1}]}';
+      final String path =
+          writeZip(<String, String>{'calendar.json': calendarJson});
+
+      await makeService().restoreFromBackup(zipPath: path);
+
+      verify(() => trackedDao.subscribe(1, DataSource.tmdb, MediaType.tvShow))
+          .called(1);
+      verify(() => calendarDao.upsert(any())).called(1);
+    });
+
+    test('restores watch progress onto matching collection items', () async {
+      final MockTvShowDao tvDao = MockTvShowDao();
+      final MockCollectionDao collDao = MockCollectionDao();
+      when(() => database.tvShowDao).thenReturn(tvDao);
+      when(() => database.collectionDao).thenReturn(collDao);
+      when(() => collDao.findAllCollectionItems(
+            mediaType: MediaType.tvShow,
+            externalId: 200,
+          )).thenAnswer((_) async => <CollectionItem>[
+            createTestCollectionItem(
+              id: 1,
+              collectionId: 7,
+              mediaType: MediaType.tvShow,
+              externalId: 200,
+            ),
+          ]);
+      when(() => collDao.findAllCollectionItems(
+            mediaType: MediaType.animation,
+            externalId: 200,
+          )).thenAnswer((_) async => <CollectionItem>[]);
+      when(() => tvDao.markEpisodeWatchedAt(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+          )).thenAnswer((_) async {});
+
+      const String watchedJson =
+          '[{"show_id":200,"season_number":1,"episode_number":4,'
+          '"watched_at":1705320000000}]';
+      final String path = writeZip(
+        <String, String>{'watched_episodes.json': watchedJson},
+      );
+
+      await makeService().restoreFromBackup(zipPath: path);
+
+      verify(() => tvDao.markEpisodeWatchedAt(7, 200, 1, 4, 1705320000000))
+          .called(1);
+    });
+
+    test('looks up a show once when restoring several of its episodes',
+        () async {
+      final MockTvShowDao tvDao = MockTvShowDao();
+      final MockCollectionDao collDao = MockCollectionDao();
+      when(() => database.tvShowDao).thenReturn(tvDao);
+      when(() => database.collectionDao).thenReturn(collDao);
+      when(() => collDao.findAllCollectionItems(
+            mediaType: MediaType.tvShow,
+            externalId: 200,
+          )).thenAnswer((_) async => <CollectionItem>[
+            createTestCollectionItem(
+              id: 1,
+              collectionId: 7,
+              mediaType: MediaType.tvShow,
+              externalId: 200,
+            ),
+          ]);
+      when(() => collDao.findAllCollectionItems(
+            mediaType: MediaType.animation,
+            externalId: 200,
+          )).thenAnswer((_) async => <CollectionItem>[]);
+      when(() => tvDao.markEpisodeWatchedAt(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+          )).thenAnswer((_) async {});
+
+      const String watchedJson =
+          '[{"show_id":200,"season_number":1,"episode_number":1,'
+          '"watched_at":1},'
+          '{"show_id":200,"season_number":1,"episode_number":2,'
+          '"watched_at":2}]';
+      final String path = writeZip(
+        <String, String>{'watched_episodes.json': watchedJson},
+      );
+
+      await makeService().restoreFromBackup(zipPath: path);
+
+      verify(() => collDao.findAllCollectionItems(
+            mediaType: MediaType.tvShow,
+            externalId: 200,
+          )).called(1);
+      verify(() => tvDao.markEpisodeWatchedAt(any(), any(), any(), any(), any()))
+          .called(2);
     });
   });
 }

--- a/test/features/collections/providers/collections_provider_test.dart
+++ b/test/features/collections/providers/collections_provider_test.dart
@@ -435,11 +435,17 @@ void main() {
 
   group('CollectionItemsNotifier.removeItem', () {
     late MockTierListDao mockTierListDao;
+    late MockCalendarEntryDao mockCalendarDao;
+    late MockTrackedReleaseDao mockTrackedDao;
 
     setUp(() {
       mockTierListDao = MockTierListDao();
       when(() => mockTierListDao.getTierListById(any()))
           .thenAnswer((_) async => null);
+      mockCalendarDao = MockCalendarEntryDao();
+      mockTrackedDao = MockTrackedReleaseDao();
+      when(() => mockCalendarDao.deleteOrphaned()).thenAnswer((_) async {});
+      when(() => mockTrackedDao.deleteOrphaned()).thenAnswer((_) async {});
     });
 
     ProviderContainer createTierContainer({
@@ -456,6 +462,8 @@ void main() {
           collectionRepositoryProvider.overrideWithValue(mockRepository),
           sharedPreferencesProvider.overrideWithValue(sharedPrefs),
           tierListDaoProvider.overrideWithValue(mockTierListDao),
+          calendarEntryDaoProvider.overrideWithValue(mockCalendarDao),
+          trackedReleaseDaoProvider.overrideWithValue(mockTrackedDao),
         ],
       );
       addTearDown(container.dispose);

--- a/test/features/releases/providers/releases_provider_test.dart
+++ b/test/features/releases/providers/releases_provider_test.dart
@@ -5,6 +5,8 @@ import 'package:tonkatsu_box/core/api/tmdb_api.dart';
 import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/features/releases/models/release_event.dart';
 import 'package:tonkatsu_box/features/releases/providers/releases_provider.dart';
+import 'package:tonkatsu_box/shared/models/calendar_entry.dart';
+import 'package:tonkatsu_box/shared/models/calendar_recurrence.dart';
 import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/tracked_release.dart';
@@ -38,12 +40,28 @@ void main() {
     registerAllFallbacks();
     registerFallbackValue(<TvSeason>[]);
     registerFallbackValue(<TvEpisode>[]);
+    registerFallbackValue(DateTime(2024));
   });
 
   late MockDatabaseService mockDb;
   late MockTrackedReleaseDao trackedDao;
   late MockTvShowDao tvDao;
   late MockCollectionDao collDao;
+  late MockCalendarEntryDao calendarDao;
+
+  CalendarEntry calEntry(
+    int id,
+    DateTime start,
+    CalendarRecurrence recurrence,
+  ) =>
+      CalendarEntry(
+        externalId: id,
+        source: DataSource.tmdb,
+        mediaType: MediaType.movie,
+        startDate: start,
+        recurrence: recurrence,
+        createdAt: DateTime(2024),
+      );
 
   TrackedRelease tracked(int id, DataSource source, MediaType type) =>
       TrackedRelease(
@@ -70,12 +88,24 @@ void main() {
     trackedDao = MockTrackedReleaseDao();
     tvDao = MockTvShowDao();
     collDao = MockCollectionDao();
+    calendarDao = MockCalendarEntryDao();
     when(() => mockDb.trackedReleaseDao).thenReturn(trackedDao);
     when(() => mockDb.tvShowDao).thenReturn(tvDao);
     when(() => mockDb.collectionDao).thenReturn(collDao);
+    when(() => mockDb.calendarEntryDao).thenReturn(calendarDao);
+    when(() => calendarDao.deletePastOnce(any())).thenAnswer((_) async {});
+    when(() => calendarDao.getAll())
+        .thenAnswer((_) async => <CalendarEntry>[]);
+    when(() => trackedDao.getAll())
+        .thenAnswer((_) async => <TrackedRelease>[]);
 
     // By default every tracked show still lives in a collection.
     when(() => collDao.findCollectionItem(
+          collectionId: any(named: 'collectionId'),
+          mediaType: any(named: 'mediaType'),
+          externalId: any(named: 'externalId'),
+        )).thenAnswer((_) async => createTestCollectionItem());
+    when(() => collDao.findCollectionItemWithData(
           collectionId: any(named: 'collectionId'),
           mediaType: any(named: 'mediaType'),
           externalId: any(named: 'externalId'),
@@ -207,6 +237,58 @@ void main() {
       await container.read(releasesProvider.future);
 
       expect(container.read(releasesTodayCountProvider), 1);
+    });
+
+    test('manual once entry in the future produces one event', () async {
+      when(() => calendarDao.getAll()).thenAnswer((_) async => <CalendarEntry>[
+            calEntry(1, DateTime(2999, 1, 1), CalendarRecurrence.once),
+          ]);
+
+      final ReleasesCalendarData data =
+          await makeContainer().read(releasesProvider.future);
+
+      expect(data.trackedCount, 1);
+      expect(data.events.length, 1);
+      expect(data.events.single.season, isNull);
+      // Cache routing is carried from the hydrated item for poster caching.
+      expect(data.events.single.cacheImageId, isNotNull);
+      expect(data.events.single.imageType, isNotNull);
+    });
+
+    test('weekly entry expands to multiple upcoming occurrences', () async {
+      final DateTime start =
+          DateTime.now().subtract(const Duration(days: 30));
+      when(() => calendarDao.getAll()).thenAnswer((_) async => <CalendarEntry>[
+            calEntry(1, start, CalendarRecurrence.weekly),
+          ]);
+
+      final ReleasesCalendarData data =
+          await makeContainer().read(releasesProvider.future);
+      final DateTime now = DateTime.now();
+      final DateTime today = DateTime(now.year, now.month, now.day);
+
+      expect(data.events.length, greaterThan(1));
+      expect(
+        data.events.every((ReleaseEvent e) => !e.airDate.isBefore(today)),
+        isTrue,
+      );
+    });
+
+    test('manual entry is skipped when item is in no collection', () async {
+      when(() => calendarDao.getAll()).thenAnswer((_) async => <CalendarEntry>[
+            calEntry(1, DateTime(2999, 1, 1), CalendarRecurrence.once),
+          ]);
+      when(() => collDao.findCollectionItemWithData(
+            collectionId: any(named: 'collectionId'),
+            mediaType: any(named: 'mediaType'),
+            externalId: any(named: 'externalId'),
+          )).thenAnswer((_) async => null);
+
+      final ReleasesCalendarData data =
+          await makeContainer().read(releasesProvider.future);
+
+      expect(data.trackedCount, 1);
+      expect(data.events, isEmpty);
     });
 
     test('should skip episodes without a parseable air date', () async {

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -20,6 +20,7 @@ import 'package:tonkatsu_box/core/database/dao/game_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/movie_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/tracked_release_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/calendar_entry_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/custom_media_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/anime_dao.dart';
 import 'package:tonkatsu_box/core/services/discord_rpc_service.dart';
@@ -96,6 +97,8 @@ class MockMovieDao extends Mock implements MovieDao {}
 class MockTvShowDao extends Mock implements TvShowDao {}
 
 class MockTrackedReleaseDao extends Mock implements TrackedReleaseDao {}
+
+class MockCalendarEntryDao extends Mock implements CalendarEntryDao {}
 
 class MockVisualNovelDao extends Mock implements VisualNovelDao {}
 

--- a/test/shared/models/calendar_entry_test.dart
+++ b/test/shared/models/calendar_entry_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/calendar_entry.dart';
+import 'package:tonkatsu_box/shared/models/calendar_recurrence.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+void main() {
+  group('CalendarRecurrence', () {
+    test('should parse from value and fall back to once', () {
+      expect(CalendarRecurrence.fromValue('weekly'), CalendarRecurrence.weekly);
+      expect(CalendarRecurrence.fromValue('monthly'),
+          CalendarRecurrence.monthly);
+      expect(CalendarRecurrence.fromValue('bogus'), CalendarRecurrence.once);
+      expect(CalendarRecurrence.fromValue(null), CalendarRecurrence.once);
+    });
+  });
+
+  group('CalendarEntry', () {
+    test('formatDate pads to YYYY-MM-DD', () {
+      expect(CalendarEntry.formatDate(DateTime(2026, 7, 5)), '2026-07-05');
+    });
+
+    test('should round-trip through toDb / fromDb', () {
+      final CalendarEntry entry = CalendarEntry(
+        externalId: 42,
+        source: DataSource.mangabaka,
+        mediaType: MediaType.manga,
+        startDate: DateTime(2026, 7, 5),
+        recurrence: CalendarRecurrence.monthly,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+      );
+
+      final CalendarEntry restored = CalendarEntry.fromDb(entry.toDb());
+
+      expect(restored.externalId, 42);
+      expect(restored.source, DataSource.mangabaka);
+      expect(restored.mediaType, MediaType.manga);
+      expect(restored.startDate, DateTime(2026, 7, 5));
+      expect(restored.recurrence, CalendarRecurrence.monthly);
+      expect(restored.createdAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000000));
+    });
+  });
+}


### PR DESCRIPTION
Add a calendar bell on every item detail screen. TV shows and anime keep episode tracking; everything else uses a manual calendar entry (date + once/weekly/monthly recurrence) shown on the Releases calendar. Entries are keyed by item identity, backed up, and pruned when their item leaves all collections. Posters now use the on-disk image cache.