### PR TITLE
feat(import): restore Kinorium title matching, name every wishlist skip reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,31 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Kinorium import: restore title matching and explain every wishlist skip**
+
+  Title matching is back: when no TMDB result carries the row's exact year the
+  importer keeps the best title match instead of dropping the row, so far fewer
+  real films are missed. Rows that still can't be imported now land in the
+  wishlist with the reason spelled out in their note — not found on TMDB, a TMDB
+  error or rate limit, an unsupported type (the original Kinorium kind is named,
+  e.g. "Эпизод"), or a duplicate of another row's title. The reasons are
+  localized.
+
+  * lib/core/import/tmdb_matcher.dart (TmdbMatcher._search, _pickBest): Prefer
+    the matching-year result, otherwise fall back to the first (title) result.
+  * lib/core/import/sources/kinorium/kinorium_import_service.dart
+    (KinoriumImportOptions.reasons, KinoriumWishlistReasons, KinoriumImportService.import,
+    _composeNote): Track a per-row skip reason and prepend it to the wishlist note.
+  * lib/core/import/sources/kinorium/kinorium_entry.dart (KinoriumEntry.rawType,
+    typeLabel), kinorium_csv_parser.dart: Keep the verbatim `Type` text so the
+    reason can name the original kind.
+  * lib/features/settings/content/kinorium_import_content.dart
+    (_KinoriumImportContentState._startImport): Build the localized reasons from
+    the UI and pass them into the import.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (kinoriumReasonNotFound,
+    kinoriumReasonApiError, kinoriumReasonUnsupportedType, kinoriumReasonDuplicate):
+    New strings.
+
 - **Mark the Uncategorized collection as deprecated across the UI**
 
   The Uncategorized bucket is now a read-only legacy collection: it can no

--- a/lib/core/import/sources/kinorium/kinorium_csv_parser.dart
+++ b/lib/core/import/sources/kinorium/kinorium_csv_parser.dart
@@ -61,10 +61,12 @@ class KinoriumCsvParser {
       final String title = _cell(row, index, _titleCol);
       if (title.isEmpty) continue;
 
+      final String rawType = _cell(row, index, _typeCol);
       entries.add(KinoriumEntry(
         title: title,
         originalTitle: _nullable(_cell(row, index, _originalTitleCol)),
-        type: KinoriumType.fromRaw(_cell(row, index, _typeCol)),
+        type: KinoriumType.fromRaw(rawType),
+        rawType: rawType,
         year: _parseYear(_cell(row, index, _yearCol)),
         myRating: _parseRating(_cell(row, index, _ratingCol)),
         date: _parseDate(_cell(row, index, _dateCol)),

--- a/lib/core/import/sources/kinorium/kinorium_entry.dart
+++ b/lib/core/import/sources/kinorium/kinorium_entry.dart
@@ -47,6 +47,7 @@ class KinoriumEntry {
   const KinoriumEntry({
     required this.title,
     required this.type,
+    this.rawType = '',
     this.originalTitle,
     this.year,
     this.myRating,
@@ -65,6 +66,10 @@ class KinoriumEntry {
   final String? originalTitle;
 
   final KinoriumType type;
+
+  /// Verbatim `Type` column text, kept so a skipped row can name its original
+  /// Kinorium kind in the wishlist reason even when [type] is [KinoriumType.unknown].
+  final String rawType;
 
   /// Release year; `null` when the CSV holds `0` or a blank.
   final int? year;
@@ -95,4 +100,9 @@ class KinoriumEntry {
   }
 
   bool get hasValidQuery => searchQuery.isNotEmpty;
+
+  /// Human-readable kind for wishlist reasons: the source `Type` text when
+  /// present, otherwise the parsed enum name.
+  String get typeLabel =>
+      rawType.trim().isNotEmpty ? rawType.trim() : type.name;
 }

--- a/lib/core/import/sources/kinorium/kinorium_import_service.dart
+++ b/lib/core/import/sources/kinorium/kinorium_import_service.dart
@@ -39,6 +39,7 @@ class KinoriumImportOptions extends ImportOptions {
     super.collectionId,
     this.isWishlist = false,
     this.importNotes = false,
+    this.reasons = const KinoriumWishlistReasons.english(),
   });
 
   final String filePath;
@@ -50,6 +51,38 @@ class KinoriumImportOptions extends ImportOptions {
 
   /// Append actors/directors/notes to the item comment.
   final bool importNotes;
+
+  /// Localized texts for why a row was wishlisted instead of imported.
+  final KinoriumWishlistReasons reasons;
+}
+
+/// Localized reasons a Kinorium row landed in the wishlist. Built in the UI
+/// (the import service has no [BuildContext]) and passed via the options; the
+/// service falls back to [KinoriumWishlistReasons.english] when none is given.
+class KinoriumWishlistReasons {
+  const KinoriumWishlistReasons({
+    required this.notFound,
+    required this.apiError,
+    required this.unsupportedType,
+    required this.duplicate,
+  });
+
+  /// English defaults so the service and tests work without the UI layer.
+  const KinoriumWishlistReasons.english()
+      : notFound = 'Not found on TMDB',
+        apiError = 'TMDB error or rate limit',
+        unsupportedType = _englishUnsupportedType,
+        duplicate = _englishDuplicate;
+
+  final String notFound;
+  final String apiError;
+  final String Function(String type) unsupportedType;
+  final String Function(String otherTitle) duplicate;
+
+  static String _englishUnsupportedType(String type) =>
+      'Unsupported type: $type';
+  static String _englishDuplicate(String otherTitle) =>
+      'Duplicate of "$otherTitle"';
 }
 
 /// Imports a Kinorium CSV export by matching each title against TMDB.
@@ -114,9 +147,13 @@ class KinoriumImportService implements ImportSource {
       }
 
       // Phase 1 — match every row against TMDB (the slow, network-bound part).
+      final KinoriumWishlistReasons reasons = options.reasons;
       final List<(KinoriumEntry, TmdbMatch)> matched =
           <(KinoriumEntry, TmdbMatch)>[];
-      final List<KinoriumEntry> unmatched = <KinoriumEntry>[];
+      // Each unmatched row carries the reason it was wishlisted instead of
+      // imported, surfaced in the wishlist note so the user knows what to fix.
+      final List<(KinoriumEntry, String)> unmatched =
+          <(KinoriumEntry, String)>[];
       final List<String> errors = <String>[];
       int skipped = 0;
       final Map<String, TmdbMatch?> matchCache = <String, TmdbMatch?>{};
@@ -131,15 +168,20 @@ class KinoriumImportService implements ImportSource {
           message: 'Matching "${entry.title}"...',
         ));
 
-        if (!_isSupported(entry) || !entry.hasValidQuery) {
-          // Not representable as a collection item (episodes, unrecognized
-          // types). Route to the wishlist instead of dropping, so nothing the
-          // file lists disappears silently.
-          unmatched.add(entry);
+        // Not representable as a collection item (episodes, unrecognized
+        // types). Route to the wishlist instead of dropping, so nothing the
+        // file lists disappears silently.
+        if (!_isSupported(entry)) {
+          unmatched.add((entry, reasons.unsupportedType(entry.typeLabel)));
+          continue;
+        }
+        if (!entry.hasValidQuery) {
+          unmatched.add((entry, reasons.notFound));
           continue;
         }
 
         TmdbMatch? match;
+        bool apiFailed = false;
         try {
           match = await _resolveMatch(
             entry,
@@ -149,11 +191,12 @@ class KinoriumImportService implements ImportSource {
             onProgress,
           );
         } on TmdbApiException catch (e) {
+          apiFailed = true;
           _log.warning('TMDB search failed for "${entry.title}": ${e.message}');
         }
 
         if (match == null) {
-          unmatched.add(entry);
+          unmatched.add((entry, apiFailed ? reasons.apiError : reasons.notFound));
         } else {
           matched.add((entry, match));
         }
@@ -164,6 +207,7 @@ class KinoriumImportService implements ImportSource {
       // and send the rest to the wishlist rather than dropping them as silent
       // duplicates, so a wrong collapse is recoverable by hand.
       final Set<String> seenKeys = <String>{};
+      final Map<String, String> firstTitleByKey = <String, String>{};
       final List<(KinoriumEntry, TmdbMatch)> uniqueMatched =
           <(KinoriumEntry, TmdbMatch)>[];
       for (final (KinoriumEntry, TmdbMatch) pair in matched) {
@@ -174,8 +218,11 @@ class KinoriumImportService implements ImportSource {
         );
         if (seenKeys.add(key)) {
           uniqueMatched.add(pair);
+          firstTitleByKey[key] = pair.$1.title;
         } else {
-          unmatched.add(pair.$1);
+          unmatched.add(
+            (pair.$1, reasons.duplicate(firstTitleByKey[key] ?? '')),
+          );
         }
       }
 
@@ -216,11 +263,11 @@ class KinoriumImportService implements ImportSource {
 
       final Map<MediaType, int> wishlistedByType = await _writer.writeWishlist(
         entries: <WishlistCandidate>[
-          for (final KinoriumEntry entry in unmatched)
+          for (final (KinoriumEntry, String) u in unmatched)
             WishlistCandidate(
-              text: entry.title,
-              mediaType: _wishlistType(entry),
-              note: _composeNote(entry, includeCastCrew: true),
+              text: u.$1.title,
+              mediaType: _wishlistType(u.$1),
+              note: _composeNote(u.$1, includeCastCrew: true, reason: u.$2),
             ),
         ],
         tag: buildImportTag('Kinorium'),
@@ -376,14 +423,19 @@ class KinoriumImportService implements ImportSource {
     return match;
   }
 
-  /// Builds the item comment. Cast & crew are included only when
-  /// [includeCastCrew] is set (the wishlist always passes it), followed by any
-  /// original Note text, and always a Kinorium search link (markdown, so the
-  /// note renders a clickable "Link" instead of a raw URL).
-  String _composeNote(KinoriumEntry entry, {required bool includeCastCrew}) {
+  /// Builds the item comment. An optional [reason] (why the row was wishlisted)
+  /// leads, then cast & crew when [includeCastCrew] is set (the wishlist always
+  /// passes it), any original Note text, and always a Kinorium search link
+  /// (markdown, so the note renders a clickable "Link" instead of a raw URL).
+  String _composeNote(
+    KinoriumEntry entry, {
+    required bool includeCastCrew,
+    String? reason,
+  }) {
     final String url = 'https://en.kinorium.com/search/?q='
         '${Uri.encodeComponent(entry.searchQuery)}';
     final List<String> parts = <String>[
+      ?reason,
       if (includeCastCrew && entry.directors != null)
         'Directors: ${entry.directors}',
       if (includeCastCrew && entry.actors != null) 'Actors: ${entry.actors}',

--- a/lib/core/import/tmdb_matcher.dart
+++ b/lib/core/import/tmdb_matcher.dart
@@ -121,32 +121,24 @@ class TmdbMatcher {
           onRetry: onRateLimit,
         );
         await Future<void>.delayed(_throttle);
-        if (results.isEmpty) continue;
-        final T? pick = _pickAcceptable<T>(results, year, yearOf);
-        if (pick != null) return pick;
-        // Results came back but none fall within the requested year. TMDB's
-        // year filter matches alternate titles and any-region re-release dates,
-        // so a hit here can be an unrelated film (e.g. "The Long Night" 2019
-        // returning "Friday the 13th"). Keep trying the remaining query/year
-        // combinations instead of accepting a wrong-year guess.
+        if (results.isNotEmpty) {
+          return _pickBest<T>(results, year, yearOf);
+        }
       }
     }
     return null;
   }
 
-  /// First result whose year equals [year], scanning the whole list (a
-  /// correct-year film can rank below an unrelated popular one); null when a
-  /// year is required but unmatched, so the caller widens or drops it. Null
-  /// [year] takes the first result.
-  T? _pickAcceptable<T>(
-      List<T> results, int? year, int? Function(T result) yearOf) {
-    if (year == null) {
-      return results.isEmpty ? null : results.first;
+  /// Prefers a result whose year matches (year filters are dropped on later
+  /// attempts, so the first hit may be the wrong edition); otherwise the most
+  /// relevant (first) result.
+  T _pickBest<T>(List<T> results, int? year, int? Function(T result) yearOf) {
+    if (year != null) {
+      for (final T result in results) {
+        if (yearOf(result) == year) return result;
+      }
     }
-    for (final T result in results) {
-      if (yearOf(result) == year) return result;
-    }
-    return null;
+    return results.first;
   }
 
   /// True when TMDB genres mark the title as animation (genre name or id 16).

--- a/lib/features/settings/content/kinorium_import_content.dart
+++ b/lib/features/settings/content/kinorium_import_content.dart
@@ -291,6 +291,7 @@ class _KinoriumImportContentState extends ConsumerState<KinoriumImportContent> {
   Future<void> _startImport() async {
     final KinoriumImportService service =
         ref.read(kinoriumImportServiceProvider);
+    final S l = S.of(context);
 
     final ValueNotifier<ImportProgress?> progressNotifier =
         ValueNotifier<ImportProgress?>(null);
@@ -303,6 +304,12 @@ class _KinoriumImportContentState extends ConsumerState<KinoriumImportContent> {
         collectionId: _useNewCollection ? null : _selectedCollectionId,
         isWishlist: _isWishlist,
         importNotes: _importNotes,
+        reasons: KinoriumWishlistReasons(
+          notFound: l.kinoriumReasonNotFound,
+          apiError: l.kinoriumReasonApiError,
+          unsupportedType: l.kinoriumReasonUnsupportedType,
+          duplicate: l.kinoriumReasonDuplicate,
+        ),
       ),
       onProgress: (ImportProgress progress) {
         progressNotifier.value = progress;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -591,6 +591,20 @@
   "kinoriumStartImport": "Start Import",
   "kinoriumImporting": "Importing from Kinorium...",
   "kinoriumRecommendOwnTmdbKey": "Tip: a personal TMDB API key is recommended for large imports (Settings → API Keys), but it's optional — the built-in key works too.",
+  "kinoriumReasonNotFound": "Not found on TMDB",
+  "kinoriumReasonApiError": "TMDB error or rate limit — try again later",
+  "kinoriumReasonUnsupportedType": "Unsupported type: {type}",
+  "@kinoriumReasonUnsupportedType": {
+    "placeholders": {
+      "type": {"type": "String"}
+    }
+  },
+  "kinoriumReasonDuplicate": "Duplicate of \"{title}\"",
+  "@kinoriumReasonDuplicate": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
   "traktImportedItems": "Imported {count} items",
   "@traktImportedItems": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2508,6 +2508,30 @@ abstract class S {
   /// **'Tip: a personal TMDB API key is recommended for large imports (Settings → API Keys), but it\'s optional — the built-in key works too.'**
   String get kinoriumRecommendOwnTmdbKey;
 
+  /// No description provided for @kinoriumReasonNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Not found on TMDB'**
+  String get kinoriumReasonNotFound;
+
+  /// No description provided for @kinoriumReasonApiError.
+  ///
+  /// In en, this message translates to:
+  /// **'TMDB error or rate limit — try again later'**
+  String get kinoriumReasonApiError;
+
+  /// No description provided for @kinoriumReasonUnsupportedType.
+  ///
+  /// In en, this message translates to:
+  /// **'Unsupported type: {type}'**
+  String kinoriumReasonUnsupportedType(String type);
+
+  /// No description provided for @kinoriumReasonDuplicate.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate of \"{title}\"'**
+  String kinoriumReasonDuplicate(String title);
+
   /// No description provided for @traktImportedItems.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1377,6 +1377,23 @@ class SEn extends S {
       'Tip: a personal TMDB API key is recommended for large imports (Settings → API Keys), but it\'s optional — the built-in key works too.';
 
   @override
+  String get kinoriumReasonNotFound => 'Not found on TMDB';
+
+  @override
+  String get kinoriumReasonApiError =>
+      'TMDB error or rate limit — try again later';
+
+  @override
+  String kinoriumReasonUnsupportedType(String type) {
+    return 'Unsupported type: $type';
+  }
+
+  @override
+  String kinoriumReasonDuplicate(String title) {
+    return 'Duplicate of \"$title\"';
+  }
+
+  @override
   String traktImportedItems(int count) {
     return 'Imported $count items';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1396,6 +1396,23 @@ class SRu extends S {
       'Совет: для больших импортов рекомендуется свой ключ TMDB (Настройки → API ключи), но это не обязательно — встроенный ключ тоже работает.';
 
   @override
+  String get kinoriumReasonNotFound => 'Не найдено в TMDB';
+
+  @override
+  String get kinoriumReasonApiError =>
+      'Ошибка TMDB или лимит запросов — попробуйте позже';
+
+  @override
+  String kinoriumReasonUnsupportedType(String type) {
+    return 'Тип не поддерживается: $type';
+  }
+
+  @override
+  String kinoriumReasonDuplicate(String title) {
+    return 'Дубль тайтла «$title»';
+  }
+
+  @override
   String traktImportedItems(int count) {
     return 'Импортировано тайтлов: $count';
   }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -532,6 +532,20 @@
   "kinoriumStartImport": "Начать импорт",
   "kinoriumImporting": "Импорт из Kinorium...",
   "kinoriumRecommendOwnTmdbKey": "Совет: для больших импортов рекомендуется свой ключ TMDB (Настройки → API ключи), но это не обязательно — встроенный ключ тоже работает.",
+  "kinoriumReasonNotFound": "Не найдено в TMDB",
+  "kinoriumReasonApiError": "Ошибка TMDB или лимит запросов — попробуйте позже",
+  "kinoriumReasonUnsupportedType": "Тип не поддерживается: {type}",
+  "@kinoriumReasonUnsupportedType": {
+    "placeholders": {
+      "type": {"type": "String"}
+    }
+  },
+  "kinoriumReasonDuplicate": "Дубль тайтла «{title}»",
+  "@kinoriumReasonDuplicate": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
   "traktImportedItems": "Импортировано тайтлов: {count}",
   "traktImporting": "Импорт из Trakt",
 

--- a/test/core/import/sources/kinorium/kinorium_import_service_test.dart
+++ b/test/core/import/sources/kinorium/kinorium_import_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/tmdb_api.dart';
 import 'package:tonkatsu_box/core/import/sources/kinorium/kinorium_import_service.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
@@ -105,6 +106,11 @@ void main() {
 
   List<Map<String, dynamic>> capturedItemRows() =>
       verify(() => mockRepo.addItemsBatch(any(), captureAny()))
+          .captured
+          .single as List<Map<String, dynamic>>;
+
+  List<Map<String, dynamic>> capturedWishlistRows() =>
+      verify(() => mockWishlist.addWishlistItemsBatch(captureAny()))
           .captured
           .single as List<Map<String, dynamic>>;
 
@@ -263,6 +269,24 @@ void main() {
           reason: 'wishlist items get a single import tag');
       expect(wlRows.single['note'],
           contains('https://en.kinorium.com/search/?q='));
+      expect(wlRows.single['note'], contains('Not found on TMDB'),
+          reason: 'wishlist note states why the row did not match');
+    });
+
+    test('TMDB API error → wishlisted with the API-error reason', () async {
+      writeCsv(_csv(<List<String>>[
+        <String>['', '', 'Фильм с ошибкой', 'Broken Movie', 'Фильм', '2020'],
+      ]));
+      when(() => mockTmdb.searchMovies(any(), year: any(named: 'year')))
+          .thenThrow(const TmdbApiException('boom'));
+
+      final UniversalImportResult result =
+          await sut.import(KinoriumImportOptions(filePath: csvPath));
+
+      expect(result.success, isTrue);
+      expect(result.totalWishlisted, 1);
+      expect(capturedWishlistRows().single['note'],
+          contains('TMDB error or rate limit'));
     });
 
     test('missing file → failure result', () async {
@@ -385,6 +409,8 @@ void main() {
       // The duplicate row resolves to the same TMDB id; rather than being
       // silently dropped it is routed to the wishlist so nothing is lost.
       expect(result.totalWishlisted, 1);
+      expect(capturedWishlistRows().single['note'],
+          contains('Duplicate of "Токсичный мститель 2"'));
     });
 
     test('unsupported type (episode) → wishlisted without a TMDB search',
@@ -401,6 +427,8 @@ void main() {
       // Episodes aren't collection items, but the row is preserved in the
       // wishlist rather than dropped — and no TMDB search is spent on it.
       expect(result.totalWishlisted, 1);
+      expect(capturedWishlistRows().single['note'],
+          contains('Unsupported type: Эпизод'));
       verifyNever(() => mockTmdb.searchMovies(any(), year: any(named: 'year')));
     });
   });

--- a/test/core/import/tmdb_matcher_test.dart
+++ b/test/core/import/tmdb_matcher_test.dart
@@ -26,11 +26,11 @@ void main() {
 
   group('TmdbMatcher', () {
     group('matchMovie', () {
-      test('drops the server year filter, still verifies the result year',
+      test('drops the server year filter and still prefers the matching year',
           () async {
         // TMDB's `year=` filter is unreliable and can miss a correctly-dated
-        // film. The matcher widens to a no-year search, but only accepts a
-        // result whose actual release year matches the requested one.
+        // film. The matcher widens to a no-year search and prefers the result
+        // whose actual release year matches the requested one.
         when(() => mockTmdb.searchMovies(any(), year: 1992))
             .thenAnswer((_) async => <Movie>[]);
         when(() => mockTmdb.searchMovies(any(), year: null)).thenAnswer(
@@ -44,10 +44,11 @@ void main() {
         expect(match.mediaType, MediaType.movie);
       });
 
-      test('does not accept a wrong-year result from the no-year search',
+      test('falls back to the title match when no result has the wanted year',
           () async {
-        // Regression guard: a popular same-title film of a different year must
-        // not be substituted when the requested year has no match.
+        // When the requested year has no hit, the matcher keeps the best title
+        // match (first result) rather than dropping the row — fewer real films
+        // are missed, at the cost of an occasional wrong-edition guess.
         when(() => mockTmdb.searchMovies(any(), year: 1997))
             .thenAnswer((_) async => <Movie>[]);
         when(() => mockTmdb.searchMovies(any(), year: null)).thenAnswer(
@@ -56,7 +57,8 @@ void main() {
         final TmdbMatch? match =
             await matcher.matchMovie(primaryQuery: 'The Odyssey', year: 1997);
 
-        expect(match, isNull);
+        expect(match, isNotNull);
+        expect(match!.tmdbId, 99);
       });
 
       test('prefers the result whose year matches the requested year',


### PR DESCRIPTION
Restore the title fallback removed by the exact-year fix: when no TMDB result carries the row's exact year, keep the best title match instead of dropping the row, so far fewer real films are missed.

Rows that still cannot be imported now land in the wishlist with the reason written into their note — not found on TMDB, a TMDB error/rate limit, an unsupported type (the original Kinorium kind is named), or a duplicate of another row's title. Reasons are localized (en/ru) and built in the UI, then passed into the import service via the options.