### PR TITLE
feat(personalization): add genre/platform/decade preference cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,53 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Personalization word cloud of genres, platforms and decades**
+
+  A new Personalization view that lays out the whole library's genres, platforms
+  and release decades as a frequency-sized word cloud. Word size follows how
+  often a value appears; word colour follows the dominant media type. Two chip
+  rows filter the cloud by facet (genres / platforms / decades) and by media
+  type, and the result can be saved as a PNG poster. The view opens from the new
+  centre nav button, which replaces the old top-bar logo; the nav row and rail
+  reserve a middle slot for it.
+
+  * lib/features/genre_cloud/facet.dart (Facet), genre_cloud/facet_value.dart
+    (FacetValue): The facet dimensions and a single (facet, value) tally. New.
+  * lib/features/genre_cloud/genre_cloud_aggregate.dart (extractItemFacets,
+    aggregateFacets, presentFacets, presentMediaTypes): Pure aggregation over
+    collection items, reading the typed sub-models. Counting is case-insensitive
+    and de-duped per item. New.
+  * lib/features/genre_cloud/genre_cloud_layout.dart (layoutGenreCloud,
+    PlacedWord, GenreCloudLayout, rotatedAtIndex): Flutter-free Archimedean
+    spiral placement with rank-based font tiers and auto-fit shrinking. New.
+  * lib/features/genre_cloud/widgets/genre_cloud_view.dart (GenreCloudView,
+    genreWordSpan, measureGenreWord): On-screen painter sharing one span builder
+    between measurement and painting. Grows the canvas to fit every word, wraps
+    it in an InteractiveViewer for pan and pinch-zoom, and shows a recenter
+    button that restores the default centred view. New.
+  * lib/features/genre_cloud/widgets/genre_cloud_export_view.dart
+    (GenreCloudExportView): Fixed 1200×800 poster captured to PNG; renders the
+    cloud non-interactively. New.
+  * lib/features/genre_cloud/providers/genre_cloud_provider.dart
+    (genreCloudItemsProvider): Exposes the whole library's items from the
+    all-items notifier. New.
+  * lib/features/genre_cloud/screens/genre_cloud_screen.dart (GenreCloudScreen):
+    Facet legend, media-type legend, cloud and image export. New.
+  * lib/shared/navigation/nav_center_button.dart (NavCenterButton): The app logo
+    as a focusable centre nav item. New.
+  * lib/shared/navigation/nav_destinations.dart (kNavCenterSlot, navSelectedSlot):
+    Shared centre-slot index and the selected-index → visual-slot mapping that
+    skips the reserved centre slot.
+  * lib/shared/navigation/app_bottom_bar.dart (AppBottomBar.onCenterTap,
+    AppBottomBar.centerActive), lib/shared/navigation/app_sidebar.dart
+    (AppSidebar.onCenterTap, AppSidebar.centerActive): Reserve the middle slot,
+    draw the centre button, and highlight it when Personalization is open.
+  * lib/shared/navigation/app_shell.dart (_AppShellState._openPreferenceCloud):
+    Show the cloud as a shell-level destination (an extra IndexedStack child),
+    toggled by the centre nav button.
+  * lib/shared/navigation/app_top_bar.dart: Drop the top-bar logo, now shown as
+    the centre nav button.
+
 - **Mark collection items as favorite**
 
   A per-item favorite flag the user sets from the poster card (a heart in the

--- a/lib/features/genre_cloud/facet.dart
+++ b/lib/features/genre_cloud/facet.dart
@@ -1,0 +1,21 @@
+// Facet dimensions visualized in the preference cloud.
+//
+// Word colour encodes the media type (see MediaTypeTheme), not the facet — the
+// facet is a filter dimension toggled via the legend.
+
+/// A searchable dimension the preference cloud groups words by.
+enum Facet {
+  /// Genres / book subjects.
+  genre('genre'),
+
+  /// Game / visual-novel platforms.
+  platform('platform'),
+
+  /// Release decade (bucketed from the year).
+  decade('decade');
+
+  const Facet(this.value);
+
+  /// Stable string id.
+  final String value;
+}

--- a/lib/features/genre_cloud/facet_value.dart
+++ b/lib/features/genre_cloud/facet_value.dart
@@ -1,0 +1,48 @@
+// One facet value with its frequency and dominant media type.
+
+import 'package:flutter/foundation.dart';
+
+import '../../shared/models/media_type.dart';
+import 'facet.dart';
+
+/// A single value of some [Facet] (e.g. genre "RPG", platform "PlayStation 2",
+/// decade "1990s"), how many items carry it, and the media type that
+/// predominantly carries it (drives the word colour).
+@immutable
+class FacetValue {
+  /// Creates a [FacetValue].
+  const FacetValue({
+    required this.facet,
+    required this.label,
+    required this.count,
+    required this.type,
+  });
+
+  /// Which dimension this value belongs to.
+  final Facet facet;
+
+  /// Display label (original casing of the first occurrence).
+  final String label;
+
+  /// How many items carry this value.
+  final int count;
+
+  /// Dominant media type for this value.
+  final MediaType type;
+
+  /// Stable identity key (facet + folded label).
+  String get key => '${facet.value}:${label.toLowerCase()}';
+
+  @override
+  bool operator ==(Object other) =>
+      other is FacetValue &&
+      other.key == key &&
+      other.count == count &&
+      other.type == type;
+
+  @override
+  int get hashCode => Object.hash(key, count, type);
+
+  @override
+  String toString() => 'FacetValue(${facet.value}, $label, $count, ${type.value})';
+}

--- a/lib/features/genre_cloud/genre_cloud_aggregate.dart
+++ b/lib/features/genre_cloud/genre_cloud_aggregate.dart
@@ -1,0 +1,209 @@
+// Pure aggregation: collection items -> facet values across genre/platform/decade.
+
+import '../../shared/models/anime.dart';
+import '../../shared/models/book.dart';
+import '../../shared/models/collection_item.dart';
+import '../../shared/models/custom_media.dart';
+import '../../shared/models/game.dart';
+import '../../shared/models/manga.dart';
+import '../../shared/models/media_type.dart';
+import '../../shared/models/movie.dart';
+import '../../shared/models/tv_show.dart';
+import '../../shared/models/visual_novel.dart';
+import 'facet.dart';
+import 'facet_value.dart';
+
+/// A single (facet, value) pair extracted from one item.
+typedef FacetEntry = ({Facet facet, String value});
+
+/// Extracts every (facet, value) pair an item contributes, reading the typed
+/// sub-models directly. Only genre, platform and decade are produced.
+///
+/// Reads whichever sub-models are attached rather than switching on
+/// `mediaType`, so the `animation` type (stored as a Movie or TvShow) is
+/// handled for free.
+List<FacetEntry> extractItemFacets(CollectionItem item) {
+  final List<FacetEntry> out = <FacetEntry>[];
+
+  void addAll(Facet facet, List<String>? values) {
+    if (values == null) return;
+    for (final String value in values) {
+      final String trimmed = value.trim();
+      if (trimmed.isNotEmpty) out.add((facet: facet, value: trimmed));
+    }
+  }
+
+  void addOne(Facet facet, String? value) {
+    final String trimmed = value?.trim() ?? '';
+    if (trimmed.isNotEmpty) out.add((facet: facet, value: trimmed));
+  }
+
+  final Game? game = item.game;
+  if (game != null) {
+    addAll(Facet.genre, game.genres);
+    addOne(Facet.decade, _decadeOf(game.releaseDate?.year));
+  }
+  // The owned platform of a game item.
+  addOne(Facet.platform, item.platform?.name);
+
+  final Movie? movie = item.movie;
+  if (movie != null) {
+    addAll(Facet.genre, movie.genres);
+    addOne(Facet.decade, _decadeOf(movie.releaseYear));
+  }
+
+  final TvShow? tvShow = item.tvShow;
+  if (tvShow != null) {
+    addAll(Facet.genre, tvShow.genres);
+    addOne(Facet.decade, _decadeOf(tvShow.firstAirYear));
+  }
+
+  final Anime? anime = item.anime;
+  if (anime != null) {
+    addAll(Facet.genre, anime.genres);
+    addOne(Facet.decade, _decadeOf(anime.startYear));
+  }
+
+  final Manga? manga = item.manga;
+  if (manga != null) {
+    addAll(Facet.genre, manga.genres);
+    addOne(Facet.decade, _decadeOf(manga.startYear));
+  }
+
+  final VisualNovel? vn = item.visualNovel;
+  if (vn != null) {
+    addAll(Facet.platform, vn.platforms);
+    addOne(Facet.decade, _decadeOf(_yearFromReleased(vn.released)));
+  }
+
+  final Book? book = item.book;
+  if (book != null) {
+    addAll(Facet.genre, book.subjects);
+  }
+
+  final CustomMedia? custom = item.customMedia;
+  if (custom != null) {
+    addAll(Facet.genre, custom.genreList);
+  }
+
+  return out;
+}
+
+/// Counts how many items carry each facet value and resolves a dominant media
+/// type per value, sorted by frequency (descending). Counting is
+/// case-insensitive and de-duped per item.
+///
+/// [includeFacets] limits which dimensions contribute; [includeTypes] limits
+/// which media types contribute (a hidden type's items are ignored, so counts,
+/// dominant type and colour recompute as if it were absent).
+List<FacetValue> aggregateFacets(
+  List<CollectionItem> items, {
+  Set<Facet>? includeFacets,
+  Set<MediaType>? includeTypes,
+}) {
+  final Map<String, _FacetAccumulator> byKey = <String, _FacetAccumulator>{};
+
+  for (final CollectionItem item in items) {
+    if (includeTypes != null && !includeTypes.contains(item.mediaType)) {
+      continue;
+    }
+    final Set<String> seenInItem = <String>{};
+    for (final FacetEntry entry in extractItemFacets(item)) {
+      if (includeFacets != null && !includeFacets.contains(entry.facet)) {
+        continue;
+      }
+      final String key = '${entry.facet.value}:${entry.value.toLowerCase()}';
+      if (!seenInItem.add(key)) continue;
+
+      final _FacetAccumulator acc = byKey.putIfAbsent(
+        key,
+        () => _FacetAccumulator(entry.facet, entry.value),
+      );
+      acc.count++;
+      acc.typeCounts.update(
+        item.mediaType,
+        (int value) => value + 1,
+        ifAbsent: () => 1,
+      );
+    }
+  }
+
+  final List<FacetValue> result = byKey.values
+      .map(
+        (_FacetAccumulator acc) => FacetValue(
+          facet: acc.facet,
+          label: acc.label,
+          count: acc.count,
+          type: acc.dominantType,
+        ),
+      )
+      .toList();
+
+  result.sort((FacetValue a, FacetValue b) {
+    final int byCount = b.count.compareTo(a.count);
+    if (byCount != 0) return byCount;
+    return a.label.toLowerCase().compareTo(b.label.toLowerCase());
+  });
+
+  return result;
+}
+
+/// The set of facet dimensions present among [items] (drives the facet legend).
+Set<Facet> presentFacets(List<CollectionItem> items) {
+  final Set<Facet> facets = <Facet>{};
+  for (final CollectionItem item in items) {
+    for (final FacetEntry entry in extractItemFacets(item)) {
+      facets.add(entry.facet);
+    }
+  }
+  return facets;
+}
+
+/// The media types among [items] that contribute at least one facet value
+/// (drives the media-type legend).
+Set<MediaType> presentMediaTypes(List<CollectionItem> items) {
+  final Set<MediaType> types = <MediaType>{};
+  for (final CollectionItem item in items) {
+    if (extractItemFacets(item).isNotEmpty) {
+      types.add(item.mediaType);
+    }
+  }
+  return types;
+}
+
+String? _decadeOf(int? year) {
+  if (year == null || year < 1900 || year > 2100) return null;
+  return '${(year ~/ 10) * 10}s';
+}
+
+int? _yearFromReleased(String? released) {
+  if (released == null) return null;
+  final RegExpMatch? match = RegExp(r'(\d{4})').firstMatch(released);
+  if (match == null) return null;
+  return int.tryParse(match.group(1)!);
+}
+
+/// Mutable accumulator used while folding items into per-value tallies.
+class _FacetAccumulator {
+  _FacetAccumulator(this.facet, this.label);
+
+  final Facet facet;
+  final String label;
+  int count = 0;
+  final Map<MediaType, int> typeCounts = <MediaType, int>{};
+
+  /// Media type with the most items for this value; ties break by [MediaType]
+  /// declaration order.
+  MediaType get dominantType {
+    MediaType best = MediaType.values.first;
+    int bestCount = -1;
+    for (final MediaType type in MediaType.values) {
+      final int c = typeCounts[type] ?? 0;
+      if (c > bestCount) {
+        bestCount = c;
+        best = type;
+      }
+    }
+    return best;
+  }
+}

--- a/lib/features/genre_cloud/genre_cloud_layout.dart
+++ b/lib/features/genre_cloud/genre_cloud_layout.dart
@@ -1,0 +1,251 @@
+// Pure word-cloud layout: places facet words on a canvas with no overlaps.
+//
+// Kept free of Flutter widget code so it can be unit-tested with an injected
+// text measurement function. Words are placed largest-first along an
+// Archimedean spiral; if not everything fits, the size scale is shrunk and the
+// layout is retried (auto-fit). Whatever still cannot be placed is reported via
+// [hidden].
+
+import 'dart:math' as math;
+import 'dart:ui' show Offset, Rect, Size;
+
+import 'facet_value.dart';
+
+/// Measures the unrotated pixel size of [word] rendered at [fontSize]
+/// (including any count suffix the renderer draws).
+typedef MeasureWord = Size Function(FacetValue word, double fontSize);
+
+/// A facet word positioned on the cloud canvas.
+class PlacedWord {
+  /// Creates a [PlacedWord].
+  const PlacedWord({
+    required this.word,
+    required this.fontSize,
+    required this.center,
+    required this.rotated,
+  });
+
+  /// The facet value this word represents.
+  final FacetValue word;
+
+  /// Font size the word is drawn at.
+  final double fontSize;
+
+  /// Centre of the word's bounding box, in canvas coordinates.
+  final Offset center;
+
+  /// Whether the word is rotated 90° (drawn vertically).
+  final bool rotated;
+}
+
+/// Result of laying out a cloud.
+class GenreCloudLayout {
+  /// Creates a [GenreCloudLayout].
+  const GenreCloudLayout({
+    required this.placed,
+    required this.hidden,
+    required this.size,
+  });
+
+  /// Words that were placed, in descending frequency order.
+  final List<PlacedWord> placed;
+
+  /// How many words could not be placed (safeguard for pathological inputs).
+  final int hidden;
+
+  /// Canvas size the layout was computed for.
+  final Size size;
+
+  /// Whether nothing was placed.
+  bool get isEmpty => placed.isEmpty;
+}
+
+/// Largest font tried before auto-fit shrinking, and the floor it shrinks to.
+const double _defaultMaxFontSize = 64;
+const double _defaultMinFontSize = 13;
+
+/// Maximum number of distinct size tiers.
+///
+/// Sizing is rank-based: words are sized by where their *count* ranks among the
+/// distinct counts, not by the raw count. Equal counts share a size; any
+/// difference in count moves a word to a different tier. When there are more
+/// distinct counts than this cap, adjacent ranks are grouped so the geometric
+/// step between tiers stays clearly visible instead of collapsing.
+const int _defaultMaxTiers = 10;
+
+/// Decides whether the word at [index] (descending frequency) is rotated.
+///
+/// The most frequent word (index 0) always stays horizontal for readability;
+/// roughly every third word after it is rotated, giving the classic tag-cloud
+/// look without randomness (keeps exports reproducible).
+bool rotatedAtIndex(int index) => index > 0 && index % 3 == 1;
+
+/// Lays out [words] inside [canvasSize], measuring text via [measure].
+GenreCloudLayout layoutGenreCloud({
+  required List<FacetValue> words,
+  required Size canvasSize,
+  required MeasureWord measure,
+  double minFontSize = _defaultMinFontSize,
+  double maxFontSize = _defaultMaxFontSize,
+  int maxTiers = _defaultMaxTiers,
+}) {
+  if (words.isEmpty || canvasSize.width <= 0 || canvasSize.height <= 0) {
+    return GenreCloudLayout(
+      placed: const <PlacedWord>[],
+      hidden: 0,
+      size: canvasSize,
+    );
+  }
+
+  final List<FacetValue> sorted = List<FacetValue>.of(words)
+    ..sort((FacetValue a, FacetValue b) {
+      final int byCount = b.count.compareTo(a.count);
+      if (byCount != 0) return byCount;
+      return a.label.toLowerCase().compareTo(b.label.toLowerCase());
+    });
+
+  // Rank distinct counts (highest = rank 0). Equal counts -> same rank.
+  final List<int> distinctCounts = sorted
+      .map((FacetValue w) => w.count)
+      .toSet()
+      .toList()
+    ..sort((int a, int b) => b.compareTo(a));
+  final Map<int, int> rankByCount = <int, int>{
+    for (int i = 0; i < distinctCounts.length; i++) distinctCounts[i]: i,
+  };
+  final int distinct = distinctCounts.length;
+
+  double scaleMax = maxFontSize;
+  _Attempt attempt = _placeAll(
+    sorted, canvasSize, measure, minFontSize, scaleMax,
+    rankByCount, distinct, maxTiers,
+  );
+  // Auto-fit: shrink the top of the scale until everything fits or we hit the
+  // floor (then [hidden] carries whatever still does not fit).
+  while (attempt.hidden > 0 && scaleMax > minFontSize + 1) {
+    scaleMax = math.max(minFontSize, scaleMax * 0.85);
+    attempt = _placeAll(
+      sorted, canvasSize, measure, minFontSize, scaleMax,
+      rankByCount, distinct, maxTiers,
+    );
+  }
+
+  return GenreCloudLayout(
+    placed: attempt.placed,
+    hidden: attempt.hidden,
+    size: canvasSize,
+  );
+}
+
+/// One placement pass at a given [scaleMax].
+_Attempt _placeAll(
+  List<FacetValue> sorted,
+  Size size,
+  MeasureWord measure,
+  double minFont,
+  double scaleMax,
+  Map<int, int> rankByCount,
+  int distinct,
+  int maxTiers,
+) {
+  final List<PlacedWord> placed = <PlacedWord>[];
+  final List<Rect> occupied = <Rect>[];
+  int hidden = 0;
+
+  final double cx = size.width / 2;
+  final double cy = size.height / 2;
+  const double pad = 4;
+  const double margin = 6;
+  const double aspect = 1.7; // spread wider than tall, like a real cloud
+
+  for (int i = 0; i < sorted.length; i++) {
+    final FacetValue word = sorted[i];
+    final double fontSize = _fontForRank(
+      rankByCount[word.count] ?? 0, distinct, maxTiers, minFont, scaleMax,
+    );
+    final Size raw = measure(word, fontSize);
+    final bool rotated = rotatedAtIndex(i);
+    final double w = rotated ? raw.height : raw.width;
+    final double h = rotated ? raw.width : raw.height;
+
+    // Word too large for the canvas at this scale -> defer to a smaller scale.
+    if (w > size.width - margin * 2 || h > size.height - margin * 2) {
+      hidden++;
+      continue;
+    }
+
+    Offset? center;
+    double t = 0;
+    for (int step = 0; step < 6000; step++) {
+      final double r = 3.0 * t;
+      final double x = cx + r * math.cos(t) * aspect;
+      final double y = cy + r * math.sin(t);
+      t += 0.2;
+
+      final Rect rect = Rect.fromCenter(
+        center: Offset(x, y),
+        width: w + pad,
+        height: h + pad,
+      );
+      if (rect.left < margin ||
+          rect.top < margin ||
+          rect.right > size.width - margin ||
+          rect.bottom > size.height - margin) {
+        if (r > size.width + size.height) break; // spiral left the canvas
+        continue;
+      }
+
+      bool collides = false;
+      for (final Rect other in occupied) {
+        if (other.overlaps(rect)) {
+          collides = true;
+          break;
+        }
+      }
+      if (!collides) {
+        center = Offset(x, y);
+        occupied.add(rect);
+        break;
+      }
+    }
+
+    if (center == null) {
+      hidden++;
+      continue;
+    }
+    placed.add(
+      PlacedWord(
+        word: word,
+        fontSize: fontSize,
+        center: center,
+        rotated: rotated,
+      ),
+    );
+  }
+
+  return _Attempt(placed, hidden);
+}
+
+/// Maps a count [rank] (0 = most frequent) to a font size along a geometric
+/// ladder from [scaleMax] down to [minFont].
+double _fontForRank(
+  int rank,
+  int distinct,
+  int maxTiers,
+  double minFont,
+  double scaleMax,
+) {
+  final int tiers = math.min(distinct, maxTiers);
+  if (tiers <= 1 || distinct <= 1) return scaleMax;
+  final int tier = ((rank / (distinct - 1)) * (tiers - 1)).round();
+  final double tNorm = tier / (tiers - 1);
+  return scaleMax * math.pow(minFont / scaleMax, tNorm).toDouble();
+}
+
+/// Outcome of a single [_placeAll] pass.
+class _Attempt {
+  const _Attempt(this.placed, this.hidden);
+
+  final List<PlacedWord> placed;
+  final int hidden;
+}

--- a/lib/features/genre_cloud/providers/genre_cloud_provider.dart
+++ b/lib/features/genre_cloud/providers/genre_cloud_provider.dart
@@ -1,0 +1,14 @@
+// Riverpod glue: the whole library's items for the preference cloud to aggregate.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../shared/models/collection_item.dart';
+import '../../home/providers/all_items_provider.dart';
+
+/// Items the preference cloud is built from (the whole library). Aggregation and
+/// media-type filtering are done by the screen so the legend can re-filter
+/// without re-reading.
+final Provider<AsyncValue<List<CollectionItem>>> genreCloudItemsProvider =
+    Provider<AsyncValue<List<CollectionItem>>>(
+  (Ref ref) => ref.watch(allItemsNotifierProvider),
+);

--- a/lib/features/genre_cloud/screens/genre_cloud_screen.dart
+++ b/lib/features/genre_cloud/screens/genre_cloud_screen.dart
@@ -1,0 +1,344 @@
+// Preference cloud screen: facet legend + media-type legend + cloud + image
+// export. Filtering is "broad strokes" via the two chip rows.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/constants/media_type_theme.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/services/png_export_service.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/draggable_fab.dart';
+import '../facet.dart';
+import '../facet_value.dart';
+import '../genre_cloud_aggregate.dart';
+import '../providers/genre_cloud_provider.dart';
+import '../widgets/genre_cloud_export_view.dart';
+import '../widgets/genre_cloud_view.dart';
+
+/// Shows a preference cloud (genres / platforms / decades) for the whole
+/// library. Words are coloured by media type; two chip rows filter by facet and
+/// by media type.
+class GenreCloudScreen extends ConsumerStatefulWidget {
+  /// Creates a [GenreCloudScreen].
+  const GenreCloudScreen({super.key});
+
+  @override
+  ConsumerState<GenreCloudScreen> createState() => _GenreCloudScreenState();
+}
+
+class _GenreCloudScreenState extends ConsumerState<GenreCloudScreen> {
+  static final Logger _log = Logger('GenreCloudScreen');
+
+  final GlobalKey _exportKey = GlobalKey();
+
+  // "Broad strokes" filters: hidden facet dimensions and hidden media types.
+  final Set<Facet> _hiddenFacets = <Facet>{};
+  final Set<MediaType> _hiddenTypes = <MediaType>{};
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    final AsyncValue<List<CollectionItem>> itemsAsync =
+        ref.watch(genreCloudItemsProvider);
+    final List<CollectionItem> items =
+        itemsAsync.valueOrNull ?? const <CollectionItem>[];
+
+    final Set<Facet> presentF = presentFacets(items);
+    final List<Facet> facets = Facet.values.where(presentF.contains).toList();
+    final Set<MediaType> presentT = presentMediaTypes(items);
+    final List<MediaType> types =
+        MediaType.values.where(presentT.contains).toList();
+
+    final Set<Facet> includedFacets =
+        presentF.where((Facet f) => !_hiddenFacets.contains(f)).toSet();
+    final Set<MediaType> includedTypes =
+        presentT.where((MediaType t) => !_hiddenTypes.contains(t)).toSet();
+
+    final List<FacetValue> words = aggregateFacets(
+      items,
+      includeFacets: includedFacets,
+      includeTypes: includedTypes,
+    );
+    final bool hasWords = words.isNotEmpty;
+
+    return Material(
+      color: AppColors.background,
+      child: Stack(
+        children: <Widget>[
+          Column(
+            children: <Widget>[
+              _buildHeader(l),
+              if (facets.length > 1) _buildFacetLegend(l, facets),
+              if (types.length > 1) _buildTypeLegend(l, types),
+              Expanded(child: _buildBody(l, itemsAsync, words)),
+            ],
+          ),
+          if (hasWords)
+            Positioned(
+              left: -10000,
+              top: -10000,
+              child: SizedBox(
+                width: kGenreCloudExportWidth,
+                height: kGenreCloudExportHeight,
+                child: GenreCloudExportView(
+                  repaintKey: _exportKey,
+                  title: l.genreCloudTitle,
+                  words: words,
+                ),
+              ),
+            ),
+          if (hasWords)
+            DraggableFab(
+              mainAction: DraggableFabItem(
+                icon: Icons.image_outlined,
+                label: l.genreCloudExportImage,
+                onTap: () => _exportAsImage(context, words),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  // Title strip without a back button — this screen is a standalone view
+  // reached from the centre nav button, navigated away via the nav bar.
+  Widget _buildHeader(S l) {
+    return Container(
+      height: 44,
+      alignment: Alignment.centerLeft,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+      decoration: const BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: AppColors.surfaceBorder, width: 0.5),
+        ),
+      ),
+      child: Text(
+        l.genreCloudTitle,
+        style: AppTypography.body.copyWith(
+          fontWeight: FontWeight.w600,
+          color: AppColors.textSecondary,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFacetLegend(S l, List<Facet> facets) {
+    return _ChipRow(
+      children: <Widget>[
+        for (final Facet facet in facets)
+          _LegendChip(
+            label: _facetLabel(l, facet),
+            hidden: _hiddenFacets.contains(facet),
+            onTap: () => setState(() {
+              if (!_hiddenFacets.remove(facet)) _hiddenFacets.add(facet);
+            }),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildTypeLegend(S l, List<MediaType> types) {
+    return _ChipRow(
+      children: <Widget>[
+        for (final MediaType type in types)
+          _LegendChip(
+            label: type.localizedLabel(l),
+            color: MediaTypeTheme.colorFor(type),
+            hidden: _hiddenTypes.contains(type),
+            onTap: () => setState(() {
+              if (!_hiddenTypes.remove(type)) _hiddenTypes.add(type);
+            }),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildBody(
+    S l,
+    AsyncValue<List<CollectionItem>> itemsAsync,
+    List<FacetValue> words,
+  ) {
+    return itemsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (Object error, StackTrace stack) => Center(
+        child: Text(
+          '${l.settingsError}: $error',
+          style: AppTypography.body.copyWith(color: AppColors.textSecondary),
+        ),
+      ),
+      data: (List<CollectionItem> _) {
+        if (words.isEmpty) return _buildEmptyState(l);
+        return Padding(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          child: GenreCloudView(
+            words: words,
+            resetTooltip: l.genreCloudResetView,
+            hiddenLabel: l.genreCloudHidden,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState(S l) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Icon(
+              Icons.cloud_off,
+              size: 64,
+              color: AppColors.textTertiary.withAlpha(120),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              l.genreCloudEmpty,
+              style: AppTypography.h3.copyWith(color: AppColors.textTertiary),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              l.genreCloudEmptyHint,
+              textAlign: TextAlign.center,
+              style:
+                  AppTypography.body.copyWith(color: AppColors.textSecondary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _facetLabel(S l, Facet facet) {
+    switch (facet) {
+      case Facet.genre:
+        return l.facetGenre;
+      case Facet.platform:
+        return l.facetPlatform;
+      case Facet.decade:
+        return l.facetDecade;
+    }
+  }
+
+  Future<void> _exportAsImage(
+    BuildContext context,
+    List<FacetValue> words,
+  ) async {
+    final S l = S.of(context);
+    // Wait for the current frame so the offscreen export view is rendered.
+    await WidgetsBinding.instance.endOfFrame;
+
+    final String safeBase = sanitizeFileName(l.genreCloudTitle);
+    final String fileName =
+        '${safeBase.isEmpty ? 'preference_cloud' : safeBase}.png';
+
+    final BulkExportResult result = await saveBoundaryAsPng(
+      repaintKey: _exportKey,
+      suggestedFileName: fileName,
+      saveDialogTitle: l.genreCloudExportImage,
+    );
+    if (!context.mounted) return;
+
+    switch (result.status) {
+      case BulkExportStatus.saved:
+        context.showSnack(l.genreCloudImageSaved, type: SnackType.success);
+      case BulkExportStatus.cancelled:
+        break;
+      case BulkExportStatus.failed:
+        _log.warning('Failed to export preference cloud image', result.error);
+        context.showSnack(l.genreCloudExportFailed, type: SnackType.error);
+    }
+  }
+}
+
+/// A horizontally-wrapping row of legend chips.
+class _ChipRow extends StatelessWidget {
+  const _ChipRow({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        0,
+      ),
+      child: Wrap(
+        spacing: AppSpacing.sm,
+        runSpacing: AppSpacing.sm,
+        children: children,
+      ),
+    );
+  }
+}
+
+/// Legend pill. Tapping toggles whether its dimension/type is hidden. An
+/// optional [color] dot is shown for media-type chips (colour = the cloud's
+/// encoding); facet chips omit it.
+class _LegendChip extends StatelessWidget {
+  const _LegendChip({
+    required this.label,
+    required this.hidden,
+    required this.onTap,
+    this.color,
+  });
+
+  final String label;
+  final bool hidden;
+  final VoidCallback onTap;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(20),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: AppColors.surfaceBorder, width: 0.5),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (color != null) ...<Widget>[
+              Container(
+                width: 9,
+                height: 9,
+                decoration: BoxDecoration(
+                  color: hidden ? AppColors.textTertiary : color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 6),
+            ],
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color:
+                    hidden ? AppColors.textTertiary : AppColors.textSecondary,
+                decoration:
+                    hidden ? TextDecoration.lineThrough : TextDecoration.none,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/genre_cloud/widgets/genre_cloud_export_view.dart
+++ b/lib/features/genre_cloud/widgets/genre_cloud_export_view.dart
@@ -1,0 +1,86 @@
+// Offscreen fixed-size preference cloud rendered into a PNG.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_assets.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../facet_value.dart';
+import 'genre_cloud_view.dart';
+
+/// Fixed pixel size of the exported poster (logical pixels; the PNG export
+/// multiplies this by the pixel ratio for a crisp image).
+const double kGenreCloudExportWidth = 1200;
+
+/// Fixed pixel height of the exported poster.
+const double kGenreCloudExportHeight = 800;
+
+/// The widget captured by the PNG exporter: a titled, solid-background poster
+/// of the cloud with the app credit footer.
+class GenreCloudExportView extends StatelessWidget {
+  /// Creates a [GenreCloudExportView].
+  const GenreCloudExportView({
+    required this.repaintKey,
+    required this.title,
+    required this.words,
+    super.key,
+  });
+
+  /// Key whose render boundary is captured to a PNG.
+  final GlobalKey repaintKey;
+
+  /// Poster heading (collection name or library title).
+  final String title;
+
+  /// Facet values to render.
+  final List<FacetValue> words;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      key: repaintKey,
+      child: Container(
+        width: kGenreCloudExportWidth,
+        height: kGenreCloudExportHeight,
+        color: AppColors.background,
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.h2.copyWith(color: AppColors.textPrimary),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Expanded(
+              child: GenreCloudView(
+                words: words,
+                minFontSize: 18,
+                maxFontSize: 150,
+                interactive: false,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                Image.asset(AppAssets.logo, width: 16, height: 16),
+                const SizedBox(width: 4),
+                Text(
+                  'made by Tonkatsu Box',
+                  style: AppTypography.caption.copyWith(
+                    color: AppColors.textTertiary,
+                    fontSize: 10,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/genre_cloud/widgets/genre_cloud_view.dart
+++ b/lib/features/genre_cloud/widgets/genre_cloud_view.dart
@@ -1,0 +1,337 @@
+// On-screen preference cloud: lays out and paints facet words.
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/constants/media_type_theme.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../facet_value.dart';
+import '../genre_cloud_layout.dart';
+
+/// Base text style for a cloud word.
+TextStyle genreWordStyle(double fontSize, Color color) => TextStyle(
+      fontSize: fontSize,
+      fontWeight: FontWeight.w700,
+      letterSpacing: -0.2,
+      height: 1,
+      color: color,
+    );
+
+/// Builds the rich span for a cloud word: the label plus an optional smaller,
+/// dimmed count suffix. Used by both measurement and painting so the laid-out
+/// footprint matches what is drawn. [labelShadows] is paint-only.
+TextSpan genreWordSpan(
+  FacetValue word,
+  double fontSize,
+  Color color, {
+  required bool showCount,
+  List<Shadow>? labelShadows,
+}) {
+  return TextSpan(
+    text: word.label,
+    style: genreWordStyle(fontSize, color).copyWith(shadows: labelShadows),
+    children: showCount
+        ? <InlineSpan>[
+            TextSpan(
+              text: '  ${word.count}',
+              style: genreWordStyle(
+                math.max(8, fontSize * 0.38),
+                color.withAlpha(140),
+              ).copyWith(fontWeight: FontWeight.w600),
+            ),
+          ]
+        : null,
+  );
+}
+
+/// Measures a cloud word (label + optional count) at [fontSize].
+Size measureGenreWord(
+  FacetValue word,
+  double fontSize, {
+  required bool showCount,
+}) {
+  final TextPainter painter = TextPainter(
+    text: genreWordSpan(
+      word,
+      fontSize,
+      const Color(0xFFFFFFFF),
+      showCount: showCount,
+    ),
+    textDirection: TextDirection.ltr,
+    maxLines: 1,
+  )..layout();
+  return Size(painter.width, painter.height);
+}
+
+/// Paints a preference cloud. Word size scales with frequency rank; colour
+/// follows the dominant media type. Which facets and media types appear is
+/// controlled by the legend (callers filter [words] upstream).
+///
+/// When [interactive] (the default) the cloud is laid out on a canvas grown to
+/// fit every word and wrapped in an [InteractiveViewer], so on small screens the
+/// user pans and pinch-zooms to reach words instead of losing them to the hidden
+/// counter. The offscreen export view sets it false to render a fixed,
+/// fully-visible poster.
+class GenreCloudView extends StatefulWidget {
+  /// Creates a [GenreCloudView].
+  const GenreCloudView({
+    required this.words,
+    this.minFontSize = 14,
+    this.maxFontSize = 64,
+    this.showCount = true,
+    this.interactive = true,
+    this.resetTooltip,
+    this.hiddenLabel,
+    super.key,
+  });
+
+  /// Facet values to render.
+  final List<FacetValue> words;
+
+  /// Smallest font size used for the rarest tier.
+  final double minFontSize;
+
+  /// Largest font size for the most frequent tier (auto-fit may shrink it).
+  final double maxFontSize;
+
+  /// Whether to draw the item count next to each word.
+  final bool showCount;
+
+  /// Whether to grow the canvas to fit every word and allow pan/zoom.
+  final bool interactive;
+
+  /// Tooltip for the recenter button (shown only while the view is panned or
+  /// zoomed away from the default). Omit to hide the tooltip.
+  final String? resetTooltip;
+
+  /// Builds the caption shown when some words could not be placed.
+  final String Function(int hidden)? hiddenLabel;
+
+  @override
+  State<GenreCloudView> createState() => _GenreCloudViewState();
+}
+
+class _GenreCloudViewState extends State<GenreCloudView> {
+  /// Max canvas growth passes before giving up (then [hidden] carries the rest).
+  static const int _maxGrowthPasses = 4;
+
+  final TransformationController _controller = TransformationController();
+
+  // Cached layout: the placement is expensive, so recompute only when the words
+  // or the viewport actually change, not on every unrelated rebuild.
+  GenreCloudLayout? _layout;
+  List<FacetValue>? _laidOutWords;
+  Size? _laidOutViewport;
+
+  // Canvas the view is currently centred for; re-centre only when it changes so
+  // the user's own panning survives rebuilds.
+  Size? _centeredFor;
+
+  // The default (centred, unzoomed) transform the recenter button restores.
+  Matrix4? _homeTransform;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  bool _isHome(Matrix4 transform) =>
+      _homeTransform == null || transform == _homeTransform;
+
+  void _resetView() {
+    final Matrix4? home = _homeTransform;
+    if (home != null) _controller.value = home;
+  }
+
+  GenreCloudLayout _compute(Size canvas) => layoutGenreCloud(
+        words: widget.words,
+        canvasSize: canvas,
+        measure: (FacetValue word, double fontSize) =>
+            measureGenreWord(word, fontSize, showCount: widget.showCount),
+        minFontSize: widget.minFontSize,
+        maxFontSize: widget.maxFontSize,
+      );
+
+  GenreCloudLayout _resolveLayout(Size viewport) {
+    if (!widget.interactive) return _compute(viewport);
+
+    if (_layout != null &&
+        _laidOutViewport == viewport &&
+        _laidOutWords != null &&
+        listEquals(_laidOutWords, widget.words)) {
+      return _layout!;
+    }
+
+    Size canvas = viewport;
+    GenreCloudLayout layout = _compute(canvas);
+    // Grow the canvas (keeping fonts readable) until everything fits, so the
+    // pan/zoom can reach every word.
+    int pass = 0;
+    while (layout.hidden > 0 && pass < _maxGrowthPasses) {
+      canvas = Size(canvas.width * 1.4, canvas.height * 1.4);
+      layout = _compute(canvas);
+      pass++;
+    }
+
+    _layout = layout;
+    _laidOutWords = List<FacetValue>.of(widget.words);
+    _laidOutViewport = viewport;
+    return layout;
+  }
+
+  void _maybeRecenter(Size viewport, Size canvas) {
+    final double dx = (viewport.width - canvas.width) / 2;
+    final double dy = (viewport.height - canvas.height) / 2;
+    final Matrix4 home = Matrix4.translationValues(dx, dy, 0);
+    _homeTransform = home;
+    if (_centeredFor == canvas) return;
+    _centeredFor = canvas;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _controller.value = home;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final Size viewport = Size(constraints.maxWidth, constraints.maxHeight);
+        final GenreCloudLayout layout = _resolveLayout(viewport);
+
+        final Widget content;
+        if (widget.interactive) {
+          _maybeRecenter(viewport, layout.size);
+          content = InteractiveViewer(
+            transformationController: _controller,
+            constrained: false,
+            minScale: 0.4,
+            maxScale: 4,
+            boundaryMargin: const EdgeInsets.all(64),
+            child: CustomPaint(
+              size: layout.size,
+              painter: _GenreCloudPainter(layout, showCount: widget.showCount),
+            ),
+          );
+        } else {
+          content = CustomPaint(
+            painter: _GenreCloudPainter(layout, showCount: widget.showCount),
+          );
+        }
+
+        return Stack(
+          children: <Widget>[
+            Positioned.fill(child: content),
+            if (widget.interactive)
+              Positioned(
+                left: 8,
+                bottom: 8,
+                child: ValueListenableBuilder<Matrix4>(
+                  valueListenable: _controller,
+                  builder: (BuildContext context, Matrix4 value, Widget? _) {
+                    if (_isHome(value)) return const SizedBox.shrink();
+                    return _RecenterButton(
+                      onTap: _resetView,
+                      tooltip: widget.resetTooltip,
+                    );
+                  },
+                ),
+              ),
+            if (layout.hidden > 0 && widget.hiddenLabel != null)
+              Positioned(
+                right: 8,
+                bottom: 8,
+                child: Text(
+                  widget.hiddenLabel!(layout.hidden),
+                  style: const TextStyle(
+                    fontSize: 11,
+                    color: Color(0xFF707070),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Small circular button that restores the cloud to its default centred view.
+class _RecenterButton extends StatelessWidget {
+  const _RecenterButton({required this.onTap, this.tooltip});
+
+  final VoidCallback onTap;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget button = Material(
+      color: AppColors.surface,
+      shape: const CircleBorder(
+        side: BorderSide(color: AppColors.surfaceBorder, width: 0.5),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        customBorder: const CircleBorder(),
+        child: const Padding(
+          padding: EdgeInsets.all(8),
+          child: Icon(
+            Icons.filter_center_focus,
+            size: 20,
+            color: AppColors.textSecondary,
+          ),
+        ),
+      ),
+    );
+    final String? message = tooltip;
+    if (message == null) return button;
+    return Tooltip(message: message, child: button);
+  }
+}
+
+class _GenreCloudPainter extends CustomPainter {
+  _GenreCloudPainter(this.layout, {required this.showCount});
+
+  final GenreCloudLayout layout;
+  final bool showCount;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final PlacedWord placed in layout.placed) {
+      final FacetValue word = placed.word;
+      final Color color = MediaTypeTheme.colorFor(word.type);
+      final TextPainter painter = TextPainter(
+        text: genreWordSpan(
+          word,
+          placed.fontSize,
+          color,
+          showCount: showCount,
+          labelShadows: <Shadow>[
+            Shadow(color: color.withAlpha(70), blurRadius: 14),
+          ],
+        ),
+        textDirection: TextDirection.ltr,
+        maxLines: 1,
+      )..layout();
+
+      canvas.save();
+      canvas.translate(placed.center.dx, placed.center.dy);
+      if (placed.rotated) {
+        canvas.rotate(-math.pi / 2);
+      }
+      painter.paint(
+        canvas,
+        Offset(-painter.width / 2, -painter.height / 2),
+      );
+      canvas.restore();
+    }
+  }
+
+  @override
+  bool shouldRepaint(_GenreCloudPainter oldDelegate) =>
+      !identical(oldDelegate.layout, layout) ||
+      oldDelegate.showCount != showCount;
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2334,5 +2334,21 @@
   "screenScraperMediaTitle": "Title",
   "screenScraperMediaScreenshot": "Screenshot",
   "screenScraperMediaFanart": "Fanart",
-  "screenScraperMediaMix": "Mix"
+  "screenScraperMediaMix": "Mix",
+  "genreCloudTitle": "Personalization",
+  "genreCloudEmpty": "No genres yet",
+  "genreCloudEmptyHint": "Add items with genres to build the cloud",
+  "genreCloudExportImage": "Save as image",
+  "genreCloudImageSaved": "Image saved",
+  "genreCloudExportFailed": "Couldn't save the image",
+  "genreCloudResetView": "Reset view",
+  "genreCloudHidden": "{count, plural, =1{1 hidden (didn't fit)} other{{count} hidden (didn't fit)}}",
+  "@genreCloudHidden": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "facetGenre": "Genres",
+  "facetPlatform": "Platforms",
+  "facetDecade": "Decades"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9125,6 +9125,72 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Mix'**
   String get screenScraperMediaMix;
+
+  /// No description provided for @genreCloudTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Personalization'**
+  String get genreCloudTitle;
+
+  /// No description provided for @genreCloudEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No genres yet'**
+  String get genreCloudEmpty;
+
+  /// No description provided for @genreCloudEmptyHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add items with genres to build the cloud'**
+  String get genreCloudEmptyHint;
+
+  /// No description provided for @genreCloudExportImage.
+  ///
+  /// In en, this message translates to:
+  /// **'Save as image'**
+  String get genreCloudExportImage;
+
+  /// No description provided for @genreCloudImageSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Image saved'**
+  String get genreCloudImageSaved;
+
+  /// No description provided for @genreCloudExportFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save the image'**
+  String get genreCloudExportFailed;
+
+  /// No description provided for @genreCloudResetView.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset view'**
+  String get genreCloudResetView;
+
+  /// No description provided for @genreCloudHidden.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 hidden (didn\'t fit)} other{{count} hidden (didn\'t fit)}}'**
+  String genreCloudHidden(int count);
+
+  /// No description provided for @facetGenre.
+  ///
+  /// In en, this message translates to:
+  /// **'Genres'**
+  String get facetGenre;
+
+  /// No description provided for @facetPlatform.
+  ///
+  /// In en, this message translates to:
+  /// **'Platforms'**
+  String get facetPlatform;
+
+  /// No description provided for @facetDecade.
+  ///
+  /// In en, this message translates to:
+  /// **'Decades'**
+  String get facetDecade;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5080,4 +5080,45 @@ class SEn extends S {
 
   @override
   String get screenScraperMediaMix => 'Mix';
+
+  @override
+  String get genreCloudTitle => 'Personalization';
+
+  @override
+  String get genreCloudEmpty => 'No genres yet';
+
+  @override
+  String get genreCloudEmptyHint => 'Add items with genres to build the cloud';
+
+  @override
+  String get genreCloudExportImage => 'Save as image';
+
+  @override
+  String get genreCloudImageSaved => 'Image saved';
+
+  @override
+  String get genreCloudExportFailed => 'Couldn\'t save the image';
+
+  @override
+  String get genreCloudResetView => 'Reset view';
+
+  @override
+  String genreCloudHidden(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count hidden (didn\'t fit)',
+      one: '1 hidden (didn\'t fit)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get facetGenre => 'Genres';
+
+  @override
+  String get facetPlatform => 'Platforms';
+
+  @override
+  String get facetDecade => 'Decades';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -5166,4 +5166,48 @@ class SRu extends S {
 
   @override
   String get screenScraperMediaMix => 'Микс';
+
+  @override
+  String get genreCloudTitle => 'Персонализация';
+
+  @override
+  String get genreCloudEmpty => 'Пока нет жанров';
+
+  @override
+  String get genreCloudEmptyHint =>
+      'Добавьте элементы с жанрами, чтобы построить облако';
+
+  @override
+  String get genreCloudExportImage => 'Сохранить картинкой';
+
+  @override
+  String get genreCloudImageSaved => 'Картинка сохранена';
+
+  @override
+  String get genreCloudExportFailed => 'Не удалось сохранить картинку';
+
+  @override
+  String get genreCloudResetView => 'Сбросить вид';
+
+  @override
+  String genreCloudHidden(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'скрыто $count (не поместились)',
+      many: 'скрыто $count (не поместились)',
+      few: 'скрыто $count (не поместились)',
+      one: 'скрыто $count (не поместилось)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get facetGenre => 'Жанры';
+
+  @override
+  String get facetPlatform => 'Платформы';
+
+  @override
+  String get facetDecade => 'Десятилетия';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -2009,5 +2009,16 @@
   "screenScraperMediaTitle": "Заставка",
   "screenScraperMediaScreenshot": "Скриншот",
   "screenScraperMediaFanart": "Фан-арт",
-  "screenScraperMediaMix": "Микс"
+  "screenScraperMediaMix": "Микс",
+  "genreCloudTitle": "Персонализация",
+  "genreCloudEmpty": "Пока нет жанров",
+  "genreCloudEmptyHint": "Добавьте элементы с жанрами, чтобы построить облако",
+  "genreCloudExportImage": "Сохранить картинкой",
+  "genreCloudImageSaved": "Картинка сохранена",
+  "genreCloudExportFailed": "Не удалось сохранить картинку",
+  "genreCloudResetView": "Сбросить вид",
+  "genreCloudHidden": "{count, plural, =1{скрыто {count} (не поместилось)} few{скрыто {count} (не поместились)} many{скрыто {count} (не поместились)} other{скрыто {count} (не поместились)}}",
+  "facetGenre": "Жанры",
+  "facetPlatform": "Платформы",
+  "facetDecade": "Десятилетия"
 }

--- a/lib/shared/navigation/app_bottom_bar.dart
+++ b/lib/shared/navigation/app_bottom_bar.dart
@@ -6,8 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/releases/providers/releases_provider.dart';
 import '../../features/welcome/providers/menu_tour_provider.dart';
 import '../../features/wishlist/providers/wishlist_provider.dart';
+import '../../l10n/app_localizations.dart';
 import '../theme/app_colors.dart';
 import 'liquid_indicator.dart';
+import 'nav_center_button.dart';
 import 'nav_destinations.dart';
 import 'nav_icon_button.dart';
 import 'nav_tab.dart';
@@ -19,12 +21,14 @@ const double kAppBottomBarHeight = 64;
 /// Bottom navigation bar (horizontal).
 ///
 /// Used on narrow screens instead of [AppSidebar]. Settings is not here — it
-/// lives in [AppTopBar].
+/// lives in [AppTopBar]. The middle slot is left empty for the centre button.
 class AppBottomBar extends ConsumerWidget {
   /// Creates an [AppBottomBar].
   const AppBottomBar({
     required this.selectedTab,
     required this.onDestinationSelected,
+    required this.onCenterTap,
+    this.centerActive = false,
     super.key,
   });
 
@@ -33,6 +37,13 @@ class AppBottomBar extends ConsumerWidget {
 
   /// Called when a tab is selected.
   final void Function(NavTab tab) onDestinationSelected;
+
+  /// Called when the centre button is tapped.
+  final VoidCallback onCenterTap;
+
+  /// Whether the centre button is the active destination (highlights it and
+  /// dims the tabs).
+  final bool centerActive;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -51,6 +62,13 @@ class AppBottomBar extends ConsumerWidget {
     final int selectedIndex =
         destinations.indexWhere((NavDestination d) => d.tab == selectedTab);
 
+    // One extra slot in the middle is reserved for the centre button.
+    final int slotCount = destinations.length + 1;
+    final int selectedSlot = navSelectedSlot(
+      selectedIndex: selectedIndex,
+      centerActive: centerActive,
+    );
+
     return SizedBox(
       height: kAppBottomBarHeight + MediaQuery.paddingOf(context).bottom,
       child: DecoratedBox(
@@ -64,28 +82,44 @@ class AppBottomBar extends ConsumerWidget {
           top: false,
           child: LayoutBuilder(
             builder: (BuildContext context, BoxConstraints constraints) {
-              final double itemWidth = constraints.maxWidth / destinations.length;
+              final double itemWidth = constraints.maxWidth / slotCount;
               return SizedBox(
                 height: kAppBottomBarHeight,
                 child: Stack(
+                  clipBehavior: Clip.none,
                   children: <Widget>[
                     LiquidIndicator(
-                      selectedIndex: selectedIndex,
+                      selectedIndex: selectedSlot,
                       itemExtent: itemWidth,
                       crossExtent: kAppBottomBarHeight,
                       axis: Axis.horizontal,
+                      // The centre logo is larger than a tab icon, so its
+                      // highlight needs to be bigger too.
+                      size: centerActive ? 50 : 40,
                     ),
                     Row(
                       children: <Widget>[
-                        for (final NavDestination d in destinations)
+                        for (int i = 0; i < destinations.length; i++) ...<Widget>[
+                          if (i == kNavCenterSlot)
+                            NavCenterButton(
+                              width: itemWidth,
+                              height: kAppBottomBarHeight,
+                              tooltip: S.of(context).genreCloudTitle,
+                              onTap: onCenterTap,
+                            ),
                           NavIconButton(
-                            key: tourActive ? tourKeys.keyFor(d.tab) : null,
-                            destination: d,
-                            active: d.tab == selectedTab,
+                            key: tourActive
+                                ? tourKeys.keyFor(destinations[i].tab)
+                                : null,
+                            destination: destinations[i],
+                            active: !centerActive &&
+                                destinations[i].tab == selectedTab,
                             width: itemWidth,
                             height: kAppBottomBarHeight,
-                            onTap: () => onDestinationSelected(d.tab),
+                            onTap: () =>
+                                onDestinationSelected(destinations[i].tab),
                           ),
+                        ],
                       ],
                     ),
                   ],

--- a/lib/shared/navigation/app_shell.dart
+++ b/lib/shared/navigation/app_shell.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/collections/screens/collection_screen.dart';
 import '../../features/collections/screens/home_screen.dart';
+import '../../features/genre_cloud/screens/genre_cloud_screen.dart';
 import '../../features/home/screens/all_items_screen.dart';
 import '../../features/collections/screens/item_detail_screen.dart';
 import '../../features/releases/screens/releases_screen.dart';
@@ -199,6 +200,8 @@ class _AppShellState extends ConsumerState<AppShell> {
         bottomNavigationBar: AppBottomBar(
           selectedTab: activeTab,
           onDestinationSelected: onTabSelected,
+          onCenterTap: _openPreferenceCloud,
+          centerActive: _personalizationOpen,
         ),
       );
     }
@@ -209,11 +212,32 @@ class _AppShellState extends ConsumerState<AppShell> {
           AppSidebar(
             selectedTab: activeTab,
             onDestinationSelected: onTabSelected,
+            onCenterTap: _openPreferenceCloud,
+            centerActive: _personalizationOpen,
           ),
           Expanded(child: _buildContent()),
         ],
       ),
     );
+  }
+
+  /// Whether the Personalization view is the active view (shown in the content
+  /// area and highlighting the centre nav button like a selected tab).
+  bool _personalizationOpen = false;
+
+  /// Whether Personalization has been opened at least once, so its IndexedStack
+  /// child is built lazily on first open rather than on every app start.
+  bool _personalizationEverOpened = false;
+
+  /// Shows the preference cloud as a shell-level destination — a sibling of the
+  /// tab navigators, not a route pushed onto one — so switching tabs simply
+  /// hides it instead of leaving it on a tab's navigator stack.
+  void _openPreferenceCloud() {
+    if (_personalizationOpen) return;
+    setState(() {
+      _personalizationEverOpened = true;
+      _personalizationOpen = true;
+    });
   }
 
   /// Captures printable characters from the global Focus and redirects them to
@@ -223,6 +247,8 @@ class _AppShellState extends ConsumerState<AppShell> {
   /// not already inside another [EditableText].
   KeyEventResult _handleTypeToSearch(FocusNode node, KeyEvent event) {
     if (kIsMobile) return KeyEventResult.ignored;
+    // Personalization has no search field; don't hijack typing for it.
+    if (_personalizationOpen) return KeyEventResult.ignored;
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
       return KeyEventResult.ignored;
     }
@@ -266,13 +292,23 @@ class _AppShellState extends ConsumerState<AppShell> {
 
   Widget _buildContent() {
     return IndexedStack(
-      index: _selectedIndex,
-      children: List<Widget>.generate(_tabCount, (int index) {
-        if (!_initializedTabs.contains(index)) {
-          return const SizedBox.shrink();
-        }
-        return _buildTabNavigator(index);
-      }),
+      index: _personalizationOpen ? _tabCount : _selectedIndex,
+      children: <Widget>[
+        for (int index = 0; index < _tabCount; index++)
+          if (_initializedTabs.contains(index))
+            _buildTabNavigator(index)
+          else
+            const SizedBox.shrink(),
+        // Personalization is a shell-level destination, not a tab: it lives as
+        // an extra IndexedStack child rather than a route pushed onto a tab's
+        // navigator, so switching tabs hides it instead of leaving it glued to
+        // a tab's stack with the highlight pointing elsewhere. Built lazily on
+        // first open, then kept alive alongside the tabs.
+        if (_personalizationEverOpened)
+          const GenreCloudScreen()
+        else
+          const SizedBox.shrink(),
+      ],
     );
   }
 
@@ -302,8 +338,10 @@ class _AppShellState extends ConsumerState<AppShell> {
   }
 
   void _onDestinationSelected(int index) {
-    if (index == _selectedIndex) {
-      // Pressing again returns to the tab root.
+    if (index == _selectedIndex && !_personalizationOpen) {
+      // Pressing again returns to the tab root. While Personalization is open
+      // this must fall through instead, so tapping the underlying tab closes
+      // the cloud rather than silently popping a hidden tab to its root.
       _navigatorKeys[index]
           .currentState
           ?.popUntil((Route<dynamic> route) => route.isFirst);
@@ -313,7 +351,12 @@ class _AppShellState extends ConsumerState<AppShell> {
       _resetSearchTab();
     }
     _initializedTabs.add(index);
-    setState(() => _selectedIndex = index);
+    setState(() {
+      _selectedIndex = index;
+      // Switching to a real tab moves the selection highlight off the centre
+      // button.
+      _personalizationOpen = false;
+    });
     // Explicitly focus the new tab's content for the gamepad.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -365,6 +408,10 @@ class _AppShellState extends ConsumerState<AppShell> {
   ///
   /// Returns `true` if navigation was handled; `false` if the app should exit.
   bool _handleBack() {
+    if (_personalizationOpen) {
+      setState(() => _personalizationOpen = false);
+      return true;
+    }
     final NavigatorState? tabNav =
         _navigatorKeys[_selectedIndex].currentState;
     if (tabNav != null && tabNav.canPop()) {

--- a/lib/shared/navigation/app_sidebar.dart
+++ b/lib/shared/navigation/app_sidebar.dart
@@ -6,8 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/releases/providers/releases_provider.dart';
 import '../../features/welcome/providers/menu_tour_provider.dart';
 import '../../features/wishlist/providers/wishlist_provider.dart';
+import '../../l10n/app_localizations.dart';
 import '../theme/app_colors.dart';
 import 'liquid_indicator.dart';
+import 'nav_center_button.dart';
 import 'nav_destinations.dart';
 import 'nav_icon_button.dart';
 import 'nav_tab.dart';
@@ -33,6 +35,8 @@ class AppSidebar extends ConsumerWidget {
   const AppSidebar({
     required this.selectedTab,
     required this.onDestinationSelected,
+    required this.onCenterTap,
+    this.centerActive = false,
     super.key,
   });
 
@@ -41,6 +45,13 @@ class AppSidebar extends ConsumerWidget {
 
   /// Called when a tab is selected.
   final void Function(NavTab tab) onDestinationSelected;
+
+  /// Called when the centre button is tapped.
+  final VoidCallback onCenterTap;
+
+  /// Whether the centre button is the active destination (highlights it and
+  /// dims the tabs).
+  final bool centerActive;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -77,32 +88,54 @@ class AppSidebar extends ConsumerWidget {
             ),
             LayoutBuilder(
               builder: (BuildContext ctx, BoxConstraints c) {
+                // One extra slot in the middle holds the centre button.
+                final int slotCount = destinations.length + 1;
                 // Shrink button height when the screen is shorter than ideal,
                 // but never below the minimum or the icons blur together.
-                final double itemHeight = (c.maxHeight / destinations.length)
+                final double itemHeight = (c.maxHeight / slotCount)
                     .clamp(_kItemHeightMin, _kItemHeight);
-                final double totalHeight = itemHeight * destinations.length;
+                final double totalHeight = itemHeight * slotCount;
+                final int selectedSlot = navSelectedSlot(
+                  selectedIndex: selectedIndex,
+                  centerActive: centerActive,
+                );
                 return Center(
                   child: SizedBox(
                     height: totalHeight,
                     child: Stack(
+                      clipBehavior: Clip.none,
                       children: <Widget>[
                         LiquidIndicator(
-                          selectedIndex: selectedIndex,
+                          selectedIndex: selectedSlot,
                           itemExtent: itemHeight,
                           crossExtent: kAppSidebarWidth,
+                          // The centre logo is larger than a tab icon, so its
+                          // highlight needs to be bigger too.
+                          size: centerActive ? 50 : 40,
                         ),
                         Column(
                           children: <Widget>[
-                            for (final NavDestination d in destinations)
+                            for (int i = 0; i < destinations.length; i++) ...<Widget>[
+                              if (i == kNavCenterSlot)
+                                NavCenterButton(
+                                  width: kAppSidebarWidth,
+                                  height: itemHeight,
+                                  tooltip: S.of(context).genreCloudTitle,
+                                  onTap: onCenterTap,
+                                ),
                               NavIconButton(
-                                key: tourActive ? tourKeys.keyFor(d.tab) : null,
-                                destination: d,
-                                active: d.tab == selectedTab,
+                                key: tourActive
+                                    ? tourKeys.keyFor(destinations[i].tab)
+                                    : null,
+                                destination: destinations[i],
+                                active: !centerActive &&
+                                    destinations[i].tab == selectedTab,
                                 width: kAppSidebarWidth,
                                 height: itemHeight,
-                                onTap: () => onDestinationSelected(d.tab),
+                                onTap: () =>
+                                    onDestinationSelected(destinations[i].tab),
                               ),
+                            ],
                           ],
                         ),
                       ],

--- a/lib/shared/navigation/app_top_bar.dart
+++ b/lib/shared/navigation/app_top_bar.dart
@@ -10,7 +10,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/update_service.dart';
 import '../../features/welcome/providers/menu_tour_provider.dart';
 import '../constants/platform_features.dart';
-import '../theme/app_assets.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_spacing.dart';
 import '../theme/app_typography.dart';
@@ -150,14 +149,6 @@ class _AppTopBarState extends ConsumerState<AppTopBar> {
       ),
       child: Row(
         children: <Widget>[
-          Image.asset(
-            AppAssets.logo,
-            width: 40,
-            height: 40,
-          ),
-          SizedBox(
-            width: MediaQuery.sizeOf(context).width < 700 ? 12 : 56,
-          ),
           Expanded(
             child: Align(
               alignment: Alignment.centerLeft,

--- a/lib/shared/navigation/nav_center_button.dart
+++ b/lib/shared/navigation/nav_center_button.dart
@@ -1,0 +1,60 @@
+// Centre navigation button: the app logo. Sits inline in the nav row/rail.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_assets.dart';
+
+/// The app logo as a nav item. Fills the `width × height` cell it is given
+/// (matching [NavIconButton]) and is focusable for gamepad via [InkResponse].
+class NavCenterButton extends StatelessWidget {
+  /// Creates a [NavCenterButton].
+  const NavCenterButton({
+    required this.onTap,
+    required this.tooltip,
+    required this.width,
+    required this.height,
+    super.key,
+  });
+
+  /// Tap callback.
+  final VoidCallback onTap;
+
+  /// Tooltip / accessibility label.
+  final String tooltip;
+
+  /// Cell width.
+  final double width;
+
+  /// Cell height.
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    final double cell = math.min(width, height);
+    final double logoSize = math.min(cell * 0.78, 36);
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Tooltip(
+        message: tooltip,
+        waitDuration: const Duration(milliseconds: 400),
+        child: InkResponse(
+          onTap: onTap,
+          radius: cell * 0.5,
+          containedInkWell: false,
+          highlightShape: BoxShape.circle,
+          child: Center(
+            child: Image.asset(
+              AppAssets.logo,
+              width: logoSize,
+              height: logoSize,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/navigation/nav_destinations.dart
+++ b/lib/shared/navigation/nav_destinations.dart
@@ -59,3 +59,18 @@ List<NavDestination> buildNavDestinations({
     ),
   ];
 }
+
+/// Slot the centre button occupies in the nav row/rail. [AppShell] draws the
+/// button (a docked logo); the bars reserve an empty slot here so the tabs
+/// split evenly around it.
+const int kNavCenterSlot = 3;
+
+/// Maps the selected destination index to its visual slot once the empty
+/// centre slot is accounted for. Returns [kNavCenterSlot] while the centre
+/// button is active, -1 when nothing is selected, and otherwise shifts any
+/// destination at or past the centre by one to skip the reserved slot.
+int navSelectedSlot({required int selectedIndex, required bool centerActive}) {
+  if (centerActive) return kNavCenterSlot;
+  if (selectedIndex < 0) return -1;
+  return selectedIndex < kNavCenterSlot ? selectedIndex : selectedIndex + 1;
+}

--- a/test/features/genre_cloud/genre_cloud_aggregate_test.dart
+++ b/test/features/genre_cloud/genre_cloud_aggregate_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/genre_cloud/facet.dart';
+import 'package:tonkatsu_box/features/genre_cloud/facet_value.dart';
+import 'package:tonkatsu_box/features/genre_cloud/genre_cloud_aggregate.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+import 'package:tonkatsu_box/shared/models/platform.dart';
+
+import '../../helpers/test_helpers.dart';
+
+CollectionItem _game({
+  List<String>? genres,
+  DateTime? release,
+  Platform? platform,
+  int id = 1,
+}) =>
+    createTestCollectionItem(
+      id: id,
+      mediaType: MediaType.game,
+      platform: platform,
+      game: createTestGame(genres: genres, releaseDate: release),
+    );
+
+CollectionItem _movie({List<String>? genres, int? year, int id = 1}) =>
+    createTestCollectionItem(
+      id: id,
+      mediaType: MediaType.movie,
+      movie: createTestMovie(genres: genres, releaseYear: year),
+    );
+
+CollectionItem _anime({List<String>? genres, int? startYear, int id = 1}) =>
+    createTestCollectionItem(
+      id: id,
+      mediaType: MediaType.anime,
+      anime: createTestAnime(genres: genres, startYear: startYear),
+    );
+
+CollectionItem _vn({List<String>? platforms, String? released, int id = 1}) =>
+    createTestCollectionItem(
+      id: id,
+      mediaType: MediaType.visualNovel,
+      visualNovel: createTestVisualNovel(
+        platforms: platforms,
+        released: released,
+      ),
+    );
+
+Iterable<String> _values(List<FacetValue> values, Facet facet) => values
+    .where((FacetValue v) => v.facet == facet)
+    .map((FacetValue v) => v.label);
+
+void main() {
+  group('extractItemFacets', () {
+    test('reads genre, decade and owned platform from a game', () {
+      final List<FacetEntry> facets = extractItemFacets(
+        _game(
+          genres: <String>['Action', 'RPG'],
+          release: DateTime(1998, 5, 1),
+          platform: const Platform(id: 1, name: 'PlayStation'),
+        ),
+      );
+      expect(
+        facets
+            .where((FacetEntry e) => e.facet == Facet.genre)
+            .map((FacetEntry e) => e.value),
+        containsAll(<String>['Action', 'RPG']),
+      );
+      expect(
+        facets.firstWhere((FacetEntry e) => e.facet == Facet.decade).value,
+        '1990s',
+      );
+      expect(
+        facets.firstWhere((FacetEntry e) => e.facet == Facet.platform).value,
+        'PlayStation',
+      );
+    });
+
+    test('reads only genre and decade from anime', () {
+      final Set<Facet> dims = extractItemFacets(
+        _anime(genres: <String>['Action'], startYear: 2011),
+      ).map((FacetEntry e) => e.facet).toSet();
+      expect(dims, <Facet>{Facet.genre, Facet.decade});
+    });
+
+    test('reads platform and decade from a visual novel', () {
+      final List<FacetEntry> facets = extractItemFacets(
+        _vn(platforms: <String>['Windows'], released: '2009-10-30'),
+      );
+      expect(
+        facets.firstWhere((FacetEntry e) => e.facet == Facet.platform).value,
+        'Windows',
+      );
+      expect(
+        facets.firstWhere((FacetEntry e) => e.facet == Facet.decade).value,
+        '2000s',
+      );
+    });
+  });
+
+  group('aggregateFacets', () {
+    test('returns empty for no items', () {
+      expect(aggregateFacets(const <CollectionItem>[]), isEmpty);
+    });
+
+    test('counts a facet value across items', () {
+      final List<FacetValue> result = aggregateFacets(<CollectionItem>[
+        _game(genres: <String>['Action'], id: 1),
+        _game(genres: <String>['Action', 'RPG'], id: 2),
+      ]);
+      expect(
+        result
+            .firstWhere(
+                (FacetValue v) => v.facet == Facet.genre && v.label == 'Action')
+            .count,
+        2,
+      );
+    });
+
+    test('same label in different facets stays separate', () {
+      final List<FacetValue> result = aggregateFacets(<CollectionItem>[
+        _game(genres: <String>['Action'], id: 1),
+        _vn(platforms: <String>['Action'], id: 2),
+      ]);
+      expect(_values(result, Facet.genre), contains('Action'));
+      expect(_values(result, Facet.platform), contains('Action'));
+      expect(result.where((FacetValue v) => v.label == 'Action'), hasLength(2));
+    });
+
+    test('is case-insensitive within a facet', () {
+      final List<FacetValue> result = aggregateFacets(<CollectionItem>[
+        _game(genres: <String>['RPG'], id: 1),
+        _game(genres: <String>['rpg'], id: 2),
+      ]);
+      expect(_values(result, Facet.genre), hasLength(1));
+      expect(result.first.count, 2);
+    });
+
+    test('dominant media type is the one with the most items', () {
+      final List<FacetValue> result = aggregateFacets(<CollectionItem>[
+        _game(genres: <String>['Action'], id: 1),
+        _game(genres: <String>['Action'], id: 2),
+        _movie(genres: <String>['Action'], id: 3),
+      ]);
+      expect(result.single.type, MediaType.game);
+    });
+
+    test('includeFacets keeps only the listed dimensions', () {
+      final List<FacetValue> result = aggregateFacets(
+        <CollectionItem>[
+          _game(
+            genres: <String>['Action'],
+            platform: const Platform(id: 1, name: 'PC'),
+          ),
+        ],
+        includeFacets: <Facet>{Facet.genre},
+      );
+      expect(result.every((FacetValue v) => v.facet == Facet.genre), isTrue);
+      expect(_values(result, Facet.platform), isEmpty);
+    });
+
+    test('includeTypes ignores items of other media types', () {
+      final List<FacetValue> result = aggregateFacets(
+        <CollectionItem>[
+          _game(genres: <String>['Action'], id: 1),
+          _movie(genres: <String>['Drama'], id: 2),
+        ],
+        includeTypes: <MediaType>{MediaType.game},
+      );
+      expect(_values(result, Facet.genre), <String>['Action']);
+    });
+
+    test('sorts by count descending', () {
+      final List<FacetValue> result = aggregateFacets(<CollectionItem>[
+        _game(genres: <String>['Rare'], id: 1),
+        _game(genres: <String>['Common'], id: 2),
+        _game(genres: <String>['Common'], id: 3),
+      ]);
+      expect(result.first.label, 'Common');
+      expect(result.first.count, 2);
+    });
+  });
+
+  group('present sets', () {
+    test('presentFacets returns the dimensions present', () {
+      final Set<Facet> facets = presentFacets(<CollectionItem>[
+        _game(
+          genres: <String>['Action'],
+          platform: const Platform(id: 1, name: 'PC'),
+        ),
+        _anime(genres: <String>['Action'], id: 2),
+      ]);
+      expect(facets, <Facet>{Facet.genre, Facet.platform});
+    });
+
+    test('presentMediaTypes returns contributing types', () {
+      final Set<MediaType> types = presentMediaTypes(<CollectionItem>[
+        _game(genres: <String>['Action'], id: 1),
+        _anime(genres: <String>['Comedy'], id: 2),
+      ]);
+      expect(types, <MediaType>{MediaType.game, MediaType.anime});
+    });
+  });
+}

--- a/test/features/genre_cloud/genre_cloud_layout_test.dart
+++ b/test/features/genre_cloud/genre_cloud_layout_test.dart
@@ -1,0 +1,166 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/genre_cloud/facet.dart';
+import 'package:tonkatsu_box/features/genre_cloud/facet_value.dart';
+import 'package:tonkatsu_box/features/genre_cloud/genre_cloud_layout.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+FacetValue _w(String label, int count) => FacetValue(
+      facet: Facet.genre,
+      label: label,
+      count: count,
+      type: MediaType.game,
+    );
+
+// Deterministic stand-in for real text metrics: width scales with label length
+// and font size, height with font size. Keeps the layout test font-independent.
+Size _fakeMeasure(FacetValue word, double fontSize) =>
+    Size(word.label.length * fontSize * 0.5, fontSize * 1.2);
+
+void main() {
+  group('rotatedAtIndex', () {
+    test('keeps the most frequent word horizontal', () {
+      expect(rotatedAtIndex(0), isFalse);
+    });
+
+    test('rotates roughly every third word', () {
+      expect(rotatedAtIndex(1), isTrue);
+      expect(rotatedAtIndex(2), isFalse);
+      expect(rotatedAtIndex(3), isFalse);
+      expect(rotatedAtIndex(4), isTrue);
+    });
+  });
+
+  group('layoutGenreCloud', () {
+    test('returns empty layout for no words', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: const <FacetValue>[],
+        canvasSize: const Size(500, 500),
+        measure: _fakeMeasure,
+      );
+      expect(layout.isEmpty, isTrue);
+      expect(layout.hidden, 0);
+    });
+
+    test('returns empty layout for a zero-area canvas', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[_w('Action', 5)],
+        canvasSize: Size.zero,
+        measure: _fakeMeasure,
+      );
+      expect(layout.isEmpty, isTrue);
+    });
+
+    test('places a single word at the canvas centre', () {
+      const Size canvas = Size(400, 300);
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[_w('Action', 5)],
+        canvasSize: canvas,
+        measure: _fakeMeasure,
+      );
+      expect(layout.placed, hasLength(1));
+      final PlacedWord placed = layout.placed.first;
+      expect(placed.center.dx, closeTo(canvas.width / 2, 0.001));
+      expect(placed.center.dy, closeTo(canvas.height / 2, 0.001));
+      expect(layout.hidden, 0);
+    });
+
+    test('places every word when they fit', () {
+      final List<FacetValue> words = <FacetValue>[
+        _w('Action', 50),
+        _w('RPG', 40),
+        _w('Indie', 30),
+        _w('Shooter', 20),
+        _w('Puzzle', 10),
+      ];
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: words,
+        canvasSize: const Size(1600, 1200),
+        measure: _fakeMeasure,
+      );
+      expect(layout.placed, hasLength(words.length));
+      expect(layout.hidden, 0);
+    });
+
+    test('font size grows with frequency', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[
+          _w('Big', 100),
+          _w('Mid', 50),
+          _w('Small', 5),
+        ],
+        canvasSize: const Size(1600, 1200),
+        measure: _fakeMeasure,
+      );
+      expect(
+        layout.placed.first.fontSize,
+        greaterThan(layout.placed.last.fontSize),
+      );
+    });
+
+    test('biggest word stays horizontal, the next is rotated', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[
+          _w('Big', 100),
+          _w('Second', 80),
+          _w('Third', 60),
+        ],
+        canvasSize: const Size(1600, 1200),
+        measure: _fakeMeasure,
+      );
+      expect(layout.placed[0].rotated, isFalse);
+      expect(layout.placed[1].rotated, isTrue);
+    });
+
+    test('clustered but unequal counts still get distinct sizes', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[_w('A', 50), _w('B', 49), _w('C', 48)],
+        canvasSize: const Size(4000, 3000),
+        measure: _fakeMeasure,
+        minFontSize: 10,
+        maxFontSize: 110,
+      );
+      final Set<double> sizes =
+          layout.placed.map((PlacedWord w) => w.fontSize).toSet();
+      expect(sizes, hasLength(3));
+      final double top =
+          layout.placed.map((PlacedWord w) => w.fontSize).reduce(math.max);
+      final double bottom =
+          layout.placed.map((PlacedWord w) => w.fontSize).reduce(math.min);
+      expect(top / bottom, greaterThan(3));
+    });
+
+    test('equal counts share the same size', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[_w('A', 50), _w('B', 50), _w('C', 10)],
+        canvasSize: const Size(4000, 3000),
+        measure: _fakeMeasure,
+        minFontSize: 10,
+        maxFontSize: 110,
+      );
+      final double a = layout.placed
+          .firstWhere((PlacedWord w) => w.word.label == 'A')
+          .fontSize;
+      final double b = layout.placed
+          .firstWhere((PlacedWord w) => w.word.label == 'B')
+          .fontSize;
+      final double c = layout.placed
+          .firstWhere((PlacedWord w) => w.word.label == 'C')
+          .fontSize;
+      expect(a, b);
+      expect(a, isNot(c));
+    });
+
+    test('reports hidden words when nothing fits the canvas', () {
+      final GenreCloudLayout layout = layoutGenreCloud(
+        words: <FacetValue>[_w('Adventure', 5)],
+        canvasSize: const Size(40, 40),
+        measure: _fakeMeasure,
+      );
+      expect(layout.placed, isEmpty);
+      expect(layout.hidden, 1);
+    });
+  });
+}

--- a/test/features/genre_cloud/genre_cloud_screen_test.dart
+++ b/test/features/genre_cloud/genre_cloud_screen_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/genre_cloud/providers/genre_cloud_provider.dart';
+import 'package:tonkatsu_box/features/genre_cloud/screens/genre_cloud_screen.dart';
+import 'package:tonkatsu_box/features/genre_cloud/widgets/genre_cloud_view.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+import '../../helpers/test_helpers.dart';
+
+List<CollectionItem> _itemsWithGenres() => <CollectionItem>[
+      createTestCollectionItem(
+        id: 1,
+        mediaType: MediaType.game,
+        game: createTestGame(genres: <String>['Action', 'RPG']),
+      ),
+      createTestCollectionItem(
+        id: 2,
+        mediaType: MediaType.movie,
+        movie: createTestMovie(genres: <String>['Action', 'Drama']),
+      ),
+    ];
+
+Override _items(List<CollectionItem> items) =>
+    genreCloudItemsProvider.overrideWith(
+      (Ref ref) => AsyncValue<List<CollectionItem>>.data(items),
+    );
+
+void main() {
+  group('GenreCloudScreen', () {
+    testWidgets('should render the cloud when items carry facets', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        const GenreCloudScreen(),
+        overrides: <Override>[_items(_itemsWithGenres())],
+        mediaQuerySize: const Size(360, 640),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(GenreCloudView), findsWidgets);
+    });
+
+    testWidgets('should show the empty state when no item carries a facet', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        const GenreCloudScreen(),
+        overrides: <Override>[_items(const <CollectionItem>[])],
+        mediaQuerySize: const Size(360, 640),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(GenreCloudView), findsNothing);
+    });
+  });
+}

--- a/test/features/genre_cloud/genre_cloud_view_test.dart
+++ b/test/features/genre_cloud/genre_cloud_view_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/genre_cloud/facet.dart';
+import 'package:tonkatsu_box/features/genre_cloud/facet_value.dart';
+import 'package:tonkatsu_box/features/genre_cloud/widgets/genre_cloud_view.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+import '../../helpers/test_helpers.dart';
+
+List<FacetValue> _sample() => const <FacetValue>[
+      FacetValue(
+          facet: Facet.genre,
+          label: 'Action',
+          count: 40,
+          type: MediaType.anime),
+      FacetValue(
+          facet: Facet.platform,
+          label: 'PlayStation',
+          count: 33,
+          type: MediaType.game),
+      FacetValue(
+          facet: Facet.decade,
+          label: '2010s',
+          count: 21,
+          type: MediaType.movie),
+      FacetValue(
+          facet: Facet.genre,
+          label: 'Comedy',
+          count: 12,
+          type: MediaType.tvShow),
+      FacetValue(
+          facet: Facet.genre,
+          label: 'Drama',
+          count: 6,
+          type: MediaType.book),
+    ];
+
+void main() {
+  group('GenreCloudView', () {
+    testWidgets('renders a populated cloud without exceptions', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        SizedBox(
+          width: 360,
+          height: 560,
+          child: GenreCloudView(words: _sample()),
+        ),
+        mediaQuerySize: const Size(360, 640),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(GenreCloudView), findsOneWidget);
+    });
+
+    testWidgets('renders an empty cloud without exceptions', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        const SizedBox(
+          width: 360,
+          height: 560,
+          child: GenreCloudView(words: <FacetValue>[]),
+        ),
+        mediaQuerySize: const Size(360, 640),
+      );
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('is pannable/zoomable by default (interactive)', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        SizedBox(
+          width: 360,
+          height: 560,
+          child: GenreCloudView(words: _sample()),
+        ),
+        mediaQuerySize: const Size(360, 640),
+      );
+
+      expect(find.byType(InteractiveViewer), findsOneWidget);
+    });
+
+    testWidgets('is static when interactive is false (export poster)', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        SizedBox(
+          width: 1200,
+          height: 800,
+          child: GenreCloudView(words: _sample(), interactive: false),
+        ),
+        mediaQuerySize: const Size(1200, 800),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(InteractiveViewer), findsNothing);
+    });
+  });
+}

--- a/test/helpers/builders.dart
+++ b/test/helpers/builders.dart
@@ -300,6 +300,9 @@ Anime createTestAnime({
   int? episodes,
   String? format,
   List<String>? genres,
+  List<String>? tags,
+  String? status,
+  int? startYear,
 }) {
   return Anime(
     id: id,
@@ -310,6 +313,9 @@ Anime createTestAnime({
     episodes: episodes,
     format: format,
     genres: genres,
+    tags: tags,
+    status: status,
+    startYear: startYear,
   );
 }
 

--- a/test/shared/navigation/app_bottom_bar_tour_keys_test.dart
+++ b/test/shared/navigation/app_bottom_bar_tour_keys_test.dart
@@ -19,6 +19,7 @@ void main() {
     Widget bar() => AppBottomBar(
           selectedTab: NavTab.home,
           onDestinationSelected: (_) {},
+          onCenterTap: () {},
         );
 
     Widget wrap(Widget child, {required ProviderContainer container}) {

--- a/test/shared/navigation/app_shell_personalization_test.dart
+++ b/test/shared/navigation/app_shell_personalization_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tonkatsu_box/app.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/core/services/update_service.dart';
+import 'package:tonkatsu_box/data/repositories/collection_repository.dart';
+import 'package:tonkatsu_box/features/genre_cloud/providers/genre_cloud_provider.dart';
+import 'package:tonkatsu_box/features/genre_cloud/screens/genre_cloud_screen.dart';
+import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
+import 'package:tonkatsu_box/features/welcome/screens/welcome_screen.dart';
+import 'package:tonkatsu_box/shared/models/collection.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/navigation/nav_center_button.dart';
+import 'package:tonkatsu_box/shared/navigation/nav_icon_button.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('AppShell personalization destination', () {
+    late MockCollectionRepository mockRepo;
+    late MockDatabaseService mockDb;
+    late MockGameDao mockGameDao;
+
+    setUp(() {
+      mockRepo = MockCollectionRepository();
+      when(() => mockRepo.getAll()).thenAnswer((_) async => <Collection>[]);
+      when(() => mockRepo.getStats(any())).thenAnswer(
+        (_) async => CollectionStats.empty,
+      );
+
+      mockDb = MockDatabaseService();
+      mockGameDao = MockGameDao();
+      when(() => mockDb.gameDao).thenReturn(mockGameDao);
+      when(() => mockDb.database).thenAnswer((_) async => MockDatabase());
+      when(() => mockGameDao.getPlatformCount()).thenAnswer((_) async => 0);
+    });
+
+    Future<void> pumpShell(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        kWelcomeCompletedKey: true,
+      });
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            collectionRepositoryProvider.overrideWithValue(mockRepo),
+            databaseServiceProvider.overrideWithValue(mockDb),
+            updateCheckProvider.overrideWith((Ref ref) async => null),
+            genreCloudItemsProvider.overrideWith(
+              (Ref ref) => const AsyncValue<List<CollectionItem>>.data(
+                <CollectionItem>[],
+              ),
+            ),
+          ],
+          child: const TonkatsuBoxApp(),
+        ),
+      );
+
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('should not stay shown after switching tabs and returning', (
+      WidgetTester tester,
+    ) async {
+      await pumpShell(tester);
+      expect(find.byType(GenreCloudScreen), findsNothing);
+
+      // Open Personalization via the centre nav button.
+      await tester.tap(find.byType(NavCenterButton));
+      await tester.pumpAndSettle();
+      expect(find.byType(GenreCloudScreen), findsOneWidget);
+
+      // Switch to another tab — the cloud must be hidden.
+      await tester.tap(find.byType(NavIconButton).at(1));
+      await tester.pumpAndSettle();
+      expect(find.byType(GenreCloudScreen), findsNothing);
+
+      // Return to the first tab — the cloud must NOT reappear (the regression:
+      // it used to stay glued to that tab's navigator while Home was highlighted).
+      await tester.tap(find.byType(NavIconButton).at(0));
+      await tester.pumpAndSettle();
+      expect(find.byType(GenreCloudScreen), findsNothing);
+    });
+
+    testWidgets('should reopen the cloud from the centre button', (
+      WidgetTester tester,
+    ) async {
+      await pumpShell(tester);
+
+      await tester.tap(find.byType(NavCenterButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(NavIconButton).at(0));
+      await tester.pumpAndSettle();
+      expect(find.byType(GenreCloudScreen), findsNothing);
+
+      await tester.tap(find.byType(NavCenterButton));
+      await tester.pumpAndSettle();
+      expect(find.byType(GenreCloudScreen), findsOneWidget);
+    });
+  });
+}

--- a/test/shared/navigation/nav_destinations_test.dart
+++ b/test/shared/navigation/nav_destinations_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/navigation/nav_destinations.dart';
+
+void main() {
+  group('navSelectedSlot', () {
+    test('should highlight the centre slot when the centre button is active',
+        () {
+      expect(
+        navSelectedSlot(selectedIndex: 0, centerActive: true),
+        kNavCenterSlot,
+      );
+      expect(
+        navSelectedSlot(selectedIndex: 5, centerActive: true),
+        kNavCenterSlot,
+      );
+    });
+
+    test('should return -1 when nothing is selected', () {
+      expect(
+        navSelectedSlot(selectedIndex: -1, centerActive: false),
+        -1,
+      );
+    });
+
+    test('should keep destinations before the centre slot in place', () {
+      for (int i = 0; i < kNavCenterSlot; i++) {
+        expect(navSelectedSlot(selectedIndex: i, centerActive: false), i);
+      }
+    });
+
+    test('should shift destinations at or past the centre slot by one', () {
+      expect(
+        navSelectedSlot(selectedIndex: kNavCenterSlot, centerActive: false),
+        kNavCenterSlot + 1,
+      );
+      expect(
+        navSelectedSlot(selectedIndex: kNavCenterSlot + 2, centerActive: false),
+        kNavCenterSlot + 3,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Whole-library word cloud of genres, platforms and release decades, coloured by dominant media type, with facet and media-type filter chips, pan/zoom + recenter, and PNG export. Reached from a new centre nav button that replaces the top-bar logo and opens as a shell-level view.