### PR TITLE
feat(search): add results to multiple collections at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,50 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
   * lib/features/wishlist/widgets/wishlist_tile.dart (WishlistTile): trailing resolve, edit and delete icon buttons.
 
+- **Add search results to several collections at once**
+
+  The Search tab gains a row of collection chips under the filter bar. With
+  none selected, tapping a result opens its details as before. Select one or
+  more and a tap drops the result straight into every selected collection — no
+  per-result dialog — and a single summary snackbar reports how many it landed
+  in. A pinned counter at the row's leading edge shows how many collections are
+  selected (visible even when the chips have scrolled off-screen, e.g. on a
+  phone) and clears the selection on tap. Opening Search from a collection's
+  "add items" prefills that collection's chip. Games still ask for the platform
+  once, then reuse it for every target.
+
+  * lib/features/search/widgets/collection_chips_row.dart (CollectionChipsRow):
+    New — horizontal, multi-select chip row that reads and writes
+    `searchTargetCollectionsProvider`; collapses to nothing when there are no
+    collections; pins a `SelectedCountChip` at the leading edge while a
+    selection is active.
+  * lib/shared/widgets/selected_count_chip.dart (SelectedCountChip): New —
+    reusable pinned pill showing the selected count and clearing the selection
+    on tap.
+  * lib/features/search/services/search_collection_adder.dart (SearchCollectionAdder.addToCollections):
+    New — batch add that upserts the model and caches the image once, skips
+    collections that already hold the item, drops ids of collections deleted
+    while selected, and reports one summary snackbar.
+  * lib/shared/navigation/search_providers.dart (searchTargetCollectionsProvider, SearchTabRequest.collectionId):
+    Replace the single `searchTargetCollectionProvider` (`int?`) with a
+    `Set<int>` for the multi-select selection.
+  * lib/features/search/handlers/game_handler.dart (GameHandler.onTap, GameHandler._addToCollections),
+    lib/features/search/handlers/movie_handler.dart (MovieHandler.onTap, MovieHandler._addToCollections),
+    lib/features/search/handlers/tv_show_handler.dart (TvShowHandler.onTap, TvShowHandler._addToCollections),
+    lib/features/search/handlers/simple_media_handler.dart (SimpleMediaHandler.onTap, SimpleMediaHandler._addToCollections),
+    lib/features/search/handlers/media_handlers.dart (MediaHandlers):
+    Take a `Set<int> Function() targetCollections` closure resolved at tap time
+    and forward to `addToCollections`.
+  * lib/features/search/screens/search_screen.dart (_SearchScreenState._buildHandlers):
+    Read the target collections live so the handlers never rebuild when the
+    selection changes; mount `CollectionChipsRow` under the filter bar.
+  * lib/shared/navigation/app_shell.dart (resetSearchTabState, _AppShellState._openSearchTab):
+    Reset clears the set; opening Search from a collection seeds it with that
+    one id.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (searchAddedToCollections, searchAlreadyInCollections):
+    New pluralised "added to N collections" / "already in the selected
+    collections" snackbar strings.
+
 ### Changed
 
 - **Config export/import now covers every credential and setting** — all source credentials (ComicVine, Google Books, ScreenScraper, RetroAchievements, Steam, AniList), the app language, and the display/feature toggles (recommendations, Blu-ray and platform overlays, Discord RPC, RA sync, rich collections, hide-empty-media chevrons).
@@ -146,6 +190,20 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
   * lib/core/import/sources/trakt/trakt_import_service.dart (TraktImportService): relocated from lib/core/services and reimplemented as an ImportSource over ImportWriter.
   * lib/features/settings/content/trakt_import_content.dart, test/helpers/mocks.dart (MockTraktImportService): updated to the new API.
+
+- **Media-type subfilter bar: scroll affordances and a selection highlight**
+
+  The subfilter chip row under the search and collection filters now uses the
+  same ScrollableRowWithArrows treatment as the rest of the app, so overflowing
+  chips can be reached with hover arrows and the mouse wheel on desktop, not
+  just a touch swipe. When any subfilter is active the whole strip is tinted
+  with the selected media type's accent, so an active filter stays obvious even
+  when the selected chip has scrolled off-screen.
+
+  * lib/shared/widgets/filter_subfilter_bar.dart (SubfilterBar): Converted to a
+    StatefulWidget that owns a ScrollController, wraps its row in
+    ScrollableRowWithArrows, and tints the strip with the first selected chip's
+    accent while a subfilter is active.
 
 ### Fixed
 

--- a/lib/features/search/handlers/game_handler.dart
+++ b/lib/features/search/handlers/game_handler.dart
@@ -24,18 +24,18 @@ class GameHandler implements MediaActionHandler {
     required WidgetRef ref,
     required SearchCollectionAdder adder,
     required Map<int, Platform> Function() platformMap,
-    required int? targetCollectionId,
+    required Set<int> Function() targetCollections,
     void Function(Game game)? onGameSelected,
   })  : _ref = ref,
         _adder = adder,
         _platformMap = platformMap,
-        _targetCollectionId = targetCollectionId,
+        _targetCollections = targetCollections,
         _onGameSelected = onGameSelected;
 
   final WidgetRef _ref;
   final SearchCollectionAdder _adder;
   final Map<int, Platform> Function() _platformMap;
-  final int? _targetCollectionId;
+  final Set<int> Function() _targetCollections;
   final void Function(Game game)? _onGameSelected;
 
   @override
@@ -49,8 +49,9 @@ class GameHandler implements MediaActionHandler {
       _onGameSelected(game);
       return;
     }
-    if (_targetCollectionId != null) {
-      await _addToCollection(context, _targetCollectionId, game);
+    final Set<int> targets = _targetCollections();
+    if (targets.isNotEmpty) {
+      await _addToCollections(context, targets, game);
       return;
     }
     showDetails(context, game, mediaType);
@@ -114,14 +115,19 @@ class GameHandler implements MediaActionHandler {
     );
   }
 
-  Future<void> _addToCollection(
+  /// Adds [game] to all [collectionIds] (multi-select add). The platform is
+  /// asked once, then reused for every target collection.
+  Future<void> _addToCollections(
     BuildContext context,
-    int collectionId,
+    Set<int> collectionIds,
     Game game,
   ) async {
     final List<CollectedItemInfo> infos = await _collectedInfos(game.id);
+    // Platforms already present in any of the target collections — used only to
+    // mark them in the picker, not to block (same game on a new platform is OK).
     final Set<int> alreadyPlatforms = infos
-        .where((CollectedItemInfo i) => i.collectionId == collectionId)
+        .where((CollectedItemInfo i) =>
+            i.collectionId != null && collectionIds.contains(i.collectionId))
         .map((CollectedItemInfo i) => i.platformId)
         .whereType<int>()
         .toSet();
@@ -134,9 +140,9 @@ class GameHandler implements MediaActionHandler {
     );
     if (platformId == null || !context.mounted) return;
 
-    await _adder.addToCollection(
+    await _adder.addToCollections(
       context: context,
-      collectionId: collectionId,
+      collectionIds: collectionIds,
       mediaType: MediaType.game,
       externalId: game.id,
       platformId: platformId,

--- a/lib/features/search/handlers/media_handlers.dart
+++ b/lib/features/search/handlers/media_handlers.dart
@@ -43,7 +43,7 @@ class MediaHandlers {
   MediaHandlers({
     required WidgetRef ref,
     required Map<int, Platform> Function() platformMap,
-    required int? targetCollectionId,
+    required Set<int> Function() targetCollections,
     void Function(Game game)? onGameSelected,
   }) {
     final SearchCollectionAdder adder = SearchCollectionAdder(ref);
@@ -51,23 +51,23 @@ class MediaHandlers {
       ref: ref,
       adder: adder,
       platformMap: platformMap,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
       onGameSelected: onGameSelected,
     );
     _byType[Movie] = MovieHandler(
       ref: ref,
       adder: adder,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
     );
     _byType[TvShow] = TvShowHandler(
       ref: ref,
       adder: adder,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
     );
     _byType[VisualNovel] = SimpleMediaHandler<VisualNovel>(
       ref: ref,
       adder: adder,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
       mediaType: MediaType.visualNovel,
       imageType: ImageType.vnCover,
       collectedProvider: collectedVisualNovelIdsProvider,
@@ -83,7 +83,7 @@ class MediaHandlers {
     _byType[Manga] = SimpleMediaHandler<Manga>(
       ref: ref,
       adder: adder,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
       mediaType: MediaType.manga,
       imageType: ImageType.mangaCover,
       collectedProvider: collectedMangaIdsProvider,
@@ -109,7 +109,7 @@ class MediaHandlers {
     _byType[Anime] = SimpleMediaHandler<Anime>(
       ref: ref,
       adder: adder,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
       mediaType: MediaType.anime,
       imageType: ImageType.animeCover,
       collectedProvider: collectedAnimeIdsProvider,
@@ -134,7 +134,7 @@ class MediaHandlers {
     _byType[Book] = SimpleMediaHandler<Book>(
       ref: ref,
       adder: adder,
-      targetCollectionId: targetCollectionId,
+      targetCollections: targetCollections,
       mediaType: MediaType.book,
       imageType: ImageType.bookCover,
       collectedProvider: collectedBookIdsProvider,

--- a/lib/features/search/handlers/movie_handler.dart
+++ b/lib/features/search/handlers/movie_handler.dart
@@ -17,17 +17,17 @@ import 'media_action_handler.dart';
 /// unions movie + animation collections because the same TMDB id may
 /// have been added under either media type.
 class MovieHandler implements MediaActionHandler {
-  const MovieHandler({
+  MovieHandler({
     required WidgetRef ref,
     required SearchCollectionAdder adder,
-    required int? targetCollectionId,
+    required Set<int> Function() targetCollections,
   })  : _ref = ref,
         _adder = adder,
-        _targetCollectionId = targetCollectionId;
+        _targetCollections = targetCollections;
 
   final WidgetRef _ref;
   final SearchCollectionAdder _adder;
-  final int? _targetCollectionId;
+  final Set<int> Function() _targetCollections;
 
   @override
   Future<void> onTap(
@@ -36,8 +36,9 @@ class MovieHandler implements MediaActionHandler {
     MediaType mediaType,
   ) async {
     final Movie movie = item as Movie;
-    if (_targetCollectionId != null) {
-      await _addToCollection(context, _targetCollectionId, movie, mediaType);
+    final Set<int> targets = _targetCollections();
+    if (targets.isNotEmpty) {
+      await _addToCollections(context, targets, movie, mediaType);
       return;
     }
     showDetails(context, movie, mediaType);
@@ -95,15 +96,15 @@ class MovieHandler implements MediaActionHandler {
     );
   }
 
-  Future<void> _addToCollection(
+  Future<void> _addToCollections(
     BuildContext context,
-    int collectionId,
+    Set<int> collectionIds,
     Movie movie,
     MediaType mediaType,
   ) async {
-    await _adder.addToCollection(
+    await _adder.addToCollections(
       context: context,
-      collectionId: collectionId,
+      collectionIds: collectionIds,
       mediaType: mediaType,
       externalId: movie.tmdbId,
       platformId: mediaType == MediaType.animation
@@ -116,5 +117,4 @@ class MovieHandler implements MediaActionHandler {
       imageUrl: movie.posterUrl,
     );
   }
-
 }

--- a/lib/features/search/handlers/simple_media_handler.dart
+++ b/lib/features/search/handlers/simple_media_handler.dart
@@ -20,7 +20,7 @@ class SimpleMediaHandler<T extends Object> implements MediaActionHandler {
   SimpleMediaHandler({
     required WidgetRef ref,
     required SearchCollectionAdder adder,
-    required int? targetCollectionId,
+    required Set<int> Function() targetCollections,
     required this.mediaType,
     required this.imageType,
     required this.collectedProvider,
@@ -35,11 +35,11 @@ class SimpleMediaHandler<T extends Object> implements MediaActionHandler {
     this.enrichBeforeDetails,
   })  : _ref = ref,
         _adder = adder,
-        _targetCollectionId = targetCollectionId;
+        _targetCollections = targetCollections;
 
   final WidgetRef _ref;
   final SearchCollectionAdder _adder;
-  final int? _targetCollectionId;
+  final Set<int> Function() _targetCollections;
 
   final MediaType mediaType;
   final ImageType imageType;
@@ -84,8 +84,9 @@ class SimpleMediaHandler<T extends Object> implements MediaActionHandler {
     MediaType mediaType,
   ) async {
     final T typed = item as T;
-    if (_targetCollectionId != null) {
-      await _addToCollection(context, _targetCollectionId, typed);
+    final Set<int> targets = _targetCollections();
+    if (targets.isNotEmpty) {
+      await _addToCollections(context, targets, typed);
       return;
     }
     // Sources with sparse search rows (Fantlab) fetch the full record before
@@ -146,16 +147,16 @@ class SimpleMediaHandler<T extends Object> implements MediaActionHandler {
     );
   }
 
-  Future<void> _addToCollection(
+  Future<void> _addToCollections(
     BuildContext context,
-    int collectionId,
+    Set<int> collectionIds,
     T item,
   ) async {
     final T typed = await _enriched(context, item);
     if (!context.mounted) return;
-    await _adder.addToCollection(
+    await _adder.addToCollections(
       context: context,
-      collectionId: collectionId,
+      collectionIds: collectionIds,
       mediaType: mediaType,
       externalId: externalIdOf(typed),
       source: sourceOf?.call(typed),

--- a/lib/features/search/handlers/tv_show_handler.dart
+++ b/lib/features/search/handlers/tv_show_handler.dart
@@ -20,17 +20,17 @@ import 'media_action_handler.dart';
 /// seasons/episodes cache is warmed so the detail screen opens without
 /// a network round-trip.
 class TvShowHandler implements MediaActionHandler {
-  const TvShowHandler({
+  TvShowHandler({
     required WidgetRef ref,
     required SearchCollectionAdder adder,
-    required int? targetCollectionId,
+    required Set<int> Function() targetCollections,
   })  : _ref = ref,
         _adder = adder,
-        _targetCollectionId = targetCollectionId;
+        _targetCollections = targetCollections;
 
   final WidgetRef _ref;
   final SearchCollectionAdder _adder;
-  final int? _targetCollectionId;
+  final Set<int> Function() _targetCollections;
 
   @override
   Future<void> onTap(
@@ -39,8 +39,9 @@ class TvShowHandler implements MediaActionHandler {
     MediaType mediaType,
   ) async {
     final TvShow tvShow = item as TvShow;
-    if (_targetCollectionId != null) {
-      await _addToCollection(context, _targetCollectionId, tvShow, mediaType);
+    final Set<int> targets = _targetCollections();
+    if (targets.isNotEmpty) {
+      await _addToCollections(context, targets, tvShow, mediaType);
       return;
     }
     showDetails(context, tvShow, mediaType);
@@ -99,15 +100,15 @@ class TvShowHandler implements MediaActionHandler {
     );
   }
 
-  Future<void> _addToCollection(
+  Future<void> _addToCollections(
     BuildContext context,
-    int collectionId,
+    Set<int> collectionIds,
     TvShow tvShow,
     MediaType mediaType,
   ) async {
-    await _adder.addToCollection(
+    await _adder.addToCollections(
       context: context,
-      collectionId: collectionId,
+      collectionIds: collectionIds,
       mediaType: mediaType,
       externalId: tvShow.tmdbId,
       platformId: mediaType == MediaType.animation

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -20,6 +20,7 @@ import '../../collections/screens/item_detail_screen.dart';
 import '../handlers/media_handlers.dart';
 import '../providers/browse_provider.dart';
 import '../widgets/browse_grid.dart';
+import '../widgets/collection_chips_row.dart';
 import '../widgets/discover_customize_sheet.dart';
 import '../widgets/discover_feed.dart';
 import '../widgets/filter_bar.dart';
@@ -50,16 +51,17 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   @override
   void initState() {
     super.initState();
-    _handlers = _buildHandlers(ref.read(searchTargetCollectionProvider));
+    _handlers = _buildHandlers();
     _loadPlatforms();
   }
 
-  /// Builds the per-source handlers, targeting [targetCollectionId] for adds
-  /// (set when search is opened from a collection; null = normal picker).
-  MediaHandlers _buildHandlers(int? targetCollectionId) => MediaHandlers(
+  /// Builds the per-source handlers. Both the platform map and the add-target
+  /// collections are read live (closures), so the handlers never need rebuilding
+  /// when either changes — a tap resolves the current selection at tap time.
+  MediaHandlers _buildHandlers() => MediaHandlers(
         ref: ref,
         platformMap: () => _platformMap,
-        targetCollectionId: targetCollectionId,
+        targetCollections: () => ref.read(searchTargetCollectionsProvider),
       );
 
   Future<void> _loadPlatforms() async {
@@ -241,11 +243,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     ref.listen<String>(searchTabQueryProvider, (String? prev, String next) {
       _onQueryChanged(next);
     });
-    // Rebuild handlers when the add-target collection changes (e.g. search
-    // opened from a collection's "add items").
-    ref.listen<int?>(searchTargetCollectionProvider, (int? prev, int? next) {
-      setState(() => _handlers = _buildHandlers(next));
-    });
 
     final Widget body = Column(
       children: <Widget>[
@@ -253,6 +250,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
           onBeforeFilterChange: _syncSearchText,
           onDiscoverCustomize: _showDiscoverCustomizeSheet,
         ),
+        const CollectionChipsRow(),
         const SizedBox(height: AppSpacing.xs),
         Expanded(child: _buildContent(browseState)),
       ],

--- a/lib/features/search/services/search_collection_adder.dart
+++ b/lib/features/search/services/search_collection_adder.dart
@@ -82,6 +82,67 @@ class SearchCollectionAdder {
     return success;
   }
 
+  /// Adds [externalId] to every collection in [collectionIds] at once — the
+  /// Search tab's multi-select "add straight to these collections" flow. The
+  /// model is upserted and the image cached once; collections that already hold
+  /// the item are skipped. A single summary snackbar reports the outcome instead
+  /// of one per collection. [afterAdd] runs once if at least one add succeeded.
+  Future<void> addToCollections({
+    required BuildContext context,
+    required Set<int> collectionIds,
+    required MediaType mediaType,
+    required int externalId,
+    int? platformId,
+    DataSource? source,
+    required String title,
+    required Future<void> Function() upsert,
+    required ImageType imageType,
+    required String imageId,
+    String? imageUrl,
+    Future<void> Function()? afterAdd,
+  }) async {
+    if (collectionIds.isEmpty) return;
+
+    // Adding to a deleted collection_id violates the FK and throws mid-batch;
+    // drop ids whose collection no longer exists (defensive — the Search tab
+    // already clears the selection on re-entry).
+    final Set<int> existingIds =
+        (_ref.read(collectionsProvider).valueOrNull ?? <Collection>[])
+            .map((Collection c) => c.id)
+            .toSet();
+    final Set<int> targets = collectionIds.intersection(existingIds);
+    if (targets.isEmpty) return;
+
+    await upsert();
+
+    int added = 0;
+    for (final int collectionId in targets) {
+      final bool success = await _ref
+          .read(collectionItemsNotifierProvider(collectionId).notifier)
+          .addItem(
+            mediaType: mediaType,
+            externalId: externalId,
+            platformId: platformId,
+            source: source,
+          );
+      if (success) added++;
+    }
+
+    if (added > 0) {
+      _cacheImage(imageType, imageId, imageUrl);
+      if (afterAdd != null) await afterAdd();
+    }
+
+    if (!context.mounted) return;
+    final S l = S.of(context);
+    context.showSnack(
+      added > 0
+          ? l.searchAddedToCollections(title, added)
+          : l.searchAlreadyInCollections(title),
+      type: added > 0 ? SnackType.success : SnackType.info,
+    );
+  }
+
   /// Returns `null` when the user cancels or the context unmounts.
   Future<PickedCollection?> pickCollection({
     required BuildContext context,

--- a/lib/features/search/widgets/collection_chips_row.dart
+++ b/lib/features/search/widgets/collection_chips_row.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/collection.dart';
+import '../../../shared/navigation/search_providers.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/widgets/filter_subfilter_bar.dart';
+import '../../../shared/widgets/scrollable_row_with_arrows.dart';
+import '../../../shared/widgets/selected_count_chip.dart';
+import '../../collections/providers/collections_provider.dart';
+
+/// Row height passed to [ScrollableRowWithArrows] for arrow positioning.
+const double _kRowHeight = 32;
+
+/// Horizontal, multi-select row of collection chips under the Search tab's
+/// filter bar.
+///
+/// Nothing selected → the normal flow (tap a result to open its details and add
+/// via the in-sheet picker). One or more selected → tapping a result adds it
+/// straight into every selected collection, no extra dialog. A pinned counter
+/// at the leading edge shows how many are selected (visible even when the
+/// chips have scrolled off-screen) and clears the selection on tap. Reads and
+/// writes [searchTargetCollectionsProvider].
+///
+/// Only real collections are offered (Uncategorized is never a target here).
+/// When there are no collections the row collapses to nothing.
+///
+/// Visually reuses [FilterTabChip] — the same flat underline-tab chip as the
+/// media-type subfilters — tinted with the brand accent.
+class CollectionChipsRow extends ConsumerStatefulWidget {
+  /// Creates a [CollectionChipsRow].
+  const CollectionChipsRow({super.key});
+
+  @override
+  ConsumerState<CollectionChipsRow> createState() => _CollectionChipsRowState();
+}
+
+class _CollectionChipsRowState extends ConsumerState<CollectionChipsRow> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Collection> collections =
+        ref.watch(collectionsProvider).valueOrNull ?? <Collection>[];
+    if (collections.isEmpty) return const SizedBox.shrink();
+
+    final Set<int> selected = ref.watch(searchTargetCollectionsProvider);
+
+    final List<Widget> chips = <Widget>[];
+    for (int i = 0; i < collections.length; i++) {
+      if (i > 0) chips.add(const SizedBox(width: AppSpacing.sm));
+      final Collection collection = collections[i];
+      chips.add(
+        FilterTabChip(
+          data: SubfilterChipData(
+            label: collection.name,
+            accent: AppColors.brand,
+            selected: selected.contains(collection.id),
+            onTap: () => _toggle(collection.id),
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.sm,
+        AppSpacing.xs,
+        AppSpacing.sm,
+        AppSpacing.sm,
+      ),
+      child: Row(
+        children: <Widget>[
+          // Pinned (never scrolls) so the active selection stays visible even
+          // when the selected chips have scrolled off-screen.
+          if (selected.isNotEmpty) ...<Widget>[
+            SelectedCountChip(
+              count: selected.length,
+              onClear: _clear,
+              clearTooltip: S.of(context).bulkClearSelection,
+            ),
+            const SizedBox(width: AppSpacing.sm),
+          ],
+          // Desktop scrolling, all three ways: hover arrows, mouse wheel, and
+          // click-drag (ScrollableRowWithArrows bundles them). Touch swipe on mobile.
+          Expanded(
+            child: ScrollableRowWithArrows(
+              controller: _scrollController,
+              height: _kRowHeight,
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                scrollDirection: Axis.horizontal,
+                child: Row(children: chips),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _toggle(int collectionId) {
+    final Set<int> next = <int>{...ref.read(searchTargetCollectionsProvider)};
+    if (!next.remove(collectionId)) next.add(collectionId);
+    ref.read(searchTargetCollectionsProvider.notifier).state = next;
+  }
+
+  void _clear() =>
+      ref.read(searchTargetCollectionsProvider.notifier).state = <int>{};
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1041,6 +1041,19 @@
       "collection": {"type": "String"}
     }
   },
+  "searchAddedToCollections": "{name} added to {count, plural, =1{1 collection} other{{count} collections}}",
+  "@searchAddedToCollections": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "count": {"type": "int"}
+    }
+  },
+  "searchAlreadyInCollections": "{name} already in the selected collections",
+  "@searchAlreadyInCollections": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
   "searchGoToSettings": "Go to Settings",
   "searchMinCharsHint": "Type at least 2 characters and press Enter",
   "searchNoResults": "No results found",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4158,6 +4158,18 @@ abstract class S {
   /// **'{name} already in {collection}'**
   String searchAlreadyInNamed(String name, String collection);
 
+  /// No description provided for @searchAddedToCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} added to {count, plural, =1{1 collection} other{{count} collections}}'**
+  String searchAddedToCollections(String name, int count);
+
+  /// No description provided for @searchAlreadyInCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} already in the selected collections'**
+  String searchAlreadyInCollections(String name);
+
   /// No description provided for @searchGoToSettings.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2291,6 +2291,22 @@ class SEn extends S {
   }
 
   @override
+  String searchAddedToCollections(String name, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collections',
+      one: '1 collection',
+    );
+    return '$name added to $_temp0';
+  }
+
+  @override
+  String searchAlreadyInCollections(String name) {
+    return '$name already in the selected collections';
+  }
+
+  @override
   String get searchGoToSettings => 'Go to Settings';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2318,6 +2318,23 @@ class SRu extends S {
   }
 
   @override
+  String searchAddedToCollections(String name, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count коллекций',
+      few: '$count коллекции',
+      one: '1 коллекцию',
+    );
+    return '$name добавлен в $_temp0';
+  }
+
+  @override
+  String searchAlreadyInCollections(String name) {
+    return '$name уже во всех выбранных коллекциях';
+  }
+
+  @override
   String get searchGoToSettings => 'Перейти в настройки';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -844,6 +844,8 @@
   "searchAddedToNamed": "{name} добавлен в {collection}",
   "searchAlreadyInCollection": "{name} уже в коллекции",
   "searchAlreadyInNamed": "{name} уже в {collection}",
+  "searchAddedToCollections": "{name} добавлен в {count, plural, =1{1 коллекцию} few{{count} коллекции} other{{count} коллекций}}",
+  "searchAlreadyInCollections": "{name} уже во всех выбранных коллекциях",
   "searchGoToSettings": "Перейти в настройки",
   "searchMinCharsHint": "Введите минимум 2 символа и нажмите Enter",
   "searchNoResults": "Ничего не найдено",

--- a/lib/shared/navigation/app_shell.dart
+++ b/lib/shared/navigation/app_shell.dart
@@ -40,7 +40,7 @@ const int _tabCount = 7;
 @visibleForTesting
 void resetSearchTabState(WidgetRef ref) {
   ref.read(searchTabQueryProvider.notifier).state = '';
-  ref.read(searchTargetCollectionProvider.notifier).state = null;
+  ref.read(searchTargetCollectionsProvider.notifier).state = <int>{};
   ref.read(browseProvider.notifier).clearSearch();
 }
 
@@ -345,8 +345,12 @@ class _AppShellState extends ConsumerState<AppShell> {
       });
     }
 
-    ref.read(searchTargetCollectionProvider.notifier).state =
-        request.collectionId;
+    final int? collectionId = request.collectionId;
+    if (collectionId != null) {
+      ref.read(searchTargetCollectionsProvider.notifier).state = <int>{
+        collectionId,
+      };
+    }
     if (request.sourceId != null) {
       ref.read(browseProvider.notifier).setSource(request.sourceId!);
     }

--- a/lib/shared/navigation/search_providers.dart
+++ b/lib/shared/navigation/search_providers.dart
@@ -47,11 +47,14 @@ final Provider<FocusNode> appTopBarFocusProvider = Provider<FocusNode>((
   return node;
 });
 
-/// Collection that items added from the Search tab go into. Set when search is
-/// opened from a collection's "add items"; `null` means the normal "add to any
-/// collection" picker. Cleared whenever the Search tab is entered plainly.
-final StateProvider<int?> searchTargetCollectionProvider =
-    StateProvider<int?>((Ref ref) => null);
+/// Collections that items added from the Search tab go into, shown as a
+/// multi-select chip row under the filter bar. Empty means the normal "open
+/// details, pick a collection in the sheet" flow; a non-empty set switches the
+/// tab into "tap a result to add it straight into all of these" mode. Prefilled
+/// when search is opened from a collection's "add items"; cleared whenever the
+/// Search tab is entered plainly.
+final StateProvider<Set<int>> searchTargetCollectionsProvider =
+    StateProvider<Set<int>>((Ref ref) => <int>{});
 
 /// One-shot request to open the Search tab, optionally prefilled. Set from
 /// another tab (Wishlist, a collection) instead of pushing a separate search
@@ -66,7 +69,8 @@ class SearchTabRequest {
   /// Browse source to preselect (e.g. `games`), or null to keep the current.
   final String? sourceId;
 
-  /// Collection to add results into; sets [searchTargetCollectionProvider].
+  /// Collection to add results into; preselected in
+  /// [searchTargetCollectionsProvider].
   final int? collectionId;
 }
 

--- a/lib/shared/widgets/filter_subfilter_bar.dart
+++ b/lib/shared/widgets/filter_subfilter_bar.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_colors.dart';
+import '../theme/app_durations.dart';
 import '../theme/app_spacing.dart';
 import '../theme/app_typography.dart';
+import 'scrollable_row_with_arrows.dart';
+
+/// Row height passed to [ScrollableRowWithArrows] for arrow positioning.
+const double _kSubfilterRowHeight = 34;
 
 /// One subfilter chip in a [SubfilterBar].
 class SubfilterChipData {
@@ -29,17 +34,34 @@ class SubfilterChipData {
 /// accent and split from the next group by a divider, so when several types
 /// are active their subfilters share one scrolling row instead of stacking.
 /// Empty groups are dropped; renders nothing when all are empty.
-class SubfilterBar extends StatelessWidget {
+class SubfilterBar extends StatefulWidget {
   const SubfilterBar({required this.groups, super.key});
 
   final List<List<SubfilterChipData>> groups;
 
   @override
+  State<SubfilterBar> createState() => _SubfilterBarState();
+}
+
+class _SubfilterBarState extends State<SubfilterBar> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final List<List<SubfilterChipData>> active = groups
+    final List<List<SubfilterChipData>> active = widget.groups
         .where((List<SubfilterChipData> g) => g.isNotEmpty)
         .toList();
     if (active.isEmpty) return const SizedBox.shrink();
+
+    // Highlight the whole strip when any subfilter is on, tinted with the first
+    // selected chip's media accent (any one of them when several types are on).
+    final Color? highlight = _selectedAccent(active);
 
     final List<Widget> children = <Widget>[];
     for (int g = 0; g < active.length; g++) {
@@ -60,17 +82,48 @@ class SubfilterBar extends StatelessWidget {
     }
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.sm,
-        AppSpacing.xs,
-        AppSpacing.sm,
-        AppSpacing.sm,
+      // Vertical only — the highlight band runs full width (edge to edge), so
+      // the horizontal inset lives inside it (below) instead.
+      padding: const EdgeInsets.only(
+        top: AppSpacing.xs,
+        bottom: AppSpacing.sm,
       ),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(children: children),
+      // Full-bleed band with no border or radius so the highlight reads as one
+      // even row with no seams; the inner padding keeps the chips inset. Geometry
+      // is constant, so the strip never jumps when the highlight toggles — only
+      // the color animates in.
+      child: AnimatedContainer(
+        duration: AppDurations.fast,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
+        decoration: BoxDecoration(
+          color: highlight?.withAlpha(38) ?? Colors.transparent,
+        ),
+        // Desktop scrolling, all three ways: hover arrows, mouse wheel, and
+        // click-drag (ScrollableRowWithArrows bundles them). Touch swipe on mobile.
+        child: ScrollableRowWithArrows(
+          controller: _scrollController,
+          height: _kSubfilterRowHeight,
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            scrollDirection: Axis.horizontal,
+            child: Row(children: children),
+          ),
+        ),
       ),
     );
+  }
+
+  /// Accent of the first selected chip, or null when nothing is selected.
+  Color? _selectedAccent(List<List<SubfilterChipData>> groups) {
+    for (final List<SubfilterChipData> group in groups) {
+      for (final SubfilterChipData chip in group) {
+        if (chip.selected) return chip.accent;
+      }
+    }
+    return null;
   }
 }
 

--- a/lib/shared/widgets/selected_count_chip.dart
+++ b/lib/shared/widgets/selected_count_chip.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_spacing.dart';
+import '../theme/app_typography.dart';
+
+/// Pinned, non-scrolling pill showing how many chips in a row are selected,
+/// clearing the whole selection when tapped.
+///
+/// Meant to sit at the leading edge of a scrollable chip row so an active
+/// selection stays visible even when the selected chips have scrolled out of
+/// view — the case that is easy to miss on a phone, where there are no hover
+/// arrows. Show it only when [count] is greater than zero.
+class SelectedCountChip extends StatelessWidget {
+  /// Creates a [SelectedCountChip].
+  const SelectedCountChip({
+    required this.count,
+    required this.onClear,
+    required this.clearTooltip,
+    this.accent = AppColors.brand,
+    super.key,
+  });
+
+  /// How many chips are selected.
+  final int count;
+
+  /// Clears the whole selection.
+  final VoidCallback onClear;
+
+  /// Localized label for the tooltip and screen readers (e.g. "Clear selection").
+  final String clearTooltip;
+
+  /// Pill background; defaults to the app brand accent.
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: clearTooltip,
+      child: Semantics(
+        button: true,
+        label: clearTooltip,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onClear,
+            borderRadius: BorderRadius.circular(AppSpacing.sm),
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.sm,
+                vertical: 4,
+              ),
+              decoration: BoxDecoration(
+                color: accent,
+                borderRadius: BorderRadius.circular(AppSpacing.sm),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  const Icon(
+                    Icons.check,
+                    size: 14,
+                    color: AppColors.background,
+                  ),
+                  const SizedBox(width: 3),
+                  Text(
+                    '$count',
+                    style: AppTypography.caption.copyWith(
+                      color: AppColors.background,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/search/handlers/media_handlers_test.dart
+++ b/test/features/search/handlers/media_handlers_test.dart
@@ -56,7 +56,7 @@ void main() {
       handlers = MediaHandlers(
         ref: ref,
         platformMap: () => const <int, Platform>{},
-        targetCollectionId: null,
+        targetCollections: () => <int>{},
       );
     });
 

--- a/test/features/search/handlers/tmdb_handlers_test.dart
+++ b/test/features/search/handlers/tmdb_handlers_test.dart
@@ -13,10 +13,9 @@ import '../../../helpers/test_helpers.dart';
 
 class _MockAdder extends Mock implements SearchCollectionAdder {}
 
-/// Captured args for the most recent `addToCollection` call.
+/// Captured args for the most recent `addToCollections` call.
 class _Capture {
-  int? collectionId;
-  String? collectionName;
+  Set<int>? collectionIds;
   MediaType? mediaType;
   int? externalId;
   int? platformId;
@@ -24,6 +23,7 @@ class _Capture {
   ImageType? imageType;
   String? imageId;
   String? imageUrl;
+  Future<void> Function()? afterAdd;
 }
 
 void main() {
@@ -35,9 +35,9 @@ void main() {
   setUp(() {
     adder = _MockAdder();
     cap = _Capture();
-    when(() => adder.addToCollection(
+    when(() => adder.addToCollections(
           context: any(named: 'context'),
-          collectionId: any(named: 'collectionId'),
+          collectionIds: any(named: 'collectionIds'),
           mediaType: any(named: 'mediaType'),
           externalId: any(named: 'externalId'),
           platformId: any(named: 'platformId'),
@@ -47,29 +47,28 @@ void main() {
           imageId: any(named: 'imageId'),
           imageUrl: any(named: 'imageUrl'),
           afterAdd: any(named: 'afterAdd'),
-          collectionName: any(named: 'collectionName'),
         )).thenAnswer((Invocation inv) async {
       cap
-        ..collectionId = inv.namedArguments[#collectionId] as int?
-        ..collectionName = inv.namedArguments[#collectionName] as String?
+        ..collectionIds = inv.namedArguments[#collectionIds] as Set<int>?
         ..mediaType = inv.namedArguments[#mediaType] as MediaType?
         ..externalId = inv.namedArguments[#externalId] as int?
         ..platformId = inv.namedArguments[#platformId] as int?
         ..title = inv.namedArguments[#title] as String?
         ..imageType = inv.namedArguments[#imageType] as ImageType?
         ..imageId = inv.namedArguments[#imageId] as String?
-        ..imageUrl = inv.namedArguments[#imageUrl] as String?;
-      return true;
+        ..imageUrl = inv.namedArguments[#imageUrl] as String?
+        ..afterAdd =
+            inv.namedArguments[#afterAdd] as Future<void> Function()?;
     });
   });
 
-  group('MovieHandler.onTap with targetCollectionId', () {
-    testWidgets('regular movie → platformId is null',
+  group('MovieHandler.onTap with target collections', () {
+    testWidgets('regular movie → platformId is null, adds to all targets',
         (WidgetTester tester) async {
       final MovieHandler handler = MovieHandler(
         ref: MockWidgetRef(),
         adder: adder,
-        targetCollectionId: 42,
+        targetCollections: () => <int>{42, 43},
       );
       await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
       await handler.onTap(
@@ -78,7 +77,7 @@ void main() {
         MediaType.movie,
       );
 
-      expect(cap.collectionId, 42);
+      expect(cap.collectionIds, <int>{42, 43});
       expect(cap.mediaType, MediaType.movie);
       expect(cap.externalId, 100);
       expect(cap.platformId, isNull);
@@ -90,7 +89,7 @@ void main() {
       final MovieHandler handler = MovieHandler(
         ref: MockWidgetRef(),
         adder: adder,
-        targetCollectionId: 42,
+        targetCollections: () => <int>{42},
       );
       await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
       await handler.onTap(
@@ -104,37 +103,14 @@ void main() {
     });
   });
 
-  group('TvShowHandler.onTap with targetCollectionId', () {
+  group('TvShowHandler.onTap with target collections', () {
     testWidgets('regular tv show → platformId is null, afterAdd is set',
         (WidgetTester tester) async {
       final TvShowHandler handler = TvShowHandler(
         ref: MockWidgetRef(),
         adder: adder,
-        targetCollectionId: 7,
+        targetCollections: () => <int>{7},
       );
-      Future<void> Function()? capturedAfterAdd;
-      when(() => adder.addToCollection(
-            context: any(named: 'context'),
-            collectionId: any(named: 'collectionId'),
-            mediaType: any(named: 'mediaType'),
-            externalId: any(named: 'externalId'),
-            platformId: any(named: 'platformId'),
-            title: any(named: 'title'),
-            upsert: any(named: 'upsert'),
-            imageType: any(named: 'imageType'),
-            imageId: any(named: 'imageId'),
-            imageUrl: any(named: 'imageUrl'),
-            afterAdd: any(named: 'afterAdd'),
-            collectionName: any(named: 'collectionName'),
-          )).thenAnswer((Invocation inv) async {
-        capturedAfterAdd =
-            inv.namedArguments[#afterAdd] as Future<void> Function()?;
-        cap
-          ..mediaType = inv.namedArguments[#mediaType] as MediaType?
-          ..platformId = inv.namedArguments[#platformId] as int?
-          ..imageType = inv.namedArguments[#imageType] as ImageType?;
-        return true;
-      });
 
       await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
       await handler.onTap(
@@ -143,10 +119,11 @@ void main() {
         MediaType.tvShow,
       );
 
+      expect(cap.collectionIds, <int>{7});
       expect(cap.mediaType, MediaType.tvShow);
       expect(cap.platformId, isNull);
       expect(cap.imageType, ImageType.tvShowPoster);
-      expect(capturedAfterAdd, isNotNull);
+      expect(cap.afterAdd, isNotNull);
     });
 
     testWidgets('animation tv → platformId = AnimationSource.tvShow',
@@ -154,7 +131,7 @@ void main() {
       final TvShowHandler handler = TvShowHandler(
         ref: MockWidgetRef(),
         adder: adder,
-        targetCollectionId: 7,
+        targetCollections: () => <int>{7},
       );
       await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
       await handler.onTap(

--- a/test/features/search/services/search_collection_adder_test.dart
+++ b/test/features/search/services/search_collection_adder_test.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:tonkatsu_box/core/services/image_cache_service.dart';
+import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
+import 'package:tonkatsu_box/features/search/services/search_collection_adder.dart';
+import 'package:tonkatsu_box/shared/models/collection.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+/// Collections 1 and 2 exist; the batch add filters its targets against these.
+final List<Collection> _testCollections = <Collection>[
+  createTestCollection(id: 1, name: 'One'),
+  createTestCollection(id: 2, name: 'Two'),
+];
+
+class _FakeCollectionsNotifier extends CollectionsNotifier {
+  _FakeCollectionsNotifier(this._collections);
+
+  final List<Collection> _collections;
+
+  @override
+  Future<List<Collection>> build() async => _collections;
+}
+
+/// Fake items notifier: records which collection each `addItem` targets and
+/// returns a per-collection success flag (false = item already present there).
+class _FakeItemsNotifier extends CollectionItemsNotifier {
+  _FakeItemsNotifier(this._addedReturns, this._calls);
+
+  final Map<int?, bool> _addedReturns;
+  final List<int?> _calls;
+
+  @override
+  AsyncValue<List<CollectionItem>> build(int? arg) =>
+      const AsyncData<List<CollectionItem>>(<CollectionItem>[]);
+
+  @override
+  Future<bool> addItem({
+    required MediaType mediaType,
+    required int externalId,
+    int? platformId,
+    DataSource? source,
+    String? authorComment,
+  }) async {
+    _calls.add(arg);
+    return _addedReturns[arg] ?? true;
+  }
+}
+
+class _Harness extends ConsumerWidget {
+  const _Harness(this.action);
+
+  final Future<void> Function(WidgetRef ref, BuildContext context) action;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Resolve collectionsProvider before the action runs (the batch add filters
+    // its targets against it); pumpApp's pumpAndSettle waits for it.
+    ref.watch(collectionsProvider);
+    // Own Scaffold so the button has a Material ancestor and snackbars have a
+    // ScaffoldMessenger to land in.
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => action(ref, context),
+          child: const Text('go'),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('SearchCollectionAdder.addToCollections', () {
+    testWidgets('adds to every selected collection, one success snackbar',
+        (WidgetTester tester) async {
+      final List<int?> calls = <int?>[];
+      int upsertCount = 0;
+
+      await tester.pumpApp(
+        _Harness((WidgetRef ref, BuildContext context) {
+          return SearchCollectionAdder(ref).addToCollections(
+            context: context,
+            collectionIds: <int>{1, 2},
+            mediaType: MediaType.game,
+            externalId: 42,
+            title: 'Zelda',
+            upsert: () async => upsertCount++,
+            imageType: ImageType.gameCover,
+            imageId: '42',
+          );
+        }),
+        overrides: <Override>[
+          collectionsProvider.overrideWith(
+            () => _FakeCollectionsNotifier(_testCollections),
+          ),
+          collectionItemsNotifierProvider.overrideWith(
+            () => _FakeItemsNotifier(const <int?, bool>{}, calls),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(upsertCount, 1);
+      expect(calls.toSet(), <int?>{1, 2});
+      expect(find.text('Zelda added to 2 collections'), findsOneWidget);
+    });
+
+    testWidgets('counts only the collections it was actually added to',
+        (WidgetTester tester) async {
+      final List<int?> calls = <int?>[];
+
+      await tester.pumpApp(
+        _Harness((WidgetRef ref, BuildContext context) {
+          return SearchCollectionAdder(ref).addToCollections(
+            context: context,
+            collectionIds: <int>{1, 2},
+            mediaType: MediaType.game,
+            externalId: 42,
+            title: 'Zelda',
+            upsert: () async {},
+            imageType: ImageType.gameCover,
+            imageId: '42',
+          );
+        }),
+        overrides: <Override>[
+          collectionsProvider.overrideWith(
+            () => _FakeCollectionsNotifier(_testCollections),
+          ),
+          collectionItemsNotifierProvider.overrideWith(
+            // Collection 2 already has the item → not counted.
+            () => _FakeItemsNotifier(const <int?, bool>{1: true, 2: false}, calls),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Zelda added to 1 collection'), findsOneWidget);
+    });
+
+    testWidgets('ignores a selected id whose collection was deleted',
+        (WidgetTester tester) async {
+      final List<int?> calls = <int?>[];
+
+      await tester.pumpApp(
+        _Harness((WidgetRef ref, BuildContext context) {
+          return SearchCollectionAdder(ref).addToCollections(
+            context: context,
+            // 99 no longer exists → filtered out; only 1 is added.
+            collectionIds: <int>{1, 99},
+            mediaType: MediaType.game,
+            externalId: 42,
+            title: 'Zelda',
+            upsert: () async {},
+            imageType: ImageType.gameCover,
+            imageId: '42',
+          );
+        }),
+        overrides: <Override>[
+          collectionsProvider.overrideWith(
+            () => _FakeCollectionsNotifier(_testCollections),
+          ),
+          collectionItemsNotifierProvider.overrideWith(
+            () => _FakeItemsNotifier(const <int?, bool>{}, calls),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(calls, <int?>[1]);
+      expect(find.text('Zelda added to 1 collection'), findsOneWidget);
+    });
+
+    testWidgets('already in all selected → info snackbar, no count',
+        (WidgetTester tester) async {
+      final List<int?> calls = <int?>[];
+
+      await tester.pumpApp(
+        _Harness((WidgetRef ref, BuildContext context) {
+          return SearchCollectionAdder(ref).addToCollections(
+            context: context,
+            collectionIds: <int>{1, 2},
+            mediaType: MediaType.game,
+            externalId: 42,
+            title: 'Zelda',
+            upsert: () async {},
+            imageType: ImageType.gameCover,
+            imageId: '42',
+          );
+        }),
+        overrides: <Override>[
+          collectionsProvider.overrideWith(
+            () => _FakeCollectionsNotifier(_testCollections),
+          ),
+          collectionItemsNotifierProvider.overrideWith(
+            () =>
+                _FakeItemsNotifier(const <int?, bool>{1: false, 2: false}, calls),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        find.text('Zelda already in the selected collections'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('empty set is a no-op (no upsert, no add, no snackbar)',
+        (WidgetTester tester) async {
+      final List<int?> calls = <int?>[];
+      int upsertCount = 0;
+
+      await tester.pumpApp(
+        _Harness((WidgetRef ref, BuildContext context) {
+          return SearchCollectionAdder(ref).addToCollections(
+            context: context,
+            collectionIds: const <int>{},
+            mediaType: MediaType.game,
+            externalId: 42,
+            title: 'Zelda',
+            upsert: () async => upsertCount++,
+            imageType: ImageType.gameCover,
+            imageId: '42',
+          );
+        }),
+        overrides: <Override>[
+          collectionsProvider.overrideWith(
+            () => _FakeCollectionsNotifier(_testCollections),
+          ),
+          collectionItemsNotifierProvider.overrideWith(
+            () => _FakeItemsNotifier(const <int?, bool>{}, calls),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('go'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(upsertCount, 0);
+      expect(calls, isEmpty);
+      expect(find.byType(SnackBar), findsNothing);
+    });
+  });
+}

--- a/test/features/search/widgets/collection_chips_row_test.dart
+++ b/test/features/search/widgets/collection_chips_row_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
+import 'package:tonkatsu_box/features/search/widgets/collection_chips_row.dart';
+import 'package:tonkatsu_box/l10n/app_localizations.dart';
+import 'package:tonkatsu_box/shared/models/collection.dart';
+import 'package:tonkatsu_box/shared/navigation/search_providers.dart';
+import 'package:tonkatsu_box/shared/widgets/filter_subfilter_bar.dart';
+import 'package:tonkatsu_box/shared/widgets/selected_count_chip.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+class _FakeCollectionsNotifier extends CollectionsNotifier {
+  _FakeCollectionsNotifier(this._collections);
+
+  final List<Collection> _collections;
+
+  @override
+  Future<List<Collection>> build() async => _collections;
+}
+
+ProviderContainer _pump(
+  WidgetTester tester, {
+  required List<Collection> collections,
+}) {
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      collectionsProvider.overrideWith(
+        () => _FakeCollectionsNotifier(collections),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Future<void> _pumpRow(
+  WidgetTester tester,
+  ProviderContainer container,
+) async {
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(
+        localizationsDelegates: S.localizationsDelegates,
+        supportedLocales: S.supportedLocales,
+        locale: Locale('en'),
+        home: Scaffold(body: CollectionChipsRow()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('CollectionChipsRow', () {
+    testWidgets('renders nothing when there are no collections',
+        (WidgetTester tester) async {
+      final ProviderContainer container =
+          _pump(tester, collections: <Collection>[]);
+      await _pumpRow(tester, container);
+
+      expect(find.byType(FilterTabChip), findsNothing);
+    });
+
+    testWidgets('renders one chip per collection',
+        (WidgetTester tester) async {
+      final ProviderContainer container = _pump(
+        tester,
+        collections: createTestCollections(count: 3),
+      );
+      await _pumpRow(tester, container);
+
+      expect(find.byType(FilterTabChip), findsNWidgets(3));
+    });
+
+    testWidgets('tapping a chip selects its collection',
+        (WidgetTester tester) async {
+      final List<Collection> collections = <Collection>[
+        createTestCollection(id: 5, name: 'Alpha'),
+      ];
+      final ProviderContainer container =
+          _pump(tester, collections: collections);
+      await _pumpRow(tester, container);
+
+      expect(container.read(searchTargetCollectionsProvider), isEmpty);
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(searchTargetCollectionsProvider), <int>{5});
+    });
+
+    testWidgets('tapping a selected chip deselects it',
+        (WidgetTester tester) async {
+      final List<Collection> collections = <Collection>[
+        createTestCollection(id: 5, name: 'Alpha'),
+      ];
+      final ProviderContainer container =
+          _pump(tester, collections: collections);
+      container.read(searchTargetCollectionsProvider.notifier).state = <int>{5};
+      await _pumpRow(tester, container);
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(searchTargetCollectionsProvider), isEmpty);
+    });
+
+    testWidgets('selection is multi-select', (WidgetTester tester) async {
+      final List<Collection> collections = <Collection>[
+        createTestCollection(id: 1, name: 'Alpha'),
+        createTestCollection(id: 2, name: 'Beta'),
+      ];
+      final ProviderContainer container =
+          _pump(tester, collections: collections);
+      await _pumpRow(tester, container);
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(searchTargetCollectionsProvider), <int>{1, 2});
+    });
+
+    testWidgets('no count chip when nothing is selected',
+        (WidgetTester tester) async {
+      final ProviderContainer container = _pump(
+        tester,
+        collections: createTestCollections(count: 2),
+      );
+      await _pumpRow(tester, container);
+
+      expect(find.byType(SelectedCountChip), findsNothing);
+    });
+
+    testWidgets('count chip appears and shows the number selected',
+        (WidgetTester tester) async {
+      final ProviderContainer container = _pump(
+        tester,
+        collections: createTestCollections(count: 3),
+      );
+      await _pumpRow(tester, container);
+
+      await tester.tap(find.text('Collection 1'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Collection 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SelectedCountChip), findsOneWidget);
+      expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets('tapping the count chip clears the selection',
+        (WidgetTester tester) async {
+      final ProviderContainer container = _pump(
+        tester,
+        collections: createTestCollections(count: 2),
+      );
+      container.read(searchTargetCollectionsProvider.notifier).state =
+          <int>{1, 2};
+      await _pumpRow(tester, container);
+
+      await tester.tap(find.byType(SelectedCountChip));
+      await tester.pumpAndSettle();
+
+      expect(container.read(searchTargetCollectionsProvider), isEmpty);
+    });
+  });
+}

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -46,6 +46,7 @@ void registerAllFallbacks() {
   registerFallbackValue(const <Anime>[]);
   registerFallbackValue(const <Manga>[]);
   registerFallbackValue(const <int>[]);
+  registerFallbackValue(const <int>{});
 
   registerFallbackValue(<TierDefinition>[]);
 

--- a/test/shared/navigation/app_shell_search_reset_test.dart
+++ b/test/shared/navigation/app_shell_search_reset_test.dart
@@ -90,13 +90,13 @@ void main() {
       expect(container.read(browseProvider).sourceId, 'games');
     });
 
-    testWidgets('clears the add-target collection', (WidgetTester tester) async {
+    testWidgets('clears the add-target collections', (WidgetTester tester) async {
       final ProviderContainer container = createContainer();
-      container.read(searchTargetCollectionProvider.notifier).state = 7;
+      container.read(searchTargetCollectionsProvider.notifier).state = <int>{7};
 
       await pumpAndReset(tester, container);
 
-      expect(container.read(searchTargetCollectionProvider), isNull);
+      expect(container.read(searchTargetCollectionsProvider), isEmpty);
     });
 
     testWidgets('is a no-op on an already empty search',
@@ -107,7 +107,7 @@ void main() {
 
       expect(container.read(searchTabQueryProvider), isEmpty);
       expect(container.read(browseProvider).searchQuery, isEmpty);
-      expect(container.read(searchTargetCollectionProvider), isNull);
+      expect(container.read(searchTargetCollectionsProvider), isEmpty);
     });
   });
 }

--- a/test/shared/widgets/filter_subfilter_bar_test.dart
+++ b/test/shared/widgets/filter_subfilter_bar_test.dart
@@ -78,5 +78,45 @@ void main() {
 
       expect(tapped, isTrue);
     });
+
+    BoxDecoration stripDecoration(WidgetTester tester) {
+      return tester
+              .widget<AnimatedContainer>(
+                find.descendant(
+                  of: find.byType(SubfilterBar),
+                  matching: find.byType(AnimatedContainer),
+                ),
+              )
+              .decoration!
+          as BoxDecoration;
+    }
+
+    testWidgets('strip is not highlighted when nothing is selected', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        SubfilterBar(
+          groups: <List<SubfilterChipData>>[
+            <SubfilterChipData>[chip('A'), chip('B')],
+          ],
+        ),
+      );
+
+      expect(stripDecoration(tester).color, Colors.transparent);
+    });
+
+    testWidgets('strip is highlighted when any subfilter is selected', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        SubfilterBar(
+          groups: <List<SubfilterChipData>>[
+            <SubfilterChipData>[chip('A', selected: true), chip('B')],
+          ],
+        ),
+      );
+
+      expect(stripDecoration(tester).color, isNot(Colors.transparent));
+    });
   });
 }

--- a/test/shared/widgets/selected_count_chip_test.dart
+++ b/test/shared/widgets/selected_count_chip_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/widgets/selected_count_chip.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('SelectedCountChip', () {
+    testWidgets('shows the selected count', (WidgetTester tester) async {
+      await tester.pumpApp(
+        SelectedCountChip(
+          count: 3,
+          onClear: () {},
+          clearTooltip: 'Clear',
+        ),
+        wrapInScaffold: true,
+      );
+
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('invokes onClear when tapped', (WidgetTester tester) async {
+      int cleared = 0;
+      await tester.pumpApp(
+        SelectedCountChip(
+          count: 2,
+          onClear: () => cleared++,
+          clearTooltip: 'Clear',
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.byType(SelectedCountChip));
+      await tester.pump();
+
+      expect(cleared, 1);
+    });
+  });
+}


### PR DESCRIPTION
Replace the single add-target collection with a multi-select chip row under the Search filter bar: pick several collections and tapping a result drops it into all of them with one summary snackbar. A pinned counter shows how many are selected and clears them on tap.

The media-type subfilter bar (collections and All Items) gains desktop scroll arrows / mouse wheel and a full-width selection highlight tinted with the active media accent, so an active filter stays visible when chips have scrolled off-screen.