### PR TITLE
fix: guard missing gyroscope in search and count all API key sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,19 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **API Keys settings row now shows active/total instead of a single count**
+
+  The Data Sources → API Keys row counted only IGDB, SteamGridDB and TMDB, so
+  it capped at "3" even though the credentials screen has six sources. It now
+  reads `active/total` (e.g. `3/6`) across all six — IGDB, SteamGridDB, TMDB,
+  ComicVine, Google Books and ScreenScraper — and only turns green when every
+  source is configured.
+
+  * lib/features/settings/screens/settings_screen.dart (_SettingsScreenState._apiKeyStates, _apiKeysValue, _apiKeysAllSet):
+    Derive both the count and the all-set state from one six-source list.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (settingsApiKeysValue): Change the
+    string from `{count} keys` to `{active}/{total}`.
+
 - **Moved the Steam, RetroAchievements, MyAnimeList and AniList importers onto the shared import layer**
 
   The four source importers now live under `lib/core/import/sources/<name>/` next
@@ -240,6 +253,23 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     `{count}` placeholder; drop the now-unused cacheCleared toast string.
 
 ### Fixed
+
+- **Search crashing on Android devices without a gyroscope**
+
+  Opening an item's detail sheet in search threw `PlatformException(NO_SENSOR,
+  ... no Gyroscope sensor)` on devices that lack a hardware gyroscope (e.g.
+  Honor "Lite" models, many tablets and emulators), because the poster
+  parallax subscribed to the gyroscope without handling the sensor-missing
+  error. The parallax now degrades to a plain static image instead of letting
+  the error surface, fixing every place the effect is used (the search detail
+  sheet and the shared media detail view).
+
+  * lib/shared/widgets/gyroscope_parallax_image.dart (GyroscopeParallaxImage, _GyroscopeParallaxImageState._onGyroscopeError):
+    Add an `onError` handler (with `cancelOnError`) that cancels the
+    subscription and falls back to a static image; `_ticker` becomes nullable
+    and is the single "parallax active" flag, replacing the scattered
+    `Platform.isAndroid` checks. Add a `@visibleForTesting` `gyroscopeStream`
+    seam so the sensor path is testable off-device.
 
 - **Folder picker crashing with "Permission denied" on some newer Android builds**
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -1,4 +1,4 @@
-// Экран-хаб настроек приложения с единым grouped-list лейаутом.
+// Settings hub screen with a single grouped-list layout.
 
 import 'dart:async';
 
@@ -50,25 +50,25 @@ import 'profiles_screen.dart';
 import '../../../shared/models/profile.dart';
 import '../providers/profile_provider.dart';
 
-/// Breakpoint для переключения ширины контента.
+/// Breakpoint for switching content width.
 const double _desktopBreakpoint = 800;
 
-// iOS-style цветовая палитра для capsule-иконок в настройках.
-const Color _kProfileColor = Color(0xFF4A90E2); // синий
-const Color _kBackupColor = Color(0xFF42A5F5); // голубой
-const Color _kStorageColor = Color(0xFF8E8E93); // серый
-const Color _kAppearanceColor = Color(0xFFA86ED4); // фиолетовый
-const Color _kApiKeysColor = Color(0xFFEF5350); // красный
+// iOS-style colour palette for the settings capsule icons.
+const Color _kProfileColor = Color(0xFF4A90E2);
+const Color _kBackupColor = Color(0xFF42A5F5);
+const Color _kStorageColor = Color(0xFF8E8E93);
+const Color _kAppearanceColor = Color(0xFFA86ED4);
+const Color _kApiKeysColor = Color(0xFFEF5350);
 const Color _kDiscordColor = Color(0xFF5865F2); // Discord blurple (used for RA-sync Icons.sync tile)
-const Color _kAboutColor = Color(0xFF8E8E93); // серый
-const Color _kDebugColor = Color(0xFFAB47BC); // пурпурный
+const Color _kAboutColor = Color(0xFF8E8E93);
+const Color _kDebugColor = Color(0xFFAB47BC);
 
-/// Хаб настроек приложения.
+/// Settings hub screen.
 ///
-/// Единый grouped-list лейаут для всех платформ.
-/// На десктопе (>= 800px) — контент центрирован с maxWidth: 600.
+/// One grouped-list layout for all platforms; on desktop (>= 800px) the
+/// content is centred at maxWidth 600.
 class SettingsScreen extends ConsumerStatefulWidget {
-  /// Создаёт [SettingsScreen].
+  /// Creates a [SettingsScreen].
   const SettingsScreen({super.key});
 
   @override
@@ -124,10 +124,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
-  /// Фильтрует секции настроек по поисковому запросу.
+  /// Filters the settings sections by the search query.
   ///
-  /// Оставляет только [SettingsGroup], у которых title или любой дочерний
-  /// [SettingsTile] содержит query.
+  /// Keeps only [SettingsGroup]s whose title or any child [SettingsTile]
+  /// contains the query.
   static List<Widget> _filterSections(List<Widget> sections, String query) {
     final List<Widget> result = <Widget>[];
     for (final Widget section in sections) {
@@ -163,7 +163,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     const Widget gap = SizedBox(height: AppSpacing.md);
 
     return <Widget>[
-      // ============ ПРОФИЛЬ ============
       SettingsGroup(
         title: l.profiles,
         titleIcon: Icons.person_outline,
@@ -222,7 +221,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ),
       gap,
 
-      // ============ ДАННЫЕ (поднято выше по фидбеку) ============
+      // Data group sits above Appearance per user feedback.
       SettingsGroup(
         title: l.settingsBackup,
         subtitle: l.settingsBackupSubtitle,
@@ -325,7 +324,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ),
       gap,
 
-      // ============ ОФОРМЛЕНИЕ ============
       SettingsGroup(
         title: l.settingsAppearance,
         subtitle: l.settingsAppearanceSubtitle,
@@ -442,7 +440,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ),
       gap,
 
-      // ============ СЕРВИСЫ ============
       SettingsGroup(
         title: l.settingsDataSources,
         subtitle: l.settingsDataSourcesSubtitle,
@@ -542,7 +539,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ),
       gap,
 
-      // ============ О ПРИЛОЖЕНИИ ============
       SettingsGroup(
         title: l.settingsAbout,
         titleIcon: Icons.info_outline,
@@ -598,18 +594,24 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
+  /// Key-source states in the same order as the credentials screen sections.
+  List<bool> _apiKeyStates(SettingsState settings) => <bool>[
+        settings.hasCredentials,
+        settings.hasSteamGridDbKey,
+        settings.hasTmdbKey,
+        settings.hasComicVineKey,
+        settings.hasGoogleBooksKey,
+        settings.hasScreenScraperCreds,
+      ];
+
   String _apiKeysValue(SettingsState settings) {
-    int count = 0;
-    if (settings.hasCredentials) count++;
-    if (settings.hasSteamGridDbKey) count++;
-    if (settings.hasTmdbKey) count++;
-    return S.of(context).settingsApiKeysValue(count);
+    final List<bool> states = _apiKeyStates(settings);
+    final int active = states.where((bool isSet) => isSet).length;
+    return S.of(context).settingsApiKeysValue(active, states.length);
   }
 
   bool _apiKeysAllSet(SettingsState settings) =>
-      settings.hasCredentials &&
-      settings.hasSteamGridDbKey &&
-      settings.hasTmdbKey;
+      _apiKeyStates(settings).every((bool isSet) => isSet);
 
   void _showLanguagePicker(SettingsState settings) {
     showDialog<void>(
@@ -875,7 +877,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     WidgetRef ref,
     S l,
   ) async {
-    // 1. Выбор файла
+    // 1. Pick the file.
     final bool useAny = defaultTargetPlatform == TargetPlatform.android;
     final FilePickerResult? picked = await FilePicker.platform.pickFiles(
       dialogTitle: l.settingsRestoreBackup,
@@ -888,7 +890,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final String? zipPath = picked.files.first.path;
     if (zipPath == null) return;
 
-    // 2. Читаем манифест
+    // 2. Read the manifest.
     final BackupService service = ref.read(backupServiceProvider);
     final BackupManifest? manifest = await service.readManifest(zipPath);
 
@@ -899,7 +901,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       return;
     }
 
-    // 3. Диалог подтверждения
+    // 3. Confirmation dialog.
     if (!context.mounted) return;
     final _RestoreOptions? options = await showDialog<_RestoreOptions>(
       context: context,
@@ -968,7 +970,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
     if (options == null) return;
 
-    // 4. Выполнение восстановления
+    // 4. Run the restore.
     if (!context.mounted) return;
 
     final ValueNotifier<BackupProgress?> progressNotifier =
@@ -1092,7 +1094,7 @@ class _RestoreProgressDialog extends StatelessWidget {
   }
 }
 
-/// Опции восстановления из диалога подтверждения.
+/// Restore options chosen in the confirmation dialog.
 class _RestoreOptions {
   const _RestoreOptions({
     required this.restoreWishlist,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -204,10 +204,11 @@
   "settingsAppLanguage": "App Language",
   "settingsConnections": "Connections",
   "settingsApiKeys": "API Keys",
-  "settingsApiKeysValue": "{count} keys",
+  "settingsApiKeysValue": "{active}/{total}",
   "@settingsApiKeysValue": {
     "placeholders": {
-      "count": {"type": "int"}
+      "active": {"type": "int"},
+      "total": {"type": "int"}
     }
   },
   "settingsAppearance": "Appearance",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -976,8 +976,8 @@ abstract class S {
   /// No description provided for @settingsApiKeysValue.
   ///
   /// In en, this message translates to:
-  /// **'{count} keys'**
-  String settingsApiKeysValue(int count);
+  /// **'{active}/{total}'**
+  String settingsApiKeysValue(int active, int total);
 
   /// No description provided for @settingsAppearance.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -500,8 +500,8 @@ class SEn extends S {
   String get settingsApiKeys => 'API Keys';
 
   @override
-  String settingsApiKeysValue(int count) {
-    return '$count keys';
+  String settingsApiKeysValue(int active, int total) {
+    return '$active/$total';
   }
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -510,8 +510,8 @@ class SRu extends S {
   String get settingsApiKeys => 'API ключи';
 
   @override
-  String settingsApiKeysValue(int count) {
-    return '$count ключей';
+  String settingsApiKeysValue(int active, int total) {
+    return '$active/$total';
   }
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -204,10 +204,11 @@
   "settingsAppLanguage": "Язык приложения",
   "settingsConnections": "Подключения",
   "settingsApiKeys": "API ключи",
-  "settingsApiKeysValue": "{count} ключей",
+  "settingsApiKeysValue": "{active}/{total}",
   "@settingsApiKeysValue": {
     "placeholders": {
-      "count": {"type": "int"}
+      "active": {"type": "int"},
+      "total": {"type": "int"}
     }
   },
   "settingsAppearance": "Оформление",

--- a/lib/shared/widgets/gyroscope_parallax_image.dart
+++ b/lib/shared/widgets/gyroscope_parallax_image.dart
@@ -1,4 +1,4 @@
-// Изображение с параллакс-эффектом на основе гироскопа (только Android).
+// Image with a gyroscope-driven parallax effect (Android only).
 
 import 'dart:async';
 import 'dart:io' show Platform;
@@ -7,38 +7,43 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 
-/// Максимальное смещение параллакса в пикселях.
+/// Max parallax offset in pixels.
 const double _kMaxOffset = 20.0;
 
-/// Коэффициент сглаживания (lerp) — чем меньше, тем плавнее.
+/// Lerp smoothing factor — lower is smoother.
 const double _kSmoothing = 0.08;
 
-/// Изображение с параллакс-эффектом при наклоне устройства.
+/// Image that shifts slightly with device tilt to fake depth.
 ///
-/// На Android подписывается на гироскоп и слегка сдвигает изображение
-/// в противоположную сторону наклона, создавая иллюзию глубины.
-/// На других платформах рендерит обычное [CachedNetworkImage].
+/// Subscribes to the gyroscope where available; otherwise (no sensor, or a
+/// non-Android platform) it renders a plain [CachedNetworkImage].
 class GyroscopeParallaxImage extends StatefulWidget {
-  /// Создаёт [GyroscopeParallaxImage].
+  /// Creates a [GyroscopeParallaxImage].
   const GyroscopeParallaxImage({
     required this.imageUrl,
     this.fit = BoxFit.cover,
     this.alignment = Alignment.center,
     this.errorWidget,
+    this.gyroscopeStream,
     super.key,
   });
 
-  /// URL изображения.
+  /// Image URL.
   final String imageUrl;
 
-  /// Как изображение вписывается в доступное пространство.
+  /// How the image fits the available space.
   final BoxFit fit;
 
-  /// Выравнивание изображения.
+  /// Image alignment.
   final Alignment alignment;
 
-  /// Виджет при ошибке загрузки.
+  /// Widget shown on load error.
   final Widget Function(BuildContext, String, Object)? errorWidget;
+
+  /// Gyroscope event source. Defaults to the system gyroscope (Android only);
+  /// overridden in tests.
+  @visibleForTesting
+  final Stream<GyroscopeEvent>? gyroscopeStream;
 
   @override
   State<GyroscopeParallaxImage> createState() =>
@@ -48,52 +53,74 @@ class GyroscopeParallaxImage extends StatefulWidget {
 class _GyroscopeParallaxImageState extends State<GyroscopeParallaxImage>
     with SingleTickerProviderStateMixin {
   StreamSubscription<GyroscopeEvent>? _subscription;
-  late final AnimationController _ticker;
+  AnimationController? _ticker;
 
-  // Целевое смещение (из гироскопа)
+  // Target offset (raw from gyroscope).
   double _targetX = 0;
   double _targetY = 0;
 
-  // Текущее смещение (сглаженное)
+  // Current offset (smoothed toward target).
   double _currentX = 0;
   double _currentY = 0;
 
   @override
   void initState() {
     super.initState();
-    if (!Platform.isAndroid) return;
+    final Stream<GyroscopeEvent>? stream = widget.gyroscopeStream ??
+        (Platform.isAndroid
+            ? gyroscopeEventStream(
+                samplingPeriod: const Duration(milliseconds: 16),
+              )
+            : null);
+    if (stream == null) return;
 
-    _ticker = AnimationController.unbounded(vsync: this)
-      ..addListener(_onTick);
-    _ticker.animateTo(1, duration: Duration.zero);
+    final AnimationController ticker =
+        AnimationController.unbounded(vsync: this)..addListener(_onTick);
+    ticker.animateTo(1, duration: Duration.zero);
+    _ticker = ticker;
 
-    _subscription = gyroscopeEventStream(
-      samplingPeriod: const Duration(milliseconds: 16),
-    ).listen(_onGyroscope);
+    _subscription = stream.listen(
+      _onGyroscope,
+      onError: _onGyroscopeError,
+      cancelOnError: true,
+    );
+  }
+
+  void _onGyroscopeError(Object error) {
+    // No gyroscope (PlatformException NO_SENSOR) — drop the parallax and fall
+    // back to a plain static image instead of letting the error surface.
+    _subscription?.cancel();
+    _subscription = null;
+    _ticker?.dispose();
+    _ticker = null;
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   void _onGyroscope(GyroscopeEvent event) {
-    // Гироскоп отдаёт угловую скорость (рад/с).
-    // Интегрируем в смещение и кламплим.
+    final AnimationController? ticker = _ticker;
+    if (ticker == null) return;
+
+    // Gyroscope reports angular velocity (rad/s) — integrate into an offset
+    // and clamp.
     _targetX = (_targetX + event.y).clamp(-_kMaxOffset, _kMaxOffset);
     _targetY = (_targetY - event.x).clamp(-_kMaxOffset, _kMaxOffset);
 
-    // Запускаем тикер если остановлен
-    if (!_ticker.isAnimating) {
-      _ticker.animateTo(
-        _ticker.value + 1,
+    if (!ticker.isAnimating) {
+      ticker.animateTo(
+        ticker.value + 1,
         duration: const Duration(seconds: 10),
       );
     }
   }
 
   void _onTick() {
-    // Плавное сглаживание через lerp
     final double newX = _currentX + (_targetX - _currentX) * _kSmoothing;
     final double newY = _currentY + (_targetY - _currentY) * _kSmoothing;
 
+    // Close enough to the target — skip the rebuild.
     if ((newX - _currentX).abs() < 0.01 && (newY - _currentY).abs() < 0.01) {
-      // Достаточно близко — остановить тикер
       return;
     }
 
@@ -106,9 +133,7 @@ class _GyroscopeParallaxImageState extends State<GyroscopeParallaxImage>
   @override
   void dispose() {
     _subscription?.cancel();
-    if (Platform.isAndroid) {
-      _ticker.dispose();
-    }
+    _ticker?.dispose();
     super.dispose();
   }
 
@@ -123,9 +148,10 @@ class _GyroscopeParallaxImageState extends State<GyroscopeParallaxImage>
               const SizedBox.shrink(),
     );
 
-    if (!Platform.isAndroid) return image;
+    // No active gyroscope (no sensor / not Android) — render the static image.
+    if (_ticker == null) return image;
 
-    // Масштабируем чуть больше чтобы при смещении не было видно краёв
+    // Scale up slightly so the edges stay hidden as the image shifts.
     return ClipRect(
       child: Transform.translate(
         offset: Offset(_currentX, _currentY),

--- a/test/features/settings/screens/settings_screen_test.dart
+++ b/test/features/settings/screens/settings_screen_test.dart
@@ -174,6 +174,25 @@ void main() {
         expect(find.text('...'), findsWidgets);
       });
     });
+
+    group('Data Sources section', () {
+      testWidgets('API Keys value counts every configured source out of total',
+          (WidgetTester tester) async {
+        // 4 of 6 sources set, including ComicVine and Google Books which the
+        // counter previously ignored (it capped at the original 3).
+        await prefs.setString(SettingsKeys.clientId, 'cid');
+        await prefs.setString(SettingsKeys.clientSecret, 'secret');
+        await prefs.setString(SettingsKeys.tmdbApiKey, 'tmdb');
+        await prefs.setString(SettingsKeys.comicVineApiKey, 'cv');
+        await prefs.setString(SettingsKeys.googleBooksApiKey, 'gb');
+
+        await tester.pumpWidget(createWidget());
+        await tester.pumpAndSettle();
+
+        await scrollTo(tester, '4/6');
+        expect(find.text('4/6'), findsOneWidget);
+      });
+    });
   });
 }
 

--- a/test/shared/widgets/gyroscope_parallax_image_test.dart
+++ b/test/shared/widgets/gyroscope_parallax_image_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sensors_plus/sensors_plus.dart';
+import 'package:tonkatsu_box/shared/widgets/gyroscope_parallax_image.dart';
+
+void main() {
+  group('GyroscopeParallaxImage', () {
+    Widget buildWidget(Stream<GyroscopeEvent> stream) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: GyroscopeParallaxImage(
+          imageUrl: 'https://example.com/poster.jpg',
+          gyroscopeStream: stream,
+          errorWidget: (BuildContext context, String url, Object error) =>
+              const SizedBox.shrink(),
+        ),
+      );
+    }
+
+    testWidgets(
+      'swallows a gyroscope stream error (device without sensor) and '
+      'cancels the subscription',
+      (WidgetTester tester) async {
+        final StreamController<GyroscopeEvent> controller =
+            StreamController<GyroscopeEvent>();
+        addTearDown(controller.close);
+
+        await tester.pumpWidget(buildWidget(controller.stream));
+        expect(controller.hasListener, isTrue);
+
+        // A device without a gyroscope: sensors_plus throws a PlatformException.
+        controller.addError(
+          PlatformException(
+            code: 'NO_SENSOR',
+            message: 'Sensor not found',
+            details: 'It seems that your device has no Gyroscope sensor',
+          ),
+        );
+        await tester.pump();
+
+        // The error is swallowed, the widget stays in the tree, and the sensor
+        // subscription is cancelled (no leak / repeated errors).
+        expect(tester.takeException(), isNull);
+        expect(controller.hasListener, isFalse);
+        expect(find.byType(GyroscopeParallaxImage), findsOneWidget);
+      },
+    );
+
+    testWidgets('cancels the gyroscope subscription on dispose',
+        (WidgetTester tester) async {
+      final StreamController<GyroscopeEvent> controller =
+          StreamController<GyroscopeEvent>();
+      addTearDown(controller.close);
+
+      await tester.pumpWidget(buildWidget(controller.stream));
+      expect(controller.hasListener, isTrue);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      expect(controller.hasListener, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Opening an item's detail sheet in search threw PlatformException(NO_SENSOR) on Android devices without a hardware gyroscope (e.g. Honor "Lite" models, many tablets and emulators). The poster parallax now handles the stream error, cancels the sensor subscription and degrades to a static image, so the search detail sheet and the shared media detail view no longer crash.

The Settings -> API Keys row counted only IGDB, SteamGridDB and TMDB, so it capped at "3" even though the credentials screen has six sources. It now shows active/total (e.g. 3/6) across all six and only turns green when every source is configured.

Touched-file comments translated to English; banner dividers dropped.