### PR TITLE
feat(collections): add "always show subcategories" setting and Discord cover art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Setting to always show subcategory filters**
+
+  A new appearance toggle keeps the subcategory subfilters (game platforms,
+  anime / manga formats) visible without first selecting their media-type
+  chevron. Off by default; mirrors how the other appearance toggles persist.
+  Applies to both the collection screen and the all-items (Home) screen.
+
+  * lib/features/settings/providers/settings_provider.dart (SettingsKeys.alwaysShowSubcategories,
+    SettingsState.alwaysShowSubcategories, SettingsNotifier.setAlwaysShowSubcategories):
+    New persisted flag with loader, copyWith, setter and clear handling.
+  * lib/features/settings/screens/settings_screen.dart: New toggle tile under appearance.
+  * lib/features/collections/widgets/collection_filter_bar.dart
+    (_CollectionFilterBarState._subfilterGroups, _formatGroup): Gate subfilters on
+    the setting in addition to the selected type.
+  * lib/features/home/screens/all_items_screen.dart
+    (_AllItemsScreenState._subfilterGroups, _formatGroup): Same gating for the Home grid.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (settingsAlwaysShowSubcategories,
+    settingsAlwaysShowSubcategoriesSubtitle): New strings.
+
 - **Universal progress tracker for custom items**
 
   Custom cards now carry a count and reading/watching progress, mirroring manga
@@ -130,6 +149,18 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     lanSyncImportConfigSubtitle, lanSyncReceivingSettings): New.
 
 ### Changed
+
+- **Show the item cover as the Discord Rich Presence large image**
+
+  The Discord status now uses the current item's real cover (game / movie /
+  manga art) as the large image, with the app logo moved to the small icon for
+  branding. Custom items with a local-file cover fall back to the logo since
+  Discord can only fetch remote URLs; the RetroAchievements icon still takes the
+  small slot when present.
+
+  * lib/core/services/discord_rpc_service.dart (DiscordRpcService.updatePresence,
+    DiscordRpcService._remoteCoverUrl): Build the large/small assets from the
+    item's cover URL, falling back to the logo.
 
 - **Mark the Uncategorized collection as deprecated across the UI**
 

--- a/lib/core/services/discord_rpc_service.dart
+++ b/lib/core/services/discord_rpc_service.dart
@@ -128,6 +128,21 @@ class DiscordRpcService {
     if (!_initialized) await _connect();
     if (!_initialized || _rpc == null) return;
 
+    // The item's cover becomes the large image; the logo moves to the small
+    // icon for branding. With no usable cover URL the logo stays large.
+    final String? coverUrl = _remoteCoverUrl(item);
+    final DiscordAsset largeAsset = coverUrl != null
+        ? DiscordAsset.fromUrl(
+            coverUrl,
+            text: item.displayName(animeMangaTitleLanguage),
+          )
+        : const DiscordAsset(key: 'logo', text: 'Tonkatsu Box');
+    final DiscordAsset? smallAsset = raData != null
+        ? DiscordAsset(key: 'ra', text: _buildRaTooltip(raData))
+        : coverUrl != null
+            ? const DiscordAsset(key: 'logo', text: 'Tonkatsu Box')
+            : null;
+
     try {
       await _rpc!.setPresence(DiscordPresence(
         details: '${_activityVerb(item.mediaType)} '
@@ -136,16 +151,8 @@ class DiscordRpcService {
         timestamps: DiscordTimestamps(
           start: DateTime.now().millisecondsSinceEpoch ~/ 1000,
         ),
-        largeAsset: const DiscordAsset(
-          key: 'logo',
-          text: 'Tonkatsu Box',
-        ),
-        smallAsset: raData != null
-            ? DiscordAsset(
-                key: 'ra',
-                text: _buildRaTooltip(raData),
-              )
-            : null,
+        largeAsset: largeAsset,
+        smallAsset: smallAsset,
       ));
     } on Exception catch (e) {
       _log.fine('Failed to update Discord presence: $e');
@@ -315,6 +322,15 @@ class DiscordRpcService {
     }
 
     return progress;
+  }
+
+  /// The item's cover URL when Discord can fetch it directly — i.e. a remote
+  /// http(s) link. Custom items may store a `local://` file marker instead;
+  /// those return null so the caller falls back to the logo.
+  static String? _remoteCoverUrl(CollectionItem item) {
+    final String? url = item.coverUrl;
+    if (url == null) return null;
+    return url.startsWith('http') ? url : null;
   }
 
   /// Tooltip for the RA icon.

--- a/lib/features/collections/widgets/collection_filter_bar.dart
+++ b/lib/features/collections/widgets/collection_filter_bar.dart
@@ -116,20 +116,31 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
     final S l = S.of(context);
     final CollectionStats? stats = widget.statsAsync.valueOrNull;
 
+    final bool alwaysShowSubcategories = ref.watch(
+      settingsNotifierProvider.select(
+        (SettingsState s) => s.alwaysShowSubcategories,
+      ),
+    );
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         _buildTypeChevronBar(l, stats),
-        SubfilterBar(groups: _subfilterGroups()),
+        SubfilterBar(
+          groups: _subfilterGroups(alwaysShow: alwaysShowSubcategories),
+        ),
       ],
     );
   }
 
   /// One subfilter group per active type — game platforms, manga formats,
   /// anime formats — each tinted with its media-type accent.
-  List<List<SubfilterChipData>> _subfilterGroups() {
+  ///
+  /// A group normally appears only once its media-type chevron is selected;
+  /// with [alwaysShow] every group whose type has items is shown upfront.
+  List<List<SubfilterChipData>> _subfilterGroups({required bool alwaysShow}) {
     return <List<SubfilterChipData>>[
-      if (widget.filterTypes.contains(MediaType.game))
+      if (alwaysShow || widget.filterTypes.contains(MediaType.game))
         <SubfilterChipData>[
           for (final Platform p in _extractPlatforms())
             SubfilterChipData(
@@ -143,11 +154,13 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
         MediaType.manga,
         widget.filterMangaFormats,
         widget.onMangaFormatToggled,
+        alwaysShow: alwaysShow,
       ),
       _formatGroup(
         MediaType.anime,
         widget.filterAnimeFormats,
         widget.onAnimeFormatToggled,
+        alwaysShow: alwaysShow,
       ),
     ];
   }
@@ -155,9 +168,12 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
   List<SubfilterChipData> _formatGroup(
     MediaType type,
     Set<String> selected,
-    ValueChanged<String?> onToggled,
-  ) {
-    if (!widget.filterTypes.contains(type)) return const <SubfilterChipData>[];
+    ValueChanged<String?> onToggled, {
+    required bool alwaysShow,
+  }) {
+    if (!alwaysShow && !widget.filterTypes.contains(type)) {
+      return const <SubfilterChipData>[];
+    }
     return <SubfilterChipData>[
       for (final String code in _formatsFor(type))
         SubfilterChipData(

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -297,13 +297,22 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
 
   /// One subfilter group per active type — game platforms, manga formats,
   /// anime formats — each tinted with its media-type accent, on one row.
+  ///
+  /// A group normally appears only once its media-type chevron is selected;
+  /// with the "always show subcategories" setting every group whose type has
+  /// items is shown upfront.
   List<List<SubfilterChipData>> _subfilterGroups(
     AsyncValue<List<CollectionItem>> itemsAsync,
   ) {
     final List<CollectionItem> items =
         itemsAsync.valueOrNull ?? const <CollectionItem>[];
+    final bool alwaysShow = ref.watch(
+      settingsNotifierProvider.select(
+        (SettingsState s) => s.alwaysShowSubcategories,
+      ),
+    );
     return <List<SubfilterChipData>>[
-      if (_selectedTypes.contains(MediaType.game))
+      if (alwaysShow || _selectedTypes.contains(MediaType.game))
         <SubfilterChipData>[
           for (final Platform p
               in ref.watch(allItemsPlatformsProvider).valueOrNull ??
@@ -321,17 +330,22 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
               }),
             ),
         ],
-      _formatGroup(MediaType.manga, _selectedMangaFormats, items),
-      _formatGroup(MediaType.anime, _selectedAnimeFormats, items),
+      _formatGroup(MediaType.manga, _selectedMangaFormats, items,
+          alwaysShow: alwaysShow),
+      _formatGroup(MediaType.anime, _selectedAnimeFormats, items,
+          alwaysShow: alwaysShow),
     ];
   }
 
   List<SubfilterChipData> _formatGroup(
     MediaType type,
     Set<String> selected,
-    List<CollectionItem> items,
-  ) {
-    if (!_selectedTypes.contains(type)) return const <SubfilterChipData>[];
+    List<CollectionItem> items, {
+    required bool alwaysShow,
+  }) {
+    if (!alwaysShow && !_selectedTypes.contains(type)) {
+      return const <SubfilterChipData>[];
+    }
     return <SubfilterChipData>[
       for (final String code in MediaFormat.present(items, type))
         SubfilterChipData(

--- a/lib/features/settings/providers/settings_provider.dart
+++ b/lib/features/settings/providers/settings_provider.dart
@@ -83,6 +83,10 @@ abstract class SettingsKeys {
   static const String hideEmptyMediaTypeChevrons =
       'hide_empty_media_type_chevrons';
 
+  /// Always show subcategory subfilters (game platforms, anime/manga formats)
+  /// even when their media-type chevron is not selected.
+  static const String alwaysShowSubcategories = 'always_show_subcategories';
+
   /// Date display format id (see [DateFormatPreset]).
   static const String dateFormat = 'date_format';
 
@@ -120,6 +124,7 @@ class SettingsState {
     this.discordRaSyncEnabled = false,
     this.richCollectionsEnabled = false,
     this.hideEmptyMediaTypeChevrons = false,
+    this.alwaysShowSubcategories = false,
     this.dateFormat = SettingsKeys.dateFormatDefault,
     this.animeMangaTitleLanguage = SettingsKeys.animeMangaTitleLanguageDefault,
   });
@@ -181,6 +186,10 @@ class SettingsState {
 
   /// Hide media-type chevrons with zero items in the current filter bar.
   final bool hideEmptyMediaTypeChevrons;
+
+  /// Always show subcategory subfilters (platforms, formats) without first
+  /// selecting their media-type chevron.
+  final bool alwaysShowSubcategories;
 
   /// Date display format preset id.
   final String dateFormat;
@@ -275,6 +284,7 @@ class SettingsState {
     bool? discordRaSyncEnabled,
     bool? richCollectionsEnabled,
     bool? hideEmptyMediaTypeChevrons,
+    bool? alwaysShowSubcategories,
     String? dateFormat,
     String? animeMangaTitleLanguage,
   }) {
@@ -306,6 +316,8 @@ class SettingsState {
           richCollectionsEnabled ?? this.richCollectionsEnabled,
       hideEmptyMediaTypeChevrons:
           hideEmptyMediaTypeChevrons ?? this.hideEmptyMediaTypeChevrons,
+      alwaysShowSubcategories:
+          alwaysShowSubcategories ?? this.alwaysShowSubcategories,
       dateFormat: dateFormat ?? this.dateFormat,
       animeMangaTitleLanguage:
           animeMangaTitleLanguage ?? this.animeMangaTitleLanguage,
@@ -440,6 +452,8 @@ class SettingsNotifier extends Notifier<SettingsState> {
         _prefs.getBool(SettingsKeys.richCollectionsEnabled) ?? false;
     final bool hideEmptyMediaTypeChevrons =
         _prefs.getBool(SettingsKeys.hideEmptyMediaTypeChevrons) ?? false;
+    final bool alwaysShowSubcategories =
+        _prefs.getBool(SettingsKeys.alwaysShowSubcategories) ?? false;
     final String dateFormat =
         _prefs.getString(SettingsKeys.dateFormat) ??
             SettingsKeys.dateFormatDefault;
@@ -478,6 +492,7 @@ class SettingsNotifier extends Notifier<SettingsState> {
       discordRaSyncEnabled: discordRaSyncEnabled,
       richCollectionsEnabled: richCollectionsEnabled,
       hideEmptyMediaTypeChevrons: hideEmptyMediaTypeChevrons,
+      alwaysShowSubcategories: alwaysShowSubcategories,
       dateFormat: dateFormat,
       animeMangaTitleLanguage: animeMangaTitleLanguage,
     );
@@ -749,6 +764,11 @@ class SettingsNotifier extends Notifier<SettingsState> {
     state = state.copyWith(hideEmptyMediaTypeChevrons: enabled);
   }
 
+  Future<void> setAlwaysShowSubcategories({required bool enabled}) async {
+    await _prefs.setBool(SettingsKeys.alwaysShowSubcategories, enabled);
+    state = state.copyWith(alwaysShowSubcategories: enabled);
+  }
+
   Future<void> setDateFormat(String presetId) async {
     await _prefs.setString(SettingsKeys.dateFormat, presetId);
     state = state.copyWith(dateFormat: presetId);
@@ -881,6 +901,7 @@ class SettingsNotifier extends Notifier<SettingsState> {
     await _prefs.remove(SettingsKeys.discordRaSyncEnabled);
     await _prefs.remove(SettingsKeys.richCollectionsEnabled);
     await _prefs.remove(SettingsKeys.hideEmptyMediaTypeChevrons);
+    await _prefs.remove(SettingsKeys.alwaysShowSubcategories);
     await _prefs.remove(SettingsKeys.dateFormat);
     await _prefs.remove(SettingsKeys.animeMangaTitleLanguage);
     await _prefs.remove(SettingsKeys.raUsername);

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -392,6 +392,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             ),
           ),
           SettingsTile(
+            leadingIcon: Icons.account_tree_outlined,
+            leadingColor: _kAppearanceColor,
+            title: l.settingsAlwaysShowSubcategories,
+            subtitle: l.settingsAlwaysShowSubcategoriesSubtitle,
+            showChevron: false,
+            trailing: Switch(
+              value: settings.alwaysShowSubcategories,
+              onChanged: (bool value) {
+                ref
+                    .read(settingsNotifierProvider.notifier)
+                    .setAlwaysShowSubcategories(enabled: value);
+              },
+            ),
+          ),
+          SettingsTile(
             leadingIcon: Icons.videogame_asset_outlined,
             leadingColor: _kAppearanceColor,
             title: l.settingsShowPlatformOverlay,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1540,6 +1540,8 @@
   "settingsShowRecommendationsSubtitle": "Similar movies and TV shows on detail pages",
   "settingsHideEmptyMediaTypeChevrons": "Hide empty media type filters",
   "settingsHideEmptyMediaTypeChevronsSubtitle": "Hide media type chevrons (Games, Movies, etc.) when there are no items of that type",
+  "settingsAlwaysShowSubcategories": "Always show subcategories",
+  "settingsAlwaysShowSubcategoriesSubtitle": "Show subcategory filters (game platforms, anime/manga types) without selecting their media type first",
   "settingsShowPlatformOverlay": "Game platform covers",
   "settingsShowPlatformOverlaySubtitle": "Show platform overlay on game posters (PS5, Switch, etc.)",
   "settingsShowBlurayOverlay": "Blu-ray covers",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6174,6 +6174,18 @@ abstract class S {
   /// **'Hide media type chevrons (Games, Movies, etc.) when there are no items of that type'**
   String get settingsHideEmptyMediaTypeChevronsSubtitle;
 
+  /// No description provided for @settingsAlwaysShowSubcategories.
+  ///
+  /// In en, this message translates to:
+  /// **'Always show subcategories'**
+  String get settingsAlwaysShowSubcategories;
+
+  /// No description provided for @settingsAlwaysShowSubcategoriesSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show subcategory filters (game platforms, anime/manga types) without selecting their media type first'**
+  String get settingsAlwaysShowSubcategoriesSubtitle;
+
   /// No description provided for @settingsShowPlatformOverlay.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3437,6 +3437,13 @@ class SEn extends S {
       'Hide media type chevrons (Games, Movies, etc.) when there are no items of that type';
 
   @override
+  String get settingsAlwaysShowSubcategories => 'Always show subcategories';
+
+  @override
+  String get settingsAlwaysShowSubcategoriesSubtitle =>
+      'Show subcategory filters (game platforms, anime/manga types) without selecting their media type first';
+
+  @override
   String get settingsShowPlatformOverlay => 'Game platform covers';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3485,6 +3485,14 @@ class SRu extends S {
       'Скрывать шевроны типов медиа (Игры, Фильмы и т.д.), если в коллекции нет таких записей';
 
   @override
+  String get settingsAlwaysShowSubcategories =>
+      'Всегда показывать подкатегории';
+
+  @override
+  String get settingsAlwaysShowSubcategoriesSubtitle =>
+      'Показывать фильтры подкатегорий (платформы игр, типы аниме и манги) без предварительного выбора типа медиа';
+
+  @override
   String get settingsShowPlatformOverlay => 'Обложки платформ';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1264,6 +1264,8 @@
   "settingsShowRecommendationsSubtitle": "Похожие фильмы и сериалы на странице деталей",
   "settingsHideEmptyMediaTypeChevrons": "Скрывать пустые фильтры типов",
   "settingsHideEmptyMediaTypeChevronsSubtitle": "Скрывать шевроны типов медиа (Игры, Фильмы и т.д.), если в коллекции нет таких записей",
+  "settingsAlwaysShowSubcategories": "Всегда показывать подкатегории",
+  "settingsAlwaysShowSubcategoriesSubtitle": "Показывать фильтры подкатегорий (платформы игр, типы аниме и манги) без предварительного выбора типа медиа",
   "settingsShowPlatformOverlay": "Обложки платформ",
   "settingsShowPlatformOverlaySubtitle": "Оверлей платформы на постерах игр (PS5, Switch и т.д.)",
   "settingsShowBlurayOverlay": "Обложки Blu-ray",

--- a/test/features/collections/widgets/collection_filter_bar_test.dart
+++ b/test/features/collections/widgets/collection_filter_bar_test.dart
@@ -17,13 +17,20 @@ import 'package:tonkatsu_box/shared/widgets/chevron_filter_bar.dart';
 import 'package:tonkatsu_box/shared/widgets/filter_subfilter_bar.dart';
 
 class TestSettingsNotifier extends SettingsNotifier {
-  TestSettingsNotifier({this.hideEmptyChevrons = false});
+  TestSettingsNotifier({
+    this.hideEmptyChevrons = false,
+    this.alwaysShowSubcategories = false,
+  });
 
   final bool hideEmptyChevrons;
+  final bool alwaysShowSubcategories;
 
   @override
   SettingsState build() {
-    return SettingsState(hideEmptyMediaTypeChevrons: hideEmptyChevrons);
+    return SettingsState(
+      hideEmptyMediaTypeChevrons: hideEmptyChevrons,
+      alwaysShowSubcategories: alwaysShowSubcategories,
+    );
   }
 }
 
@@ -226,13 +233,18 @@ Widget _buildFilterBar({
 List<Override> _defaultOverrides({
   CollectionSortMode sortMode = CollectionSortMode.addedDate,
   bool isDescending = false,
+  bool alwaysShowSubcategories = false,
 }) {
   return <Override>[
     collectionSortProvider
         .overrideWith(() => TestCollectionSortNotifier(sortMode)),
     collectionSortDescProvider
         .overrideWith(() => TestCollectionSortDescNotifier(isDescending)),
-    settingsNotifierProvider.overrideWith(TestSettingsNotifier.new),
+    settingsNotifierProvider.overrideWith(
+      () => TestSettingsNotifier(
+        alwaysShowSubcategories: alwaysShowSubcategories,
+      ),
+    ),
   ];
 }
 
@@ -520,6 +532,49 @@ void main() {
           await tester.pumpAndSettle();
 
           expect(find.byType(FilterTabChip), findsNothing);
+        },
+      );
+    });
+
+    group('always show subcategories setting', () {
+      testWidgets(
+        'shows platform chips without selecting Games when setting is on',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            _buildTestApp(
+              overrides:
+                  _defaultOverrides(alwaysShowSubcategories: true),
+              child: _buildFilterBar(
+                itemsAsync: AsyncData<List<CollectionItem>>(
+                  _gameItemsWithPlatforms,
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('PS1'), findsOneWidget);
+          expect(find.text('SNES'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'shows manga format chips without selecting Manga when setting is on',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            _buildTestApp(
+              overrides:
+                  _defaultOverrides(alwaysShowSubcategories: true),
+              child: _buildFilterBar(
+                itemsAsync: AsyncData<List<CollectionItem>>(
+                  _mangaItemsWithFormats,
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('Manhwa'), findsOneWidget);
         },
       );
     });

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -140,14 +140,16 @@ void main() {
     );
   });
 
-  Widget buildTestWidget() {
+  Widget buildTestWidget({bool alwaysShowSubcategories = false}) {
     return ProviderScope(
       overrides: <Override>[
         collectionRepositoryProvider.overrideWithValue(mockRepo),
         databaseServiceProvider.overrideWithValue(mockDb),
         sharedPreferencesProvider.overrideWithValue(prefs),
         settingsNotifierProvider.overrideWith(
-          () => _FakeSettingsNotifier(),
+          () => _FakeSettingsNotifier(
+            alwaysShowSubcategories: alwaysShowSubcategories,
+          ),
         ),
         currentProfileProvider.overrideWithValue(Profile(
           id: 'test',
@@ -412,6 +414,17 @@ void main() {
 
       expect(find.byType(CustomScrollView), findsOneWidget);
     });
+
+    testWidgets(
+        'показывает чипы платформ без выбора Games когда настройка включена',
+        (WidgetTester tester) async {
+      await tester
+          .pumpWidget(buildTestWidget(alwaysShowSubcategories: true));
+      await tester.pumpAndSettle();
+
+      expect(find.text('SNES'), findsOneWidget);
+      expect(find.text('GBA'), findsOneWidget);
+    });
   });
 
   group('AllItemsScreen Visual Novel фильтр', () {
@@ -498,12 +511,17 @@ void main() {
 }
 
 class _FakeSettingsNotifier extends SettingsNotifier {
-  _FakeSettingsNotifier({this.hideEmptyMediaTypeChevrons = false});
+  _FakeSettingsNotifier({
+    this.hideEmptyMediaTypeChevrons = false,
+    this.alwaysShowSubcategories = false,
+  });
 
   final bool hideEmptyMediaTypeChevrons;
+  final bool alwaysShowSubcategories;
 
   @override
   SettingsState build() => SettingsState(
         hideEmptyMediaTypeChevrons: hideEmptyMediaTypeChevrons,
+        alwaysShowSubcategories: alwaysShowSubcategories,
       );
 }

--- a/test/features/settings/providers/settings_provider_always_show_subcategories_test.dart
+++ b/test/features/settings/providers/settings_provider_always_show_subcategories_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tonkatsu_box/core/api/igdb_api.dart';
+import 'package:tonkatsu_box/core/api/steamgriddb_api.dart';
+import 'package:tonkatsu_box/core/api/tmdb_api.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/core/services/api_key_initializer.dart';
+import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockIgdbApi mockIgdbApi;
+  late MockSteamGridDbApi mockSteamGridDbApi;
+  late MockTmdbApi mockTmdbApi;
+  late MockDatabaseService mockDbService;
+  late MockGameDao mockGameDao;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    mockIgdbApi = MockIgdbApi();
+    mockSteamGridDbApi = MockSteamGridDbApi();
+    mockTmdbApi = MockTmdbApi();
+    mockDbService = MockDatabaseService();
+    mockGameDao = MockGameDao();
+    when(() => mockDbService.gameDao).thenReturn(mockGameDao);
+
+    when(() => mockGameDao.getPlatformCount()).thenAnswer((_) async => 0);
+  });
+
+  Future<ProviderContainer> createContainer({
+    Map<String, Object> initialPrefs = const <String, Object>{},
+  }) async {
+    SharedPreferences.setMockInitialValues(initialPrefs);
+    prefs = await SharedPreferences.getInstance();
+
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        apiKeysProvider.overrideWithValue(const ApiKeys()),
+        igdbApiProvider.overrideWithValue(mockIgdbApi),
+        steamGridDbApiProvider.overrideWithValue(mockSteamGridDbApi),
+        tmdbApiProvider.overrideWithValue(mockTmdbApi),
+        databaseServiceProvider.overrideWithValue(mockDbService),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SettingsNotifier — alwaysShowSubcategories', () {
+    test('alwaysShowSubcategories == false по умолчанию', () async {
+      final ProviderContainer container = await createContainer();
+
+      final SettingsState state = container.read(settingsNotifierProvider);
+
+      expect(state.alwaysShowSubcategories, isFalse);
+    });
+
+    group('setAlwaysShowSubcategories', () {
+      test('enabled: true — сохраняет в prefs и обновляет состояние', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setAlwaysShowSubcategories(enabled: true);
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.alwaysShowSubcategories, isTrue);
+        expect(prefs.getBool('always_show_subcategories'), isTrue);
+      });
+
+      test('enabled: false — сохраняет в prefs и обновляет состояние',
+          () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'always_show_subcategories': true,
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        SettingsState state = container.read(settingsNotifierProvider);
+        expect(state.alwaysShowSubcategories, isTrue);
+
+        await notifier.setAlwaysShowSubcategories(enabled: false);
+
+        state = container.read(settingsNotifierProvider);
+
+        expect(state.alwaysShowSubcategories, isFalse);
+        expect(prefs.getBool('always_show_subcategories'), isFalse);
+      });
+    });
+
+    group('_loadFromPrefs', () {
+      test('загружает true из prefs', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'always_show_subcategories': true,
+          },
+        );
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.alwaysShowSubcategories, isTrue);
+      });
+    });
+
+    group('clearSettings', () {
+      test('сбрасывает alwaysShowSubcategories к false', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{
+            'always_show_subcategories': true,
+          },
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.clearSettings();
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.alwaysShowSubcategories, isFalse);
+        expect(prefs.getBool('always_show_subcategories'), isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('alwaysShowSubcategories обновляется через copyWith', () {
+        const SettingsState original =
+            SettingsState(alwaysShowSubcategories: false);
+        final SettingsState updated =
+            original.copyWith(alwaysShowSubcategories: true);
+
+        expect(updated.alwaysShowSubcategories, isTrue);
+        expect(original.alwaysShowSubcategories, isFalse);
+      });
+
+      test('copyWith без alwaysShowSubcategories сохраняет текущее значение',
+          () {
+        const SettingsState original =
+            SettingsState(alwaysShowSubcategories: true);
+        final SettingsState updated = original.copyWith(tmdbApiKey: 'key');
+
+        expect(updated.alwaysShowSubcategories, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Two small release/0.37 tweaks delivered together:

- Add a global "always show subcategories" appearance toggle that keeps the subcategory subfilters (game platforms, anime/manga formats) visible without first selecting their media-type chevron. Off by default; applies to both the collection screen and the all-items (Home) screen.
- Discord Rich Presence now shows the current item's real cover as the large image, with the app logo moved to the small icon for branding. Custom items with a local-file cover fall back to the logo (Discord fetches remote URLs only); the RetroAchievements icon still takes the small slot when present.