### PR TITLE
feat(search): show average time-to-beat on game search cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Show average time-to-beat on game search cards**
+
+  IGDB game search and browse cards now carry a clock badge with the average
+  time to beat (IGDB `game_time_to_beats`), in whole hours. The value is the
+  normal playthrough, falling back to the rushed or completionist figure. It is
+  fetched per page alongside the results and kept only in memory — never written
+  to the database — so it appears on the search screen only.
+
+  * lib/shared/models/game_time_to_beat.dart (GameTimeToBeat, GameTimeToBeat.fromJson, GameTimeToBeat.primarySeconds, GameTimeToBeat.primaryHours):
+    New — transient model wrapping IGDB time-to-beat (seconds), with the
+    primary-value selection and hours rounding.
+  * lib/core/api/igdb/igdb_games_api.dart (IgdbGamesApi.getTimeToBeat), lib/core/api/igdb_api.dart (IgdbApi.getTimeToBeat):
+    Fetch `game_time_to_beats` for a batch of game ids (batched by 500), keyed
+    by game id.
+  * lib/shared/models/game.dart (Game.timeToBeat, Game.copyWith): New transient
+    field, excluded from `toDb` / `fromDb` / `fromJson`.
+  * lib/features/search/sources/igdb_games_source.dart (IgdbGamesSource.fetch, IgdbGamesSource._attachTimeToBeat):
+    Attach time-to-beat to each game with one batched request; best-effort, so a
+    failure leaves the search results unchanged.
+  * lib/features/search/widgets/browse_grid.dart (_BrowseGridState._buildCard):
+    Pass `timeToBeatHours: item.timeToBeat?.primaryHours` for game cards.
+  * lib/shared/widgets/media_poster_card.dart (MediaPosterCard.timeToBeatHours):
+    New optional clock badge drawn over the poster (grid/compact), hidden when a
+    status badge is shown; reuses the `runtimeHours` localization.
+
 - **Show manga/anime format on cards and filter by it**
 
   Manga and anime cards now caption the specific format (Manhwa, OVA, Light

--- a/lib/core/api/igdb/igdb_games_api.dart
+++ b/lib/core/api/igdb/igdb_games_api.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../../../shared/models/game.dart';
+import '../../../shared/models/game_time_to_beat.dart';
 import 'igdb_http_client.dart';
 import 'igdb_types.dart';
 
@@ -305,6 +306,57 @@ class IgdbGamesApi {
       return allGames;
     } on DioException catch (e) {
       throw _client.handleDioException(e, 'Failed to fetch games');
+    }
+  }
+
+  /// Fetches average time-to-beat for the given IGDB game ids.
+  ///
+  /// Returns a map keyed by game id; games without time-to-beat data are
+  /// simply absent. Times are kept in seconds (IGDB's unit).
+  Future<Map<int, GameTimeToBeat>> getTimeToBeat(List<int> gameIds) async {
+    _client.ensureCredentials();
+
+    if (gameIds.isEmpty) {
+      return <int, GameTimeToBeat>{};
+    }
+
+    try {
+      final Map<int, GameTimeToBeat> result = <int, GameTimeToBeat>{};
+
+      // IGDB caps a single request at 500 records.
+      for (int i = 0; i < gameIds.length; i += 500) {
+        final List<int> batch = gameIds.sublist(
+          i,
+          i + 500 > gameIds.length ? gameIds.length : i + 500,
+        );
+
+        final String idsString = batch.join(',');
+
+        final Response<dynamic> response = await _client.post(
+          '/game_time_to_beats',
+          data: 'fields game_id,hastily,normally,completely,count; '
+              'where game_id = ($idsString); limit 500;',
+        );
+
+        if (response.statusCode != 200 || response.data == null) {
+          throw IgdbApiException(
+            'Failed to fetch time to beat',
+            statusCode: response.statusCode,
+          );
+        }
+
+        final List<dynamic> data = response.data as List<dynamic>;
+        for (final dynamic item in data) {
+          final Map<String, dynamic> map = item as Map<String, dynamic>;
+          final int? gameId = map['game_id'] as int?;
+          if (gameId == null) continue;
+          result[gameId] = GameTimeToBeat.fromJson(map);
+        }
+      }
+
+      return result;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to fetch time to beat');
     }
   }
 

--- a/lib/core/api/igdb_api.dart
+++ b/lib/core/api/igdb_api.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/api_key_initializer.dart';
 import '../../shared/models/game.dart';
+import '../../shared/models/game_time_to_beat.dart';
 import '../../shared/models/platform.dart';
 import 'igdb/igdb_games_api.dart';
 import 'igdb/igdb_genres_api.dart';
@@ -119,6 +120,9 @@ class IgdbApi {
 
   Future<List<Game>> getGamesByIds(List<int> gameIds) =>
       _games.getGamesByIds(gameIds);
+
+  Future<Map<int, GameTimeToBeat>> getTimeToBeat(List<int> gameIds) =>
+      _games.getTimeToBeat(gameIds);
 
   Future<List<Game>> getTopGamesByPlatform({
     required int platformId,

--- a/lib/features/search/sources/igdb_games_source.dart
+++ b/lib/features/search/sources/igdb_games_source.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/igdb_api.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/game.dart';
+import '../../../shared/models/game_time_to_beat.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_assets.dart';
 import '../filters/igdb_game_mode_filter.dart';
@@ -103,8 +104,10 @@ class IgdbGamesSource extends SearchSource {
         offset: offset,
       );
 
+      final List<Game> withTime = await _attachTimeToBeat(igdb, games);
+
       return BrowseResult(
-        items: games,
+        items: withTime,
         mediaType: MediaType.game,
         hasMore: games.length >= pageSize,
         currentPage: page,
@@ -127,12 +130,32 @@ class IgdbGamesSource extends SearchSource {
       offset: offset,
     );
 
+    final List<Game> withTime = await _attachTimeToBeat(igdb, games);
+
     return BrowseResult(
-      items: games,
+      items: withTime,
       mediaType: MediaType.game,
       hasMore: games.length >= pageSize,
       currentPage: page,
     );
+  }
+
+  /// Attaches IGDB average time-to-beat to each game (one batched request).
+  ///
+  /// Best-effort: a failure here must not break search, so the games are
+  /// returned unchanged if the extra request fails.
+  Future<List<Game>> _attachTimeToBeat(IgdbApi igdb, List<Game> games) async {
+    if (games.isEmpty) return games;
+    try {
+      final Map<int, GameTimeToBeat> byId =
+          await igdb.getTimeToBeat(games.map((Game g) => g.id).toList());
+      if (byId.isEmpty) return games;
+      return games
+          .map((Game g) => g.copyWith(timeToBeat: byId[g.id]))
+          .toList();
+    } on Exception {
+      return games;
+    }
   }
 
   @override

--- a/lib/features/search/widgets/browse_grid.dart
+++ b/lib/features/search/widgets/browse_grid.dart
@@ -340,6 +340,7 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         apiRating: item.rating != null ? item.rating! / 10.0 : null,
         year: item.releaseYear,
         platformLabel: _buildPlatformLabel(item.platformIds),
+        timeToBeatHours: item.timeToBeat?.primaryHours,
         mediaType: mediaType,
         isInCollection: inColl,
         onTap: () => widget.onItemTap(item, mediaType),

--- a/lib/shared/models/game.dart
+++ b/lib/shared/models/game.dart
@@ -1,3 +1,5 @@
+import 'game_time_to_beat.dart';
+
 /// Модель игры из IGDB.
 ///
 /// Представляет игру с метаданными из IGDB API.
@@ -16,6 +18,7 @@ class Game {
     this.externalUrl,
     this.cachedAt,
     this.artworkUrl,
+    this.timeToBeat,
   });
 
   /// Создаёт [Game] из JSON ответа IGDB API.
@@ -162,6 +165,12 @@ class Game {
   /// URL artwork для фонового изображения.
   final String? artworkUrl;
 
+  /// Среднее время прохождения (IGDB `game_time_to_beats`).
+  ///
+  /// Транзиентное поле: подтягивается при поиске, в базе не хранится
+  /// (исключено из [toDb] / [fromDb] / [fromJson]).
+  final GameTimeToBeat? timeToBeat;
+
   /// Возвращает год релиза или null.
   int? get releaseYear => releaseDate?.year;
 
@@ -238,6 +247,7 @@ class Game {
     String? externalUrl,
     int? cachedAt,
     String? artworkUrl,
+    GameTimeToBeat? timeToBeat,
   }) {
     return Game(
       id: id ?? this.id,
@@ -252,6 +262,7 @@ class Game {
       externalUrl: externalUrl ?? this.externalUrl,
       cachedAt: cachedAt ?? this.cachedAt,
       artworkUrl: artworkUrl ?? this.artworkUrl,
+      timeToBeat: timeToBeat ?? this.timeToBeat,
     );
   }
 }

--- a/lib/shared/models/game_time_to_beat.dart
+++ b/lib/shared/models/game_time_to_beat.dart
@@ -1,0 +1,47 @@
+/// Среднее время прохождения игры из IGDB (`game_time_to_beats`).
+///
+/// Транзиентная сущность: подтягивается при поиске и едет вместе с [Game] в
+/// памяти, в базе не хранится. Значения IGDB отдаёт в секундах.
+class GameTimeToBeat {
+  const GameTimeToBeat({
+    this.hastily,
+    this.normally,
+    this.completely,
+    this.count = 0,
+  });
+
+  /// Создаёт [GameTimeToBeat] из записи `game_time_to_beats` IGDB API.
+  factory GameTimeToBeat.fromJson(Map<String, dynamic> json) {
+    return GameTimeToBeat(
+      hastily: json['hastily'] as int?,
+      normally: json['normally'] as int?,
+      completely: json['completely'] as int?,
+      count: (json['count'] as int?) ?? 0,
+    );
+  }
+
+  /// «По-быстрому» (≈ Main Story), секунды.
+  final int? hastily;
+
+  /// «Нормально» (≈ Main + Extra), секунды.
+  final int? normally;
+
+  /// «На 100%» (≈ Completionist), секунды.
+  final int? completely;
+
+  /// Число пользовательских замеров — надёжность данных.
+  final int count;
+
+  /// Наиболее репрезентативное значение в секундах: нормальное прохождение, с
+  /// откатом к быстрому, затем к полному.
+  int? get primarySeconds => normally ?? hastily ?? completely;
+
+  /// Основное значение в часах, округлённое (минимум 1ч, если время > 0).
+  /// Возвращает `null`, когда у игры нет данных о времени прохождения.
+  int? get primaryHours {
+    final int? seconds = primarySeconds;
+    if (seconds == null || seconds <= 0) return null;
+    final int hours = (seconds / 3600).round();
+    return hours < 1 ? 1 : hours;
+  }
+}

--- a/lib/shared/widgets/media_poster_card.dart
+++ b/lib/shared/widgets/media_poster_card.dart
@@ -49,6 +49,7 @@ class MediaPosterCard extends StatefulWidget {
     this.platformLabel,
     this.platformColor,
     this.platformOverlayAsset,
+    this.timeToBeatHours,
     this.onTap,
     this.onLongPress,
     this.onSecondaryTap,
@@ -100,6 +101,10 @@ class MediaPosterCard extends StatefulWidget {
   /// Platform overlay asset (PNG 600×900); when set, drawn over the poster
   /// instead of a text badge.
   final String? platformOverlayAsset;
+
+  /// Average time-to-beat in whole hours (IGDB). When set, a small clock
+  /// badge is drawn over the poster. Grid/compact only; used on search cards.
+  final int? timeToBeatHours;
 
   /// Drives the border color and placeholder icon (canvas).
   final MediaType? mediaType;
@@ -429,6 +434,44 @@ class _MediaPosterCardState extends State<MediaPosterCard>
                     widget.status!.materialIcon,
                     size: _isCompact ? 8 : 12,
                     color: Colors.white,
+                  ),
+                ),
+              ),
+
+            // Average time-to-beat (bottom-left) — search cards only.
+            if (widget.timeToBeatHours != null &&
+                !(widget.status != null &&
+                    widget.status != ItemStatus.notStarted))
+              Positioned(
+                bottom: _isCompact ? 2 : AppSpacing.xs,
+                left: _isCompact ? 2 : AppSpacing.xs,
+                child: Container(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: _isCompact ? 3 : 5,
+                    vertical: _isCompact ? 1 : 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withAlpha(170),
+                    borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: <Widget>[
+                      Icon(
+                        Icons.schedule,
+                        size: _isCompact ? 8 : 11,
+                        color: Colors.white,
+                      ),
+                      SizedBox(width: _isCompact ? 1 : 2),
+                      Text(
+                        S.of(context).runtimeHours(widget.timeToBeatHours!),
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: _isCompact ? 7 : 9,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/test/core/api/igdb_api_games_test.dart
+++ b/test/core/api/igdb_api_games_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/api/igdb_api.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
+import 'package:tonkatsu_box/shared/models/game_time_to_beat.dart';
 
 import '../../helpers/test_helpers.dart';
 
@@ -639,6 +640,151 @@ void main() {
 
         // Should make 2 requests: first for 500, second for 100
         expect(callCount, 2);
+      });
+    });
+
+    group('getTimeToBeat', () {
+      test('returns time-to-beat keyed by game id', () async {
+        when(() => mockDio.post<dynamic>(
+              any(),
+              options: any(named: 'options'),
+              data: any(named: 'data'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              requestOptions: RequestOptions(path: ''),
+              statusCode: 200,
+              data: <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'game_id': 1942,
+                  'hastily': 134552,
+                  'normally': 254778,
+                  'completely': 581483,
+                  'count': 41,
+                },
+                <String, dynamic>{
+                  'game_id': 732,
+                  'normally': 122400,
+                  'count': 18,
+                },
+              ],
+            ));
+
+        final Map<int, GameTimeToBeat> result =
+            await api.getTimeToBeat(<int>[1942, 732]);
+
+        expect(result, hasLength(2));
+        expect(result[1942]!.normally, 254778);
+        expect(result[1942]!.count, 41);
+        expect(result[732]!.normally, 122400);
+        expect(result[732]!.hastily, isNull);
+      });
+
+      test('returns empty map for empty ids without calling the API',
+          () async {
+        final Map<int, GameTimeToBeat> result =
+            await api.getTimeToBeat(<int>[]);
+
+        expect(result, isEmpty);
+        verifyNever(() => mockDio.post<dynamic>(
+              any(),
+              options: any(named: 'options'),
+              data: any(named: 'data'),
+            ));
+      });
+
+      test('posts to /game_time_to_beats with game_id filter', () async {
+        String? capturedUrl;
+        String? capturedData;
+
+        when(() => mockDio.post<dynamic>(
+              any(),
+              options: any(named: 'options'),
+              data: any(named: 'data'),
+            )).thenAnswer((Invocation inv) async {
+          capturedUrl = inv.positionalArguments[0] as String;
+          capturedData = inv.namedArguments[const Symbol('data')] as String?;
+          return Response<dynamic>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 200,
+            data: <Map<String, dynamic>>[],
+          );
+        });
+
+        await api.getTimeToBeat(<int>[1942, 732]);
+
+        expect(capturedUrl, endsWith('/game_time_to_beats'));
+        expect(capturedData, contains('where game_id = (1942,732)'));
+      });
+
+      test('skips entries missing a game id', () async {
+        when(() => mockDio.post<dynamic>(
+              any(),
+              options: any(named: 'options'),
+              data: any(named: 'data'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              requestOptions: RequestOptions(path: ''),
+              statusCode: 200,
+              data: <Map<String, dynamic>>[
+                <String, dynamic>{'normally': 7200},
+                <String, dynamic>{'game_id': 1942, 'normally': 254778},
+              ],
+            ));
+
+        final Map<int, GameTimeToBeat> result =
+            await api.getTimeToBeat(<int>[1942]);
+
+        expect(result, hasLength(1));
+        expect(result.containsKey(1942), isTrue);
+      });
+
+      test('batches requests for more than 500 ids', () async {
+        int callCount = 0;
+        when(() => mockDio.post<dynamic>(
+              any(),
+              options: any(named: 'options'),
+              data: any(named: 'data'),
+            )).thenAnswer((_) async {
+          callCount++;
+          return Response<dynamic>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 200,
+            data: <Map<String, dynamic>>[],
+          );
+        });
+
+        await api.getTimeToBeat(List<int>.generate(600, (int i) => i + 1));
+
+        expect(callCount, 2);
+      });
+
+      test('throws IgdbApiException on HTTP error', () async {
+        when(() => mockDio.post<dynamic>(
+              any(),
+              options: any(named: 'options'),
+              data: any(named: 'data'),
+            )).thenThrow(DioException(
+          requestOptions: RequestOptions(path: ''),
+          response: Response<dynamic>(
+            requestOptions: RequestOptions(path: ''),
+            statusCode: 500,
+          ),
+          type: DioExceptionType.badResponse,
+        ));
+
+        expect(
+          () => api.getTimeToBeat(<int>[1942]),
+          throwsA(isA<IgdbApiException>()),
+        );
+      });
+
+      test('throws IgdbApiException when credentials not set', () async {
+        final IgdbApi apiWithoutCreds = IgdbApi(dio: mockDio);
+
+        expect(
+          () => apiWithoutCreds.getTimeToBeat(<int>[1942]),
+          throwsA(isA<IgdbApiException>()
+              .having((IgdbApiException e) => e.message, 'message',
+                  contains('credentials'))),
+        );
       });
     });
   });

--- a/test/shared/models/game_test.dart
+++ b/test/shared/models/game_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
+import 'package:tonkatsu_box/shared/models/game_time_to_beat.dart';
 
 void main() {
   group('Game', () {
@@ -297,6 +298,28 @@ void main() {
 
         expect(copy.summary, 'Summary');
         expect(copy.rating, 80.0);
+      });
+
+      test('carries the transient timeToBeat', () {
+        const Game original = Game(id: 1, name: 'Original');
+
+        final Game copy = original.copyWith(
+          timeToBeat: const GameTimeToBeat(normally: 7200),
+        );
+
+        expect(copy.timeToBeat?.normally, 7200);
+      });
+    });
+
+    group('timeToBeat is transient', () {
+      test('is excluded from toDb', () {
+        const Game game = Game(
+          id: 1,
+          name: 'Test',
+          timeToBeat: GameTimeToBeat(normally: 7200),
+        );
+
+        expect(game.toDb().containsKey('time_to_beat'), isFalse);
       });
     });
 

--- a/test/shared/models/game_time_to_beat_test.dart
+++ b/test/shared/models/game_time_to_beat_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/game_time_to_beat.dart';
+
+void main() {
+  group('GameTimeToBeat', () {
+    group('fromJson', () {
+      test('parses all fields', () {
+        final GameTimeToBeat ttb = GameTimeToBeat.fromJson(<String, dynamic>{
+          'game_id': 1942,
+          'hastily': 134552,
+          'normally': 254778,
+          'completely': 581483,
+          'count': 41,
+        });
+
+        expect(ttb.hastily, 134552);
+        expect(ttb.normally, 254778);
+        expect(ttb.completely, 581483);
+        expect(ttb.count, 41);
+      });
+
+      test('leaves missing time fields null and count defaults to 0', () {
+        final GameTimeToBeat ttb = GameTimeToBeat.fromJson(<String, dynamic>{
+          'game_id': 293842,
+        });
+
+        expect(ttb.hastily, isNull);
+        expect(ttb.normally, isNull);
+        expect(ttb.completely, isNull);
+        expect(ttb.count, 0);
+      });
+    });
+
+    group('primarySeconds', () {
+      test('prefers normally', () {
+        const GameTimeToBeat ttb = GameTimeToBeat(
+          hastily: 3600,
+          normally: 7200,
+          completely: 10800,
+        );
+
+        expect(ttb.primarySeconds, 7200);
+      });
+
+      test('falls back to hastily when normally is null', () {
+        const GameTimeToBeat ttb =
+            GameTimeToBeat(hastily: 3600, completely: 10800);
+
+        expect(ttb.primarySeconds, 3600);
+      });
+
+      test('falls back to completely when normally and hastily are null', () {
+        const GameTimeToBeat ttb = GameTimeToBeat(completely: 10800);
+
+        expect(ttb.primarySeconds, 10800);
+      });
+
+      test('is null when no times are present', () {
+        const GameTimeToBeat ttb = GameTimeToBeat();
+
+        expect(ttb.primarySeconds, isNull);
+      });
+    });
+
+    group('primaryHours', () {
+      test('rounds seconds to nearest hour', () {
+        const GameTimeToBeat ttb = GameTimeToBeat(normally: 254778);
+
+        expect(ttb.primaryHours, 71);
+      });
+
+      test('clamps sub-hour times up to 1', () {
+        const GameTimeToBeat ttb = GameTimeToBeat(completely: 100);
+
+        expect(ttb.primaryHours, 1);
+      });
+
+      test('is null when there is no time data', () {
+        const GameTimeToBeat ttb = GameTimeToBeat();
+
+        expect(ttb.primaryHours, isNull);
+      });
+    });
+  });
+}

--- a/test/shared/widgets/media_poster_card_test.dart
+++ b/test/shared/widgets/media_poster_card_test.dart
@@ -22,6 +22,7 @@ void main() {
     String? subtitle,
     MediaType? mediaType,
     IconData? placeholderIcon,
+    int? timeToBeatHours,
     VoidCallback? onTap,
     VoidCallback? onLongPress,
     VoidCallback? onOpenInCollection,
@@ -47,6 +48,7 @@ void main() {
             subtitle: subtitle,
             mediaType: mediaType,
             placeholderIcon: placeholderIcon,
+            timeToBeatHours: timeToBeatHours,
             onTap: onTap,
             onLongPress: onLongPress,
             onOpenInCollection: onOpenInCollection,
@@ -313,6 +315,47 @@ void main() {
         expect(tooltipFinder, findsOneWidget);
         final Tooltip tooltip = tester.widget<Tooltip>(tooltipFinder);
         expect(tooltip.message, 'Wolfenstein II: The New Colossus');
+      });
+    });
+
+    group('time-to-beat badge', () {
+      testWidgets('shows the formatted hours when timeToBeatHours is set',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard(timeToBeatHours: 71));
+        await tester.pumpAndSettle();
+
+        expect(find.text('71h'), findsOneWidget);
+      });
+
+      testWidgets('is hidden when timeToBeatHours is null',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.schedule), findsNothing);
+      });
+
+      testWidgets('is hidden when a status badge is shown',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard(
+          timeToBeatHours: 71,
+          status: ItemStatus.inProgress,
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.text('71h'), findsNothing);
+      });
+
+      testWidgets('is not rendered on the canvas variant',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard(
+          variant: CardVariant.canvas,
+          mediaType: MediaType.game,
+          timeToBeatHours: 71,
+        ));
+        await tester.pumpAndSettle();
+
+        expect(find.text('71h'), findsNothing);
       });
     });
 


### PR DESCRIPTION
Game search/browse cards now show a clock badge with IGDB's average time-to-beat in hours (normal playthrough, falling back to rushed or completionist). Fetched per page alongside the results and kept only in memory — never persisted — so it appears on the search screen only.