### PR TITLE
feat(collections): add per-item favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Mark collection items as favorite**
+
+  A per-item favorite flag the user sets from the poster card (a heart in the
+  top-right corner), the item detail screen, the right-click / long-press menu,
+  or the table view. Favorites are per collection item, so the same title in
+  two collections is tracked independently. The collection table gains a
+  favorite column with an inline toggle and a header filter that cycles all →
+  favorites only → non-favorites only; the collection Sort menu gains a
+  "Favorite" mode (favorites first); and the home (All Items) screen gains a
+  favorites-only toggle in the filter bar after the status filter, persisted
+  per profile. The flag travels in `.xcollx` exports and backups under the
+  "personal data" toggle.
+
+  * lib/core/database/migrations/migration_v50.dart (MigrationV50): New — adds
+    the `is_favorite` column to `collection_items` via idempotent
+    `addColumnIfAbsent`.
+  * lib/core/database/migrations/migration_registry.dart (MigrationRegistry.all),
+    lib/core/database/database_service.dart (DatabaseService.setItemFavorite):
+    Register v50 and bump the schema version 49 → 50; delegate the setter to the DAO.
+  * lib/core/database/dao/collection_dao.dart (CollectionDao.setItemFavorite),
+    lib/data/repositories/collection_repository.dart (CollectionRepository.setItemFavorite):
+    Single-column update of `is_favorite`.
+  * lib/shared/models/collection_item.dart (CollectionItem.isFavorite, CollectionItem.fromDbWithJoins, CollectionItem.toDb, CollectionItem.fromExport, CollectionItem.toExport, CollectionItem.copyWith, CollectionItem.internalDbFields):
+    New field; round-trips through the DB and, under `user_data`, the export.
+  * lib/features/collections/providers/collections_provider.dart (CollectionItemsNotifier.toggleFavorite, CollectionItemsNotifier.setFavorite, HomeFavoriteFilterNotifier, homeFavoriteFilterProvider),
+    lib/features/home/providers/all_items_provider.dart (AllItemsNotifier.toggleFavorite, AllItemsNotifier.updateFavoriteLocally):
+    Persist with an optimistic local patch. All Items toggles write the DB,
+    patch the All Items list, and invalidate the item's per-collection notifier
+    so the collection grid and detail screen reload the new flag — avoiding a
+    race where a freshly-built, still-loading collection notifier overwrote it
+    with its pre-write snapshot. `HomeFavoriteFilterNotifier` holds the home
+    favorites-only filter, persisted per profile.
+  * lib/features/home/screens/all_items_screen.dart (AllItemsScreen._buildMediaTypeBar, AllItemsScreen._matchesNonTypeFilters, AllItemsScreen._countByMediaType),
+    lib/shared/widgets/chevron_filter_bar.dart (StatusDropdownSegment.isLast):
+    Favorites-only chevron segment after the status filter; `isLast` lets the
+    status segment grow a right-pointing edge so the favorite segment can follow.
+  * lib/shared/widgets/media_poster_card.dart (MediaPosterCard.isFavorite, MediaPosterCard.showFavorite, MediaPosterCard.onToggleFavorite, _FavoriteButton):
+    Heart badge in the top-right stack — small visible circle with a finger-sized
+    tap target, shown as a static indicator during multi-select.
+  * lib/features/collections/widgets/item_detail/item_detail_app_bar.dart (ItemDetailAppBar.onToggleFavorite),
+    lib/features/collections/screens/item_detail_screen.dart: Heart toggle in the detail app bar.
+  * lib/features/collections/widgets/collection_items_view.dart, lib/features/home/screens/all_items_screen.dart:
+    Favorite entry in the item context menu; wire the card heart toggle.
+  * lib/features/collections/widgets/collection_table/table_column.dart (TableColumn.favorite),
+    lib/features/collections/widgets/collection_table/table_header.dart (TableHeader.filterFavorite),
+    lib/features/collections/widgets/collection_table/table_row.dart (TableRow.onFavoriteToggled),
+    lib/features/collections/widgets/collection_table/collection_table_view.dart (CollectionTableView.onFavoriteToggled),
+    lib/features/collections/widgets/collection_table/cells/favorite_cell.dart (FavoriteCell):
+    Favorite table column with an inline toggle and a three-state header filter.
+  * lib/shared/models/collection_sort_mode.dart (CollectionSortMode.favorite),
+    lib/features/collections/providers/sort_utils.dart (applySortMode, _compareByDisplayName):
+    "Favorite" sort mode (favorites first, then by name); extracted the shared name comparison.
+  * lib/core/services/import_service.dart (ImportService._hasUserData, ImportService._restoreUserData):
+    Restore `is_favorite` on import.
+  * lib/shared/theme/app_colors.dart (AppColors.favorite): New heart colour.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (favorite, addToFavorites, removeFromFavorites, sortFavoriteDisplay, sortFavoriteShort, sortFavoriteDesc): New strings.
+  * docs/RCOLL_FORMAT.md: Document the `is_favorite` user-data field.
+
 - **Show average time-to-beat on game search cards**
 
   IGDB game search and browse cards now carry a clock badge with the average

--- a/docs/RCOLL_FORMAT.md
+++ b/docs/RCOLL_FORMAT.md
@@ -171,6 +171,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 |-------|------|-------------|
 | status | string | `"not_started"`, `"in_progress"`, `"completed"`, `"dropped"`, or `"planned"` |
 | user_comment | string | User's personal notes |
+| is_favorite | number | `1` if the user marked the item a favorite; absent or `0` otherwise |
 | current_season | number | Current season (TV shows) |
 | current_episode | number | Current episode (TV shows) |
 | added_at | number | Unix timestamp (seconds) when item was added |

--- a/lib/core/database/dao/collection_dao.dart
+++ b/lib/core/database/dao/collection_dao.dart
@@ -633,6 +633,16 @@ class CollectionDao {
     );
   }
 
+  Future<void> setItemFavorite(int id, {required bool isFavorite}) async {
+    final Database db = await _getDatabase();
+    await db.update(
+      'collection_items',
+      <String, dynamic>{'is_favorite': isFavorite ? 1 : 0},
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+    );
+  }
+
   /// Moves item to another collection (null = uncategorized) and appends to its
   /// sort order. Returns false on UNIQUE conflict (already present in target).
   Future<bool> updateItemCollectionId(int id, int? collectionId) async {

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -244,7 +244,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 49,
+        version: 50,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {
@@ -495,6 +495,9 @@ class DatabaseService {
   /// `totalMinutes` is stored in minutes.
   Future<void> updateItemTimeSpent(int id, int totalMinutes) =>
       collectionDao.updateItemTimeSpent(id, totalMinutes);
+
+  Future<void> setItemFavorite(int id, {required bool isFavorite}) =>
+      collectionDao.setItemFavorite(id, isFavorite: isFavorite);
 
   Future<bool> updateItemCollectionId(int id, int? collectionId) =>
       collectionDao.updateItemCollectionId(id, collectionId);

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -48,6 +48,7 @@ import 'migration_v46.dart';
 import 'migration_v47.dart';
 import 'migration_v48.dart';
 import 'migration_v49.dart';
+import 'migration_v50.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
@@ -100,6 +101,7 @@ abstract final class MigrationRegistry {
     MigrationV47(),
     MigrationV48(),
     MigrationV49(),
+    MigrationV50(),
   ];
 
   /// Schema version this build can open; newer databases must be rejected.

--- a/lib/core/database/migrations/migration_v50.dart
+++ b/lib/core/database/migrations/migration_v50.dart
@@ -1,0 +1,24 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Adds the user-set `is_favorite` flag to `collection_items`. Per-item and
+/// per-collection: the same title in two collections has independent flags.
+/// Existing rows default to not-favorite (0).
+class MigrationV50 extends Migration {
+  @override
+  int get version => 50;
+
+  @override
+  String get description => 'Collection items: is_favorite flag';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await Migration.addColumnIfAbsent(
+      db,
+      'collection_items',
+      'is_favorite',
+      'is_favorite INTEGER NOT NULL DEFAULT 0',
+    );
+  }
+}

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -552,7 +552,8 @@ class ImportService {
         parsed.lastActivityAt != null ||
         parsed.currentSeason > 0 ||
         parsed.currentEpisode > 0 ||
-        parsed.overrideName != null;
+        parsed.overrideName != null ||
+        parsed.isFavorite;
   }
 
   Future<void> _restoreUserData(int itemId, CollectionItem parsed) async {
@@ -571,6 +572,9 @@ class ImportService {
     }
     if (parsed.overrideName != null) {
       await _database.setItemOverrideName(itemId, parsed.overrideName);
+    }
+    if (parsed.isFavorite) {
+      await _database.setItemFavorite(itemId, isFavorite: true);
     }
     if (parsed.startedAt != null ||
         parsed.completedAt != null ||

--- a/lib/data/repositories/collection_repository.dart
+++ b/lib/data/repositories/collection_repository.dart
@@ -262,6 +262,10 @@ class CollectionRepository {
     await _db.updateItemTimeSpent(id, totalMinutes);
   }
 
+  Future<void> setItemFavorite(int id, {required bool isFavorite}) async {
+    await _db.setItemFavorite(id, isFavorite: isFavorite);
+  }
+
   Future<void> updateItemActivityDates(
     int id, {
     DateTime? startedAt,

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -348,6 +348,34 @@ class HomeStatusFilterNotifier extends Notifier<ItemStatus?> {
   }
 }
 
+const String _homeFavoriteFilterKey = 'home_favorite_filter';
+
+/// `true` shows only favorited items on the home (All Items) screen.
+final NotifierProvider<HomeFavoriteFilterNotifier, bool>
+    homeFavoriteFilterProvider =
+    NotifierProvider<HomeFavoriteFilterNotifier, bool>(
+  HomeFavoriteFilterNotifier.new,
+);
+
+/// Per-profile persistence: key `home_favorite_filter_{profileId}`.
+class HomeFavoriteFilterNotifier extends Notifier<bool> {
+  String get _prefsKey {
+    final String profileId = ref.read(currentProfileProvider).id;
+    return '${_homeFavoriteFilterKey}_$profileId';
+  }
+
+  @override
+  bool build() {
+    final SharedPreferences prefs = ref.watch(sharedPreferencesProvider);
+    return prefs.getBool(_prefsKey) ?? false;
+  }
+
+  void toggle() {
+    state = !state;
+    ref.read(sharedPreferencesProvider).setBool(_prefsKey, state);
+  }
+}
+
 /// Collection IDs containing items with the selected status.
 final FutureProvider<Set<int?>> filteredCollectionIdsProvider =
     FutureProvider<Set<int?>>((Ref ref) async {
@@ -781,6 +809,34 @@ class CollectionItemsNotifier
     ref
         .read(allItemsNotifierProvider.notifier)
         .updateStatusLocally(id, status);
+  }
+
+  /// Flips the favorite flag based on the current (loaded) state.
+  Future<void> toggleFavorite(int id) async {
+    final CollectionItem? target =
+        state.valueOrNull?.where((CollectionItem i) => i.id == id).firstOrNull;
+    await setFavorite(id, isFavorite: !(target?.isFavorite ?? false));
+  }
+
+  /// Persists [isFavorite] and patches local state without a reload. Also syncs
+  /// the All Items view so both stay consistent regardless of which screen
+  /// triggered the change.
+  Future<void> setFavorite(int id, {required bool isFavorite}) async {
+    await _repository.setItemFavorite(id, isFavorite: isFavorite);
+
+    final List<CollectionItem>? items = state.valueOrNull;
+    if (items != null) {
+      state = AsyncData<List<CollectionItem>>(
+        items
+            .map((CollectionItem i) =>
+                i.id == id ? i.copyWith(isFavorite: isFavorite) : i)
+            .toList(),
+      );
+    }
+
+    ref
+        .read(allItemsNotifierProvider.notifier)
+        .updateFavoriteLocally(id, isFavorite: isFavorite);
   }
 
   // Bulk ops needing single-collection context (sort_order). Collection-agnostic

--- a/lib/features/collections/providers/sort_utils.dart
+++ b/lib/features/collections/providers/sort_utils.dart
@@ -1,6 +1,11 @@
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/collection_sort_mode.dart';
 
+int _compareByDisplayName(CollectionItem a, CollectionItem b, String lang) =>
+    a.displayName(lang).toLowerCase().compareTo(
+          b.displayName(lang).toLowerCase(),
+        );
+
 /// [CollectionSortMode.manual] returns the user-defined `sortOrder` as is;
 /// [isDescending] inverts every other mode but never manual.
 List<CollectionItem> applySortMode(
@@ -28,17 +33,12 @@ List<CollectionItem> applySortMode(
         final int cmp =
             a.status.statusSortPriority.compareTo(b.status.statusSortPriority);
         if (cmp != 0) return cmp;
-        return a
-            .displayName(animeMangaTitleLanguage)
-            .toLowerCase()
-            .compareTo(b.displayName(animeMangaTitleLanguage).toLowerCase());
+        return _compareByDisplayName(a, b, animeMangaTitleLanguage);
       });
     case CollectionSortMode.name:
       sorted.sort(
-        (CollectionItem a, CollectionItem b) => a
-            .displayName(animeMangaTitleLanguage)
-            .toLowerCase()
-            .compareTo(b.displayName(animeMangaTitleLanguage).toLowerCase()),
+        (CollectionItem a, CollectionItem b) =>
+            _compareByDisplayName(a, b, animeMangaTitleLanguage),
       );
     case CollectionSortMode.rating:
       sorted.sort((CollectionItem a, CollectionItem b) {
@@ -49,6 +49,13 @@ List<CollectionItem> applySortMode(
         if (rA == null) return 1;
         if (rB == null) return -1;
         return rB.compareTo(rA);
+      });
+    case CollectionSortMode.favorite:
+      sorted.sort((CollectionItem a, CollectionItem b) {
+        if (a.isFavorite != b.isFavorite) {
+          return a.isFavorite ? -1 : 1;
+        }
+        return _compareByDisplayName(a, b, animeMangaTitleLanguage);
       });
     case CollectionSortMode.externalRating:
       sorted.sort((CollectionItem a, CollectionItem b) {

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -569,6 +569,11 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
           onEditCustom: () => _editCustomItem(item),
           onMenuSelected: (ItemDetailMenuAction action) =>
               _handleMenuAction(action, item),
+          onToggleFavorite: () => ref
+              .read(
+                collectionItemsNotifierProvider(widget.collectionId).notifier,
+              )
+              .toggleFavorite(item.id),
           canTrackReleases: true,
           isTracked: _isEpisodeType(item)
               ? ref

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -143,6 +143,11 @@ class CollectionItemsView extends ConsumerWidget {
                       .updateItemTag(itemId, tagId);
                 }
               : null,
+          onFavoriteToggled: canEdit
+              ? (int itemId) => ref
+                  .read(collectionItemsNotifierProvider(collectionId).notifier)
+                  .toggleFavorite(itemId)
+              : null,
           onReorder: isManualSort
               ? (int oldIndex, int newIndex) {
                   ref
@@ -397,6 +402,14 @@ class CollectionItemsView extends ConsumerWidget {
       mediaType: item.displayMediaType,
       typeLabelOverride: item.formatLabel,
       status: item.status,
+      isFavorite: item.isFavorite,
+      showFavorite: canEdit,
+      enableHoverScale: !isSelected,
+      onToggleFavorite: canEdit && !selectionActive
+          ? () => ref
+              .read(collectionItemsNotifierProvider(collectionId).notifier)
+              .toggleFavorite(item.id)
+          : null,
       tagName: tag?.name,
       tagColor: tag?.color,
       tagGlow: tagGlow,
@@ -539,6 +552,15 @@ class CollectionItemsView extends ConsumerWidget {
         Offset.zero & overlay.size,
       ),
       items: <PopupMenuEntry<String>>[
+        if (canEdit) ...<PopupMenuEntry<String>>[
+          contextMenuItem<String>(
+            value: 'favorite',
+            icon: item.isFavorite ? Icons.favorite : Icons.favorite_border,
+            label:
+                item.isFavorite ? l.removeFromFavorites : l.addToFavorites,
+          ),
+          const PopupMenuDivider(),
+        ],
         if (isManualSort) ...<PopupMenuEntry<String>>[
           contextMenuItem<String>(
             value: 'moveToTop',
@@ -589,6 +611,10 @@ class CollectionItemsView extends ConsumerWidget {
         return;
       }
       switch (value) {
+        case 'favorite':
+          ref
+              .read(collectionItemsNotifierProvider(collectionId).notifier)
+              .toggleFavorite(item.id);
         case 'moveToTop':
           ref
               .read(collectionItemsNotifierProvider(collectionId).notifier)

--- a/lib/features/collections/widgets/collection_table/cells/favorite_cell.dart
+++ b/lib/features/collections/widgets/collection_table/cells/favorite_cell.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../shared/theme/app_colors.dart';
+
+/// Favorite column cell: a filled heart for favorites, a faint outline
+/// otherwise. When [onToggle] is supplied the heart is tappable to flip the
+/// flag inline (mirroring the editable rating / status cells).
+class FavoriteCell extends StatelessWidget {
+  const FavoriteCell({
+    required this.isFavorite,
+    this.onToggle,
+    super.key,
+  });
+
+  final bool isFavorite;
+  final VoidCallback? onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget content = Center(
+      child: Icon(
+        isFavorite ? Icons.favorite : Icons.favorite_border,
+        size: 16,
+        color: isFavorite ? AppColors.favorite : AppColors.textTertiary,
+      ),
+    );
+
+    if (onToggle == null) return content;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onToggle,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: content,
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/collection_table/collection_table_view.dart
+++ b/lib/features/collections/widgets/collection_table/collection_table_view.dart
@@ -29,6 +29,7 @@ class CollectionTableView extends ConsumerStatefulWidget {
     this.onRatingChanged,
     this.onStatusChanged,
     this.onTagChanged,
+    this.onFavoriteToggled,
     this.onReorder,
     this.selectedIds,
     this.onToggleSelect,
@@ -47,6 +48,7 @@ class CollectionTableView extends ConsumerStatefulWidget {
   final void Function(int itemId, ItemStatus status, MediaType mediaType)?
       onStatusChanged;
   final void Function(int itemId, int? tagId)? onTagChanged;
+  final void Function(int itemId)? onFavoriteToggled;
   final void Function(int oldIndex, int newIndex)? onReorder;
   final Set<int>? selectedIds;
   final void Function(int itemId)? onToggleSelect;
@@ -61,7 +63,7 @@ class CollectionTableView extends ConsumerStatefulWidget {
 }
 
 class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
-  static const double _minTableWidth = 864;
+  static const double _minTableWidth = 908;
 
   TableColumn _sortColumn = TableColumn.name;
   bool _sortAscending = true;
@@ -71,6 +73,7 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
   double? _filterRating;
   int? _filterTagId;
   String? _filterPlatform;
+  bool? _filterFavorite;
 
   late Map<int, CollectionTag> _cachedTagMap;
 
@@ -94,6 +97,7 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
       _filterRating = null;
       _filterTagId = null;
       _filterPlatform = null;
+      _filterFavorite = null;
       if (hadStatusFilter) {
         WidgetsBinding.instance.addPostFrameCallback(
           (_) => widget.onFilterStatusChanged?.call(null),
@@ -127,6 +131,7 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
           filterRating: _filterRating,
           filterTagId: _filterTagId,
           filterPlatform: _filterPlatform,
+          filterFavorite: _filterFavorite,
           tagMap: _cachedTagMap,
           l: l,
           isReorderable: isReorderable,
@@ -208,6 +213,7 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
         onRatingChanged: widget.onRatingChanged,
         onStatusChanged: widget.onStatusChanged,
         onTagChanged: widget.onTagChanged,
+        onFavoriteToggled: widget.onFavoriteToggled,
         dragIndex: dragIndex,
         isSelected: widget.selectedIds?.contains(item.id) ?? false,
         onToggleSelect: widget.onToggleSelect != null
@@ -251,6 +257,13 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
             widget.items.map(_platformLabel),
             (String a, String b) => a.compareTo(b),
           );
+        case TableColumn.favorite:
+          // All -> favorites only -> non-favorites only -> all.
+          _filterFavorite = switch (_filterFavorite) {
+            null => true,
+            true => false,
+            false => null,
+          };
         default:
           if (_sortColumn == column) {
             _sortAscending = !_sortAscending;
@@ -282,7 +295,8 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
         _filterType != null ||
         _filterRating != null ||
         _filterTagId != null ||
-        _filterPlatform != null;
+        _filterPlatform != null ||
+        _filterFavorite != null;
 
     final List<CollectionItem> list = hasFilter
         ? widget.items
@@ -293,7 +307,8 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
                     (i.userRating ?? 0) == _filterRating) &&
                 (_filterTagId == null || (i.tagId ?? 0) == _filterTagId) &&
                 (_filterPlatform == null ||
-                    _platformLabel(i) == _filterPlatform))
+                    _platformLabel(i) == _filterPlatform) &&
+                (_filterFavorite == null || i.isFavorite == _filterFavorite))
             .toList()
         : List<CollectionItem>.of(widget.items);
 
@@ -309,6 +324,11 @@ class _CollectionTableViewState extends ConsumerState<CollectionTableView> {
           return _platformLabel(a).compareTo(_platformLabel(b)) * dir;
         case TableColumn.status:
           return a.status.index.compareTo(b.status.index) * dir;
+        case TableColumn.favorite:
+          // Favorite is a filter-only column; this keeps the switch exhaustive.
+          final int fa = a.isFavorite ? 1 : 0;
+          final int fb = b.isFavorite ? 1 : 0;
+          return fb.compareTo(fa) * dir;
         case TableColumn.tag:
           return _tagName(a).compareTo(_tagName(b)) * dir;
         case TableColumn.rating:

--- a/lib/features/collections/widgets/collection_table/table_column.dart
+++ b/lib/features/collections/widgets/collection_table/table_column.dart
@@ -4,6 +4,7 @@ enum TableColumn {
   type,
   platform,
   status,
+  favorite,
   tag,
   rating,
   externalRating,

--- a/lib/features/collections/widgets/collection_table/table_header.dart
+++ b/lib/features/collections/widgets/collection_table/table_header.dart
@@ -26,6 +26,7 @@ class TableHeader extends StatelessWidget {
     this.filterRating,
     this.filterTagId,
     this.filterPlatform,
+    this.filterFavorite,
     this.isReorderable = false,
     this.selectionState,
     this.onToggleSelectAll,
@@ -41,6 +42,10 @@ class TableHeader extends StatelessWidget {
   final double? filterRating;
   final int? filterTagId;
   final String? filterPlatform;
+
+  /// Favorite column filter: null = all, true = favorites only, false =
+  /// non-favorites only.
+  final bool? filterFavorite;
   final Map<int, CollectionTag> tagMap;
   final bool isReorderable;
 
@@ -113,6 +118,16 @@ class TableHeader extends StatelessWidget {
             isFiltered: filterStatus != null,
           ),
           _col(
+            l.favorite,
+            TableColumn.favorite,
+            width: 44,
+            alignCenter: true,
+            isFiltered: filterFavorite != null,
+            icon: filterFavorite == null
+                ? Icons.favorite_border
+                : (filterFavorite! ? Icons.favorite : Icons.heart_broken),
+          ),
+          _col(
             filterRating != null
                 ? (filterRating == 0
                     ? '—'
@@ -158,10 +173,36 @@ class TableHeader extends StatelessWidget {
     bool alignEnd = false,
     bool alignCenter = false,
     bool isFiltered = false,
+    IconData? icon,
   }) {
     final bool isActive = !isReorderable && column == sortColumn;
     final bool showFilterIcon = !isReorderable && isFiltered;
     final bool highlighted = isActive || showFilterIcon;
+
+    // Icon-only header (favorite column): the heart shape already conveys the
+    // filter state, so [label] is used as a tooltip instead of a caption.
+    if (icon != null) {
+      return SizedBox(
+        width: width,
+        child: InkWell(
+          key: ValueKey<TableColumn>(column),
+          onTap: isReorderable ? null : () => onSort(column),
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          child: Tooltip(
+            message: label,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+              child: Icon(
+                icon,
+                size: 14,
+                color: highlighted ? AppColors.brand : AppColors.textTertiary,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
     final Widget cell = InkWell(
       key: ValueKey<TableColumn>(column),
       onTap: isReorderable ? null : () => onSort(column),

--- a/lib/features/collections/widgets/collection_table/table_row.dart
+++ b/lib/features/collections/widgets/collection_table/table_row.dart
@@ -10,6 +10,7 @@ import '../../../../shared/theme/app_colors.dart';
 import '../../../../shared/theme/app_spacing.dart';
 import '../../../../shared/theme/app_typography.dart';
 import '../../extensions/item_display_name.dart';
+import 'cells/favorite_cell.dart';
 import 'cells/rating_cell.dart';
 import 'cells/status_cell.dart';
 import 'cells/tag_cell.dart';
@@ -27,6 +28,7 @@ class TableRow extends StatefulWidget {
     this.onRatingChanged,
     this.onStatusChanged,
     this.onTagChanged,
+    this.onFavoriteToggled,
     this.tag,
     this.tags = const <CollectionTag>[],
     this.dragIndex,
@@ -42,6 +44,7 @@ class TableRow extends StatefulWidget {
   final void Function(int itemId, ItemStatus status, MediaType mediaType)?
       onStatusChanged;
   final void Function(int itemId, int? tagId)? onTagChanged;
+  final void Function(int itemId)? onFavoriteToggled;
   final CollectionTag? tag;
   final List<CollectionTag> tags;
 
@@ -102,6 +105,7 @@ class _TableRowState extends State<TableRow> {
                   onRatingChanged: widget.onRatingChanged,
                   onStatusChanged: widget.onStatusChanged,
                   onTagChanged: widget.onTagChanged,
+                  onFavoriteToggled: widget.onFavoriteToggled,
                 ),
               ),
             ),
@@ -123,6 +127,7 @@ class _RowContent extends ConsumerWidget {
     required this.onRatingChanged,
     required this.onStatusChanged,
     required this.onTagChanged,
+    required this.onFavoriteToggled,
   });
 
   final CollectionItem item;
@@ -135,6 +140,7 @@ class _RowContent extends ConsumerWidget {
   final void Function(int itemId, ItemStatus status, MediaType mediaType)?
       onStatusChanged;
   final void Function(int itemId, int? tagId)? onTagChanged;
+  final void Function(int itemId)? onFavoriteToggled;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -240,6 +246,15 @@ class _RowContent extends ConsumerWidget {
             onStatusChanged: onStatusChanged != null
                 ? (ItemStatus s) =>
                     onStatusChanged!(item.id, s, item.mediaType)
+                : null,
+          ),
+        ),
+        SizedBox(
+          width: 44,
+          child: FavoriteCell(
+            isFavorite: item.isFavorite,
+            onToggle: onFavoriteToggled != null
+                ? () => onFavoriteToggled!(item.id)
                 : null,
           ),
         ),

--- a/lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
+++ b/lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
@@ -21,6 +21,7 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
     required this.onToggleCanvas,
     required this.onEditCustom,
     required this.onMenuSelected,
+    this.onToggleFavorite,
     this.canTrackReleases = false,
     this.isTracked = false,
     this.onToggleTracked,
@@ -39,6 +40,9 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback onToggleCanvas;
   final VoidCallback onEditCustom;
   final ValueChanged<ItemDetailMenuAction> onMenuSelected;
+
+  /// Toggles the favorite flag; when null the heart is hidden.
+  final VoidCallback? onToggleFavorite;
 
   /// Whether the calendar bell applies to this item.
   final bool canTrackReleases;
@@ -66,6 +70,19 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
     return ScreenAppBar(
       title: displayName,
       actions: <Widget>[
+        if (isEditable && onToggleFavorite != null)
+          IconButton(
+            icon: Icon(
+              item.isFavorite ? Icons.favorite : Icons.heart_broken,
+            ),
+            color: item.isFavorite
+                ? AppColors.favorite
+                : AppColors.textSecondary,
+            tooltip: item.isFavorite
+                ? l.removeFromFavorites
+                : l.addToFavorites,
+            onPressed: onToggleFavorite,
+          ),
         if (canTrackReleases)
           IconButton(
             icon: Icon(

--- a/lib/features/home/providers/all_items_provider.dart
+++ b/lib/features/home/providers/all_items_provider.dart
@@ -165,6 +165,34 @@ class AllItemsNotifier extends Notifier<AsyncValue<List<CollectionItem>>> {
           .toList(),
     );
   }
+
+  /// Flips the favorite flag from the All Items screen: writes the DB, patches
+  /// this (visible) list, and invalidates the item's per-collection notifier so
+  /// it reloads from the DB when next shown. Invalidating (rather than patching
+  /// that notifier) avoids a race where a freshly-built, still-loading
+  /// collection notifier would overwrite the new flag with its pre-write
+  /// snapshot — which left the item detail screen showing a stale state.
+  Future<void> toggleFavorite(int id) async {
+    final CollectionItem? target =
+        state.valueOrNull?.where((CollectionItem i) => i.id == id).firstOrNull;
+    if (target == null) return;
+    final bool newValue = !target.isFavorite;
+    await _repository.setItemFavorite(id, isFavorite: newValue);
+    updateFavoriteLocally(id, isFavorite: newValue);
+    ref.invalidate(collectionItemsNotifierProvider(target.collectionId));
+  }
+
+  /// Patches an item's favorite flag locally without re-querying the DB.
+  void updateFavoriteLocally(int id, {required bool isFavorite}) {
+    final List<CollectionItem>? items = state.valueOrNull;
+    if (items == null) return;
+    state = AsyncData<List<CollectionItem>>(
+      items
+          .map((CollectionItem i) =>
+              i.id == id ? i.copyWith(isFavorite: isFavorite) : i)
+          .toList(),
+    );
+  }
 }
 
 // ==================== Platform Filter ====================

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -60,13 +60,14 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     final Map<int, CollectionTag> tagsMap =
         ref.watch(allTagsMapProvider).valueOrNull ?? <int, CollectionTag>{};
     final ItemStatus? filterStatus = ref.watch(homeStatusFilterProvider);
+    final bool favoriteOnly = ref.watch(homeFavoriteFilterProvider);
     final String searchQuery = ref.watch(homeSearchQueryProvider);
 
     final Set<int> selection = ref.watch(allItemsSelectionProvider);
     final List<CollectionItem> allItems =
         itemsAsync.valueOrNull ?? const <CollectionItem>[];
     final List<CollectionItem> visibleItems =
-        _applyFilter(allItems, filterStatus, tagsMap, searchQuery);
+        _applyFilter(allItems, filterStatus, favoriteOnly, tagsMap, searchQuery);
     final List<CollectionItem> selectedItems = selection.isEmpty
         ? const <CollectionItem>[]
         : <CollectionItem>[
@@ -76,7 +77,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
 
     return Column(
       children: <Widget>[
-        _buildMediaTypeBar(itemsAsync, filterStatus, tagsMap, searchQuery),
+        _buildMediaTypeBar(
+            itemsAsync, filterStatus, favoriteOnly, tagsMap, searchQuery),
         SubfilterBar(groups: _subfilterGroups(itemsAsync)),
         if (selectedItems.isNotEmpty)
           BulkActionBar(
@@ -109,6 +111,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
   List<CollectionItem> _applyFilter(
     List<CollectionItem> items,
     ItemStatus? filterStatus,
+    bool favoriteOnly,
     Map<int, CollectionTag> tagsMap,
     String searchQuery,
   ) {
@@ -119,17 +122,20 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         .where((CollectionItem item) =>
             (_selectedTypes.isEmpty ||
                 _selectedTypes.contains(item.mediaType)) &&
-            _matchesNonTypeFilters(item, filterStatus, tagsMap, query, lang))
+            _matchesNonTypeFilters(
+                item, filterStatus, favoriteOnly, tagsMap, query, lang))
         .toList();
   }
 
   bool _matchesNonTypeFilters(
     CollectionItem item,
     ItemStatus? filterStatus,
+    bool favoriteOnly,
     Map<int, CollectionTag> tagsMap,
     String lowerQuery,
     String animeMangaTitleLanguage,
   ) {
+    if (favoriteOnly && !item.isFavorite) return false;
     if (filterStatus != null && item.status != filterStatus) return false;
     if (_selectedPlatformIds.isNotEmpty &&
         (item.platformId == null ||
@@ -163,12 +169,13 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
   Widget _buildMediaTypeBar(
     AsyncValue<List<CollectionItem>> itemsAsync,
     ItemStatus? filterStatus,
+    bool favoriteOnly,
     Map<int, CollectionTag> tagsMap,
     String searchQuery,
   ) {
     final List<CollectionItem>? items = itemsAsync.valueOrNull;
     final Map<MediaType, int> counts =
-        _countByMediaType(items, filterStatus, tagsMap, searchQuery);
+        _countByMediaType(items, filterStatus, favoriteOnly, tagsMap, searchQuery);
     final Map<MediaType, int> totals = _rawTotalsByMediaType(items);
     final S l = S.of(context);
 
@@ -262,8 +269,23 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                 status: filterStatus,
                 compact: compact,
                 subtitle: l.detailStatus,
+                isLast: false,
                 onChanged: (ItemStatus? s) =>
                     ref.read(homeStatusFilterProvider.notifier).setFilter(s),
+              ),
+            ),
+            Expanded(
+              child: ChevronSegment(
+                label: l.favorite,
+                icon: Icons.favorite,
+                selected: favoriteOnly,
+                accentColor: AppColors.favorite,
+                isFirst: false,
+                isLast: true,
+                onTap: () =>
+                    ref.read(homeFavoriteFilterProvider.notifier).toggle(),
+                compact: compact,
+                tintWhenInactive: true,
               ),
             ),
           ],
@@ -365,6 +387,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
   Map<MediaType, int> _countByMediaType(
     List<CollectionItem>? items,
     ItemStatus? filterStatus,
+    bool favoriteOnly,
     Map<int, CollectionTag> tagsMap,
     String searchQuery,
   ) {
@@ -374,7 +397,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
         ref.read(sharedPreferencesProvider).animeMangaTitleLanguage;
     final Map<MediaType, int> counts = <MediaType, int>{};
     for (final CollectionItem item in items) {
-      if (!_matchesNonTypeFilters(item, filterStatus, tagsMap, lower, lang)) {
+      if (!_matchesNonTypeFilters(
+          item, filterStatus, favoriteOnly, tagsMap, lower, lang)) {
         continue;
       }
       counts[item.mediaType] = (counts[item.mediaType] ?? 0) + 1;
@@ -476,6 +500,14 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                       mediaType: item.mediaType,
                       typeLabelOverride: item.formatLabel,
                       status: item.status,
+                      isFavorite: item.isFavorite,
+                      showFavorite: true,
+                      enableHoverScale: !isSelected,
+                      onToggleFavorite: selection.isEmpty
+                          ? () => ref
+                              .read(allItemsNotifierProvider.notifier)
+                              .toggleFavorite(item.id)
+                          : null,
                       tagName: tag?.name,
                       tagColor: tag?.color,
                       onTap: selection.isEmpty
@@ -666,6 +698,12 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
       ),
       items: <PopupMenuEntry<String>>[
         contextMenuItem<String>(
+          value: 'favorite',
+          icon: item.isFavorite ? Icons.favorite : Icons.favorite_border,
+          label: item.isFavorite ? l.removeFromFavorites : l.addToFavorites,
+        ),
+        const PopupMenuDivider(),
+        contextMenuItem<String>(
           value: 'move',
           icon: Icons.drive_file_move_outlined,
           label: l.collectionMoveToCollection,
@@ -697,6 +735,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
       return;
     }
     switch (value) {
+      case 'favorite':
+        await ref.read(allItemsNotifierProvider.notifier).toggleFavorite(item.id);
       case 'move':
         await CollectionActions.moveItem(
           context: context,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -73,6 +73,9 @@
   "sortRatingDisplay": "My Rating",
   "sortRatingShort": "Rating",
   "sortRatingDesc": "Highest first",
+  "sortFavoriteDisplay": "Favorite",
+  "sortFavoriteShort": "Favorite",
+  "sortFavoriteDesc": "Favorites first",
   "sortExternalRatingDisplay": "External Rating",
   "sortExternalRatingShort": "IGDB/TMDB",
   "sortExternalRatingDesc": "Highest first",
@@ -105,6 +108,9 @@
   "remove": "Remove",
   "moveToTop": "Move to top",
   "moveToBottom": "Move to bottom",
+  "favorite": "Favorite",
+  "addToFavorites": "Add to favorites",
+  "removeFromFavorites": "Remove from favorites",
   "bulkSelected": "{count, plural, =1{1 selected} other{{count} selected}}",
   "@bulkSelected": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -463,6 +463,24 @@ abstract class S {
   /// **'Highest first'**
   String get sortRatingDesc;
 
+  /// No description provided for @sortFavoriteDisplay.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite'**
+  String get sortFavoriteDisplay;
+
+  /// No description provided for @sortFavoriteShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite'**
+  String get sortFavoriteShort;
+
+  /// No description provided for @sortFavoriteDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorites first'**
+  String get sortFavoriteDesc;
+
   /// No description provided for @sortExternalRatingDisplay.
   ///
   /// In en, this message translates to:
@@ -642,6 +660,24 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Move to bottom'**
   String get moveToBottom;
+
+  /// No description provided for @favorite.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite'**
+  String get favorite;
+
+  /// No description provided for @addToFavorites.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to favorites'**
+  String get addToFavorites;
+
+  /// No description provided for @removeFromFavorites.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove from favorites'**
+  String get removeFromFavorites;
 
   /// No description provided for @bulkSelected.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -195,6 +195,15 @@ class SEn extends S {
   String get sortRatingDesc => 'Highest first';
 
   @override
+  String get sortFavoriteDisplay => 'Favorite';
+
+  @override
+  String get sortFavoriteShort => 'Favorite';
+
+  @override
+  String get sortFavoriteDesc => 'Favorites first';
+
+  @override
   String get sortExternalRatingDisplay => 'External Rating';
 
   @override
@@ -283,6 +292,15 @@ class SEn extends S {
 
   @override
   String get moveToBottom => 'Move to bottom';
+
+  @override
+  String get favorite => 'Favorite';
+
+  @override
+  String get addToFavorites => 'Add to favorites';
+
+  @override
+  String get removeFromFavorites => 'Remove from favorites';
 
   @override
   String bulkSelected(int count) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -195,6 +195,15 @@ class SRu extends S {
   String get sortRatingDesc => 'Сначала лучшие';
 
   @override
+  String get sortFavoriteDisplay => 'Избранное';
+
+  @override
+  String get sortFavoriteShort => 'Избранное';
+
+  @override
+  String get sortFavoriteDesc => 'Сначала избранные';
+
+  @override
   String get sortExternalRatingDisplay => 'Внешний рейтинг';
 
   @override
@@ -283,6 +292,15 @@ class SRu extends S {
 
   @override
   String get moveToBottom => 'В конец списка';
+
+  @override
+  String get favorite => 'Избранное';
+
+  @override
+  String get addToFavorites => 'В избранное';
+
+  @override
+  String get removeFromFavorites => 'Убрать из избранного';
 
   @override
   String bulkSelected(int count) {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -73,6 +73,9 @@
   "sortRatingDisplay": "Мой рейтинг",
   "sortRatingShort": "Оценка",
   "sortRatingDesc": "Сначала лучшие",
+  "sortFavoriteDisplay": "Избранное",
+  "sortFavoriteShort": "Избранное",
+  "sortFavoriteDesc": "Сначала избранные",
   "sortExternalRatingDisplay": "Внешний рейтинг",
   "sortExternalRatingShort": "IGDB/TMDB",
   "sortExternalRatingDesc": "Сначала лучшие",
@@ -105,6 +108,9 @@
   "remove": "Убрать",
   "moveToTop": "В начало списка",
   "moveToBottom": "В конец списка",
+  "favorite": "Избранное",
+  "addToFavorites": "В избранное",
+  "removeFromFavorites": "Убрать из избранного",
   "bulkSelected": "{count, plural, =1{Выбран 1} few{Выбрано {count}} many{Выбрано {count}} other{Выбрано {count}}}",
   "@bulkSelected": {
     "placeholders": {

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -41,6 +41,7 @@ class CollectionItem with Exportable {
     this.userComment,
     this.userRating,
     this.overrideName,
+    this.isFavorite = false,
     this.game,
     this.movie,
     this.tvShow,
@@ -89,6 +90,7 @@ class CollectionItem with Exportable {
       userComment: row['user_comment'] as String?,
       userRating: (row['user_rating'] as num?)?.toDouble(),
       overrideName: row['override_name'] as String?,
+      isFavorite: (row['is_favorite'] as int?) == 1,
       addedAt: DateTime.fromMillisecondsSinceEpoch(
         (row['added_at'] as int) * 1000,
       ),
@@ -144,6 +146,7 @@ class CollectionItem with Exportable {
       userComment: json['user_comment'] as String?,
       userRating: (json['user_rating'] as num?)?.toDouble(),
       overrideName: json['override_name'] as String?,
+      isFavorite: (json['is_favorite'] as int?) == 1,
       sortOrder: (json['sort_order'] as int?) ?? 0,
       addedAt: json['added_at'] != null
           ? DateTime.fromMillisecondsSinceEpoch(
@@ -219,6 +222,10 @@ class CollectionItem with Exportable {
   /// User-set display name that overrides the cached API title. `null` means
   /// "no override" — UI falls back to the joined media's name.
   final String? overrideName;
+
+  /// User-set favorite flag. Per-item and per-collection: the same title in
+  /// two collections has independent flags.
+  final bool isFavorite;
 
   final DateTime addedAt;
   final DateTime? startedAt;
@@ -580,6 +587,7 @@ class CollectionItem with Exportable {
         'started_at', 'completed_at', 'last_activity_at',
         'status', 'current_season', 'current_episode',
         'tag_id', 'time_spent_minutes', 'override_name',
+        'is_favorite',
       };
 
   @override
@@ -604,6 +612,7 @@ class CollectionItem with Exportable {
       'user_rating': userRating,
       'time_spent_minutes': timeSpentMinutes,
       'override_name': overrideName,
+      'is_favorite': isFavorite ? 1 : 0,
       'added_at': addedAt.millisecondsSinceEpoch ~/ 1000,
       'sort_order': sortOrder,
       'started_at': startedAt != null
@@ -637,6 +646,7 @@ class CollectionItem with Exportable {
       }
       data['status'] = status.value;
       data['user_comment'] = userComment;
+      data['is_favorite'] = isFavorite ? 1 : 0;
       data['current_season'] = currentSeason;
       data['current_episode'] = currentEpisode;
       data['time_spent_minutes'] = timeSpentMinutes;
@@ -678,6 +688,7 @@ class CollectionItem with Exportable {
     bool clearUserRating = false,
     String? overrideName,
     bool clearOverrideName = false,
+    bool? isFavorite,
     DateTime? addedAt,
     DateTime? startedAt,
     bool clearStartedAt = false,
@@ -715,6 +726,7 @@ class CollectionItem with Exportable {
       userRating: clearUserRating ? null : (userRating ?? this.userRating),
       overrideName:
           clearOverrideName ? null : (overrideName ?? this.overrideName),
+      isFavorite: isFavorite ?? this.isFavorite,
       addedAt: addedAt ?? this.addedAt,
       startedAt: clearStartedAt ? null : (startedAt ?? this.startedAt),
       completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),

--- a/lib/shared/models/collection_sort_mode.dart
+++ b/lib/shared/models/collection_sort_mode.dart
@@ -19,6 +19,9 @@ enum CollectionSortMode {
   /// По пользовательскому рейтингу (userRating DESC, высшие первыми).
   rating('rating', 'My Rating', 'Rating', 'Highest first'),
 
+  /// Favorites first (isFavorite DESC, then by name).
+  favorite('favorite', 'Favorite', 'Favorite', 'Favorites first'),
+
   /// По внешнему API-рейтингу (apiRating DESC, IGDB/TMDB).
   externalRating('external_rating', 'External Rating', 'IGDB/TMDB', 'Highest first'),
 
@@ -69,6 +72,8 @@ enum CollectionSortMode {
         return l.sortNameDisplay;
       case CollectionSortMode.rating:
         return l.sortRatingDisplay;
+      case CollectionSortMode.favorite:
+        return l.sortFavoriteDisplay;
       case CollectionSortMode.externalRating:
         return l.sortExternalRatingDisplay;
       case CollectionSortMode.lastActivity:
@@ -89,6 +94,8 @@ enum CollectionSortMode {
         return l.sortNameShort;
       case CollectionSortMode.rating:
         return l.sortRatingShort;
+      case CollectionSortMode.favorite:
+        return l.sortFavoriteShort;
       case CollectionSortMode.externalRating:
         return l.sortExternalRatingShort;
       case CollectionSortMode.lastActivity:
@@ -109,6 +116,8 @@ enum CollectionSortMode {
         return l.sortNameDesc;
       case CollectionSortMode.rating:
         return l.sortRatingDesc;
+      case CollectionSortMode.favorite:
+        return l.sortFavoriteDesc;
       case CollectionSortMode.externalRating:
         return l.sortExternalRatingDesc;
       case CollectionSortMode.lastActivity:

--- a/lib/shared/theme/app_colors.dart
+++ b/lib/shared/theme/app_colors.dart
@@ -76,6 +76,9 @@ abstract final class AppColors {
   /// Error.
   static const Color error = Color(0xFFEF5350);
 
+  /// Favorite heart (filled).
+  static const Color favorite = Color(0xFFFF4D6D);
+
   // ==================== Statuses ====================
 
   /// "In Progress" status (playing/watching).

--- a/lib/shared/widgets/chevron_filter_bar.dart
+++ b/lib/shared/widgets/chevron_filter_bar.dart
@@ -270,6 +270,7 @@ class StatusDropdownSegment extends StatelessWidget {
     required this.compact,
     required this.onChanged,
     this.subtitle,
+    this.isLast = true,
     super.key,
   });
 
@@ -284,6 +285,9 @@ class StatusDropdownSegment extends StatelessWidget {
 
   /// Опциональный двухстрочный режим: подпись сверху, выбранный статус снизу.
   final String? subtitle;
+
+  /// `false` draws a right-pointing chevron edge so another segment can follow.
+  final bool isLast;
 
   static const double _chevronWidth = 6;
 
@@ -323,19 +327,19 @@ class StatusDropdownSegment extends StatelessWidget {
               status == s, s.color),
       ],
       child: ClipPath(
-        clipper: const ChevronClipper(
+        clipper: ChevronClipper(
           chevronWidth: _chevronWidth,
           hasLeftNotch: true,
-          hasRightPoint: false,
+          hasRightPoint: !isLast,
         ),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 180),
           curve: Curves.easeOut,
           color: accentColor,
           child: Padding(
-            padding: const EdgeInsets.only(
+            padding: EdgeInsets.only(
               left: _chevronWidth + 1,
-              right: 4,
+              right: isLast ? 4 : _chevronWidth + 1,
             ),
             child: Center(
               child: FittedBox(

--- a/lib/shared/widgets/media_poster_card.dart
+++ b/lib/shared/widgets/media_poster_card.dart
@@ -50,6 +50,10 @@ class MediaPosterCard extends StatefulWidget {
     this.platformColor,
     this.platformOverlayAsset,
     this.timeToBeatHours,
+    this.isFavorite = false,
+    this.showFavorite = false,
+    this.onToggleFavorite,
+    this.enableHoverScale = true,
     this.onTap,
     this.onLongPress,
     this.onSecondaryTap,
@@ -106,6 +110,23 @@ class MediaPosterCard extends StatefulWidget {
   /// badge is drawn over the poster. Grid/compact only; used on search cards.
   final int? timeToBeatHours;
 
+  /// Whether this item is marked favorite. Grid/compact only; drives the
+  /// heart toggle's filled/broken state.
+  final bool isFavorite;
+
+  /// Forces the heart to render as a static (non-tappable) indicator even when
+  /// [onToggleFavorite] is null — e.g. during multi-select, so the heart stays
+  /// visible while taps select the card. Grid/compact only.
+  final bool showFavorite;
+
+  /// Fired when the favorite heart is tapped. When null the heart isn't
+  /// tappable (and is hidden unless [showFavorite] is set). Grid/compact only.
+  final VoidCallback? onToggleFavorite;
+
+  /// When false the hover zoom is suppressed — used for selected cards, whose
+  /// fixed-size selection scrim would otherwise not track the scaled card.
+  final bool enableHoverScale;
+
   /// Drives the border color and placeholder icon (canvas).
   final MediaType? mediaType;
 
@@ -150,7 +171,7 @@ class _MediaPosterCardState extends State<MediaPosterCard>
   Animation<double>? _scaleAnimation;
   FocusNode? _focusNode;
 
-  static const double _hoverScale = 1.04;
+  static const double _hoverScale = 1.02;
 
   bool get _isGridVariant =>
       widget.variant == CardVariant.grid ||
@@ -222,7 +243,8 @@ class _MediaPosterCardState extends State<MediaPosterCard>
             animation: _hoverController!,
             builder: (BuildContext context, Widget? child) {
               return Transform.scale(
-                scale: _scaleAnimation!.value,
+                scale:
+                    widget.enableHoverScale ? _scaleAnimation!.value : 1.0,
                 child: child,
               );
             },
@@ -281,6 +303,12 @@ class _MediaPosterCardState extends State<MediaPosterCard>
         widget.platformOverlayAsset != null && !widget.isInCollection;
     final double borderRadius =
         hasOverlay ? 0 : (_isCompact ? AppSpacing.radiusSm : AppSpacing.radiusMd);
+
+    final bool showFavoriteBadge =
+        widget.onToggleFavorite != null || widget.showFavorite;
+    final bool showPlatformBadge = widget.platformOverlayAsset == null &&
+        widget.platformLabel != null &&
+        widget.platformColor != null;
 
     final Color? glowColor = widget.tagGlow && widget.tagColor != null
         ? Color(widget.tagColor!)
@@ -367,57 +395,68 @@ class _MediaPosterCardState extends State<MediaPosterCard>
                 ),
               ),
 
-            if (widget.isInCollection)
-              Positioned(
-                top: _isCompact ? 2 : AppSpacing.xs,
-                right: _isCompact ? 2 : AppSpacing.xs,
-                child: widget.onOpenInCollection != null
-                    ? _InCollectionButton(
-                        compact: _isCompact,
-                        onTap: widget.onOpenInCollection!,
-                      )
-                    : Container(
-                        padding: EdgeInsets.all(_isCompact ? 2 : 4),
-                        decoration: const BoxDecoration(
-                          color: AppColors.success,
-                          shape: BoxShape.circle,
-                        ),
-                        child: Icon(
-                          Icons.check,
+            // Top-right row: the favorite heart (collection only) sits before
+            // the in-collection button (search) or the platform text badge
+            // (games), which are mutually exclusive.
+            Positioned(
+              top: _isCompact ? 2 : AppSpacing.xs,
+              right: _isCompact ? 2 : AppSpacing.xs,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  if (showFavoriteBadge)
+                    _FavoriteButton(
+                      isFavorite: widget.isFavorite,
+                      compact: _isCompact,
+                      onTap: widget.onToggleFavorite,
+                    ),
+                  if (showFavoriteBadge &&
+                      (widget.isInCollection || showPlatformBadge))
+                    SizedBox(width: _isCompact ? 2 : 4),
+                  if (widget.isInCollection)
+                    widget.onOpenInCollection != null
+                        ? _InCollectionButton(
+                            compact: _isCompact,
+                            onTap: widget.onOpenInCollection!,
+                          )
+                        : Container(
+                            padding: EdgeInsets.all(_isCompact ? 2 : 4),
+                            decoration: const BoxDecoration(
+                              color: AppColors.success,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(
+                              Icons.check,
+                              color: Colors.white,
+                              size: _isCompact ? 8 : 12,
+                            ),
+                          )
+                  // Platform text badge — fallback when there's no overlay.
+                  else if (showPlatformBadge)
+                    Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: _isCompact ? 3 : 5,
+                        vertical: _isCompact ? 1 : 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: widget.platformColor!.withAlpha(210),
+                        borderRadius:
+                            BorderRadius.circular(AppSpacing.radiusXs),
+                      ),
+                      child: Text(
+                        widget.platformLabel!,
+                        style: TextStyle(
                           color: Colors.white,
-                          size: _isCompact ? 8 : 12,
+                          fontSize: _isCompact ? 7 : 9,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.3,
                         ),
                       ),
-              ),
-
-            // Platform text badge (top-right) — fallback when there's no overlay.
-            if (widget.platformOverlayAsset == null &&
-                widget.platformLabel != null &&
-                widget.platformColor != null &&
-                !widget.isInCollection)
-              Positioned(
-                top: _isCompact ? 2 : AppSpacing.xs,
-                right: _isCompact ? 2 : AppSpacing.xs,
-                child: Container(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: _isCompact ? 3 : 5,
-                    vertical: _isCompact ? 1 : 2,
-                  ),
-                  decoration: BoxDecoration(
-                    color: widget.platformColor!.withAlpha(210),
-                    borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
-                  ),
-                  child: Text(
-                    widget.platformLabel!,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: _isCompact ? 7 : 9,
-                      fontWeight: FontWeight.w700,
-                      letterSpacing: 0.3,
                     ),
-                  ),
-                ),
+                ],
               ),
+            ),
 
             if (widget.status != null &&
                 widget.status != ItemStatus.notStarted)
@@ -872,6 +911,67 @@ class _TagBadge extends StatelessWidget {
         onTap!(details.globalPosition);
       },
       child: badge,
+    );
+  }
+}
+
+/// Tappable favorite heart shown over the poster (top-right).
+///
+/// A solid colored circle with a white icon, matching the status /
+/// in-collection badges: the favorite color when on, a dark scrim when off. A
+/// red heart on a translucent scrim blended into colorful, warm-toned covers;
+/// white on a solid fill stays legible over any poster, and the elevation
+/// shadow separates the badge from the background.
+///
+/// The visible badge stays small, but the tap target is padded out to a finger-
+/// friendly box (the bare icon is far under the ~40px touch guideline, so on a
+/// phone it was easy to miss and open the card instead). The heart's own tap
+/// recognizer wins over the card's open-tap, so a hit on the target toggles the
+/// flag rather than opening the item.
+class _FavoriteButton extends StatelessWidget {
+  const _FavoriteButton({
+    required this.isFavorite,
+    required this.compact,
+    this.onTap,
+  });
+
+  final bool isFavorite;
+  final bool compact;
+
+  /// When null the heart is a static indicator: taps fall through to the card
+  /// (e.g. select it) instead of toggling the flag.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget badge = Material(
+      color: isFavorite ? AppColors.favorite : Colors.black.withAlpha(160),
+      shape: const CircleBorder(),
+      elevation: 2,
+      child: Padding(
+        padding: EdgeInsets.all(compact ? 2 : 4),
+        child: Icon(
+          isFavorite ? Icons.favorite : Icons.heart_broken,
+          color: Colors.white,
+          size: compact ? 10 : 13,
+        ),
+      ),
+    );
+
+    if (onTap == null) return badge;
+
+    final double target = compact ? 28 : 32;
+    return SizedBox(
+      width: target,
+      height: target,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          customBorder: const CircleBorder(),
+          child: Align(alignment: Alignment.topRight, child: badge),
+        ),
+      ),
     );
   }
 }

--- a/test/core/database/migrations/migration_v50_test.dart
+++ b/test/core/database/migrations/migration_v50_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v50.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  /// Pre-v50 `collection_items`: a minimal shape without the `is_favorite`
+  /// column.
+  Future<Database> openOldDb() async {
+    return factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 49,
+        onCreate: (Database db, int _) async {
+          await db.execute('''
+            CREATE TABLE collection_items (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              collection_id INTEGER,
+              media_type TEXT NOT NULL DEFAULT 'game',
+              external_id INTEGER NOT NULL,
+              status TEXT DEFAULT 'not_started',
+              added_at INTEGER NOT NULL
+            )
+          ''');
+        },
+      ),
+    );
+  }
+
+  Future<bool> hasFavoriteColumn(Database db) async {
+    final List<Map<String, Object?>> columns =
+        await db.rawQuery('PRAGMA table_info(collection_items)');
+    return columns.any((Map<String, Object?> c) => c['name'] == 'is_favorite');
+  }
+
+  group('MigrationV50', () {
+    late Database db;
+
+    setUp(() async {
+      db = await openOldDb();
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'game',
+        'external_id': 1942,
+        'status': 'completed',
+        'added_at': 1700000000,
+      });
+      await MigrationV50().migrate(db);
+    });
+
+    tearDown(() async => db.close());
+
+    test('adds the is_favorite column', () async {
+      expect(await hasFavoriteColumn(db), isTrue);
+    });
+
+    test('existing rows default to 0 (not favorite)', () async {
+      final List<Map<String, Object?>> rows =
+          await db.query('collection_items');
+      expect(rows.single['is_favorite'], 0);
+    });
+
+    test('is idempotent — re-running does not throw', () async {
+      await MigrationV50().migrate(db);
+      expect(await hasFavoriteColumn(db), isTrue);
+    });
+
+    test('new rows can store is_favorite = 1', () async {
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'game',
+        'external_id': 1943,
+        'status': 'not_started',
+        'added_at': 1700000001,
+        'is_favorite': 1,
+      });
+      final List<Map<String, Object?>> rows = await db.query(
+        'collection_items',
+        where: 'external_id = ?',
+        whereArgs: <Object?>[1943],
+      );
+      expect(rows.single['is_favorite'], 1);
+    });
+  });
+}

--- a/test/features/collections/providers/collections_provider_item_fields_test.dart
+++ b/test/features/collections/providers/collections_provider_item_fields_test.dart
@@ -30,6 +30,11 @@ void main() {
         .thenAnswer((_) async {});
     when(() => repo.updateItemTimeSpent(any(), any()))
         .thenAnswer((_) async {});
+    when(() => repo.setItemFavorite(any(), isFavorite: any(named: 'isFavorite')))
+        .thenAnswer((_) async {});
+    // setFavorite syncs the All Items notifier, which loads via this method.
+    when(() => repo.getAllItemsWithData())
+        .thenAnswer((_) async => <CollectionItem>[]);
   });
 
   ProviderContainer makeContainer(List<CollectionItem> items) {
@@ -106,6 +111,40 @@ void main() {
 
       await n.updateAuthorComment(7, null);
       expect(readItem(n)!.authorComment, isNull);
+    });
+  });
+
+  group('favorite', () {
+    test('toggleFavorite flips false -> true, persists and reflects', () async {
+      final CollectionItemsNotifier n = await loaded(<CollectionItem>[item()]);
+
+      await n.toggleFavorite(7);
+
+      verify(() => repo.setItemFavorite(7, isFavorite: true)).called(1);
+      expect(readItem(n)!.isFavorite, isTrue);
+    });
+
+    test('toggleFavorite flips true -> false', () async {
+      final CollectionItemsNotifier n = await loaded(
+        <CollectionItem>[item().copyWith(isFavorite: true)],
+      );
+
+      await n.toggleFavorite(7);
+
+      verify(() => repo.setItemFavorite(7, isFavorite: false)).called(1);
+      expect(readItem(n)!.isFavorite, isFalse);
+    });
+
+    test('setFavorite persists the explicit value', () async {
+      final CollectionItemsNotifier n = await loaded(<CollectionItem>[item()]);
+
+      await n.setFavorite(7, isFavorite: true);
+      verify(() => repo.setItemFavorite(7, isFavorite: true)).called(1);
+      expect(readItem(n)!.isFavorite, isTrue);
+
+      await n.setFavorite(7, isFavorite: false);
+      verify(() => repo.setItemFavorite(7, isFavorite: false)).called(1);
+      expect(readItem(n)!.isFavorite, isFalse);
     });
   });
 

--- a/test/features/collections/providers/sort_utils_test.dart
+++ b/test/features/collections/providers/sort_utils_test.dart
@@ -14,6 +14,7 @@ CollectionItem _makeItem({
   double? userRating,
   DateTime? addedAt,
   double? apiRating,
+  bool isFavorite = false,
 }) {
   return CollectionItem(
     id: id,
@@ -24,6 +25,7 @@ CollectionItem _makeItem({
     sortOrder: sortOrder,
     userRating: userRating,
     addedAt: addedAt ?? DateTime(2024, 1, id),
+    isFavorite: isFavorite,
     game: Game(id: id * 100, name: name, rating: apiRating),
   );
 }
@@ -528,6 +530,62 @@ void main() {
         expect(result[1].id, 2);
         expect(result[2].apiRating, isNull);
         expect(result[3].apiRating, isNull);
+      });
+    });
+
+    group('CollectionSortMode.favorite', () {
+      test('по умолчанию избранные первыми', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Plain A'),
+          _makeItem(id: 2, name: 'Fav', isFavorite: true),
+          _makeItem(id: 3, name: 'Plain B'),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.favorite,
+        );
+
+        expect(result.first.id, 2);
+      });
+
+      test('при равном флаге — вторичная сортировка по имени (A-Z)', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Zelda', isFavorite: true),
+          _makeItem(id: 2, name: 'Ape Escape', isFavorite: true),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.favorite,
+        );
+
+        expect(
+          result.map((CollectionItem i) => i.itemName).toList(),
+          <String>['Ape Escape', 'Zelda'],
+        );
+      });
+
+      test('isDescending=true — избранные последними', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Fav', isFavorite: true),
+          _makeItem(id: 2, name: 'Plain'),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.favorite,
+          isDescending: true,
+        );
+
+        expect(result.last.id, 1);
+      });
+
+      test('пустой список возвращается пустым', () {
+        expect(
+          applySortMode(<CollectionItem>[], CollectionSortMode.favorite),
+          isEmpty,
+        );
       });
     });
 

--- a/test/features/collections/widgets/collection_items_view_test.dart
+++ b/test/features/collections/widgets/collection_items_view_test.dart
@@ -305,8 +305,8 @@ void main() {
           await gesture.up();
           await tester.pumpAndSettle();
 
-          // Menu shows move/clone/remove + status header + status pill.
-          expect(find.byType(PopupMenuItem<String>), findsNWidgets(5));
+          // Menu shows favorite + move/clone/remove + status header + status pill.
+          expect(find.byType(PopupMenuItem<String>), findsNWidgets(6));
 
           expect(moveCalled, isFalse);
           expect(cloneCalled, isFalse);
@@ -347,7 +347,12 @@ void main() {
           await gesture.up();
           await tester.pumpAndSettle();
 
-          await tester.tap(find.byType(PopupMenuItem<String>).first);
+          await tester.tap(
+            find.widgetWithIcon(
+              PopupMenuItem<String>,
+              Icons.drive_file_move_outlined,
+            ),
+          );
           await tester.pumpAndSettle();
 
           expect(movedItem, isNotNull);

--- a/test/features/collections/widgets/collection_table_view_test.dart
+++ b/test/features/collections/widgets/collection_table_view_test.dart
@@ -78,6 +78,7 @@ void main() {
       'Type': TableColumn.type,
       'Platform': TableColumn.platform,
       'Status': TableColumn.status,
+      'Favorite': TableColumn.favorite,
       'Rating': TableColumn.rating,
       'Year': TableColumn.year,
       'Added': TableColumn.added,
@@ -98,8 +99,8 @@ void main() {
   }
 
   group('TableColumn', () {
-    test('should have 9 values', () {
-      expect(TableColumn.values.length, 9);
+    test('should have 10 values', () {
+      expect(TableColumn.values.length, 10);
     });
 
     test('should contain all expected columns', () {
@@ -110,6 +111,7 @@ void main() {
           TableColumn.type,
           TableColumn.platform,
           TableColumn.status,
+          TableColumn.favorite,
           TableColumn.tag,
           TableColumn.rating,
           TableColumn.externalRating,
@@ -296,6 +298,33 @@ void main() {
 
         // Fourth tap: reset to show all
         await tester.tap(headerFinder('Rating').first);
+        await tester.pumpAndSettle();
+        names = itemNamesInOrder(tester);
+        expect(names.length, 3);
+      });
+
+      testWidgets('should filter by favorite on tap, cycle through values',
+          (WidgetTester tester) async {
+        await pumpTableView(tester, items: <CollectionItem>[
+          gameAlpha.copyWith(isFavorite: true),
+          movieBeta,
+          tvGamma,
+        ]);
+
+        // First tap: favorites only.
+        await tester.tap(headerFinder('Favorite').first);
+        await tester.pumpAndSettle();
+        expect(itemNamesInOrder(tester), <String>['Alpha Game']);
+
+        // Second tap: non-favorites only.
+        await tester.tap(headerFinder('Favorite').first);
+        await tester.pumpAndSettle();
+        List<String> names = itemNamesInOrder(tester);
+        expect(names.length, 2);
+        expect(names, isNot(contains('Alpha Game')));
+
+        // Third tap: reset to all.
+        await tester.tap(headerFinder('Favorite').first);
         await tester.pumpAndSettle();
         names = itemNamesInOrder(tester);
         expect(names.length, 3);

--- a/test/features/home/providers/all_items_provider_test.dart
+++ b/test/features/home/providers/all_items_provider_test.dart
@@ -65,6 +65,10 @@ void main() {
         .thenAnswer((_) async => <Collection>[]);
     when(() => mockRepo.getStats(any()))
         .thenAnswer((_) async => CollectionStats.empty);
+    when(() => mockRepo.getItemsWithData(any()))
+        .thenAnswer((_) async => <CollectionItem>[]);
+    when(() => mockRepo.setItemFavorite(any(),
+        isFavorite: any(named: 'isFavorite'))).thenAnswer((_) async {});
 
     mockDb = MockDatabaseService();
     mockGameDao = MockGameDao();
@@ -405,6 +409,62 @@ void main() {
       expect(
         container.read(allItemsNotifierProvider).valueOrNull?.first.id,
         2,
+      );
+    });
+
+    test('updateFavoriteLocally патчит флаг только у нужного элемента',
+        () async {
+      final List<CollectionItem> items = <CollectionItem>[
+        _makeItem(id: 1),
+        _makeItem(id: 2),
+      ];
+      when(() => mockRepo.getAllItemsWithData())
+          .thenAnswer((_) async => items);
+
+      final ProviderContainer container = createContainer();
+      container.read(allItemsNotifierProvider);
+      await _pump();
+
+      container
+          .read(allItemsNotifierProvider.notifier)
+          .updateFavoriteLocally(1, isFavorite: true);
+
+      final List<CollectionItem>? state =
+          container.read(allItemsNotifierProvider).valueOrNull;
+      expect(
+        state!.firstWhere((CollectionItem i) => i.id == 1).isFavorite,
+        isTrue,
+      );
+      expect(
+        state.firstWhere((CollectionItem i) => i.id == 2).isFavorite,
+        isFalse,
+      );
+    });
+
+    test('toggleFavorite пишет в БД и обновляет состояние', () async {
+      final List<CollectionItem> items = <CollectionItem>[
+        _makeItem(id: 1, collectionId: 1),
+      ];
+      when(() => mockRepo.getAllItemsWithData())
+          .thenAnswer((_) async => items);
+
+      final ProviderContainer container = createContainer();
+      container.read(allItemsNotifierProvider);
+      await _pump();
+
+      await container
+          .read(allItemsNotifierProvider.notifier)
+          .toggleFavorite(1);
+      await _pump();
+
+      verify(() => mockRepo.setItemFavorite(1, isFavorite: true)).called(1);
+      expect(
+        container
+            .read(allItemsNotifierProvider)
+            .valueOrNull
+            ?.firstWhere((CollectionItem i) => i.id == 1)
+            .isFavorite,
+        isTrue,
       );
     });
   });

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -333,6 +333,31 @@ void main() {
       expect(find.textContaining('Watch List'), findsOneWidget);
       expect(find.textContaining('My Games'), findsOneWidget);
     });
+
+    testWidgets('фильтр Избранное оставляет только избранные и сбрасывается',
+        (WidgetTester tester) async {
+      when(() =>
+              mockRepo.getAllItemsWithData(mediaType: any(named: 'mediaType')))
+          .thenAnswer((_) async => <CollectionItem>[
+                testItems[0].copyWith(isFavorite: true), // game, My Games
+                testItems[2], // tvShow, Watch List, not favorite
+              ]);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('My Games'), findsOneWidget);
+      expect(find.textContaining('Watch List'), findsOneWidget);
+
+      await tester.tap(find.text('Favorite'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('My Games'), findsOneWidget);
+      expect(find.textContaining('Watch List'), findsNothing);
+
+      await tester.tap(find.text('Favorite'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Watch List'), findsOneWidget);
+    });
   });
 
   group('AllItemsScreen платформенный фильтр', () {

--- a/test/shared/models/collection_item_test.dart
+++ b/test/shared/models/collection_item_test.dart
@@ -86,6 +86,57 @@ void main() {
       });
     });
 
+    group('isFavorite', () {
+      Map<String, dynamic> baseRow(Object? isFavorite) => <String, dynamic>{
+            'id': 1,
+            'collection_id': 10,
+            'media_type': 'game',
+            'external_id': 1942,
+            'status': 'completed',
+            'added_at': testAddedAtUnix,
+            'is_favorite': isFavorite,
+          };
+
+      test('fromDb reads 1 as true, 0 and null as false', () {
+        expect(CollectionItem.fromDb(baseRow(1)).isFavorite, isTrue);
+        expect(CollectionItem.fromDb(baseRow(0)).isFavorite, isFalse);
+        expect(CollectionItem.fromDb(baseRow(null)).isFavorite, isFalse);
+      });
+
+      test('toDb writes 1 / 0', () {
+        expect(CollectionItem.fromDb(baseRow(1)).toDb()['is_favorite'], 1);
+        expect(CollectionItem.fromDb(baseRow(0)).toDb()['is_favorite'], 0);
+      });
+
+      test('toExport carries is_favorite only with user data', () {
+        final CollectionItem item = CollectionItem.fromDb(baseRow(1));
+        expect(item.toExport(includeUserData: true)['is_favorite'], 1);
+        expect(item.toExport().containsKey('is_favorite'), isFalse);
+      });
+
+      test('fromExport reads is_favorite, defaulting to false when absent', () {
+        final CollectionItem present =
+            CollectionItem.fromExport(<String, dynamic>{
+          'media_type': 'game',
+          'external_id': 1942,
+          'is_favorite': 1,
+        });
+        final CollectionItem absent =
+            CollectionItem.fromExport(<String, dynamic>{
+          'media_type': 'game',
+          'external_id': 1942,
+        });
+        expect(present.isFavorite, isTrue);
+        expect(absent.isFavorite, isFalse);
+      });
+
+      test('copyWith updates the flag', () {
+        final CollectionItem item = CollectionItem.fromDb(baseRow(0));
+        expect(item.copyWith(isFavorite: true).isFavorite, isTrue);
+        expect(item.isFavorite, isFalse);
+      });
+    });
+
     group('fromDb', () {
       test('should create CollectionItem из полной записи БД', () {
         final Map<String, dynamic> row = <String, dynamic>{

--- a/test/shared/models/collection_sort_mode_test.dart
+++ b/test/shared/models/collection_sort_mode_test.dart
@@ -4,8 +4,8 @@ import 'package:tonkatsu_box/shared/models/collection_sort_mode.dart';
 void main() {
   group('CollectionSortMode', () {
     group('значения enum', () {
-      test('should contain 7 значений', () {
-        expect(CollectionSortMode.values.length, 7);
+      test('should contain 8 значений', () {
+        expect(CollectionSortMode.values.length, 8);
       });
 
       test('should contain все режимы сортировки', () {
@@ -17,6 +17,10 @@ void main() {
         expect(CollectionSortMode.values, contains(CollectionSortMode.status));
         expect(CollectionSortMode.values, contains(CollectionSortMode.name));
         expect(CollectionSortMode.values, contains(CollectionSortMode.rating));
+        expect(
+          CollectionSortMode.values,
+          contains(CollectionSortMode.favorite),
+        );
         expect(
           CollectionSortMode.values,
           contains(CollectionSortMode.externalRating),

--- a/test/shared/widgets/media_poster_card_test.dart
+++ b/test/shared/widgets/media_poster_card_test.dart
@@ -23,9 +23,12 @@ void main() {
     MediaType? mediaType,
     IconData? placeholderIcon,
     int? timeToBeatHours,
+    bool isFavorite = false,
+    bool showFavorite = false,
     VoidCallback? onTap,
     VoidCallback? onLongPress,
     VoidCallback? onOpenInCollection,
+    VoidCallback? onToggleFavorite,
   }) {
     return MaterialApp(
       localizationsDelegates: S.localizationsDelegates,
@@ -49,9 +52,12 @@ void main() {
             mediaType: mediaType,
             placeholderIcon: placeholderIcon,
             timeToBeatHours: timeToBeatHours,
+            isFavorite: isFavorite,
+            showFavorite: showFavorite,
             onTap: onTap,
             onLongPress: onLongPress,
             onOpenInCollection: onOpenInCollection,
+            onToggleFavorite: onToggleFavorite,
           ),
         ),
       ),
@@ -179,6 +185,39 @@ void main() {
           matching: find.byType(Focus),
         );
         expect(focusWidgets, findsOneWidget);
+      });
+    });
+
+    group('favorite heart', () {
+      // The heart is the only InkWell in a plain grid card, so locating it by
+      // type stays robust if the icon/colour changes.
+      testWidgets('tapping the heart fires onToggleFavorite, not onTap',
+          (WidgetTester tester) async {
+        bool toggled = false;
+        bool cardTapped = false;
+        await tester.pumpWidget(buildCard(
+          onTap: () => cardTapped = true,
+          onToggleFavorite: () => toggled = true,
+        ));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(InkWell));
+        await tester.pumpAndSettle();
+
+        expect(toggled, isTrue);
+        expect(cardTapped, isFalse);
+      });
+
+      testWidgets('renders a static indicator when forced without a callback',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildCard(isFavorite: true, showFavorite: true),
+        );
+        await tester.pumpAndSettle();
+
+        // Forced indicator is not interactive — no InkWell tap target.
+        expect(find.byType(InkWell), findsNothing);
+        expect(tester.takeException(), isNull);
       });
     });
 


### PR DESCRIPTION
Per-item favorite flag set from the poster card, detail screen, context menu and table view. Adds a favorites column with inline toggle and a three-state header filter in the table, a "Favorite" sort mode (favorites first), and a favorites-only toggle on the home (All Items) filter bar after the status filter. Favorites are per collection item, stored in collection_items (migration v50), and travel in .xcollx exports and backups under the personal-data toggle.