### PR TITLE
fix(navigation): avoid duplicate-GlobalKey crash on database reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,17 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Fixed
 
+- **Stop the duplicate-GlobalKey crash when resetting the database**
+
+  Resetting the database (Settings → Database) recreates the app shell with
+  `pushReplacement`, so two shells were briefly alive at once. The navigation
+  buttons carried stable app-wide GlobalKeys (used only by the welcome menu
+  tour), and the two shells reused them, crashing the widget tree. The tour
+  keys are now attached only while the menu tour is running.
+
+  * lib/shared/navigation/app_bottom_bar.dart (AppBottomBar.build), app_sidebar.dart (AppSidebar.build), app_top_bar.dart (_AppTopBarState.build): Gate `tourKeys.keyFor(tab)` behind `menuTourControllerProvider`.
+  * test/shared/navigation/app_bottom_bar_tour_keys_test.dart: New — two bars coexist without a duplicate-key crash when the tour is off; keys attached while it runs.
+
 - **Offer every media type when creating a custom item**
 
   The custom-item dialog's type chooser was a hardcoded list that had silently

--- a/lib/shared/navigation/app_bottom_bar.dart
+++ b/lib/shared/navigation/app_bottom_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/releases/providers/releases_provider.dart';
+import '../../features/welcome/providers/menu_tour_provider.dart';
 import '../../features/wishlist/providers/wishlist_provider.dart';
 import '../theme/app_colors.dart';
 import 'liquid_indicator.dart';
@@ -37,6 +38,10 @@ class AppBottomBar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final int wishlistCount = ref.watch(activeWishlistCountProvider);
     final NavTourKeys tourKeys = ref.watch(navTourKeysProvider);
+    // The tour keys are stable app-wide singletons; attach them only while the
+    // menu tour runs. Otherwise two shells alive at once (e.g. the DB-reset
+    // `pushReplacement`) would reuse the same GlobalKeys and crash the tree.
+    final bool tourActive = ref.watch(menuTourControllerProvider);
 
     final List<NavDestination> destinations = buildNavDestinations(
       context: context,
@@ -74,7 +79,7 @@ class AppBottomBar extends ConsumerWidget {
                       children: <Widget>[
                         for (final NavDestination d in destinations)
                           NavIconButton(
-                            key: tourKeys.keyFor(d.tab),
+                            key: tourActive ? tourKeys.keyFor(d.tab) : null,
                             destination: d,
                             active: d.tab == selectedTab,
                             width: itemWidth,

--- a/lib/shared/navigation/app_sidebar.dart
+++ b/lib/shared/navigation/app_sidebar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/releases/providers/releases_provider.dart';
+import '../../features/welcome/providers/menu_tour_provider.dart';
 import '../../features/wishlist/providers/wishlist_provider.dart';
 import '../theme/app_colors.dart';
 import 'liquid_indicator.dart';
@@ -45,6 +46,10 @@ class AppSidebar extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final int wishlistCount = ref.watch(activeWishlistCountProvider);
     final NavTourKeys tourKeys = ref.watch(navTourKeysProvider);
+    // Tour keys are app-wide singletons; attach only during the menu tour so two
+    // shells alive at once (DB-reset `pushReplacement`) can't reuse the same
+    // GlobalKeys and crash the tree.
+    final bool tourActive = ref.watch(menuTourControllerProvider);
 
     final List<NavDestination> destinations = buildNavDestinations(
       context: context,
@@ -91,7 +96,7 @@ class AppSidebar extends ConsumerWidget {
                           children: <Widget>[
                             for (final NavDestination d in destinations)
                               NavIconButton(
-                                key: tourKeys.keyFor(d.tab),
+                                key: tourActive ? tourKeys.keyFor(d.tab) : null,
                                 destination: d,
                                 active: d.tab == selectedTab,
                                 width: kAppSidebarWidth,

--- a/lib/shared/navigation/app_top_bar.dart
+++ b/lib/shared/navigation/app_top_bar.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/update_service.dart';
+import '../../features/welcome/providers/menu_tour_provider.dart';
 import '../constants/platform_features.dart';
 import '../theme/app_assets.dart';
 import '../theme/app_colors.dart';
@@ -186,7 +187,11 @@ class _AppTopBarState extends ConsumerState<AppTopBar> {
           const ServiceBadges(),
           const SizedBox(width: AppSpacing.sm),
           _SettingsButton(
-            key: ref.watch(navTourKeysProvider).keyFor(NavTab.settings),
+            // Tour key only while the menu tour runs — otherwise two shells
+            // alive at once (DB-reset `pushReplacement`) reuse it and crash.
+            key: ref.watch(menuTourControllerProvider)
+                ? ref.watch(navTourKeysProvider).keyFor(NavTab.settings)
+                : null,
             active: settingsActive,
             pulsing: hasUpdate,
             onTap: widget.onSettingsTap,

--- a/test/shared/navigation/app_bottom_bar_tour_keys_test.dart
+++ b/test/shared/navigation/app_bottom_bar_tour_keys_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/releases/providers/releases_provider.dart';
+import 'package:tonkatsu_box/features/welcome/providers/menu_tour_provider.dart';
+import 'package:tonkatsu_box/features/wishlist/providers/wishlist_provider.dart';
+import 'package:tonkatsu_box/l10n/app_localizations.dart';
+import 'package:tonkatsu_box/shared/navigation/app_bottom_bar.dart';
+import 'package:tonkatsu_box/shared/navigation/nav_tab.dart';
+import 'package:tonkatsu_box/shared/navigation/nav_tour_keys.dart';
+
+void main() {
+  group('AppBottomBar tour keys', () {
+    List<Override> overrides() => <Override>[
+          activeWishlistCountProvider.overrideWithValue(0),
+          releasesTodayCountProvider.overrideWithValue(0),
+        ];
+
+    Widget bar() => AppBottomBar(
+          selectedTab: NavTab.home,
+          onDestinationSelected: (_) {},
+        );
+
+    Widget wrap(Widget child, {required ProviderContainer container}) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Scaffold(body: child),
+        ),
+      );
+    }
+
+    testWidgets(
+        'two bars coexist without a duplicate-key crash when the tour is off',
+        (WidgetTester tester) async {
+      final ProviderContainer container =
+          ProviderContainer(overrides: overrides());
+      addTearDown(container.dispose);
+
+      // Mimics the DB-reset `pushReplacement`: the old and new shells (each
+      // with a nav bar) are briefly alive at once.
+      await tester.pumpWidget(wrap(
+        Column(children: <Widget>[bar(), bar()]),
+        container: container,
+      ));
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('attaches the stable tour keys while the menu tour runs',
+        (WidgetTester tester) async {
+      final ProviderContainer container =
+          ProviderContainer(overrides: overrides());
+      addTearDown(container.dispose);
+      container.read(menuTourControllerProvider.notifier).start();
+      final NavTourKeys keys = container.read(navTourKeysProvider);
+
+      await tester.pumpWidget(wrap(bar(), container: container));
+
+      expect(find.byKey(keys.keyFor(NavTab.home)), findsOneWidget);
+    });
+
+    testWidgets('does not attach the tour keys when the tour is off',
+        (WidgetTester tester) async {
+      final ProviderContainer container =
+          ProviderContainer(overrides: overrides());
+      addTearDown(container.dispose);
+      final NavTourKeys keys = container.read(navTourKeysProvider);
+
+      await tester.pumpWidget(wrap(bar(), container: container));
+
+      expect(find.byKey(keys.keyFor(NavTab.home)), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Resetting the DB recreates the app shell via `pushReplacement`, so two shells were briefly alive at once. The nav buttons carried stable app-wide GlobalKeys (used only by the welcome menu tour), and both shells reused them → "Duplicate GlobalKeys detected" crash. Attach the tour keys only while the menu tour runs; the overlay's existing retry loop tolerates the deferred attach.