### PR TITLE
refactor(db): migrations as the single source of truth

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -104,31 +104,38 @@ final databaseServiceProvider = Provider<DatabaseService>((ref) => DatabaseServi
 ### База данных (`lib/core/database/`)
 - SQLite через sqflite_common_ffi
 - Провайдер: `databaseServiceProvider`
-- Актуальное количество таблиц и номер миграции смотреть в `schema.dart` / `database_service.dart` (`version:` в `_initDatabase()`) — не доверять этому файлу
+- Номер версии смотреть в `database_service.dart` (`version:` в `_initDatabase()` = версия последней миграции)
 
-#### Структура файлов БД:
+#### Модель миграций (единый источник правды)
+**Миграции — единственный источник схемы.** И свежая установка, и апгрейд строят БД одним и тем же способом — прогоном цепочки миграций по порядку:
+- `_onCreate` (свежая БД) → гоняет **всю** цепочку `MigrationRegistry.all` (v1..N) с нуля.
+- `_onUpgrade` (существующая БД) → гоняет `MigrationRegistry.pending(oldVersion)`.
+
+Никакого `createAll`/«полной схемы одним куском» в продакшене нет — это раньше был второй, руками-синхронизируемый источник, который дрейфовал от миграций (удалён). Прогон цепочки с пустой БД обязан давать ровно ту же схему, что у реально обновлённых БД — это проверяет `test/core/database/schema_parity_test.dart` (golden-снимок схемы).
+
+`schema.dart` (`DatabaseSchema`) остаётся только как набор `create*Table` DDL-хелперов, которые зовут отдельные миграции (и сетап тестов). Эти хелперы **иммутабельны наравне с миграциями**: добавить колонку в существующий `create*Table` нельзя — он отражает форму таблицы на момент её создающей миграции, и правка сломает replay.
+
 ```
 lib/core/database/
-├── database_service.dart          # CRUD-операции, _initDatabase, _onCreate, _onUpgrade
-├── schema.dart                    # DatabaseSchema — все CREATE TABLE (18 методов + createAll)
+├── database_service.dart          # CRUD + _initDatabase + _onCreate/_onUpgrade (оба гоняют цепочку)
 └── migrations/
-    ├── migration.dart             # Абстрактный класс Migration (version, description, migrate)
-    ├── migration_registry.dart    # MigrationRegistry.all / .pending(oldVersion)
-    ├── migration_v2.dart          # MigrationV2..MigrationVN — по файлу на версию
-    └── ...
+    ├── migration.dart             # Абстрактный Migration (version, description, migrate) + addColumnIfAbsent
+    ├── migration_registry.dart    # MigrationRegistry.all (v1..N) / .pending(oldVersion)
+    ├── migration_v1.dart          # Базовая схема (стартовая точка цепочки)
+    └── migration_vN.dart          # по файлу на версию
 ```
 
-#### Правила работы с миграциями:
-- **Новая таблица** → добавить метод `create*Table` в `DatabaseSchema` (`schema.dart`)
-- **Новая миграция** → создать `migration_vN.dart` с классом `MigrationVN extends Migration`
-- Зарегистрировать миграцию в `MigrationRegistry.all` (`migration_registry.dart`)
-- Увеличить `version` в `_initDatabase()` (`database_service.dart`)
-- Если миграция создаёт новую таблицу — вызывать `DatabaseSchema.create*Table(db)`, а **не** дублировать SQL
-- Если миграция содержит ALTER/UPDATE — SQL пишется inline в методе `migrate()`
-- `_onCreate` вызывает `DatabaseSchema.createAll(db)` + `MigrationV24().migrate(db)` для seed статических справочников — **не трогать**
-- `_onUpgrade` итерирует `MigrationRegistry.pending(oldVersion)` — **не трогать**
-- SQL-запросы в миграциях **нельзя** менять задним числом — только добавлять новые миграции
-- `database_service.dart` содержит **только** CRUD-операции и инициализацию — никаких CREATE TABLE / ALTER TABLE
+#### ⚠️ ГЛАВНОЕ ПРАВИЛО: существующие миграции ИММУТАБЕЛЬНЫ
+**Никогда не редактируй уже существующую миграцию — только добавляй новую.** Каждая миграция — исторический факт; её правка меняет результат прогона цепочки и расходится с реально установленными БД. Это включает SQL внутри `migrate()` и любой DDL, который она инлайнит. Менять схему = **новая** миграция.
+
+#### Как добавить изменение схемы:
+- Создать `migration_vN.dart` с `class MigrationVN extends Migration`; **DDL пиши inline в `migrate()`** (новый `CREATE`/`ALTER` — прямо в миграции). Существующие `create*Table`-хелперы трогать нельзя (см. выше).
+- Зарегистрировать в `MigrationRegistry.all` (`migration_registry.dart`), в конец.
+- Увеличить `version` в `_initDatabase()` (`database_service.dart`).
+- **Новая колонка** → `Migration.addColumnIfAbsent(db, table, column, def)` (идемпотентно), **не** голый `ALTER ... ADD COLUMN`.
+- **Индекс** → `CREATE [UNIQUE] INDEX IF NOT EXISTS`.
+- Прогнать `schema_parity_test` — обновить golden, если изменение схемы намеренное.
+- `database_service.dart` — только CRUD и инициализация, никаких CREATE/ALTER.
 
 ### Tests (test/)
 - Mirror structure: test/ mirrors lib/
@@ -297,9 +304,9 @@ D-pad и кнопка A обрабатываются глобально в `Navi
 ## Ключевые файлы для ориентации
 | Файл | Описание |
 |------|----------|
-| `lib/core/database/database_service.dart` | CRUD-операции БД |
-| `lib/core/database/schema.dart` | Определения всех таблиц (DatabaseSchema) |
-| `lib/core/database/migrations/` | Миграции БД (v2–v24, реестр, базовый класс) |
+| `lib/core/database/database_service.dart` | CRUD + инициализация; `_onCreate`/`_onUpgrade` гоняют цепочку миграций |
+| `lib/core/database/migrations/` | Миграции БД (v1..N) — единственный источник схемы; реестр, базовый класс |
+| `lib/core/database/schema.dart` | Иммутабельные `create*Table` DDL-хелперы для миграций (без `createAll`) |
 | `lib/features/collections/widgets/canvas_view.dart` | Главный виджет Board/Canvas |
 | `lib/features/collections/providers/canvas_provider.dart` | State канваса |
 | `lib/features/collections/providers/collections_provider.dart` | State коллекций |

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,11 @@ app.*.map.json
 .env.local
 
 /dev/
+
+# SQLite databases (local / reference dumps — never commit)
+*.db
+*.db-shm
+*.db-wal
+
+# Kotlin build artifacts
+android/.kotlin/

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -38,10 +38,6 @@ import 'dao/tracker_dao.dart';
 import 'dao/wishlist_dao.dart';
 import 'migrations/migration.dart';
 import 'migrations/migration_registry.dart';
-import 'migrations/migration_v24.dart';
-import 'migrations/migration_v44.dart';
-import 'migrations/migration_v48.dart';
-import 'schema.dart';
 
 final Provider<DatabaseService> databaseServiceProvider =
     Provider<DatabaseService>((Ref ref) {
@@ -273,15 +269,11 @@ class DatabaseService {
 
   Future<void> _onCreate(Database db, int version) async {
     _log.info('Creating database schema v$version');
-    await DatabaseSchema.createAll(db);
-    // Seed static reference tables (genres, tags, platforms): migrations don't
-    // run on fresh install, so invoke the seed migration explicitly.
-    await MigrationV24().migrate(db);
-    await MigrationV44.seedGenres(db);
-    // Source-aware book unique index lives in v48; replay it here so fresh
-    // installs get it too (createCollectionItemsTable is shared with the v8
-    // upgrade path and must stay untouched).
-    await MigrationV48().migrate(db);
+    // Single source of truth: a fresh DB is built by running the whole
+    // migration chain (v1..N) in order, exactly like an upgrade from zero.
+    for (final Migration migration in MigrationRegistry.all) {
+      await migration.migrate(db);
+    }
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -1,4 +1,5 @@
 import 'migration.dart';
+import 'migration_v1.dart';
 import 'migration_v2.dart';
 import 'migration_v3.dart';
 import 'migration_v4.dart';
@@ -49,6 +50,7 @@ import 'migration_v48.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
+    MigrationV1(),
     MigrationV2(),
     MigrationV3(),
     MigrationV4(),

--- a/lib/core/database/migrations/migration_v1.dart
+++ b/lib/core/database/migrations/migration_v1.dart
@@ -1,0 +1,24 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Initial schema — the `platforms` table.
+class MigrationV1 extends Migration {
+  @override
+  int get version => 1;
+
+  @override
+  String get description => 'Initial schema: platforms';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await db.execute('''
+      CREATE TABLE platforms (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        abbreviation TEXT,
+        synced_at INTEGER
+      )
+    ''');
+  }
+}

--- a/lib/core/database/migrations/migration_v16.dart
+++ b/lib/core/database/migrations/migration_v16.dart
@@ -2,24 +2,21 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migration.dart';
 
-/// Repair pass for v15: on some installs `createCollectionItemsTable` ran
-/// without the new column, so the ALTER from v15 didn't fire. Retry it and
-/// swallow the "duplicate column" error.
+/// Ensures `collection_items.user_rating` exists.
 class MigrationV16 extends Migration {
   @override
   int get version => 16;
 
   @override
-  String get description => 'Repair: ensure user_rating column exists';
+  String get description => 'Ensure collection_items.user_rating column';
 
   @override
   Future<void> migrate(Database db) async {
-    try {
-      await db.execute(
-        'ALTER TABLE collection_items ADD COLUMN user_rating INTEGER',
-      );
-    } on DatabaseException catch (_) {
-      // Column already present — repair was a no-op.
-    }
+    await Migration.addColumnIfAbsent(
+      db,
+      'collection_items',
+      'user_rating',
+      'user_rating INTEGER',
+    );
   }
 }

--- a/lib/core/database/migrations/migration_v28.dart
+++ b/lib/core/database/migrations/migration_v28.dart
@@ -11,12 +11,11 @@ class MigrationV28 extends Migration {
 
   @override
   Future<void> migrate(Database db) async {
-    try {
-      await db.execute(
-        'ALTER TABLE custom_items ADD COLUMN display_type TEXT',
-      );
-    } on DatabaseException {
-      // Column already present on installs that picked it up via _onCreate.
-    }
+    await Migration.addColumnIfAbsent(
+      db,
+      'custom_items',
+      'display_type',
+      'display_type TEXT',
+    );
   }
 }

--- a/lib/core/database/migrations/migration_v33.dart
+++ b/lib/core/database/migrations/migration_v33.dart
@@ -1,6 +1,5 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-import '../schema.dart';
 import 'migration.dart';
 
 class MigrationV33 extends Migration {
@@ -12,6 +11,36 @@ class MigrationV33 extends Migration {
 
   @override
   Future<void> migrate(Database db) async {
-    await DatabaseSchema.createAnimeCacheTable(db);
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS anime_cache (
+        id INTEGER PRIMARY KEY,
+        title TEXT NOT NULL,
+        title_english TEXT,
+        title_native TEXT,
+        description TEXT,
+        cover_url TEXT,
+        cover_url_medium TEXT,
+        banner_url TEXT,
+        average_score INTEGER,
+        mean_score INTEGER,
+        popularity INTEGER,
+        status TEXT,
+        season TEXT,
+        season_year INTEGER,
+        start_year INTEGER,
+        start_month INTEGER,
+        start_day INTEGER,
+        episodes INTEGER,
+        duration INTEGER,
+        format TEXT,
+        source TEXT,
+        genres TEXT,
+        studios TEXT,
+        next_airing_episode INTEGER,
+        next_airing_at INTEGER,
+        external_url TEXT,
+        updated_at INTEGER NOT NULL
+      )
+    ''');
   }
 }

--- a/lib/core/database/migrations/migration_v36.dart
+++ b/lib/core/database/migrations/migration_v36.dart
@@ -12,7 +12,16 @@ class MigrationV36 extends Migration {
 
   @override
   Future<void> migrate(Database db) async {
-    await DatabaseSchema.createMoodGridsTable(db);
+    await db.execute('''
+      CREATE TABLE mood_grids (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        rows INTEGER NOT NULL DEFAULT 1,
+        cols INTEGER NOT NULL DEFAULT 5,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+      )
+    ''');
     await DatabaseSchema.createMoodGridCellsTable(db);
   }
 }

--- a/lib/core/database/migrations/migration_v8.dart
+++ b/lib/core/database/migrations/migration_v8.dart
@@ -1,10 +1,9 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-import '../schema.dart';
 import 'migration.dart';
 
-/// Creates `collection_items` and folds the legacy `collection_games` table
-/// (games-only) into it under `media_type = 'game'`.
+/// Creates `collection_items`, folds the legacy `collection_games` table
+/// (games-only) into it under `media_type = 'game'`, then drops the old table.
 class MigrationV8 extends Migration {
   @override
   int get version => 8;
@@ -15,7 +14,27 @@ class MigrationV8 extends Migration {
 
   @override
   Future<void> migrate(Database db) async {
-    await DatabaseSchema.createCollectionItemsTable(db);
+    await db.execute('''
+      CREATE TABLE collection_items (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        collection_id INTEGER NOT NULL,
+        media_type TEXT NOT NULL DEFAULT 'game',
+        external_id INTEGER NOT NULL,
+        platform_id INTEGER,
+        current_season INTEGER DEFAULT 0,
+        current_episode INTEGER DEFAULT 0,
+        status TEXT DEFAULT 'not_started',
+        author_comment TEXT,
+        user_comment TEXT,
+        added_at INTEGER NOT NULL,
+        FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+        UNIQUE(collection_id, media_type, external_id)
+      )
+    ''');
+    await db.execute('''
+      CREATE INDEX idx_collection_items_collection
+      ON collection_items(collection_id)
+    ''');
     await _migrateCollectionGamesToItems(db);
   }
 
@@ -29,5 +48,6 @@ class MigrationV8 extends Migration {
         author_comment, user_comment, added_at
       FROM collection_games
     ''');
+    await db.execute('DROP TABLE collection_games');
   }
 }

--- a/lib/core/database/schema.dart
+++ b/lib/core/database/schema.dart
@@ -1,45 +1,11 @@
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+/// Immutable `CREATE TABLE` DDL helpers called by individual migrations (and
+/// test setup). There is intentionally no `createAll` — a database is built by
+/// running the migration chain (see `database_service.dart`). Each method
+/// reflects its table's shape at the migration that creates it; never modify
+/// one (it would change the migration replay).
 abstract final class DatabaseSchema {
-  static Future<void> createAll(Database db) async {
-    await createPlatformsTable(db);
-    await createGamesTable(db);
-    await createCollectionsTable(db);
-    await createCanvasItemsTable(db);
-    await createCanvasViewportTable(db);
-    await createCanvasConnectionsTable(db);
-    await createGameCanvasViewportTable(db);
-    await createMoviesCacheTable(db);
-    await createTvShowsCacheTable(db);
-    await createTvSeasonsCacheTable(db);
-    await createCollectionItemsTable(db);
-    await createTvEpisodesCacheTable(db);
-    await createWatchedEpisodesTable(db);
-    await createTmdbGenresTable(db);
-    await createWishlistTable(db);
-    await createIgdbGenresTable(db);
-    await createVisualNovelsCacheTable(db);
-    await createVndbTagsTable(db);
-    await createMangaCacheTable(db);
-    await createBooksCacheTable(db);
-    await createTierListsTable(db);
-    await createTierDefinitionsTable(db);
-    await createTierListEntriesTable(db);
-    await createCustomItemsTable(db);
-    await createCollectionTagsTable(db);
-    await createTrackerProfilesTable(db);
-    await createTrackerGameDataTable(db);
-    await createTrackerAchievementsTable(db);
-    await createAnimeCacheTable(db);
-    await createMoodGridsTable(db);
-    await createMoodGridCellsTable(db);
-    await createAniListTagsTable(db);
-    await createMangaBakaGenresTable(db);
-    await createMangaBakaTagsTable(db);
-    await createTrackedReleasesTable(db);
-    await createCalendarEntriesTable(db);
-  }
-
   static Future<void> createPlatformsTable(Database db) async {
     await db.execute('''
       CREATE TABLE platforms (

--- a/test/core/database/dao/collection_dao_covers_test.dart
+++ b/test/core/database/dao/collection_dao_covers_test.dart
@@ -9,7 +9,8 @@ import 'package:tonkatsu_box/core/database/dao/manga_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/movie_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/visual_novel_dao.dart';
-import 'package:tonkatsu_box/core/database/schema.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_registry.dart';
 import 'package:tonkatsu_box/shared/models/cover_info.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 
@@ -26,9 +27,11 @@ void main() {
     db = await databaseFactory.openDatabase(
       inMemoryDatabasePath,
       options: OpenDatabaseOptions(
-        version: 1,
+        version: MigrationRegistry.all.last.version,
         onCreate: (Database d, int _) async {
-          await DatabaseSchema.createAll(d);
+          for (final Migration m in MigrationRegistry.all) {
+            await m.migrate(d);
+          }
         },
       ),
     );


### PR DESCRIPTION
A fresh DB is now built by running the whole migration chain (v1..N) in `_onCreate`, exactly like an upgrade from zero — no more `createAll`/full-schema duplicate that silently drifted from the migrations.

- New MigrationV1 (base `platforms` table) as the chain's starting point.
- v8/v33/v36 inline their table's shape at that version instead of calling the shared `create*Table` helpers (which reflect the FINAL schema and broke the from-scratch replay: forward FKs, column-count mismatches).
- v16/v28 use idempotent `addColumnIfAbsent` instead of a blind `ALTER` wrapped in try/catch (no more "duplicate column" log noise; same result).
- Remove `DatabaseSchema.createAll`; `_onCreate` runs the chain. `create*Table` methods remain as immutable DDL helpers for migrations.
- collection_dao_covers_test builds its schema via the chain.
- CLAUDE.md: document the model + the rule that existing migrations are immutable (only ever add new ones).