### PR TITLE
fix(storage): derive volume roots without listing /storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Fixed
 
+- **Folder picker crashing with "Permission denied" on some newer Android builds**
+
+  Choosing a custom data folder failed with `PathAccessException: ... '/storage/'
+  (Permission denied)` on some newer Android builds (seen on Android 16 / Pixel)
+  even with "All files access" granted, while working on others (Android 10, 13):
+  the volume detector listed `/storage` directly, which those builds refuse
+  regardless of the permission. Storage volumes are now derived from the
+  per-volume app directories instead of listing `/storage`, so detection no
+  longer depends on that OEM-specific behaviour.
+
+  * lib/core/services/storage_volumes.dart (StorageVolumes.detect,
+    StorageVolumes.externalDirsProvider): Derive volume roots from
+    getExternalStorageDirectories() by trimming the `/Android/data/<pkg>/files`
+    suffix; no `/storage` listing. detect() is now async.
+  * lib/shared/utils/storage_access.dart (pickRawFolder): Await the async
+    detect() and guard the BuildContext across the gap.
+
 - **Restore sorting by name on the collections list**
 
   The collections folder list lost its sort-mode picker in an earlier

--- a/lib/core/services/storage_volumes.dart
+++ b/lib/core/services/storage_volumes.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 /// A mounted storage volume usable as a folder-picker root.
 class StorageVolume {
@@ -19,39 +21,56 @@ class StorageVolume {
 class StorageVolumes {
   StorageVolumes._();
 
-  /// Test seam: real volume mounts live under `/storage`.
+  static final Logger _log = Logger('StorageVolumes');
+
+  /// Test seam: the OS query for per-volume app-specific directories.
+  /// Each entry looks like `<volume>/Android/data/<pkg>/files`.
   @visibleForTesting
-  static String storageRoot = '/storage';
+  static Future<List<Directory>?> Function() externalDirsProvider =
+      () => getExternalStorageDirectories();
 
   /// Canonical primary (internal) storage path.
-  static String get primaryPath => p.join(storageRoot, 'emulated', '0');
+  static String get primaryPath => p.join('/storage', 'emulated', '0');
 
-  /// Internal storage plus mounted removable volumes (SD card, USB OTG).
+  /// Internal storage plus mounted removable volumes (SD card).
   ///
-  /// Removable volumes mount under `/storage/<VOLUME-ID>`; `emulated`
-  /// (covered by the primary entry) and `self` (a bind-mount alias of
-  /// the primary) are skipped.
-  static List<StorageVolume> detect() {
+  /// Volume roots are derived from [getExternalStorageDirectories]
+  /// (`getExternalFilesDirs` under the hood) by trimming the
+  /// `/Android/data/<pkg>/files` suffix — never by listing `/storage`,
+  /// which Android 11+ refuses with a permission error regardless of
+  /// "All files access". The first entry is the primary volume. USB OTG
+  /// is not reported: `getExternalFilesDirs` excludes it, and on modern
+  /// Android it is reachable only through SAF (no real path).
+  static Future<List<StorageVolume>> detect() async {
+    List<Directory>? appDirs;
+    try {
+      appDirs = await externalDirsProvider();
+    } on Exception catch (e) {
+      _log.warning('Failed to query external storage directories', e);
+    }
+
     final List<StorageVolume> volumes = <StorageVolume>[];
-
-    final String primary = primaryPath;
-    if (Directory(primary).existsSync()) {
-      volumes.add(StorageVolume(path: primary, isPrimary: true));
+    if (appDirs != null) {
+      for (int i = 0; i < appDirs.length; i++) {
+        final String? root = _volumeRoot(appDirs[i].path);
+        if (root == null) continue;
+        if (volumes.any((StorageVolume v) => v.path == root)) continue;
+        volumes.add(StorageVolume(path: root, isPrimary: i == 0));
+      }
     }
 
-    final Directory root = Directory(storageRoot);
-    if (!root.existsSync()) return volumes;
-
-    final List<StorageVolume> removable = <StorageVolume>[];
-    for (final FileSystemEntity entity in root.listSync()) {
-      if (entity is! Directory) continue;
-      final String name = p.basename(entity.path);
-      if (name == 'emulated' || name == 'self') continue;
-      removable.add(StorageVolume(path: entity.path, isPrimary: false));
+    // Fallback to canonical internal storage when the query yields nothing.
+    if (volumes.isEmpty && Directory(primaryPath).existsSync()) {
+      volumes.add(StorageVolume(path: primaryPath, isPrimary: true));
     }
-    removable.sort(
-      (StorageVolume a, StorageVolume b) => a.path.compareTo(b.path),
-    );
-    return volumes..addAll(removable);
+    return volumes;
+  }
+
+  /// `/storage/XXXX/Android/data/<pkg>/files` → `/storage/XXXX`.
+  static String? _volumeRoot(String appSpecificDir) {
+    const String marker = '/Android/';
+    final int idx = appSpecificDir.indexOf(marker);
+    if (idx <= 0) return null;
+    return appSpecificDir.substring(0, idx);
   }
 }

--- a/lib/shared/utils/storage_access.dart
+++ b/lib/shared/utils/storage_access.dart
@@ -55,7 +55,8 @@ Future<String?> pickRawFolder(
   }
 
   final S l10n = S.of(context);
-  final List<StorageVolume> volumes = StorageVolumes.detect();
+  final List<StorageVolume> volumes = await StorageVolumes.detect();
+  if (!context.mounted) return null;
   final List<FolderPickerRoot> roots = volumes.isEmpty
       ? <FolderPickerRoot>[
           FolderPickerRoot(

--- a/test/core/services/storage_volumes_test.dart
+++ b/test/core/services/storage_volumes_test.dart
@@ -1,79 +1,63 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:path/path.dart' as p;
 import 'package:tonkatsu_box/core/services/storage_volumes.dart';
 
 void main() {
-  late Directory tempDir;
-
-  setUp(() async {
-    tempDir = await Directory.systemTemp.createTemp('storage_volumes_test');
-    StorageVolumes.storageRoot = tempDir.path;
-  });
-
-  tearDown(() async {
-    StorageVolumes.storageRoot = '/storage';
-    if (tempDir.existsSync()) {
-      await tempDir.delete(recursive: true);
-    }
+  tearDown(() {
+    StorageVolumes.externalDirsProvider = () async => null;
   });
 
   group('StorageVolumes', () {
     group('detect', () {
-      test('finds the primary volume', () async {
-        await Directory(p.join(tempDir.path, 'emulated', '0'))
-            .create(recursive: true);
+      test('derives volume roots and marks the first as primary', () async {
+        StorageVolumes.externalDirsProvider = () async => <Directory>[
+              Directory('/storage/emulated/0/Android/data/pkg/files'),
+              Directory('/storage/ABCD-1234/Android/data/pkg/files'),
+            ];
 
-        final List<StorageVolume> volumes = StorageVolumes.detect();
+        final List<StorageVolume> volumes = await StorageVolumes.detect();
 
-        expect(volumes, hasLength(1));
-        expect(volumes.first.path, p.join(tempDir.path, 'emulated', '0'));
-        expect(volumes.first.isPrimary, isTrue);
-      });
-
-      test('finds removable volumes after the primary', () async {
-        await Directory(p.join(tempDir.path, 'emulated', '0'))
-            .create(recursive: true);
-        await Directory(p.join(tempDir.path, 'B1C2-3D4E')).create();
-        await Directory(p.join(tempDir.path, 'A1B2-3C4D')).create();
-
-        final List<StorageVolume> volumes = StorageVolumes.detect();
-
-        expect(volumes, hasLength(3));
-        expect(volumes.first.isPrimary, isTrue);
-        expect(
-          volumes.map((StorageVolume v) => p.basename(v.path)).toList(),
-          <String>['0', 'A1B2-3C4D', 'B1C2-3D4E'],
-        );
+        expect(volumes, hasLength(2));
+        expect(volumes[0].path, '/storage/emulated/0');
+        expect(volumes[0].isPrimary, isTrue);
+        expect(volumes[1].path, '/storage/ABCD-1234');
         expect(volumes[1].isPrimary, isFalse);
       });
 
-      test('skips the self alias and the emulated container', () async {
-        await Directory(p.join(tempDir.path, 'emulated', '0'))
-            .create(recursive: true);
-        await Directory(p.join(tempDir.path, 'self')).create();
+      test('dedupes repeated volume roots', () async {
+        StorageVolumes.externalDirsProvider = () async => <Directory>[
+              Directory('/storage/emulated/0/Android/data/pkg/files'),
+              Directory('/storage/emulated/0/Android/data/pkg/cache'),
+            ];
 
-        final List<StorageVolume> volumes = StorageVolumes.detect();
-
-        expect(volumes, hasLength(1));
-        expect(volumes.first.isPrimary, isTrue);
-      });
-
-      test('ignores plain files under the storage root', () async {
-        await Directory(p.join(tempDir.path, 'emulated', '0'))
-            .create(recursive: true);
-        await File(p.join(tempDir.path, 'mount.log')).writeAsString('x');
-
-        final List<StorageVolume> volumes = StorageVolumes.detect();
+        final List<StorageVolume> volumes = await StorageVolumes.detect();
 
         expect(volumes, hasLength(1));
+        expect(volumes.single.path, '/storage/emulated/0');
       });
 
-      test('returns empty when the storage root does not exist', () {
-        StorageVolumes.storageRoot = p.join(tempDir.path, 'missing');
+      test('skips entries without an Android segment', () async {
+        StorageVolumes.externalDirsProvider = () async => <Directory>[
+              Directory('/weird/path/files'),
+            ];
 
-        expect(StorageVolumes.detect(), isEmpty);
+        final List<StorageVolume> volumes = await StorageVolumes.detect();
+
+        expect(volumes, isEmpty);
+      });
+
+      test('returns empty when the query yields null', () async {
+        StorageVolumes.externalDirsProvider = () async => null;
+
+        expect(await StorageVolumes.detect(), isEmpty);
+      });
+
+      test('survives a failing query', () async {
+        StorageVolumes.externalDirsProvider =
+            () async => throw const FileSystemException('boom');
+
+        expect(await StorageVolumes.detect(), isEmpty);
       });
     });
   });


### PR DESCRIPTION
Choosing a custom data folder threw PathAccessException ("/storage/" Permission denied) on some newer Android builds (Android 16 / Pixel) even with "All files access", while working on others (Android 10, 13): the volume detector listed /storage directly, which those builds refuse regardless of the permission. Volume roots are now derived from getExternalStorageDirectories() by trimming the /Android/data/<pkg>/files suffix, so detection no longer touches /storage.