### PR TITLE
fix(detail): autosave notes on back navigation without crashing

### DIFF
--- a/lib/core/logging/startup_error.dart
+++ b/lib/core/logging/startup_error.dart
@@ -86,7 +86,9 @@ class StartupErrorView extends StatelessWidget {
                   const SizedBox(width: AppSpacing.sm),
                   Expanded(
                     child: Text(
-                      'Startup error',
+                      // The overlay also catches runtime zone errors, so the
+                      // header doesn't claim "startup".
+                      'Error',
                       style: Theme.of(context).textTheme.titleLarge?.copyWith(
                             color: AppColors.error,
                             fontWeight: FontWeight.bold,
@@ -176,6 +178,9 @@ class _CopyButtonState extends State<_CopyButton> {
       style: FilledButton.styleFrom(
         backgroundColor: AppColors.surfaceLight,
         foregroundColor: AppColors.textPrimary,
+        // The global theme forces minimumSize Size(infinity, 48); inside a
+        // Row that means "BoxConstraints forces an infinite width".
+        minimumSize: const Size(0, 40),
       ),
     );
   }

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -96,7 +96,19 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
   DiscordRpcService? _discordRpc;
   String? _currentItemName;
 
+  // Comment autosave is triggered from MediaDetailView.dispose() during route
+  // teardown, when ref.read's ProviderScope ancestor lookup is already unsafe
+  // ("Looking up a deactivated widget's ancestor"), so the container is
+  // resolved once upfront and the save callbacks read through it.
+  late final ProviderContainer _container;
+
   bool get _hasCanvas => kCanvasEnabled && widget.collectionId != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _container = ProviderScope.containerOf(context, listen: false);
+  }
 
   void _updateDiscordPresence(CollectionItem item) {
     if (!kDiscordRpcAvailable) return;
@@ -938,13 +950,13 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
   }
 
   Future<void> _saveAuthorComment(int id, String? text) async {
-    await ref
+    await _container
         .read(collectionItemsNotifierProvider(widget.collectionId).notifier)
         .updateAuthorComment(id, text);
   }
 
   Future<void> _saveUserComment(int id, String? text) async {
-    await ref
+    await _container
         .read(collectionItemsNotifierProvider(widget.collectionId).notifier)
         .updateUserComment(id, text);
   }

--- a/test/core/logging/startup_error_test.dart
+++ b/test/core/logging/startup_error_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/core/logging/startup_error.dart';
+import 'package:tonkatsu_box/shared/theme/app_theme.dart';
+
+void main() {
+  const StartupErrorInfo info = StartupErrorInfo(
+    source: 'zone',
+    error: 'Boom',
+    stack: '#0 main (package:tonkatsu_box/main.dart:1:1)',
+  );
+
+  group('StartupErrorInfo', () {
+    test('details joins source, error and stack', () {
+      expect(info.details, contains('source: zone'));
+      expect(info.details, contains('Boom'));
+      expect(info.details, contains('#0 main'));
+    });
+  });
+
+  group('recordStartupError', () {
+    tearDown(() => startupError.value = null);
+
+    test('first error wins, follow-ups are ignored', () {
+      final StartupErrorInfo first =
+          recordStartupError('database', StateError('first'), null);
+      final StartupErrorInfo second =
+          recordStartupError('zone', StateError('second'), null);
+
+      expect(second, same(first));
+      expect(startupError.value, same(first));
+      expect(startupError.value?.source, 'database');
+    });
+  });
+
+  group('StartupErrorView', () {
+    // The real app theme is essential here: it forces an infinite
+    // minimumSize on FilledButton, which used to blow up the copy button
+    // inside the header Row ("BoxConstraints forces an infinite width").
+    Widget app() => MaterialApp(
+          theme: AppTheme.darkTheme,
+          home: const StartupErrorView(info: info),
+        );
+
+    testWidgets('should render under the app theme without layout exceptions',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(app());
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Boom'), findsOneWidget);
+      expect(find.textContaining('zone'), findsOneWidget);
+    });
+
+    testWidgets('should copy details to clipboard on button tap',
+        (WidgetTester tester) async {
+      final List<MethodCall> calls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          calls.add(call);
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+
+      await tester.pumpWidget(app());
+      await tester.tap(find.byType(FilledButton));
+      // Let the "Copied" confirmation timer expire.
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(tester.takeException(), isNull);
+      final MethodCall copy = calls
+          .firstWhere((MethodCall c) => c.method == 'Clipboard.setData');
+      expect(
+        (copy.arguments as Map<Object?, Object?>)['text'],
+        info.details,
+      );
+    });
+  });
+}

--- a/test/features/collections/screens/item_detail_screen_test.dart
+++ b/test/features/collections/screens/item_detail_screen_test.dart
@@ -1835,4 +1835,83 @@ void main() {
       expect(find.text('5 seasons \u2022 62 ep'), findsNothing);
     });
   });
+
+  group('Autosave on back', () {
+    testWidgets(
+        'should save unsaved notes without exception when route is popped '
+        'while editing', (WidgetTester tester) async {
+      const Game game = Game(id: 100, name: 'Test Game');
+      final CollectionItem item = CollectionItem(
+        id: 1,
+        collectionId: 1,
+        mediaType: MediaType.game,
+        externalId: 100,
+        platformId: 18,
+        status: ItemStatus.notStarted,
+        addedAt: testDate,
+        game: game,
+        platform: const Platform(id: 18, name: 'SNES'),
+      );
+      when(() => mockRepo.getItemsWithData(
+            1,
+            mediaType: any(named: 'mediaType'),
+          )).thenAnswer((_) async => <CollectionItem>[item]);
+      when(() => mockRepo.updateItemUserComment(any(), any()))
+          .thenAnswer((_) async {});
+
+      await tester.pumpWidget(ProviderScope(
+        overrides: <Override>[
+          collectionRepositoryProvider.overrideWithValue(mockRepo),
+          databaseServiceProvider.overrideWithValue(mockDb),
+          tmdbApiProvider.overrideWithValue(mockTmdbApi),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext _) => const ItemDetailScreen(
+                        collectionId: 1,
+                        itemId: 1,
+                        isEditable: true,
+                      ),
+                    ),
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      // My Notes is the first edit icon (author's review is the last one).
+      await tester.scrollUntilVisible(
+        find.byIcon(Icons.edit).first,
+        300,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.tap(find.byIcon(Icons.edit).first);
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'unsaved note');
+      await tester.pump();
+
+      // Back without pressing the check mark.
+      tester.state<NavigatorState>(find.byType(Navigator)).pop();
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      verify(() => mockRepo.updateItemUserComment(1, 'unsaved note'))
+          .called(1);
+    });
+  });
 }


### PR DESCRIPTION
Pressing back while editing notes/review crashed in debug builds: the autosave fired from MediaDetailView.dispose() and the screen's ref.read did a ProviderScope ancestor lookup on an already deactivated element ("Looking up a deactivated widget's ancestor is unsafe"). The error escaped to the zone handler, which raised the error overlay, and that overlay itself failed to lay out (the theme forces an infinite minimumSize on FilledButton inside a Row), leaving a black screen that masked the original error.

The item detail screen now resolves the ProviderContainer once in initState and the comment save callbacks read through it, so leaving the page without pressing the check mark saves the text again. The error screen's Copy button overrides minimumSize so the overlay renders under the app theme, and its header now says "Error" since it also shows runtime errors, not only startup ones.