### PR TITLE
refactor: unify snackbars and drop Copy as List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,18 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Route every snackbar through the shared helper and shorten it**
+
+  Eight notifications still used a bare `ScaffoldMessenger.showSnackBar` (plain,
+  no icon, bottom-anchored) instead of `context.showSnack`. They now match every
+  other toast: a floating snackbar with a type icon and colored border. The
+  default visible duration also drops from 2 s to 750 ms so toasts feel snappier.
+
+  * lib/shared/extensions/snackbar_extension.dart (SnackBarExtension.showSnack): Default `duration` 2 s → 750 ms.
+  * lib/features/collections/widgets/collection_items_view.dart: Tag-update failure toast → `showSnack(..., SnackType.error)`.
+  * lib/features/settings/content/browse_collections_content.dart: Online-collection import success / download failures → `showSnack` (success / error).
+  * lib/features/settings/screens/gamepad_debug_screen.dart: Debug-log empty / export success / export failure → `showSnack` (info / success / error).
+
 - **Unify every confirmation prompt on one shared dialog**
 
   Delete / clear / reset confirmations used to be hand-rolled one by one, so
@@ -173,6 +185,21 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     snaps to a whole integer; drag removed; add −/+ nudge buttons (`step` 0.1,
     clamped 1.0–10.0, no-op at the bounds) and a private `_NudgeButton`;
     `naturalWidth` now accounts for the two buttons.
+
+### Removed
+
+- **Drop the "Copy as List" collection action**
+
+  The collection menu had both "Copy as List" (a one-tap copy using the default
+  `{name} ({year})` template) and "Copy as Text…" (the same template engine with
+  a dialog, token picker, sort and preview). "Copy as List" was just the dialog's
+  default with no options, so it is gone; "Copy as Text…" covers the same need
+  and still opens on the default template.
+
+  * lib/features/collections/widgets/collection_screen/collection_screen_fab.dart (CollectionMenuAction): Remove the `copyAsList` value and its menu item.
+  * lib/features/collections/screens/collection_screen.dart (_CollectionScreenState): Remove the `copyAsList` switch case and `_handleCopyAsList`.
+  * lib/features/collections/helpers/collection_actions.dart (CollectionActions.copyAsList): Removed, along with the now-unused `flutter/services.dart` and `text_export_service.dart` imports.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (copyAsList): Removed string.
 
 ### Fixed
 

--- a/docs/SNACKBAR.md
+++ b/docs/SNACKBAR.md
@@ -26,7 +26,7 @@ enum SnackType { success, error, info }
 context.showSnack(
   'Message text',
   type: SnackType.info,                        // default: info
-  duration: const Duration(seconds: 2),         // default: 2s
+  duration: const Duration(milliseconds: 750),  // default: 750ms
   action: SnackBarAction(label: 'UNDO', ...),   // optional
   loading: false,                                // default: false
 );
@@ -36,7 +36,7 @@ context.showSnack(
 |-----------|------|---------|-------------|
 | `message` | `String` | required | Text displayed in the notification |
 | `type` | `SnackType` | `info` | Controls icon and border color |
-| `duration` | `Duration` | 2 seconds | How long the notification stays visible |
+| `duration` | `Duration` | 750 ms | How long the notification stays visible |
 | `action` | `SnackBarAction?` | `null` | Optional button (e.g. "UNDO", "OK") |
 | `loading` | `bool` | `false` | Replaces the icon with a `CircularProgressIndicator` |
 

--- a/lib/features/collections/helpers/collection_actions.dart
+++ b/lib/features/collections/helpers/collection_actions.dart
@@ -1,7 +1,6 @@
 // Helper action methods for CollectionScreen.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/anilist_api.dart';
@@ -12,7 +11,6 @@ import '../../../core/api/vndb_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../../core/services/export_service.dart';
 import '../../../core/services/image_cache_service.dart';
-import '../../../core/services/text_export_service.dart';
 import '../../../core/services/xcoll_file.dart';
 import '../../../data/repositories/canvas_repository.dart';
 import '../../../l10n/app_localizations.dart';
@@ -305,40 +303,6 @@ class CollectionActions {
         );
       }
       return false;
-    }
-  }
-
-  /// Quick-copies the list to the clipboard (default template).
-  static Future<void> copyAsList({
-    required BuildContext context,
-    required WidgetRef ref,
-    required int? collectionId,
-  }) async {
-    final List<CollectionItem>? items =
-        ref.read(collectionItemsNotifierProvider(collectionId)).valueOrNull;
-
-    if (items == null || items.isEmpty) {
-      if (context.mounted) {
-        context.showSnack('Items not loaded yet', type: SnackType.error);
-      }
-      return;
-    }
-
-    final TextExportService service = TextExportService();
-    final String text = service.applyTemplate(
-      TextExportService.defaultTemplate,
-      items,
-      animeMangaTitleLanguage:
-          ref.read(sharedPreferencesProvider).animeMangaTitleLanguage,
-    );
-
-    await Clipboard.setData(ClipboardData(text: text));
-
-    if (context.mounted) {
-      context.showSnack(
-        S.of(context).copiedToClipboard(items.length),
-        type: SnackType.success,
-      );
     }
   }
 

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -49,18 +49,14 @@ import '../../tier_lists/screens/tier_list_detail_screen.dart';
 import '../../tier_lists/providers/tier_lists_provider.dart';
 import 'item_detail_screen.dart';
 
-/// Экран детального просмотра коллекции.
 class CollectionScreen extends ConsumerStatefulWidget {
-  /// Создаёт [CollectionScreen].
   const CollectionScreen({
     required this.collectionId,
     super.key,
   });
 
-  /// ID коллекции (null для uncategorized).
   final int? collectionId;
 
-  /// Группа хоткеев этого экрана для легенды F1.
   static const ShortcutGroup shortcutGroup = ShortcutGroup(
     title: 'Коллекция',
     entries: <ShortcutEntry>[
@@ -97,17 +93,14 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
   ItemStatus? get _effectiveStatusForChevrons =>
       _filterStatus ?? (_isTableMode ? _tableFilterStatus : null);
 
-  /// Реальная возможность редактирования с учётом режима просмотра.
+  // Effective editability considering view mode.
   bool get _effectiveIsEditable =>
       (_isUncategorized || (_collection != null && _collection!.isEditable)) &&
       !_isViewModeLocked;
 
-  /// Может ли пользователь редактировать элементы.
   bool get _canEdit =>
       _isUncategorized || (_collection != null && _collection!.isEditable);
 
-  /// Название для хлебных крошек и заголовка.
-  /// Является ли это экраном uncategorized элементов.
   bool get _isUncategorized => widget.collectionId == null;
 
   @override
@@ -391,7 +384,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             <CollectionTag>[])
         : <CollectionTag>[];
 
-    // Убираем удалённые теги из фильтра.
     final Set<int> validTagIds = <int>{
       for (final CollectionTag tag in tags) tag.id,
     };
@@ -409,8 +401,8 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     final String? heroAbsPath = (richEnabled && heroFile != null)
         ? ref.watch(collectionHeroServiceProvider).resolve(heroFile)
         : null;
-    // Rich-баннер применяется для любой коллекции (кроме uncategorized),
-    // если тогл включён — стабильный темплейт независимо от наличия hero.
+    // Rich banner applies to any collection except uncategorized when the
+    // toggle is on, giving a stable template regardless of whether a hero exists.
     final bool isRich = richEnabled && !_isUncategorized;
 
     final Widget? heroHeader = isRich
@@ -498,8 +490,8 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
               )
             : null;
 
-    // Rich vs classic теперь различаются только наличием `heroHeader`
-    // внутри `CollectionItemsView` — layout одинаковый.
+    // Rich vs classic now differ only by the presence of heroHeader inside
+    // CollectionItemsView; the layout is identical.
     return Row(
       children: <Widget>[
         Expanded(child: itemsView),
@@ -521,7 +513,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     );
   }
 
-  /// Переключает режим отображения: grid → table → grid.
   void _handleCycleViewMode() {
     setState(() {
       if (_isGridMode) {
@@ -555,8 +546,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
         _handleCreateTierList();
       case CollectionMenuAction.manageTags:
         TagManagementDialog.show(context, widget.collectionId!);
-      case CollectionMenuAction.copyAsList:
-        _handleCopyAsList();
       case CollectionMenuAction.copyAsText:
         _handleCopyAsText();
       case CollectionMenuAction.export:
@@ -572,8 +561,8 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     final CustomItemData? data = await CreateCustomItemDialog.show(context);
     if (data == null || !mounted) return;
 
-    // Для локальных файлов coverUrl оставляем null —
-    // файл будет скопирован в кэш через addCustomItem.
+    // For local files coverUrl stays null; the file is copied into the cache
+    // via addCustomItem.
     final CustomMedia customMedia = CustomMedia(
       id: 0,
       title: data.title,
@@ -609,7 +598,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       collection: _collection!,
     );
     if (changed && mounted) {
-      // Перечитаем коллекцию — могло измениться имя/обложка/описание.
       final Collection? updated = await ref
           .read(collectionRepositoryProvider)
           .getById(widget.collectionId!);
@@ -652,14 +640,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     if (deleted && mounted) {
       Navigator.of(context).pop();
     }
-  }
-
-  Future<void> _handleCopyAsList() async {
-    await CollectionActions.copyAsList(
-      context: context,
-      ref: ref,
-      collectionId: widget.collectionId,
-    );
   }
 
   Future<void> _handleCopyAsText() async {
@@ -728,7 +708,6 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     final ImportResult result = importResult!;
 
     if (result.success) {
-      // Обновляем элементы коллекции и статистику
       ref.invalidate(
         collectionItemsNotifierProvider(widget.collectionId),
       );

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -4,6 +4,7 @@ import 'package:logging/logging.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/constants/platform_features.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/collection_sort_mode.dart';
 import '../../../shared/models/collection_tag.dart';
@@ -511,10 +512,7 @@ class CollectionItemsView extends ConsumerWidget {
     }).catchError((Object error, StackTrace stack) {
       _log.warning('Failed to set tag on item ${item.id}', error, stack);
       if (context.mounted) {
-        final S l = S.of(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l.tagUpdateFailed)),
-        );
+        context.showSnack(S.of(context).tagUpdateFailed, type: SnackType.error);
       }
     });
   }

--- a/lib/features/collections/widgets/collection_screen/collection_screen_fab.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_screen_fab.dart
@@ -10,7 +10,6 @@ enum CollectionMenuAction {
   rename,
   tierList,
   manageTags,
-  copyAsList,
   copyAsText,
   export,
   import,
@@ -109,11 +108,6 @@ class CollectionScreenFab extends StatelessWidget {
         icon: Icons.label_outlined,
         label: l.tagManage,
         onTap: () => onMenuAction(CollectionMenuAction.manageTags),
-      ),
-      DraggableFabItem(
-        icon: Icons.content_copy,
-        label: l.copyAsList,
-        onTap: () => onMenuAction(CollectionMenuAction.copyAsList),
       ),
       DraggableFabItem(
         icon: Icons.text_snippet_outlined,

--- a/lib/features/collections/widgets/copy_as_text_dialog.dart
+++ b/lib/features/collections/widgets/copy_as_text_dialog.dart
@@ -1,5 +1,3 @@
-// Диалог копирования коллекции как текста с шаблоном и preview.
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,10 +11,7 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../settings/providers/settings_provider.dart';
 
-/// Показывает диалог копирования коллекции как текста.
-///
-/// [items] — элементы коллекции для экспорта.
-/// Возвращает `true` если данные были скопированы в буфер обмена.
+/// Returns `true` when the collection text was copied to the clipboard.
 Future<bool?> showCopyAsTextDialog({
   required BuildContext context,
   required List<CollectionItem> items,
@@ -41,10 +36,7 @@ class _CopyAsTextDialogState extends ConsumerState<_CopyAsTextDialog> {
   late final TextEditingController _templateController;
   TextExportSortMode _sortMode = TextExportSortMode.current;
 
-  /// Максимальное количество строк в preview.
   static const int _previewMaxLines = 5;
-
-  /// Ключ для сохранения шаблона в SharedPreferences.
   static const String _templatePrefKey = 'text_export_template';
 
   @override
@@ -137,7 +129,7 @@ class _CopyAsTextDialogState extends ConsumerState<_CopyAsTextDialog> {
     final int end = value.selection.extentOffset;
     final String tokenStr = '{$token}';
 
-    // Если курсор валидный — вставляем в позицию, иначе — в конец
+    // Insert at the caret when the selection is valid, otherwise append.
     if (start >= 0 && end >= 0) {
       final String newText =
           value.text.replaceRange(start, end, tokenStr);
@@ -248,7 +240,7 @@ class _CopyAsTextDialogState extends ConsumerState<_CopyAsTextDialog> {
 
             const SizedBox(height: AppSpacing.md),
 
-            // Sort by — PopupMenuButton вместо DropdownButtonFormField
+            // Sort by
             Wrap(
               spacing: AppSpacing.sm,
               crossAxisAlignment: WrapCrossAlignment.center,

--- a/lib/features/settings/content/browse_collections_content.dart
+++ b/lib/features/settings/content/browse_collections_content.dart
@@ -1,5 +1,3 @@
-// UI для каталога онлайн-коллекций: фильтры, список, скачивание.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -8,6 +6,7 @@ import '../../../core/services/collection_browser_service.dart';
 import '../../../core/services/import_service.dart';
 import '../../../core/services/xcoll_file.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -21,12 +20,9 @@ import '../../collections/providers/collections_provider.dart';
 import '../../home/providers/all_items_provider.dart';
 import '../../wishlist/providers/wishlist_provider.dart';
 
-/// Контент экрана каталога онлайн-коллекций.
 class BrowseCollectionsContent extends ConsumerStatefulWidget {
-  /// Создаёт [BrowseCollectionsContent].
   const BrowseCollectionsContent({super.key});
 
-  /// Обновляет индекс коллекций (вызывается из AppBar).
   static void refresh(BuildContext context) {
     final ProviderContainer container = ProviderScope.containerOf(context);
     container.read(collectionsIndexProvider.notifier).refresh();
@@ -258,9 +254,7 @@ class _BrowseCollectionsContentState
     ref.read(browserCategoryFilterProvider.notifier).state = result;
   }
 
-  /// Показывает диалог с поиском для выбора одного значения.
-  ///
-  /// Возвращает выбранный id или null (сброс).
+  /// Returns the chosen id, or null when reset/cancelled.
   Future<String?> _showSearchablePicker({
     required String title,
     required List<_PickerItem> items,
@@ -315,7 +309,6 @@ class _BrowseCollectionsContentState
   Future<void> _download(S l, RemoteCollection collection) async {
     if (_downloadingIds.contains(collection.id)) return;
 
-    // Показываем диалог выбора целевой коллекции.
     final _ImportTarget? target = await showDialog<_ImportTarget>(
       context: context,
       builder: (BuildContext context) => _ImportTargetDialog(
@@ -350,30 +343,25 @@ class _BrowseCollectionsContentState
         ref.invalidate(canvasNotifierProvider(cid));
         ref.invalidate(allItemsNotifierProvider);
         ref.invalidate(wishlistProvider);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              l.browseCollectionsImportSuccess(collection.name),
-            ),
-          ),
+        context.showSnack(
+          l.browseCollectionsImportSuccess(collection.name),
+          type: SnackType.success,
         );
       } else if (result.error != null) {
         _log.warning(
           'Collection import returned error: ${result.error}',
         );
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l.browseCollectionsDownloadFailedGeneric),
-          ),
+        context.showSnack(
+          l.browseCollectionsDownloadFailedGeneric,
+          type: SnackType.error,
         );
       }
     } on Exception catch (e, stack) {
       _log.warning('Failed to download collection', e, stack);
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(l.browseCollectionsDownloadFailedGeneric),
-        ),
+      context.showSnack(
+        l.browseCollectionsDownloadFailedGeneric,
+        type: SnackType.error,
       );
     } finally {
       if (mounted) {
@@ -383,19 +371,13 @@ class _BrowseCollectionsContentState
   }
 }
 
-// ---------------------------------------------------------------------------
-// Вспомогательные виджеты
-// ---------------------------------------------------------------------------
-
-/// Результат выбора целевой коллекции для импорта.
 class _ImportTarget {
   const _ImportTarget({this.collectionId});
 
-  /// null — создать новую коллекцию, иначе ID существующей.
+  /// null means create a new collection; otherwise an existing collection id.
   final int? collectionId;
 }
 
-/// Диалог выбора: создать новую коллекцию или импортировать в существующую.
 class _ImportTargetDialog extends ConsumerStatefulWidget {
   const _ImportTargetDialog({required this.collectionName});
 
@@ -526,10 +508,9 @@ class _ImportTargetDialogState extends ConsumerState<_ImportTargetDialog> {
   }
 }
 
-/// Sentinel для сброса фильтра (отличает "All" от закрытия диалога).
+/// Sentinel that distinguishes "reset to All" from dismissing the dialog.
 const String _resetSentinel = '__browse_reset__';
 
-/// Кнопка-дропдаун для фильтра.
 class _FilterButton extends StatelessWidget {
   const _FilterButton({
     required this.label,
@@ -581,7 +562,6 @@ class _FilterButton extends StatelessWidget {
   }
 }
 
-/// Элемент для searchable picker.
 class _PickerItem {
   const _PickerItem({required this.id, required this.label});
 
@@ -589,7 +569,6 @@ class _PickerItem {
   final String label;
 }
 
-/// Диалог с полем поиска для выбора платформы/категории.
 class _SearchablePickerDialog extends StatefulWidget {
   const _SearchablePickerDialog({
     required this.title,

--- a/lib/features/settings/screens/gamepad_debug_screen.dart
+++ b/lib/features/settings/screens/gamepad_debug_screen.dart
@@ -1,5 +1,3 @@
-// Debug-экран для отображения raw событий геймпада.
-
 import 'dart:async';
 import 'dart:io';
 
@@ -12,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../../../core/services/gamepad_service.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/gamepad/gamepad_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -19,17 +18,9 @@ import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/draggable_fab.dart';
 import '../../../shared/widgets/sub_screen_title_bar.dart';
 
-/// Максимальное количество событий в логе.
 const int _maxEvents = 100;
 
-/// Debug-экран для тестирования подключённого геймпада.
-///
-/// Показывает:
-/// - Сырые события от [Gamepads.events] в реальном времени
-/// - Обработанные события от [GamepadService]
-/// - Ключи кнопок и значения для маппинга
 class GamepadDebugScreen extends ConsumerStatefulWidget {
-  /// Создаёт [GamepadDebugScreen].
   const GamepadDebugScreen({super.key});
 
   @override
@@ -102,9 +93,7 @@ class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
 
     if (_rawEvents.isEmpty && _serviceEvents.isEmpty) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l.debugLogEmpty)),
-        );
+        context.showSnack(l.debugLogEmpty);
       }
       return;
     }
@@ -138,8 +127,9 @@ class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
         final String filePath = '${dir.path}/gamepad_log_$timestamp.txt';
         await File(filePath).writeAsString(content);
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l.debugLogExported(filePath))),
+          context.showSnack(
+            l.debugLogExported(filePath),
+            type: SnackType.success,
           );
         }
       } else {
@@ -152,16 +142,15 @@ class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
         if (outputPath == null) return;
         await File(outputPath).writeAsString(content);
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l.debugLogExported(outputPath))),
+          context.showSnack(
+            l.debugLogExported(outputPath),
+            type: SnackType.success,
           );
         }
       }
     } on Exception catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(e.toString())),
-        );
+        context.showSnack(e.toString(), type: SnackType.error);
       }
     }
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1725,7 +1725,6 @@
   "raStatsPoints": "points",
   "raStatsUnlocked": "Unlocked",
 
-  "copyAsList": "Copy as List",
   "copyAsText": "Copy as Text…",
   "copiedToClipboard": "Copied {count} items to clipboard",
   "@copiedToClipboard": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6751,12 +6751,6 @@ abstract class S {
   /// **'Unlocked'**
   String get raStatsUnlocked;
 
-  /// No description provided for @copyAsList.
-  ///
-  /// In en, this message translates to:
-  /// **'Copy as List'**
-  String get copyAsList;
-
   /// No description provided for @copyAsText.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3738,9 +3738,6 @@ class SEn extends S {
   String get raStatsUnlocked => 'Unlocked';
 
   @override
-  String get copyAsList => 'Copy as List';
-
-  @override
   String get copyAsText => 'Copy as Text…';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3783,9 +3783,6 @@ class SRu extends S {
   String get raStatsUnlocked => 'Получено';
 
   @override
-  String get copyAsList => 'Копировать списком';
-
-  @override
   String get copyAsText => 'Копировать как текст…';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1465,7 +1465,6 @@
   "raStatsPoints": "очков",
   "raStatsUnlocked": "Получено",
 
-  "copyAsList": "Копировать списком",
   "copyAsText": "Копировать как текст…",
   "copiedToClipboard": "{count,plural, =1{Скопирован 1 тайтл} few{Скопировано {count} тайтла} other{Скопировано {count} тайтлов}}",
   "textExportTemplate": "Шаблон",

--- a/lib/shared/extensions/snackbar_extension.dart
+++ b/lib/shared/extensions/snackbar_extension.dart
@@ -1,37 +1,24 @@
-// Extension для показа compact SnackBar уведомлений.
-
 import 'package:flutter/material.dart';
 
 import '../constants/platform_features.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_spacing.dart';
 
-/// Тип уведомления SnackBar.
 enum SnackType {
-  /// Успешная операция (зелёный акцент).
   success,
-
-  /// Ошибка или сбой (красный акцент).
   error,
-
-  /// Информационное уведомление (brand акцент).
   info,
 }
 
-/// Extension на [BuildContext] для единого показа compact SnackBar.
-///
-/// Все уведомления в приложении должны использовать [showSnack].
-/// Для изменения стиля достаточно изменить этот файл.
+/// Single entry point for app snackbars; change styling here to change it
+/// everywhere.
 extension SnackBarExtension on BuildContext {
-  /// Показывает compact floating SnackBar.
-  ///
-  /// Автоматически скрывает предыдущий SnackBar.
-  /// По умолчанию [type] = [SnackType.info], [duration] = 2 секунды.
-  /// [loading] заменяет иконку на [CircularProgressIndicator].
+  /// Hides any current snackbar first. [loading] swaps the type icon for a
+  /// spinner.
   void showSnack(
     String message, {
     SnackType type = SnackType.info,
-    Duration duration = const Duration(seconds: 2),
+    Duration duration = const Duration(milliseconds: 750),
     SnackBarAction? action,
     bool loading = false,
   }) {
@@ -105,7 +92,6 @@ extension SnackBarExtension on BuildContext {
     );
   }
 
-  /// Скрывает текущий SnackBar (если есть).
   void hideSnack() {
     ScaffoldMessenger.of(this).hideCurrentSnackBar();
   }

--- a/test/shared/extensions/snackbar_extension_test.dart
+++ b/test/shared/extensions/snackbar_extension_test.dart
@@ -18,7 +18,7 @@ void main() {
       );
 
   group('SnackType', () {
-    test('содержит success, error, info', () {
+    test('should expose success, error and info values', () {
       expect(SnackType.values.length, 3);
       expect(SnackType.values, contains(SnackType.success));
       expect(SnackType.values, contains(SnackType.error));
@@ -27,7 +27,7 @@ void main() {
   });
 
   group('showSnack', () {
-    testWidgets('показывает SnackBar с текстом сообщения',
+    testWidgets('should show a SnackBar with the message text',
         (WidgetTester tester) async {
       late BuildContext savedContext;
       await tester.pumpWidget(
@@ -109,7 +109,7 @@ void main() {
       expect(find.byIcon(Icons.info_outline), findsOneWidget);
     });
 
-    testWidgets('loading заменяет иконку на CircularProgressIndicator',
+    testWidgets('should replace the icon with a spinner when loading',
         (WidgetTester tester) async {
       late BuildContext ctx;
       await tester.pumpWidget(MaterialApp(
@@ -158,7 +158,7 @@ void main() {
       expect(find.text('First message'), findsNothing);
     });
 
-    testWidgets('action callback вызывается при tap',
+    testWidgets('should invoke the action callback when tapped',
         (WidgetTester tester) async {
       bool actionPressed = false;
       late BuildContext ctx;
@@ -186,7 +186,7 @@ void main() {
       expect(actionPressed, isTrue);
     });
 
-    testWidgets('custom duration пробрасывается в SnackBar',
+    testWidgets('should pass a custom duration to the SnackBar',
         (WidgetTester tester) async {
       late BuildContext ctx;
       await tester.pumpWidget(MaterialApp(
@@ -212,7 +212,7 @@ void main() {
   });
 
   group('hideSnack', () {
-    testWidgets('скрывает текущий SnackBar', (WidgetTester tester) async {
+    testWidgets('should hide the current SnackBar', (WidgetTester tester) async {
       late BuildContext savedContext;
       await tester.pumpWidget(MaterialApp(
         localizationsDelegates: S.localizationsDelegates,
@@ -237,7 +237,7 @@ void main() {
       expect(find.text('Visible'), findsNothing);
     });
 
-    testWidgets('не кидает исключение когда SnackBar не виден',
+    testWidgets('should not throw when no SnackBar is visible',
         (WidgetTester tester) async {
       late BuildContext savedContext;
       await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
Route the last 8 raw ScaffoldMessenger.showSnackBar calls through the shared context.showSnack helper and shorten the default snackbar duration from 2s to 750ms. Remove the "Copy as List" collection action (enum value, FAB item, handler, CollectionActions.copyAsList, l10n keys) — it was just Copy as Text's default template with no options. Clean up Russian comments in the touched files.