### PR TITLE
fix(collections): restore sorting by name on the collections list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restore sorting by name on the collections list**
+
+  The collections folder list lost its sort-mode picker in an earlier
+  title-bar refactor — the floating action only flipped the direction, so
+  there was no way to switch from date-created to alphabetical. The sort
+  action now opens a dialog to choose the mode (Date Created / Name) and
+  the direction together, applied only on confirm.
+
+  * lib/features/collections/screens/home_screen.dart
+    (_HomeScreenState._showSortOptions, _SortDialog, _SortChoice): New. The
+    sort entry in the floating menu is relabeled "Sort" with an Icons.sort
+    glyph and opens the dialog; the picked mode and direction are written
+    via collectionListSortProvider.setSortMode and
+    collectionListSortDescProvider.setDescending.
+
 ## [0.34.0] - 2026-06-12
 
 ### Fixed

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -106,10 +106,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                     ref.read(collectionListViewModeProvider.notifier).toggle(),
               ),
               DraggableFabItem(
-                icon: sortDesc ? Icons.arrow_upward : Icons.arrow_downward,
-                label: sortMode.localizedDisplayLabel(l),
-                onTap: () =>
-                    ref.read(collectionListSortDescProvider.notifier).toggle(),
+                icon: Icons.sort,
+                label: l.collectionFilterSort,
+                onTap: () => _showSortOptions(context, ref, sortMode, sortDesc),
               ),
             ],
           ),
@@ -543,6 +542,26 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     );
   }
 
+  Future<void> _showSortOptions(
+    BuildContext context,
+    WidgetRef ref,
+    CollectionListSortMode currentMode,
+    bool descending,
+  ) async {
+    final _SortChoice? choice = await showDialog<_SortChoice>(
+      context: context,
+      builder: (BuildContext context) => _SortDialog(
+        initialMode: currentMode,
+        initialDescending: descending,
+      ),
+    );
+    if (choice == null) return;
+    await ref.read(collectionListSortProvider.notifier).setSortMode(choice.mode);
+    await ref
+        .read(collectionListSortDescProvider.notifier)
+        .setDescending(descending: choice.descending);
+  }
+
   Future<void> _renameCollection(
     BuildContext context,
     WidgetRef ref,
@@ -677,6 +696,104 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     } else if (!result.isCancelled && result.error != null) {
       context.showSnack(result.error!, type: SnackType.error);
     }
+  }
+}
+
+/// Sort mode and direction picked in [_SortDialog].
+class _SortChoice {
+  const _SortChoice(this.mode, this.descending);
+
+  final CollectionListSortMode mode;
+  final bool descending;
+}
+
+/// Picks the collections-list sort mode and direction in one dialog, applied
+/// only when the user confirms. Returns a [_SortChoice] or null on cancel.
+class _SortDialog extends StatefulWidget {
+  const _SortDialog({
+    required this.initialMode,
+    required this.initialDescending,
+  });
+
+  final CollectionListSortMode initialMode;
+  final bool initialDescending;
+
+  @override
+  State<_SortDialog> createState() => _SortDialogState();
+}
+
+class _SortDialogState extends State<_SortDialog> {
+  late CollectionListSortMode _mode = widget.initialMode;
+  late bool _descending = widget.initialDescending;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return AlertDialog(
+      title: Text(l.collectionFilterSort),
+      scrollable: true,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          RadioGroup<CollectionListSortMode>(
+            groupValue: _mode,
+            onChanged: (CollectionListSortMode? value) {
+              if (value != null) setState(() => _mode = value);
+            },
+            child: Column(
+              children: <Widget>[
+                for (final CollectionListSortMode mode
+                    in CollectionListSortMode.values)
+                  RadioListTile<CollectionListSortMode>(
+                    title: Text(mode.localizedDisplayLabel(l)),
+                    value: mode,
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                  ),
+              ],
+            ),
+          ),
+          const Divider(),
+          RadioGroup<bool>(
+            groupValue: _descending,
+            onChanged: (bool? value) {
+              if (value != null) setState(() => _descending = value);
+            },
+            child: Column(
+              children: <Widget>[
+                RadioListTile<bool>(
+                  title: Text(
+                    _mode.localizedDescription(l, descending: false),
+                  ),
+                  value: false,
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+                RadioListTile<bool>(
+                  title: Text(
+                    _mode.localizedDescription(l, descending: true),
+                  ),
+                  value: true,
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.cancel),
+        ),
+        FilledButton(
+          onPressed: () =>
+              Navigator.of(context).pop(_SortChoice(_mode, _descending)),
+          child: Text(l.apply),
+        ),
+      ],
+    );
   }
 }
 

--- a/test/features/collections/screens/home_screen_test.dart
+++ b/test/features/collections/screens/home_screen_test.dart
@@ -406,5 +406,92 @@ void main() {
         expect(cards[1].collection.name, 'New');
       });
     });
+
+    group('диалог сортировки', () {
+      // createdDate desc=false → newest first, so the initial order is
+      // Zebra(2025), Alpha(2024); alphabetical asc flips it to Alpha, Zebra.
+      final List<Collection> collections = <Collection>[
+        Collection(
+          id: 1,
+          name: 'Zebra',
+          author: 'User',
+          type: CollectionType.own,
+          createdAt: DateTime(2025),
+        ),
+        Collection(
+          id: 2,
+          name: 'Alpha',
+          author: 'User',
+          type: CollectionType.own,
+          createdAt: DateTime(2024),
+        ),
+      ];
+
+      Future<void> openSortDialog(WidgetTester tester) async {
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.tap(find.text('Sort'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+
+      testWidgets('should show both sort modes when sort item tapped',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(collections: collections));
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        await openSortDialog(tester);
+
+        expect(find.text('Date Created'), findsOneWidget);
+        expect(find.text('Name'), findsOneWidget);
+        expect(find.text('Apply'), findsOneWidget);
+      });
+
+      testWidgets('should re-sort by name when picked and applied',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(collections: collections));
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        await openSortDialog(tester);
+        await tester.tap(find.text('Name'));
+        await tester.pump();
+        await tester.tap(find.text('Apply'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+
+        final List<CollectionCard> cards = tester
+            .widgetList<CollectionCard>(find.byType(CollectionCard))
+            .toList();
+        expect(cards[0].collection.name, 'Alpha');
+        expect(cards[1].collection.name, 'Zebra');
+      });
+
+      testWidgets('should keep current sort when dialog cancelled',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(createWidget(collections: collections));
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        await openSortDialog(tester);
+        await tester.tap(find.text('Name'));
+        await tester.pump();
+        await tester.tap(find.text('Cancel'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        final List<CollectionCard> cards = tester
+            .widgetList<CollectionCard>(find.byType(CollectionCard))
+            .toList();
+        expect(cards[0].collection.name, 'Zebra');
+        expect(cards[1].collection.name, 'Alpha');
+      });
+    });
   });
 }


### PR DESCRIPTION
The collections folder list lost its sort-mode picker in an earlier title-bar refactor — the floating action only flipped the direction, so there was no way to switch from date-created to alphabetical. The sort entry now opens a dialog to choose the mode (Date Created / Name) and the direction together, applied only on confirm.