### PR TITLE
feat(collections): per-unit likes and notes on item units (item marks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Likes and notes on individual title units (episodes, seasons, chapters…)**
+
+  A universal per-unit mark: a like and/or a free-text note attached to a
+  single unit inside a collection item, stored separately from watch/read
+  progress. Marks anchor on `collection_items.id` (not the TMDB show id), so
+  the feature works for every media type and cascades away with the item. For
+  media with a ready-made unit list (TV / animation from TMDB) the like-heart
+  and note button sit inline on each episode tile and season header, with a
+  summary + filter bar (All / Liked / With notes) above the season list. For
+  media without one (anime, manga, custom…) an "add mark" form lets the user
+  pick a unit type (episode / season / chapter / volume / page / part or a
+  custom string) and number, below a list of the marks they created. Marks are
+  carried in `.xcoll` / `.xcollx` user-data exports and re-anchored to the new
+  item id on import. Episodes already cached in the DB are loaded up front so
+  the summary and filter work without extra TMDB requests.
+
+  * lib/shared/models/item_mark.dart (ItemMark, kUnitEpisode/kUnitSeason/…,
+    unitCoordsFor): New model — fromDb/toDb, toExport/fromExport (seconds),
+    displayNumber, hasContent, identity by (itemId, unitType, parent, unit).
+  * lib/core/database/migrations/migration_v53.dart (MigrationV53): New
+    `item_marks` table (unique unit key, `idx_item_marks_item`, FK cascade).
+  * lib/core/database/dao/item_mark_dao.dart (ItemMarkDao): merge upsert that
+    deletes empty rows and returns the merged mark; getMarksForItem /
+    getMarksForItems / setFavorite / setComment / deleteMark / insertMarks.
+  * lib/features/collections/providers/item_marks_provider.dart
+    (itemMarksProvider, ItemMarksNotifier, ItemMarksState): family by itemId
+    with per-type liked/commented counters and
+    toggleFavorite/setComment/deleteMark.
+  * lib/features/collections/widgets/item_mark_controls.dart (ItemMarkControls,
+    ItemMarkNoteEditor, MarkNoteText, unitTypeLabel): reusable heart plus
+    inline autosaving note editor.
+  * lib/features/collections/widgets/item_marks_list_section.dart
+    (ItemMarksListSection): branch-B add-form + existing-marks list.
+  * lib/features/collections/widgets/episode_tracker_section.dart
+    (EpisodeTrackerSection, SeasonsListWidget, SeasonExpansionTile,
+    EpisodeTile): thread itemId, inline controls, summary + filter bar.
+  * lib/features/collections/widgets/anime_progress_section.dart,
+    manga_progress_section.dart: embed ItemMarksListSection.
+  * lib/core/services/export_service.dart (_attachItemMarks),
+    import_service.dart (_importItemMarks): `_marks` per item, gated on user
+    data, remapped to the new item id.
+  * lib/core/database/database_service.dart (itemMarkDao),
+    migration_registry.dart (MigrationV53): registration; DB version 52 → 53.
+  * lib/l10n/app_en.arb, app_ru.arb: itemMark* / unit* strings.
+
 - **Import a game list exported from IGDB (CSV)**
 
   A new import source under Settings → Import. Every export row carries the

--- a/docs/RCOLL_FORMAT.md
+++ b/docs/RCOLL_FORMAT.md
@@ -164,6 +164,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 | user_rating | number | no | User rating (1.0–10.0, one decimal). Integers from v2 files load as doubles |
 | _canvas | object | no | Per-item canvas data (full only) |
 | tag_name | string | no | Name of the assigned tag/section (full only, resolved to `tag_id` on import) |
+| _marks | array | no | Per-unit likes/notes. Present only when `user_data` is `true`; re-anchored to the new item id on import (see Item Marks) |
 
 **User data fields** (present only when top-level `user_data` is `true`):
 
@@ -179,6 +180,23 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 | started_at | number | Unix timestamp (seconds) when started |
 | completed_at | number | Unix timestamp (seconds) when completed |
 | last_activity_at | number | Unix timestamp (seconds) of last activity |
+
+### Item Marks
+
+Each element of an item's `_marks` array is one like and/or note on a single
+unit of that title. Marks carry no item id — they are nested inside their item
+and re-anchored to the freshly assigned `collection_item_id` on import. Empty
+marks (no like and no note) are never exported. Timestamps are Unix seconds.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| unit_type | string | yes | `"episode"`, `"season"`, `"chapter"`, `"volume"`, `"page"`, `"part"`, or a custom string |
+| parent_number | number | yes | Season / volume number, or `0` |
+| unit_number | number | yes | Episode / chapter / page number, or `0` for a season/volume-level mark |
+| is_favorite | number | yes | `1` if liked, else `0` |
+| user_comment | string | no | Free-text note |
+| liked_at | number | no | When the like was set |
+| updated_at | number | yes | Last modification time |
 
 ### Canvas Object
 
@@ -291,3 +309,4 @@ When `media` is present during import, data is restored directly from the file v
 6. Restores cover images and canvas images from base64 to local disk cache
 7. Restores tier lists — creates tier list, saves definitions, resolves entries via `itemIdMapping` (`media_type:external_id` → new item ID)
 8. Restores tracker data (RA progress) if present — upserts into `tracker_game_data`
+9. Restores per-item marks (embedded in `_marks` field of each item, when `user_data` is present) — re-anchored to the new item ID; idempotent on re-import

--- a/lib/core/database/dao/item_mark_dao.dart
+++ b/lib/core/database/dao/item_mark_dao.dart
@@ -1,0 +1,200 @@
+// DAO for per-unit item marks (likes and notes on units of a collection item).
+
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../../../shared/models/item_mark.dart';
+
+/// DAO for the `item_marks` table.
+///
+/// Writes go through a read-modify-write merge inside a transaction: the
+/// current row (if any) is combined with the incoming change, then either
+/// re-written (`INSERT OR REPLACE`) or deleted when it becomes empty (no like,
+/// no note) so the table never accumulates blank rows.
+class ItemMarkDao {
+  /// Creates the DAO with a database accessor.
+  const ItemMarkDao(this._getDatabase);
+
+  final Future<Database> Function() _getDatabase;
+
+  /// All marks for one collection item, ordered for stable display.
+  Future<List<ItemMark>> getMarksForItem(int itemId) async {
+    final Database db = await _getDatabase();
+    final List<Map<String, dynamic>> rows = await db.query(
+      'item_marks',
+      where: 'item_id = ?',
+      whereArgs: <Object?>[itemId],
+      orderBy: 'unit_type ASC, parent_number ASC, unit_number ASC',
+    );
+    return rows.map(ItemMark.fromDb).toList();
+  }
+
+  /// Marks for the given items in one pass (chunked queries so large
+  /// collections stay under SQLite's bind-variable limit).
+  Future<List<ItemMark>> getMarksForItems(List<int> itemIds) async {
+    if (itemIds.isEmpty) return <ItemMark>[];
+    final Database db = await _getDatabase();
+    const int chunkSize = 500;
+    final List<ItemMark> result = <ItemMark>[];
+    for (int i = 0; i < itemIds.length; i += chunkSize) {
+      final List<int> chunk = itemIds.sublist(
+        i,
+        (i + chunkSize < itemIds.length) ? i + chunkSize : itemIds.length,
+      );
+      final String placeholders =
+          List<String>.filled(chunk.length, '?').join(', ');
+      final List<Map<String, dynamic>> rows = await db.query(
+        'item_marks',
+        where: 'item_id IN ($placeholders)',
+        whereArgs: chunk,
+        orderBy:
+            'item_id ASC, unit_type ASC, parent_number ASC, unit_number ASC',
+      );
+      result.addAll(rows.map(ItemMark.fromDb));
+    }
+    return result;
+  }
+
+  /// Sets (or clears) the like flag on a unit, merging with any existing note.
+  /// Returns the merged mark, or null when the row was deleted (empty mark).
+  Future<ItemMark?> setFavorite(
+    int itemId,
+    String unitType,
+    int parent,
+    int unit, {
+    required bool isFavorite,
+  }) async {
+    final Database db = await _getDatabase();
+    return db.transaction((Transaction txn) async {
+      final ItemMark? existing =
+          await _readInTxn(txn, itemId, unitType, parent, unit);
+      final DateTime now = DateTime.now();
+      final DateTime? likedAt = isFavorite
+          ? (existing?.likedAt ?? now)
+          : null;
+      final ItemMark merged = ItemMark(
+        id: existing?.id ?? 0,
+        itemId: itemId,
+        unitType: unitType,
+        parentNumber: parent,
+        unitNumber: unit,
+        isFavorite: isFavorite,
+        userComment: existing?.userComment,
+        likedAt: likedAt,
+        updatedAt: now,
+      );
+      return _writeInTxn(txn, merged);
+    });
+  }
+
+  /// Sets (or clears) the note on a unit, merging with any existing like.
+  /// A blank/whitespace-only comment clears the note. Returns the merged mark,
+  /// or null when the row was deleted (empty mark).
+  Future<ItemMark?> setComment(
+    int itemId,
+    String unitType,
+    int parent,
+    int unit,
+    String? comment,
+  ) async {
+    final String? trimmed =
+        (comment == null || comment.trim().isEmpty) ? null : comment.trim();
+    final Database db = await _getDatabase();
+    return db.transaction((Transaction txn) async {
+      final ItemMark? existing =
+          await _readInTxn(txn, itemId, unitType, parent, unit);
+      final ItemMark merged = ItemMark(
+        id: existing?.id ?? 0,
+        itemId: itemId,
+        unitType: unitType,
+        parentNumber: parent,
+        unitNumber: unit,
+        isFavorite: existing?.isFavorite ?? false,
+        userComment: trimmed,
+        likedAt: existing?.likedAt,
+        updatedAt: DateTime.now(),
+      );
+      return _writeInTxn(txn, merged);
+    });
+  }
+
+  /// Deletes a mark unconditionally.
+  Future<void> deleteMark(
+    int itemId,
+    String unitType,
+    int parent,
+    int unit,
+  ) async {
+    final Database db = await _getDatabase();
+    await _delete(db, itemId, unitType, parent, unit);
+  }
+
+  /// Inserts marks verbatim in one batch (import path). Each replaces any
+  /// existing row with the same unique key.
+  Future<void> insertMarks(List<ItemMark> marks) async {
+    if (marks.isEmpty) return;
+    final Database db = await _getDatabase();
+    final Batch batch = db.batch();
+    for (final ItemMark mark in marks) {
+      batch.insert(
+        'item_marks',
+        mark.toDb(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  /// Writes [mark] within [txn], deleting instead when it holds no content.
+  /// Returns the written mark, or null when it was deleted.
+  Future<ItemMark?> _writeInTxn(Transaction txn, ItemMark mark) async {
+    if (!mark.hasContent) {
+      await _delete(
+        txn,
+        mark.itemId,
+        mark.unitType,
+        mark.parentNumber,
+        mark.unitNumber,
+      );
+      return null;
+    }
+    await txn.insert(
+      'item_marks',
+      mark.toDb(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+    return mark;
+  }
+
+  Future<ItemMark?> _readInTxn(
+    Transaction txn,
+    int itemId,
+    String unitType,
+    int parent,
+    int unit,
+  ) async {
+    final List<Map<String, dynamic>> rows = await txn.query(
+      'item_marks',
+      where: 'item_id = ? AND unit_type = ? AND parent_number = ? '
+          'AND unit_number = ?',
+      whereArgs: <Object?>[itemId, unitType, parent, unit],
+      limit: 1,
+    );
+    if (rows.isEmpty) return null;
+    return ItemMark.fromDb(rows.first);
+  }
+
+  Future<void> _delete(
+    DatabaseExecutor db,
+    int itemId,
+    String unitType,
+    int parent,
+    int unit,
+  ) async {
+    await db.delete(
+      'item_marks',
+      where: 'item_id = ? AND unit_type = ? AND parent_number = ? '
+          'AND unit_number = ?',
+      whereArgs: <Object?>[itemId, unitType, parent, unit],
+    );
+  }
+}

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -23,6 +23,7 @@ import 'dao/custom_media_dao.dart';
 import 'dao/anime_dao.dart';
 import 'dao/book_dao.dart';
 import 'dao/game_dao.dart';
+import 'dao/item_mark_dao.dart';
 import 'dao/movie_dao.dart';
 import 'dao/tag_dao.dart';
 import 'dao/tv_show_dao.dart';
@@ -211,6 +212,8 @@ class DatabaseService {
   late final CalendarEntryDao calendarEntryDao =
       CalendarEntryDao(() => database);
 
+  late final ItemMarkDao itemMarkDao = ItemMarkDao(() => database);
+
   Future<Database> _initDatabase() async {
     final String basePath = (await StorageRoot.resolve()).path;
 
@@ -244,7 +247,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 52,
+        version: 53,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -51,6 +51,7 @@ import 'migration_v49.dart';
 import 'migration_v50.dart';
 import 'migration_v51.dart';
 import 'migration_v52.dart';
+import 'migration_v53.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
@@ -106,6 +107,7 @@ abstract final class MigrationRegistry {
     MigrationV50(),
     MigrationV51(),
     MigrationV52(),
+    MigrationV53(),
   ];
 
   /// Schema version this build can open; newer databases must be rejected.

--- a/lib/core/database/migrations/migration_v53.dart
+++ b/lib/core/database/migrations/migration_v53.dart
@@ -1,0 +1,38 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Universal per-unit marks: a like and/or note on a single unit (episode,
+/// season, chapter, volume, page, part or a custom unit) inside a collection
+/// item. Anchored on `collection_items.id` with `ON DELETE CASCADE`, kept in a
+/// dedicated table separate from progress tracking.
+class MigrationV53 extends Migration {
+  @override
+  int get version => 53;
+
+  @override
+  String get description => 'item_marks: per-unit likes and notes';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS item_marks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        item_id INTEGER NOT NULL,
+        unit_type TEXT NOT NULL,
+        parent_number INTEGER NOT NULL DEFAULT 0,
+        unit_number INTEGER NOT NULL DEFAULT 0,
+        is_favorite INTEGER NOT NULL DEFAULT 0,
+        user_comment TEXT,
+        liked_at INTEGER,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (item_id) REFERENCES collection_items(id) ON DELETE CASCADE,
+        UNIQUE(item_id, unit_type, parent_number, unit_number)
+      )
+    ''');
+    await db.execute(
+      'CREATE INDEX IF NOT EXISTS idx_item_marks_item '
+      'ON item_marks(item_id)',
+    );
+  }
+}

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -12,6 +12,7 @@ import '../../shared/models/canvas_item.dart';
 import '../../shared/models/canvas_viewport.dart';
 import '../../shared/models/collection.dart';
 import '../../shared/models/collection_item.dart';
+import '../../shared/models/item_mark.dart';
 import '../../shared/models/media_type.dart';
 import '../../shared/models/tracker_game_data.dart';
 import '../../shared/models/platform.dart' as model;
@@ -158,6 +159,11 @@ class ExportService {
     // Collect hero image (if set)
     await _collectHeroImage(collection, images);
 
+    // Per-item marks (likes/notes) — user data only
+    if (includeUserData) {
+      await _attachItemMarks(items, exportItems);
+    }
+
     // Collect full media data for offline import (includes tv_seasons)
     final Map<String, dynamic> media = await _collectMediaData(items);
 
@@ -285,6 +291,34 @@ class ExportService {
       );
 
       exportItems[i]['_canvas'] = perItemCanvas.toJson();
+    }
+  }
+
+  /// Attaches per-item marks (likes/notes) under the `_marks` key. Requires a
+  /// database; no-op when unavailable. Only invoked for user-data exports.
+  /// Fetches the exported items' marks in one query and groups by item to
+  /// avoid an N+1.
+  Future<void> _attachItemMarks(
+    List<CollectionItem> items,
+    List<Map<String, dynamic>> exportItems,
+  ) async {
+    final DatabaseService? db = _database;
+    if (db == null) return;
+    final List<ItemMark> allMarks = await db.itemMarkDao.getMarksForItems(
+      <int>[for (final CollectionItem item in items) item.id],
+    );
+    if (allMarks.isEmpty) return;
+
+    final Map<int, List<ItemMark>> byItem = <int, List<ItemMark>>{};
+    for (final ItemMark m in allMarks) {
+      (byItem[m.itemId] ??= <ItemMark>[]).add(m);
+    }
+
+    for (int i = 0; i < items.length; i++) {
+      final List<ItemMark>? marks = byItem[items[i].id];
+      if (marks == null || marks.isEmpty) continue;
+      exportItems[i]['_marks'] =
+          marks.map((ItemMark m) => m.toExport()).toList();
     }
   }
 
@@ -577,6 +611,11 @@ class ExportService {
           items,
           includeUserData: includeUserData,
         );
+        // Light export is synchronous and DB-free; attach marks here where a
+        // database is available. xcoll.items is the same list built above.
+        if (includeUserData) {
+          await _attachItemMarks(items, xcoll.items);
+        }
         extension = 'xcoll';
       }
 

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -15,6 +15,7 @@ import '../../shared/models/collection.dart';
 import '../../shared/models/collection_item.dart';
 import '../../shared/models/collection_tag.dart';
 import '../../shared/models/custom_media.dart';
+import '../../shared/models/item_mark.dart';
 import '../../shared/models/item_status.dart';
 import '../../shared/models/tier_definition.dart';
 import '../../shared/models/tier_list.dart';
@@ -393,6 +394,10 @@ class ImportService {
             await _importPerItemCanvas(
                 perItemCanvas, itemId, collection.id);
           }
+
+          if (xcoll.includesUserData) {
+            await _importItemMarks(itemData, itemId);
+          }
         } else if (collectionId != null) {
           // Item already exists — update from file.
           final bool didUpdate = await _updateExistingItem(
@@ -420,6 +425,12 @@ class ImportService {
             final String fallbackKey =
                 '${parsed.mediaType.value}:${parsed.externalId}';
             itemIdMapping.putIfAbsent(fallbackKey, () => existing.id);
+
+            // Marks are idempotent (insertMarks replaces on the unique key),
+            // so re-importing onto an existing item merges, not duplicates.
+            if (xcoll.includesUserData) {
+              await _importItemMarks(itemData, existing.id);
+            }
           }
         }
       }
@@ -1294,6 +1305,22 @@ class ImportService {
 
       await repo.createConnection(conn);
     }
+  }
+
+  /// Restores per-item marks (likes/notes) nested under the item's `_marks`
+  /// key, re-anchoring each to the freshly assigned [collectionItemId].
+  Future<void> _importItemMarks(
+    Map<String, dynamic> itemData,
+    int collectionItemId,
+  ) async {
+    final List<dynamic>? rawMarks = itemData['_marks'] as List<dynamic>?;
+    if (rawMarks == null || rawMarks.isEmpty) return;
+    final List<ItemMark> marks = <ItemMark>[
+      for (final dynamic raw in rawMarks)
+        if (raw is Map<String, dynamic>)
+          ItemMark.fromExport(raw, itemId: collectionItemId),
+    ];
+    await _database.itemMarkDao.insertMarks(marks);
   }
 
   /// [itemIdMapping]: 'media_type:external_id[:platform_id]' -> new collection_item_id.

--- a/lib/features/collections/providers/episode_tracker_provider.dart
+++ b/lib/features/collections/providers/episode_tracker_provider.dart
@@ -123,6 +123,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
     if (_collectionId == null) return const EpisodeTrackerState();
 
     Future<void>.microtask(_loadWatchedEpisodes);
+    Future<void>.microtask(_loadCachedEpisodes);
 
     return const EpisodeTrackerState();
   }
@@ -136,6 +137,29 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
       state = state.copyWith(watchedEpisodes: watched);
     } on Exception catch (e) {
       state = state.copyWith(error: 'Failed to load watched episodes: $e');
+    }
+  }
+
+  /// Loads every already-cached episode (all seasons) in one query, without
+  /// touching the network. Lets the marks summary/filter resolve episode names
+  /// up front; uncached seasons still lazy-load from TMDB on expand.
+  Future<void> _loadCachedEpisodes() async {
+    try {
+      final List<TvEpisode> episodes =
+          await _db.tvShowDao.getEpisodesByShowId(_showId);
+      if (episodes.isEmpty) return;
+      final Map<int, List<TvEpisode>> bySeason = <int, List<TvEpisode>>{};
+      for (final TvEpisode ep in episodes) {
+        (bySeason[ep.seasonNumber] ??= <TvEpisode>[]).add(ep);
+      }
+      state = state.copyWith(
+        episodesBySeason: <int, List<TvEpisode>>{
+          ...bySeason,
+          ...state.episodesBySeason,
+        },
+      );
+    } on Exception catch (_) {
+      // Cache read failed — non-fatal; seasons still load lazily on expand.
     }
   }
 

--- a/lib/features/collections/providers/item_marks_provider.dart
+++ b/lib/features/collections/providers/item_marks_provider.dart
@@ -1,0 +1,137 @@
+// Provider for per-unit marks (likes and notes) of a single collection item.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/database/database_service.dart';
+import '../../../shared/models/item_mark.dart';
+
+/// Key identifying a unit within an item.
+typedef UnitKey = ({String unitType, int parent, int unit});
+
+/// State holding every mark of one collection item, indexed by unit.
+class ItemMarksState {
+  /// Creates an [ItemMarksState].
+  const ItemMarksState({this.marks = const <UnitKey, ItemMark>{}});
+
+  /// Marks keyed by their unit coordinates.
+  final Map<UnitKey, ItemMark> marks;
+
+  /// The mark for a unit, or null.
+  ItemMark? markFor(String unitType, int parent, int unit) =>
+      marks[(unitType: unitType, parent: parent, unit: unit)];
+
+  /// Whether a unit is liked.
+  bool isLiked(String unitType, int parent, int unit) =>
+      markFor(unitType, parent, unit)?.isFavorite ?? false;
+
+  /// The note on a unit (null when absent/empty).
+  String? noteFor(String unitType, int parent, int unit) =>
+      markFor(unitType, parent, unit)?.note;
+
+  /// All marks as a flat list.
+  List<ItemMark> get all => marks.values.toList();
+
+  /// Liked count restricted to one unit type.
+  int likedCountOfType(String unitType) => marks.values
+      .where((ItemMark m) => m.unitType == unitType && m.isFavorite)
+      .length;
+
+  /// Commented count restricted to one unit type.
+  int commentedCountOfType(String unitType) => marks.values
+      .where((ItemMark m) => m.unitType == unitType && m.note != null)
+      .length;
+}
+
+/// Marks provider, keyed by `collection_items.id` so it is universal across
+/// media types.
+final NotifierProviderFamily<ItemMarksNotifier, ItemMarksState, int>
+    itemMarksProvider =
+    NotifierProvider.family<ItemMarksNotifier, ItemMarksState, int>(
+  ItemMarksNotifier.new,
+);
+
+/// Notifier managing a single item's marks.
+class ItemMarksNotifier extends FamilyNotifier<ItemMarksState, int> {
+  late DatabaseService _db;
+  late int _itemId;
+
+  @override
+  ItemMarksState build(int itemId) {
+    _itemId = itemId;
+    _db = ref.watch(databaseServiceProvider);
+    unawaited(_load());
+    return const ItemMarksState();
+  }
+
+  Future<void> _load() async {
+    final List<ItemMark> marks =
+        await _db.itemMarkDao.getMarksForItem(_itemId);
+    state = ItemMarksState(
+      marks: <UnitKey, ItemMark>{
+        for (final ItemMark m in marks)
+          (unitType: m.unitType, parent: m.parentNumber, unit: m.unitNumber):
+              m,
+      },
+    );
+  }
+
+  /// Toggles the like flag on a unit.
+  Future<void> toggleFavorite(String unitType, int parent, int unit) async {
+    await setFavorite(
+      unitType,
+      parent,
+      unit,
+      value: !state.isLiked(unitType, parent, unit),
+    );
+  }
+
+  /// Sets the like flag on a unit to an explicit value.
+  Future<void> setFavorite(
+    String unitType,
+    int parent,
+    int unit, {
+    required bool value,
+  }) async {
+    final ItemMark? merged = await _db.itemMarkDao.setFavorite(
+      _itemId,
+      unitType,
+      parent,
+      unit,
+      isFavorite: value,
+    );
+    _apply((unitType: unitType, parent: parent, unit: unit), merged);
+  }
+
+  /// Sets the note on a unit (empty/null clears it).
+  Future<void> setComment(
+    String unitType,
+    int parent,
+    int unit,
+    String? comment,
+  ) async {
+    final ItemMark? merged = await _db.itemMarkDao
+        .setComment(_itemId, unitType, parent, unit, comment);
+    _apply((unitType: unitType, parent: parent, unit: unit), merged);
+  }
+
+  /// Deletes a mark outright.
+  Future<void> deleteMark(String unitType, int parent, int unit) async {
+    await _db.itemMarkDao.deleteMark(_itemId, unitType, parent, unit);
+    _apply((unitType: unitType, parent: parent, unit: unit), null);
+  }
+
+  /// Patches one unit in local state with the mark the DAO returned (null =
+  /// row deleted), so no reload is needed after a write.
+  void _apply(UnitKey key, ItemMark? mark) {
+    final Map<UnitKey, ItemMark> next =
+        Map<UnitKey, ItemMark>.of(state.marks);
+    if (mark == null) {
+      next.remove(key);
+    } else {
+      next[key] = mark;
+    }
+    state = ItemMarksState(marks: next);
+  }
+}

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -690,6 +690,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
         if (config.hasEpisodeTracker && widget.collectionId != null)
           EpisodeTrackerSection(
             collectionId: widget.collectionId,
+            itemId: item.id,
             externalId: item.externalId,
             tvShow: config.tvShow,
             accentColor: config.accentColor,

--- a/lib/features/collections/widgets/anime_progress_section.dart
+++ b/lib/features/collections/widgets/anime_progress_section.dart
@@ -3,10 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/models/anime.dart';
+import '../../../shared/models/item_mark.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/media_progress_row.dart';
 import '../providers/collections_provider.dart';
+import 'item_marks_list_section.dart';
 
 /// Tracks watched episodes via `currentEpisode` only; `currentSeason` is
 /// unused because AniList anime have no season split.
@@ -97,6 +99,13 @@ class AnimeProgressSection extends ConsumerWidget {
             ),
           ),
         ],
+
+        const SizedBox(height: AppSpacing.lg),
+        ItemMarksListSection(
+          itemId: itemId,
+          accentColor: accentColor,
+          unitPresets: const <String>[kUnitEpisode, kUnitPart],
+        ),
       ],
     );
   }

--- a/lib/features/collections/widgets/episode_tracker_section.dart
+++ b/lib/features/collections/widgets/episode_tracker_section.dart
@@ -10,17 +10,24 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/models/item_mark.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import '../../../shared/utils/date_format_preset.dart';
 import '../providers/episode_tracker_provider.dart';
+import '../providers/item_marks_provider.dart';
+import 'item_mark_controls.dart';
+
+/// Filter for the episode marks bar.
+enum _EpisodeMarkFilter { all, liked, commented }
 
 /// Episode Tracker section with a progress bar and a season list.
 class EpisodeTrackerSection extends ConsumerWidget {
   /// Creates an [EpisodeTrackerSection].
   const EpisodeTrackerSection({
     required this.collectionId,
+    required this.itemId,
     required this.externalId,
     required this.tvShow,
     required this.accentColor,
@@ -29,6 +36,9 @@ class EpisodeTrackerSection extends ConsumerWidget {
 
   /// Collection id (null for uncategorized).
   final int? collectionId;
+
+  /// Owning `collection_items.id` — anchor for per-episode marks.
+  final int itemId;
 
   /// TMDB show id.
   final int externalId;
@@ -92,6 +102,7 @@ class EpisodeTrackerSection extends ConsumerWidget {
         SeasonsListWidget(
           tmdbShowId: tmdbShowId,
           collectionId: collectionId,
+          itemId: itemId,
           accentColor: accentColor,
         ),
       ],
@@ -105,6 +116,7 @@ class SeasonsListWidget extends ConsumerStatefulWidget {
   const SeasonsListWidget({
     required this.tmdbShowId,
     required this.collectionId,
+    required this.itemId,
     required this.accentColor,
     super.key,
   });
@@ -114,6 +126,9 @@ class SeasonsListWidget extends ConsumerStatefulWidget {
 
   /// Collection id (null for uncategorized).
   final int? collectionId;
+
+  /// Owning `collection_items.id` — anchor for per-episode marks.
+  final int itemId;
 
   /// Accent color for the "all watched" indicator.
   final Color accentColor;
@@ -126,6 +141,7 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
   List<TvSeason> _seasons = <TvSeason>[];
   bool _loading = true;
   bool _refreshing = false;
+  _EpisodeMarkFilter _filter = _EpisodeMarkFilter.all;
 
   @override
   void initState() {
@@ -243,50 +259,279 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
 
     final EpisodeTrackerState trackerState =
         ref.watch(episodeTrackerNotifierProvider(_trackerArg));
+    final ItemMarksState marks =
+        ref.watch(itemMarksProvider(widget.itemId));
 
     return Column(
       children: <Widget>[
-        Align(
-          alignment: Alignment.centerRight,
-          child: _refreshing
-              ? const Padding(
-                  padding: EdgeInsets.all(4),
-                  child: SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                )
-              : IconButton(
-                  icon: const Icon(Icons.refresh, size: 18),
-                  tooltip: S.of(context).refreshFromTmdb,
-                  onPressed: _refreshSeasons,
-                  constraints: const BoxConstraints(),
-                  padding: const EdgeInsets.all(4),
-                  visualDensity: VisualDensity.compact,
-                ),
-        ),
-        for (final TvSeason season in _seasons)
-          if (season.seasonNumber > 0) // skip Specials (season 0)
-            SeasonExpansionTile(
-              key: ValueKey<int>(season.seasonNumber),
-              season: season,
-              trackerState: trackerState,
-              trackerArg: _trackerArg,
-              accentColor: widget.accentColor,
-            ),
+        _buildMarksBar(marks),
+        if (_filter != _EpisodeMarkFilter.all)
+          _buildFilteredList(marks, trackerState)
+        else ...<Widget>[
+          for (final TvSeason season in _seasons)
+            if (season.seasonNumber > 0) // skip Specials (season 0)
+              SeasonExpansionTile(
+                key: ValueKey<int>(season.seasonNumber),
+                season: season,
+                trackerState: trackerState,
+                trackerArg: _trackerArg,
+                itemId: widget.itemId,
+                accentColor: widget.accentColor,
+              ),
+        ],
       ],
+    );
+  }
+
+  /// Summary (`❤ N · 💬 M`, episode marks only) plus filter chips.
+  Widget _buildMarksBar(ItemMarksState marks) {
+    final int liked = marks.likedCountOfType(kUnitEpisode);
+    final int commented = marks.commentedCountOfType(kUnitEpisode);
+    final S l = S.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+      child: Row(
+        children: <Widget>[
+          const Icon(Icons.favorite, size: 13, color: AppColors.favorite),
+          const SizedBox(width: 2),
+          Text(
+            '$liked',
+            style: AppTypography.caption
+                .copyWith(color: AppColors.textSecondary),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          const Icon(Icons.sticky_note_2,
+              size: 13, color: AppColors.textSecondary),
+          const SizedBox(width: 2),
+          Text(
+            '$commented',
+            style: AppTypography.caption
+                .copyWith(color: AppColors.textSecondary),
+          ),
+          const Spacer(),
+          _filterChip(Icons.list, l.itemMarkFilterAll,
+              _EpisodeMarkFilter.all),
+          const SizedBox(width: 4),
+          _filterChip(Icons.favorite, l.itemMarkFilterLiked,
+              _EpisodeMarkFilter.liked,
+              color: AppColors.favorite),
+          const SizedBox(width: 4),
+          _filterChip(Icons.sticky_note_2, l.itemMarkFilterCommented,
+              _EpisodeMarkFilter.commented),
+          const SizedBox(width: AppSpacing.sm),
+          if (_refreshing)
+            const Padding(
+              padding: EdgeInsets.all(4),
+              child: SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          else
+            IconButton(
+              icon: const Icon(Icons.refresh, size: 18),
+              tooltip: l.refreshFromTmdb,
+              onPressed: _refreshSeasons,
+              constraints: const BoxConstraints(),
+              padding: const EdgeInsets.all(4),
+              visualDensity: VisualDensity.compact,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _filterChip(
+    IconData icon,
+    String tooltip,
+    _EpisodeMarkFilter filter, {
+    Color? color,
+  }) {
+    final bool selected = _filter == filter;
+    final Color chipColor = color ?? AppColors.textTertiary;
+    return Tooltip(
+      message: tooltip,
+      child: GestureDetector(
+        onTap: () => setState(() => _filter = filter),
+        child: Container(
+          width: 28,
+          height: 28,
+          decoration: BoxDecoration(
+            color: selected ? chipColor.withAlpha(25) : Colors.transparent,
+            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+            border: Border.all(
+              color: selected
+                  ? chipColor.withAlpha(80)
+                  : AppColors.surfaceBorder,
+            ),
+          ),
+          child: Icon(
+            icon,
+            size: 14,
+            color: selected ? chipColor : AppColors.textTertiary,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Flat list of episode marks matching the active filter, across all
+  /// seasons. Draws from the marks provider directly, so it works even when a
+  /// season's episode metadata hasn't been loaded (falls back to `S1·E3`).
+  Widget _buildFilteredList(
+    ItemMarksState marks,
+    EpisodeTrackerState trackerState,
+  ) {
+    final S l = S.of(context);
+    final List<ItemMark> episodeMarks = marks.all
+        .where((ItemMark m) => m.unitType == kUnitEpisode && _matchesFilter(m))
+        .toList()
+      ..sort((ItemMark a, ItemMark b) {
+        final int byParent = a.parentNumber.compareTo(b.parentNumber);
+        if (byParent != 0) return byParent;
+        return a.unitNumber.compareTo(b.unitNumber);
+      });
+
+    if (episodeMarks.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+        child: Text(
+          l.itemMarkEmpty,
+          style:
+              AppTypography.bodySmall.copyWith(color: AppColors.textSecondary),
+        ),
+      );
+    }
+
+    return Column(
+      children: <Widget>[
+        for (final ItemMark m in episodeMarks)
+          _FilteredEpisodeRow(
+            key: ValueKey<String>('${m.parentNumber}:${m.unitNumber}'),
+            mark: m,
+            title: _episodeTitle(m, trackerState, l),
+            itemId: widget.itemId,
+            accentColor: widget.accentColor,
+          ),
+      ],
+    );
+  }
+
+  bool _matchesFilter(ItemMark m) => _filter == _EpisodeMarkFilter.liked
+      ? m.isFavorite
+      : m.note != null;
+
+  String _episodeTitle(
+    ItemMark m,
+    EpisodeTrackerState trackerState,
+    S l,
+  ) {
+    final List<TvEpisode>? episodes =
+        trackerState.episodesBySeason[m.parentNumber];
+    if (episodes != null) {
+      for (final TvEpisode ep in episodes) {
+        if (ep.episodeNumber == m.unitNumber && ep.name.isNotEmpty) {
+          return ep.name;
+        }
+      }
+    }
+    return l.itemMarkEpisodeShort(m.parentNumber, m.unitNumber);
+  }
+}
+
+/// One row in the flattened liked/commented episode list.
+class _FilteredEpisodeRow extends StatefulWidget {
+  const _FilteredEpisodeRow({
+    required this.mark,
+    required this.title,
+    required this.itemId,
+    required this.accentColor,
+    super.key,
+  });
+
+  final ItemMark mark;
+  final String title;
+  final int itemId;
+  final Color accentColor;
+
+  @override
+  State<_FilteredEpisodeRow> createState() => _FilteredEpisodeRowState();
+}
+
+class _FilteredEpisodeRowState extends State<_FilteredEpisodeRow> {
+  bool _editingNote = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ItemMark mark = widget.mark;
+    final String title = widget.title;
+    final int itemId = widget.itemId;
+    final S l = S.of(context);
+    final String? note = mark.note;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    children: <InlineSpan>[
+                      TextSpan(
+                        text: l.itemMarkEpisodeShort(
+                          mark.parentNumber,
+                          mark.unitNumber,
+                        ),
+                        style: AppTypography.caption
+                            .copyWith(color: AppColors.textTertiary),
+                      ),
+                      const TextSpan(text: '  '),
+                      TextSpan(text: title, style: AppTypography.bodySmall),
+                    ],
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              ItemMarkControls(
+                itemId: itemId,
+                unitType: kUnitEpisode,
+                parentNumber: mark.parentNumber,
+                unitNumber: mark.unitNumber,
+                onNotePressed: () =>
+                    setState(() => _editingNote = !_editingNote),
+              ),
+            ],
+          ),
+          if (_editingNote)
+            ItemMarkNoteEditor(
+              itemId: itemId,
+              unitType: kUnitEpisode,
+              parentNumber: mark.parentNumber,
+              unitNumber: mark.unitNumber,
+              accentColor: widget.accentColor,
+              onDone: () => setState(() => _editingNote = false),
+            )
+          else if (note != null)
+            MarkNoteText(note: note, accentColor: widget.accentColor),
+        ],
+      ),
     );
   }
 }
 
 /// ExpansionTile for a single season and its episodes.
-class SeasonExpansionTile extends ConsumerWidget {
+class SeasonExpansionTile extends ConsumerStatefulWidget {
   /// Creates a [SeasonExpansionTile].
   const SeasonExpansionTile({
     required this.season,
     required this.trackerState,
     required this.trackerArg,
+    required this.itemId,
     required this.accentColor,
     super.key,
   });
@@ -300,11 +545,27 @@ class SeasonExpansionTile extends ConsumerWidget {
   /// Argument for the tracker provider.
   final ({int? collectionId, int showId}) trackerArg;
 
+  /// Owning `collection_items.id` — anchor for per-episode/season marks.
+  final int itemId;
+
   /// Accent color for the "all watched" indicator.
   final Color accentColor;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SeasonExpansionTile> createState() =>
+      _SeasonExpansionTileState();
+}
+
+class _SeasonExpansionTileState extends ConsumerState<SeasonExpansionTile> {
+  bool _editingNote = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final TvSeason season = widget.season;
+    final EpisodeTrackerState trackerState = widget.trackerState;
+    final ({int? collectionId, int showId}) trackerArg = widget.trackerArg;
+    final int itemId = widget.itemId;
+    final Color accentColor = widget.accentColor;
     final S l = S.of(context);
     final int seasonNum = season.seasonNumber;
     final int episodeCount = season.episodeCount ?? 0;
@@ -319,6 +580,11 @@ class SeasonExpansionTile extends ConsumerWidget {
     final String subtitle = episodeCount > 0
         ? l.seasonEpisodesProgress(watchedCount, episodeCount)
         : l.episodesWatched(watchedCount);
+    final String? note = ref.watch(
+      itemMarksProvider(itemId).select(
+        (ItemMarksState s) => s.noteFor(kUnitSeason, seasonNum, 0),
+      ),
+    );
 
     return ExpansionTile(
       tilePadding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
@@ -328,17 +594,48 @@ class SeasonExpansionTile extends ConsumerWidget {
         color: allWatched ? accentColor : AppColors.surfaceBorder,
         size: 20,
       ),
-      title: Text(
-        seasonTitle,
-        style: AppTypography.body.copyWith(
-          fontWeight: FontWeight.w600,
-        ),
+      title: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              seasonTitle,
+              style: AppTypography.body.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          ItemMarkControls(
+            itemId: itemId,
+            unitType: kUnitSeason,
+            parentNumber: seasonNum,
+            unitNumber: 0,
+            showLike: false,
+            onNotePressed: () =>
+                setState(() => _editingNote = !_editingNote),
+          ),
+        ],
       ),
-      subtitle: Text(
-        subtitle,
-        style: AppTypography.bodySmall.copyWith(
-          color: AppColors.textSecondary,
-        ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            subtitle,
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+          if (_editingNote)
+            ItemMarkNoteEditor(
+              itemId: itemId,
+              unitType: kUnitSeason,
+              parentNumber: seasonNum,
+              unitNumber: 0,
+              accentColor: accentColor,
+              onDone: () => setState(() => _editingNote = false),
+            )
+          else if (note != null)
+            MarkNoteText(note: note, accentColor: accentColor),
+        ],
       ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
@@ -400,6 +697,8 @@ class SeasonExpansionTile extends ConsumerWidget {
                   episode.episodeNumber,
                 ),
                 trackerArg: trackerArg,
+                itemId: itemId,
+                accentColor: accentColor,
               ))
         else if (episodes != null && episodes.isEmpty)
           Padding(
@@ -417,12 +716,14 @@ class SeasonExpansionTile extends ConsumerWidget {
 }
 
 /// Tile for a single episode with a checkbox.
-class EpisodeTile extends ConsumerWidget {
+class EpisodeTile extends ConsumerStatefulWidget {
   /// Creates an [EpisodeTile].
   const EpisodeTile({
     required this.episode,
     required this.isWatched,
     required this.trackerArg,
+    required this.itemId,
+    required this.accentColor,
     this.watchedAt,
     super.key,
   });
@@ -439,8 +740,24 @@ class EpisodeTile extends ConsumerWidget {
   /// Argument for the tracker provider.
   final ({int? collectionId, int showId}) trackerArg;
 
+  /// Owning `collection_items.id` — anchor for per-episode marks.
+  final int itemId;
+
+  /// Accent color of the section, tints the note block.
+  final Color accentColor;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<EpisodeTile> createState() => _EpisodeTileState();
+}
+
+class _EpisodeTileState extends ConsumerState<EpisodeTile> {
+  bool _editingNote = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final TvEpisode episode = widget.episode;
+    final bool isWatched = widget.isWatched;
+    final DateTime? watchedAt = widget.watchedAt;
     final DateFormatPreset preset = DateFormatPreset.fromId(
       ref.watch(settingsNotifierProvider.select((SettingsState s) => s.dateFormat)),
     );
@@ -457,42 +774,96 @@ class EpisodeTile extends ConsumerWidget {
     if (isWatched && watchedAt != null) {
       subtitleParts.add(
         S.of(context).episodeWatchedDate(
-          preset.format(watchedAt!, locale: localeName),
+          preset.format(watchedAt, locale: localeName),
         ),
       );
     }
+    final String? note = ref.watch(
+      itemMarksProvider(widget.itemId).select(
+        (ItemMarksState s) => s.noteFor(
+          kUnitEpisode,
+          episode.seasonNumber,
+          episode.episodeNumber,
+        ),
+      ),
+    );
 
-    return CheckboxListTile(
+    final Widget tile = CheckboxListTile(
       value: isWatched,
       onChanged: (_) {
         ref
-            .read(episodeTrackerNotifierProvider(trackerArg).notifier)
+            .read(episodeTrackerNotifierProvider(widget.trackerArg).notifier)
             .toggleEpisode(
               episode.seasonNumber,
               episode.episodeNumber,
             );
       },
-      title: Text(
-        title,
-        style: AppTypography.bodySmall.copyWith(
-          decoration: isWatched ? TextDecoration.lineThrough : null,
-          color: isWatched
-              ? AppColors.textSecondary
-              : AppColors.textPrimary,
-        ),
-      ),
-      subtitle: subtitleParts.isNotEmpty
-          ? Text(
-              subtitleParts.join(' \u2022 '),
-              style: AppTypography.caption.copyWith(
-                color: AppColors.textSecondary,
+      title: Row(
+        children: <Widget>[
+          Expanded(
+            child: Text(
+              title,
+              style: AppTypography.bodySmall.copyWith(
+                decoration: isWatched ? TextDecoration.lineThrough : null,
+                color: isWatched
+                    ? AppColors.textSecondary
+                    : AppColors.textPrimary,
               ),
+            ),
+          ),
+          ItemMarkControls(
+            itemId: widget.itemId,
+            unitType: kUnitEpisode,
+            parentNumber: episode.seasonNumber,
+            unitNumber: episode.episodeNumber,
+            onNotePressed: () =>
+                setState(() => _editingNote = !_editingNote),
+          ),
+        ],
+      ),
+      subtitle: (subtitleParts.isNotEmpty || (note != null && !_editingNote))
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                if (subtitleParts.isNotEmpty)
+                  Text(
+                    subtitleParts.join(' \u2022 '),
+                    style: AppTypography.caption.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                if (note != null && !_editingNote)
+                  MarkNoteText(note: note, accentColor: widget.accentColor),
+              ],
             )
           : null,
       dense: true,
       controlAffinity: ListTileControlAffinity.leading,
       contentPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
       visualDensity: VisualDensity.compact,
+    );
+
+    if (!_editingNote) return tile;
+
+    return Column(
+      children: <Widget>[
+        tile,
+        Padding(
+          padding: const EdgeInsets.only(
+            left: AppSpacing.xl + AppSpacing.sm,
+            right: AppSpacing.sm,
+            bottom: AppSpacing.xs,
+          ),
+          child: ItemMarkNoteEditor(
+            itemId: widget.itemId,
+            unitType: kUnitEpisode,
+            parentNumber: episode.seasonNumber,
+            unitNumber: episode.episodeNumber,
+            accentColor: widget.accentColor,
+            onDone: () => setState(() => _editingNote = false),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/collections/widgets/item_mark_controls.dart
+++ b/lib/features/collections/widgets/item_mark_controls.dart
@@ -1,0 +1,305 @@
+// Reusable like + note controls for a single unit of a collection item.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/item_mark.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../providers/item_marks_provider.dart';
+
+/// Localised label for a unit type. Falls back to the raw string for
+/// user-defined (custom) types.
+String unitTypeLabel(S l, String unitType) {
+  switch (unitType) {
+    case kUnitEpisode:
+      return l.unitEpisode;
+    case kUnitSeason:
+      return l.unitSeason;
+    case kUnitChapter:
+      return l.unitChapter;
+    case kUnitVolume:
+      return l.unitVolume;
+    case kUnitPage:
+      return l.unitPage;
+    case kUnitPart:
+      return l.unitPart;
+    default:
+      return unitType;
+  }
+}
+
+/// Rounded accent-tinted container shared by the note text and the note
+/// editor — same look as the notes block on the item card, so a note is
+/// recognisable at a glance. [emphasized] draws the stronger editing border.
+BoxDecoration markNoteDecoration(Color accentColor, {bool emphasized = false}) {
+  return BoxDecoration(
+    color: accentColor.withAlpha(20),
+    borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+    border: Border.all(color: accentColor.withAlpha(emphasized ? 80 : 40)),
+  );
+}
+
+/// Inline text of a mark's note: always visible in full, no tap needed —
+/// the editor is only for changing it.
+class MarkNoteText extends StatelessWidget {
+  /// Creates a [MarkNoteText].
+  const MarkNoteText({
+    required this.note,
+    required this.accentColor,
+    super.key,
+  });
+
+  /// The note text to show.
+  final String note;
+
+  /// Accent color of the hosting section, tints the container.
+  final Color accentColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.only(top: 2),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 6,
+      ),
+      decoration: markNoteDecoration(accentColor),
+      child: Text(
+        note,
+        style: AppTypography.caption.copyWith(
+          color: AppColors.textSecondary,
+          height: 1.4,
+        ),
+      ),
+    );
+  }
+}
+
+/// A compact like-heart plus note-button pair bound to one unit of an item.
+/// The like writes through [itemMarksProvider]; the note button only toggles
+/// the host's inline [ItemMarkNoteEditor] — no dialogs (they stutter on
+/// phones).
+class ItemMarkControls extends ConsumerWidget {
+  /// Creates [ItemMarkControls].
+  const ItemMarkControls({
+    required this.itemId,
+    required this.unitType,
+    required this.parentNumber,
+    required this.unitNumber,
+    required this.onNotePressed,
+    this.showLike = true,
+    this.iconSize = 18,
+    super.key,
+  });
+
+  /// Owning `collection_items.id`.
+  final int itemId;
+
+  /// Unit type (see [kUnitPresets]).
+  final String unitType;
+
+  /// Season / volume number (0 when not applicable).
+  final int parentNumber;
+
+  /// Episode / chapter number (0 for a season/volume-level mark).
+  final int unitNumber;
+
+  /// Toggles the host's inline note editor.
+  final VoidCallback onNotePressed;
+
+  /// Whether to show the like heart (season headers show note only).
+  final bool showLike;
+
+  /// Icon size for both buttons.
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Select only this unit's flags so a write to one unit doesn't rebuild
+    // every controls row mounted for the item.
+    final ({bool liked, bool hasNote}) mark = ref.watch(
+      itemMarksProvider(itemId).select(
+        (ItemMarksState s) => (
+          liked: s.isLiked(unitType, parentNumber, unitNumber),
+          hasNote: s.noteFor(unitType, parentNumber, unitNumber) != null,
+        ),
+      ),
+    );
+    final bool liked = mark.liked;
+    final bool hasNote = mark.hasNote;
+    final S l = S.of(context);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (showLike)
+          IconButton(
+            icon: Icon(
+              liked ? Icons.favorite : Icons.favorite_border,
+              size: iconSize,
+              color: liked ? AppColors.favorite : AppColors.textTertiary,
+            ),
+            tooltip: l.itemMarkLike,
+            visualDensity: VisualDensity.compact,
+            constraints: const BoxConstraints(),
+            padding: const EdgeInsets.all(AppSpacing.xs),
+            onPressed: () => ref
+                .read(itemMarksProvider(itemId).notifier)
+                .toggleFavorite(unitType, parentNumber, unitNumber),
+          ),
+        IconButton(
+          icon: Icon(
+            hasNote ? Icons.sticky_note_2 : Icons.sticky_note_2_outlined,
+            size: iconSize,
+            color: hasNote ? AppColors.brand : AppColors.textTertiary,
+          ),
+          tooltip: l.itemMarkNote,
+          visualDensity: VisualDensity.compact,
+          constraints: const BoxConstraints(),
+          padding: const EdgeInsets.all(AppSpacing.xs),
+          onPressed: onNotePressed,
+        ),
+      ],
+    );
+  }
+}
+
+/// Inline autosaving note editor for a unit, shown in place of the note text
+/// while editing (same pattern as the notes block in the item card). Saves
+/// after a 1s pause and flushes the pending text on dispose.
+class ItemMarkNoteEditor extends ConsumerStatefulWidget {
+  /// Creates an [ItemMarkNoteEditor].
+  const ItemMarkNoteEditor({
+    required this.itemId,
+    required this.unitType,
+    required this.parentNumber,
+    required this.unitNumber,
+    required this.onDone,
+    required this.accentColor,
+    super.key,
+  });
+
+  /// Owning `collection_items.id`.
+  final int itemId;
+
+  /// Unit type (see [kUnitPresets]).
+  final String unitType;
+
+  /// Season / volume number (0 when not applicable).
+  final int parentNumber;
+
+  /// Episode / chapter number (0 for a season/volume-level mark).
+  final int unitNumber;
+
+  /// Called when the user taps the done button; the host hides the editor.
+  final VoidCallback onDone;
+
+  /// Accent color of the hosting section, tints the container.
+  final Color accentColor;
+
+  @override
+  ConsumerState<ItemMarkNoteEditor> createState() =>
+      _ItemMarkNoteEditorState();
+}
+
+class _ItemMarkNoteEditorState extends ConsumerState<ItemMarkNoteEditor> {
+  late final TextEditingController _controller;
+  late final ItemMarksNotifier _notifier;
+  late String _lastSaved;
+  Timer? _autosaveTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    // Capture the notifier now: dispose() flushes the pending save, and `ref`
+    // is unusable once the widget is disposed.
+    _notifier = ref.read(itemMarksProvider(widget.itemId).notifier);
+    _lastSaved = ref
+            .read(itemMarksProvider(widget.itemId))
+            .noteFor(
+              widget.unitType,
+              widget.parentNumber,
+              widget.unitNumber,
+            ) ??
+        '';
+    _controller = TextEditingController(text: _lastSaved);
+    _controller.addListener(_scheduleAutosave);
+  }
+
+  void _scheduleAutosave() {
+    _autosaveTimer?.cancel();
+    _autosaveTimer = Timer(const Duration(seconds: 1), _save);
+  }
+
+  void _save() {
+    final String text = _controller.text;
+    if (text == _lastSaved) return;
+    _lastSaved = text;
+    _notifier.setComment(
+      widget.unitType,
+      widget.parentNumber,
+      widget.unitNumber,
+      text,
+    );
+  }
+
+  @override
+  void dispose() {
+    _autosaveTimer?.cancel();
+    _save();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(
+          child: Container(
+            margin: const EdgeInsets.only(top: 2),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: 6,
+            ),
+            decoration:
+                markNoteDecoration(widget.accentColor, emphasized: true),
+            child: TextField(
+              controller: _controller,
+              autofocus: true,
+              minLines: 2,
+              maxLines: 5,
+              style: AppTypography.bodySmall,
+              decoration: InputDecoration(
+                hintText: l.itemMarkNoteHint,
+                border: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                filled: false,
+                isDense: true,
+                contentPadding: EdgeInsets.zero,
+              ),
+            ),
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.check, size: 18),
+          tooltip: l.done,
+          visualDensity: VisualDensity.compact,
+          onPressed: () {
+            _save();
+            widget.onDone();
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/collections/widgets/item_marks_list_section.dart
+++ b/lib/features/collections/widgets/item_marks_list_section.dart
@@ -1,0 +1,354 @@
+// Branch B marks UI: an "add mark" form plus a list of existing marks, for
+// media that has no ready-made unit list (anime, manga, custom, books…).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/item_mark.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../providers/item_marks_provider.dart';
+import 'item_mark_controls.dart';
+
+/// Lists existing marks for an item and offers an "add mark" form. Does not
+/// synthesise empty unit rows — only marks the user actually created are shown.
+class ItemMarksListSection extends ConsumerWidget {
+  /// Creates an [ItemMarksListSection].
+  const ItemMarksListSection({
+    required this.itemId,
+    required this.accentColor,
+    this.unitPresets = kUnitPresets,
+    super.key,
+  });
+
+  /// Owning `collection_items.id`.
+  final int itemId;
+
+  /// Accent color for the section header and add button.
+  final Color accentColor;
+
+  /// Unit types offered in the add form.
+  final List<String> unitPresets;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final S l = S.of(context);
+    final ItemMarksState marks = ref.watch(itemMarksProvider(itemId));
+    final List<ItemMark> all = marks.all
+      ..sort((ItemMark a, ItemMark b) {
+        final int byType = a.unitType.compareTo(b.unitType);
+        if (byType != 0) return byType;
+        return a.displayNumber.compareTo(b.displayNumber);
+      });
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Icon(Icons.bookmark_outline, size: 20, color: accentColor),
+            const SizedBox(width: AppSpacing.sm),
+            Text(
+              l.itemMarkSectionTitle,
+              style: AppTypography.h3.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        if (all.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+            child: Text(
+              l.itemMarkEmpty,
+              style: AppTypography.bodySmall
+                  .copyWith(color: AppColors.textSecondary),
+            ),
+          )
+        else
+          ...all.map((ItemMark m) => _MarkRow(
+                key: ValueKey<String>(
+                  '${m.unitType}:${m.parentNumber}:${m.unitNumber}',
+                ),
+                itemId: itemId,
+                mark: m,
+                accentColor: accentColor,
+              )),
+        const SizedBox(height: AppSpacing.sm),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: () => _showAddForm(context, ref),
+            icon: const Icon(Icons.add, size: 18),
+            label: Text(l.itemMarkAdd),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: accentColor,
+              side: BorderSide(color: accentColor.withValues(alpha: 0.5)),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showAddForm(BuildContext context, WidgetRef ref) {
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext ctx) => _AddMarkDialog(
+        itemId: itemId,
+        unitPresets: unitPresets,
+      ),
+    );
+  }
+}
+
+class _MarkRow extends ConsumerStatefulWidget {
+  const _MarkRow({
+    required this.itemId,
+    required this.mark,
+    required this.accentColor,
+    super.key,
+  });
+
+  final int itemId;
+  final ItemMark mark;
+  final Color accentColor;
+
+  @override
+  ConsumerState<_MarkRow> createState() => _MarkRowState();
+}
+
+class _MarkRowState extends ConsumerState<_MarkRow> {
+  bool _editingNote = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final int itemId = widget.itemId;
+    final ItemMark mark = widget.mark;
+    final S l = S.of(context);
+    final String label = l.itemMarkUnitLabel(
+      unitTypeLabel(l, mark.unitType),
+      mark.displayNumber,
+    );
+    final String? note = mark.note;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  label,
+                  style: AppTypography.bodySmall.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: widget.accentColor,
+                  ),
+                ),
+              ),
+              ItemMarkControls(
+                itemId: itemId,
+                unitType: mark.unitType,
+                parentNumber: mark.parentNumber,
+                unitNumber: mark.unitNumber,
+                onNotePressed: () =>
+                    setState(() => _editingNote = !_editingNote),
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline, size: 18),
+                tooltip: l.itemMarkDelete,
+                color: AppColors.textTertiary,
+                visualDensity: VisualDensity.compact,
+                constraints: const BoxConstraints(),
+                padding: const EdgeInsets.all(AppSpacing.xs),
+                onPressed: () => ref
+                    .read(itemMarksProvider(itemId).notifier)
+                    .deleteMark(
+                      mark.unitType,
+                      mark.parentNumber,
+                      mark.unitNumber,
+                    ),
+              ),
+            ],
+          ),
+          if (_editingNote)
+            ItemMarkNoteEditor(
+              itemId: itemId,
+              unitType: mark.unitType,
+              parentNumber: mark.parentNumber,
+              unitNumber: mark.unitNumber,
+              accentColor: widget.accentColor,
+              onDone: () => setState(() => _editingNote = false),
+            )
+          else if (note != null)
+            MarkNoteText(note: note, accentColor: widget.accentColor),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddMarkDialog extends ConsumerStatefulWidget {
+  const _AddMarkDialog({
+    required this.itemId,
+    required this.unitPresets,
+  });
+
+  final int itemId;
+  final List<String> unitPresets;
+
+  @override
+  ConsumerState<_AddMarkDialog> createState() => _AddMarkDialogState();
+}
+
+class _AddMarkDialogState extends ConsumerState<_AddMarkDialog> {
+  late String _unitType;
+  bool _customType = false;
+  final TextEditingController _customTypeController = TextEditingController();
+  final TextEditingController _numberController = TextEditingController();
+  final TextEditingController _noteController = TextEditingController();
+  bool _liked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _unitType = widget.unitPresets.isNotEmpty
+        ? widget.unitPresets.first
+        : kUnitEpisode;
+  }
+
+  @override
+  void dispose() {
+    _customTypeController.dispose();
+    _numberController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  bool get _canSave {
+    final int? number = int.tryParse(_numberController.text.trim());
+    if (number == null || number < 0) return false;
+    if (_customType && _customTypeController.text.trim().isEmpty) return false;
+    return _liked || _noteController.text.trim().isNotEmpty;
+  }
+
+  Future<void> _save() async {
+    final int? number = int.tryParse(_numberController.text.trim());
+    if (number == null) return;
+    final String unitType = _customType
+        ? _customTypeController.text.trim()
+        : _unitType;
+    final ({int parent, int unit}) coords =
+        unitCoordsFor(unitType, number);
+    final ItemMarksNotifier notifier =
+        ref.read(itemMarksProvider(widget.itemId).notifier);
+    if (_liked) {
+      await notifier.setFavorite(
+        unitType,
+        coords.parent,
+        coords.unit,
+        value: true,
+      );
+    }
+    final String note = _noteController.text.trim();
+    if (note.isNotEmpty) {
+      await notifier.setComment(unitType, coords.parent, coords.unit, note);
+    }
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    return AlertDialog(
+      title: Text(l.itemMarkAdd),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            DropdownButtonFormField<String>(
+              initialValue: _customType ? _kCustomSentinel : _unitType,
+              decoration: InputDecoration(labelText: l.itemMarkType),
+              items: <DropdownMenuItem<String>>[
+                for (final String type in widget.unitPresets)
+                  DropdownMenuItem<String>(
+                    value: type,
+                    child: Text(unitTypeLabel(l, type)),
+                  ),
+                DropdownMenuItem<String>(
+                  value: _kCustomSentinel,
+                  child: Text(l.unitCustom),
+                ),
+              ],
+              onChanged: (String? value) {
+                if (value == null) return;
+                setState(() {
+                  if (value == _kCustomSentinel) {
+                    _customType = true;
+                  } else {
+                    _customType = false;
+                    _unitType = value;
+                  }
+                });
+              },
+            ),
+            if (_customType) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              TextField(
+                controller: _customTypeController,
+                decoration:
+                    InputDecoration(labelText: l.itemMarkCustomType),
+                onChanged: (_) => setState(() {}),
+              ),
+            ],
+            const SizedBox(height: AppSpacing.sm),
+            TextField(
+              controller: _numberController,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: l.itemMarkNumber,
+                hintText: l.itemMarkNumberHint,
+                helperText: l.itemMarkNumberHelper,
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            TextField(
+              controller: _noteController,
+              minLines: 2,
+              maxLines: 5,
+              decoration: InputDecoration(
+                labelText: l.itemMarkNote,
+                hintText: l.itemMarkNoteHint,
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(l.itemMarkLike),
+              value: _liked,
+              onChanged: (bool value) => setState(() => _liked = value),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.cancel),
+        ),
+        TextButton(
+          onPressed: _canSave ? _save : null,
+          child: Text(l.save),
+        ),
+      ],
+    );
+  }
+}
+
+const String _kCustomSentinel = '__custom__';

--- a/lib/features/collections/widgets/manga_progress_section.dart
+++ b/lib/features/collections/widgets/manga_progress_section.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/models/item_mark.dart';
 import '../../../shared/models/manga.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/media_progress_row.dart';
 import '../providers/collections_provider.dart';
+import 'item_marks_list_section.dart';
 
 /// Reuses existing item fields: `currentEpisode` stores chapters read,
 /// `currentSeason` stores volumes read.
@@ -97,6 +99,18 @@ class MangaProgressSection extends ConsumerWidget {
             ),
           ),
         ],
+
+        const SizedBox(height: AppSpacing.lg),
+        ItemMarksListSection(
+          itemId: itemId,
+          accentColor: accentColor,
+          unitPresets: const <String>[
+            kUnitChapter,
+            kUnitVolume,
+            kUnitPage,
+            kUnitPart,
+          ],
+        ),
       ],
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2434,5 +2434,42 @@
     "placeholders": {
       "count": {"type": "int"}
     }
-  }
+  },
+
+  "itemMarkLike": "Like",
+  "itemMarkNote": "Note",
+  "itemMarkNoteHint": "Write a note…",
+  "itemMarkSectionTitle": "Notes & likes",
+  "itemMarkAdd": "Add mark",
+  "itemMarkEmpty": "No marks yet",
+  "itemMarkDelete": "Delete",
+  "itemMarkType": "Type",
+  "itemMarkNumber": "Number",
+  "itemMarkNumberHint": "e.g. 12",
+  "itemMarkNumberHelper": "Required to save",
+  "itemMarkCustomType": "Custom type",
+  "itemMarkFilterAll": "All",
+  "itemMarkFilterLiked": "Liked",
+  "itemMarkFilterCommented": "With notes",
+  "itemMarkUnitLabel": "{type} {number}",
+  "@itemMarkUnitLabel": {
+    "placeholders": {
+      "type": {"type": "String"},
+      "number": {"type": "int"}
+    }
+  },
+  "itemMarkEpisodeShort": "S{season}·E{episode}",
+  "@itemMarkEpisodeShort": {
+    "placeholders": {
+      "season": {"type": "int"},
+      "episode": {"type": "int"}
+    }
+  },
+  "unitEpisode": "Episode",
+  "unitSeason": "Season",
+  "unitChapter": "Chapter",
+  "unitVolume": "Volume",
+  "unitPage": "Page",
+  "unitPart": "Part",
+  "unitCustom": "Custom"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9545,6 +9545,150 @@ abstract class S {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 recommendation} other{{count} recommendations}}'**
   String recommendationsCount(int count);
+
+  /// No description provided for @itemMarkLike.
+  ///
+  /// In en, this message translates to:
+  /// **'Like'**
+  String get itemMarkLike;
+
+  /// No description provided for @itemMarkNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Note'**
+  String get itemMarkNote;
+
+  /// No description provided for @itemMarkNoteHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Write a note…'**
+  String get itemMarkNoteHint;
+
+  /// No description provided for @itemMarkSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notes & likes'**
+  String get itemMarkSectionTitle;
+
+  /// No description provided for @itemMarkAdd.
+  ///
+  /// In en, this message translates to:
+  /// **'Add mark'**
+  String get itemMarkAdd;
+
+  /// No description provided for @itemMarkEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No marks yet'**
+  String get itemMarkEmpty;
+
+  /// No description provided for @itemMarkDelete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get itemMarkDelete;
+
+  /// No description provided for @itemMarkType.
+  ///
+  /// In en, this message translates to:
+  /// **'Type'**
+  String get itemMarkType;
+
+  /// No description provided for @itemMarkNumber.
+  ///
+  /// In en, this message translates to:
+  /// **'Number'**
+  String get itemMarkNumber;
+
+  /// No description provided for @itemMarkNumberHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. 12'**
+  String get itemMarkNumberHint;
+
+  /// No description provided for @itemMarkNumberHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'Required to save'**
+  String get itemMarkNumberHelper;
+
+  /// No description provided for @itemMarkCustomType.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom type'**
+  String get itemMarkCustomType;
+
+  /// No description provided for @itemMarkFilterAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get itemMarkFilterAll;
+
+  /// No description provided for @itemMarkFilterLiked.
+  ///
+  /// In en, this message translates to:
+  /// **'Liked'**
+  String get itemMarkFilterLiked;
+
+  /// No description provided for @itemMarkFilterCommented.
+  ///
+  /// In en, this message translates to:
+  /// **'With notes'**
+  String get itemMarkFilterCommented;
+
+  /// No description provided for @itemMarkUnitLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{type} {number}'**
+  String itemMarkUnitLabel(String type, int number);
+
+  /// No description provided for @itemMarkEpisodeShort.
+  ///
+  /// In en, this message translates to:
+  /// **'S{season}·E{episode}'**
+  String itemMarkEpisodeShort(int season, int episode);
+
+  /// No description provided for @unitEpisode.
+  ///
+  /// In en, this message translates to:
+  /// **'Episode'**
+  String get unitEpisode;
+
+  /// No description provided for @unitSeason.
+  ///
+  /// In en, this message translates to:
+  /// **'Season'**
+  String get unitSeason;
+
+  /// No description provided for @unitChapter.
+  ///
+  /// In en, this message translates to:
+  /// **'Chapter'**
+  String get unitChapter;
+
+  /// No description provided for @unitVolume.
+  ///
+  /// In en, this message translates to:
+  /// **'Volume'**
+  String get unitVolume;
+
+  /// No description provided for @unitPage.
+  ///
+  /// In en, this message translates to:
+  /// **'Page'**
+  String get unitPage;
+
+  /// No description provided for @unitPart.
+  ///
+  /// In en, this message translates to:
+  /// **'Part'**
+  String get unitPart;
+
+  /// No description provided for @unitCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom'**
+  String get unitCustom;
 }
 
 class _SDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5321,4 +5321,80 @@ class SEn extends S {
     );
     return '$_temp0';
   }
+
+  @override
+  String get itemMarkLike => 'Like';
+
+  @override
+  String get itemMarkNote => 'Note';
+
+  @override
+  String get itemMarkNoteHint => 'Write a note…';
+
+  @override
+  String get itemMarkSectionTitle => 'Notes & likes';
+
+  @override
+  String get itemMarkAdd => 'Add mark';
+
+  @override
+  String get itemMarkEmpty => 'No marks yet';
+
+  @override
+  String get itemMarkDelete => 'Delete';
+
+  @override
+  String get itemMarkType => 'Type';
+
+  @override
+  String get itemMarkNumber => 'Number';
+
+  @override
+  String get itemMarkNumberHint => 'e.g. 12';
+
+  @override
+  String get itemMarkNumberHelper => 'Required to save';
+
+  @override
+  String get itemMarkCustomType => 'Custom type';
+
+  @override
+  String get itemMarkFilterAll => 'All';
+
+  @override
+  String get itemMarkFilterLiked => 'Liked';
+
+  @override
+  String get itemMarkFilterCommented => 'With notes';
+
+  @override
+  String itemMarkUnitLabel(String type, int number) {
+    return '$type $number';
+  }
+
+  @override
+  String itemMarkEpisodeShort(int season, int episode) {
+    return 'S$season·E$episode';
+  }
+
+  @override
+  String get unitEpisode => 'Episode';
+
+  @override
+  String get unitSeason => 'Season';
+
+  @override
+  String get unitChapter => 'Chapter';
+
+  @override
+  String get unitVolume => 'Volume';
+
+  @override
+  String get unitPage => 'Page';
+
+  @override
+  String get unitPart => 'Part';
+
+  @override
+  String get unitCustom => 'Custom';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -5413,4 +5413,80 @@ class SRu extends S {
     );
     return '$_temp0';
   }
+
+  @override
+  String get itemMarkLike => 'Нравится';
+
+  @override
+  String get itemMarkNote => 'Заметка';
+
+  @override
+  String get itemMarkNoteHint => 'Напишите заметку…';
+
+  @override
+  String get itemMarkSectionTitle => 'Заметки и лайки';
+
+  @override
+  String get itemMarkAdd => 'Добавить пометку';
+
+  @override
+  String get itemMarkEmpty => 'Пометок пока нет';
+
+  @override
+  String get itemMarkDelete => 'Удалить';
+
+  @override
+  String get itemMarkType => 'Тип';
+
+  @override
+  String get itemMarkNumber => 'Номер';
+
+  @override
+  String get itemMarkNumberHint => 'например, 12';
+
+  @override
+  String get itemMarkNumberHelper => 'Обязательно для сохранения';
+
+  @override
+  String get itemMarkCustomType => 'Свой тип';
+
+  @override
+  String get itemMarkFilterAll => 'Все';
+
+  @override
+  String get itemMarkFilterLiked => 'Лайкнутые';
+
+  @override
+  String get itemMarkFilterCommented => 'С заметками';
+
+  @override
+  String itemMarkUnitLabel(String type, int number) {
+    return '$type $number';
+  }
+
+  @override
+  String itemMarkEpisodeShort(int season, int episode) {
+    return 'S$season·E$episode';
+  }
+
+  @override
+  String get unitEpisode => 'Серия';
+
+  @override
+  String get unitSeason => 'Сезон';
+
+  @override
+  String get unitChapter => 'Глава';
+
+  @override
+  String get unitVolume => 'Том';
+
+  @override
+  String get unitPage => 'Страница';
+
+  @override
+  String get unitPart => 'Часть';
+
+  @override
+  String get unitCustom => 'Своё';
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -2095,5 +2095,42 @@
     "placeholders": {
       "count": {"type": "int"}
     }
-  }
+  },
+
+  "itemMarkLike": "Нравится",
+  "itemMarkNote": "Заметка",
+  "itemMarkNoteHint": "Напишите заметку…",
+  "itemMarkSectionTitle": "Заметки и лайки",
+  "itemMarkAdd": "Добавить пометку",
+  "itemMarkEmpty": "Пометок пока нет",
+  "itemMarkDelete": "Удалить",
+  "itemMarkType": "Тип",
+  "itemMarkNumber": "Номер",
+  "itemMarkNumberHint": "например, 12",
+  "itemMarkNumberHelper": "Обязательно для сохранения",
+  "itemMarkCustomType": "Свой тип",
+  "itemMarkFilterAll": "Все",
+  "itemMarkFilterLiked": "Лайкнутые",
+  "itemMarkFilterCommented": "С заметками",
+  "itemMarkUnitLabel": "{type} {number}",
+  "@itemMarkUnitLabel": {
+    "placeholders": {
+      "type": {"type": "String"},
+      "number": {"type": "int"}
+    }
+  },
+  "itemMarkEpisodeShort": "S{season}·E{episode}",
+  "@itemMarkEpisodeShort": {
+    "placeholders": {
+      "season": {"type": "int"},
+      "episode": {"type": "int"}
+    }
+  },
+  "unitEpisode": "Серия",
+  "unitSeason": "Сезон",
+  "unitChapter": "Глава",
+  "unitVolume": "Том",
+  "unitPage": "Страница",
+  "unitPart": "Часть",
+  "unitCustom": "Своё"
 }

--- a/lib/shared/models/item_mark.dart
+++ b/lib/shared/models/item_mark.dart
@@ -1,0 +1,232 @@
+// Universal per-unit mark (like + note) attached to a collection item unit.
+
+/// Preset unit type: a TV / anime episode.
+const String kUnitEpisode = 'episode';
+
+/// Preset unit type: a whole season.
+const String kUnitSeason = 'season';
+
+/// Preset unit type: a manga / comic chapter.
+const String kUnitChapter = 'chapter';
+
+/// Preset unit type: a whole volume.
+const String kUnitVolume = 'volume';
+
+/// Preset unit type: a page.
+const String kUnitPage = 'page';
+
+/// Preset unit type: a part / arc.
+const String kUnitPart = 'part';
+
+/// Preset unit types offered by the "add mark" form. Users may also type an
+/// arbitrary string, so this list is not exhaustive — [ItemMark.unitType] is a
+/// free-form string, not a strict enum.
+const List<String> kUnitPresets = <String>[
+  kUnitEpisode,
+  kUnitSeason,
+  kUnitChapter,
+  kUnitVolume,
+  kUnitPage,
+  kUnitPart,
+];
+
+/// Maps a single user-entered [number] to `(parent, unit)` coordinates for a
+/// [unitType]: season / volume numbers live in `parent_number`, every other
+/// unit's number lives in `unit_number`.
+({int parent, int unit}) unitCoordsFor(String unitType, int number) {
+  if (unitType == kUnitSeason || unitType == kUnitVolume) {
+    return (parent: number, unit: 0);
+  }
+  return (parent: 0, unit: number);
+}
+
+/// A user mark on a single unit inside a collection item: a like (favorite
+/// flag) and/or a free-text note. Anchored on `collection_items.id`
+/// ([itemId]) so it works for every media type without duplicating the
+/// item's `external_id` / `source`.
+///
+/// The unit is described generically by [unitType] plus two numbers:
+/// [parentNumber] (season / volume, or 0 when not applicable) and
+/// [unitNumber] (episode / chapter / page number, or 0 for a season/volume
+/// row). See the task doc for the full mapping table.
+class ItemMark {
+  /// Creates an [ItemMark].
+  const ItemMark({
+    required this.id,
+    required this.itemId,
+    required this.unitType,
+    required this.parentNumber,
+    required this.unitNumber,
+    required this.isFavorite,
+    required this.updatedAt,
+    this.userComment,
+    this.likedAt,
+  });
+
+  /// Builds an [ItemMark] from a database row.
+  factory ItemMark.fromDb(Map<String, dynamic> row) {
+    final int? likedAtMs = row['liked_at'] as int?;
+    return ItemMark(
+      id: row['id'] as int,
+      itemId: row['item_id'] as int,
+      unitType: row['unit_type'] as String,
+      parentNumber: (row['parent_number'] as int?) ?? 0,
+      unitNumber: (row['unit_number'] as int?) ?? 0,
+      isFavorite: (row['is_favorite'] as int?) == 1,
+      userComment: row['user_comment'] as String?,
+      likedAt: likedAtMs != null
+          ? DateTime.fromMillisecondsSinceEpoch(likedAtMs)
+          : null,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(row['updated_at'] as int),
+    );
+  }
+
+  /// Builds an [ItemMark] from an export map (timestamps in seconds). [itemId]
+  /// is supplied by the caller because export nests marks inside their item and
+  /// the id is remapped on import.
+  factory ItemMark.fromExport(
+    Map<String, dynamic> json, {
+    required int itemId,
+  }) {
+    final int? likedAtSec = json['liked_at'] as int?;
+    final int? updatedAtSec = json['updated_at'] as int?;
+    return ItemMark(
+      id: 0,
+      itemId: itemId,
+      unitType: json['unit_type'] as String,
+      parentNumber: (json['parent_number'] as int?) ?? 0,
+      unitNumber: (json['unit_number'] as int?) ?? 0,
+      isFavorite: (json['is_favorite'] as int?) == 1,
+      userComment: json['user_comment'] as String?,
+      likedAt: likedAtSec != null
+          ? DateTime.fromMillisecondsSinceEpoch(likedAtSec * 1000)
+          : null,
+      updatedAt: updatedAtSec != null
+          ? DateTime.fromMillisecondsSinceEpoch(updatedAtSec * 1000)
+          : DateTime.now(),
+    );
+  }
+
+  /// Row id (0 when not yet persisted).
+  final int id;
+
+  /// Owning `collection_items.id`.
+  final int itemId;
+
+  /// Free-form unit type (see [kUnitPresets]).
+  final String unitType;
+
+  /// Season / volume number, or 0 when not applicable.
+  final int parentNumber;
+
+  /// Episode / chapter / page number, or 0 for a season/volume-level mark.
+  final int unitNumber;
+
+  /// Whether the unit is liked (favorite).
+  final bool isFavorite;
+
+  /// Free-text note, or null.
+  final String? userComment;
+
+  /// When the like was set, or null.
+  final DateTime? likedAt;
+
+  /// Last modification time.
+  final DateTime updatedAt;
+
+  /// The number shown to the user: [parentNumber] for season/volume marks,
+  /// [unitNumber] otherwise.
+  int get displayNumber =>
+      (unitType == kUnitSeason || unitType == kUnitVolume)
+          ? parentNumber
+          : unitNumber;
+
+  /// The note trimmed to null when blank.
+  String? get note {
+    final String? trimmed = userComment?.trim();
+    return (trimmed != null && trimmed.isNotEmpty) ? trimmed : null;
+  }
+
+  /// Whether the mark carries anything worth keeping. An empty mark (no like,
+  /// no note) is deleted rather than stored.
+  bool get hasContent => isFavorite || note != null;
+
+  /// Serialises to a database row. [id] is intentionally omitted so upserts
+  /// resolve against the `(item_id, unit_type, parent_number, unit_number)`
+  /// unique key instead of the surrogate id.
+  Map<String, dynamic> toDb() {
+    return <String, dynamic>{
+      'item_id': itemId,
+      'unit_type': unitType,
+      'parent_number': parentNumber,
+      'unit_number': unitNumber,
+      'is_favorite': isFavorite ? 1 : 0,
+      'user_comment': userComment,
+      'liked_at': likedAt?.millisecondsSinceEpoch,
+      'updated_at': updatedAt.millisecondsSinceEpoch,
+    };
+  }
+
+  /// Serialises for export (timestamps in seconds, no id / item_id — the mark
+  /// rides inside its item and is re-anchored on import).
+  Map<String, dynamic> toExport() {
+    return <String, dynamic>{
+      'unit_type': unitType,
+      'parent_number': parentNumber,
+      'unit_number': unitNumber,
+      'is_favorite': isFavorite ? 1 : 0,
+      'user_comment': userComment,
+      'liked_at': likedAt != null
+          ? likedAt!.millisecondsSinceEpoch ~/ 1000
+          : null,
+      'updated_at': updatedAt.millisecondsSinceEpoch ~/ 1000,
+    };
+  }
+
+  /// Returns a copy with the given fields replaced.
+  ItemMark copyWith({
+    int? id,
+    int? itemId,
+    String? unitType,
+    int? parentNumber,
+    int? unitNumber,
+    bool? isFavorite,
+    String? userComment,
+    bool clearUserComment = false,
+    DateTime? likedAt,
+    bool clearLikedAt = false,
+    DateTime? updatedAt,
+  }) {
+    return ItemMark(
+      id: id ?? this.id,
+      itemId: itemId ?? this.itemId,
+      unitType: unitType ?? this.unitType,
+      parentNumber: parentNumber ?? this.parentNumber,
+      unitNumber: unitNumber ?? this.unitNumber,
+      isFavorite: isFavorite ?? this.isFavorite,
+      userComment:
+          clearUserComment ? null : (userComment ?? this.userComment),
+      likedAt: clearLikedAt ? null : (likedAt ?? this.likedAt),
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ItemMark &&
+        other.itemId == itemId &&
+        other.unitType == unitType &&
+        other.parentNumber == parentNumber &&
+        other.unitNumber == unitNumber;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(itemId, unitType, parentNumber, unitNumber);
+
+  @override
+  String toString() =>
+      'ItemMark(item: $itemId, $unitType p$parentNumber u$unitNumber, '
+      'fav: $isFavorite, note: ${userComment != null})';
+}

--- a/test/core/database/dao/item_mark_dao_test.dart
+++ b/test/core/database/dao/item_mark_dao_test.dart
@@ -1,0 +1,244 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/dao/item_mark_dao.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v53.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  late Database db;
+  late ItemMarkDao dao;
+
+  setUp(() async {
+    // Foreign keys are left OFF so the DAO can be tested without seeding the
+    // referenced collection_items table.
+    db = await factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 53,
+        onCreate: (Database d, int _) async => MigrationV53().migrate(d),
+      ),
+    );
+    dao = ItemMarkDao(() async => db);
+  });
+
+  tearDown(() async => db.close());
+
+  group('ItemMarkDao', () {
+    const int itemId = 1;
+
+    group('setFavorite', () {
+      test('creates a row and returns it via getMarksForItem', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        final List<ItemMark> marks = await dao.getMarksForItem(itemId);
+        expect(marks, hasLength(1));
+        expect(marks.single.isFavorite, isTrue);
+        expect(marks.single.likedAt, isNotNull);
+      });
+
+      test('unliking an otherwise-empty mark deletes the row', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: false);
+        expect(await dao.getMarksForItem(itemId), isEmpty);
+      });
+
+      test('unliking keeps the row when a note remains', () async {
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, 'note');
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: false);
+        final List<ItemMark> marks = await dao.getMarksForItem(itemId);
+        expect(marks, hasLength(1));
+        expect(marks.single.isFavorite, isFalse);
+        expect(marks.single.userComment, 'note');
+      });
+
+      test('re-liking preserves the original liked_at', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        final DateTime? first =
+            (await dao.getMarksForItem(itemId)).single.likedAt;
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, 'note');
+        final DateTime? afterComment =
+            (await dao.getMarksForItem(itemId)).single.likedAt;
+        expect(afterComment, first);
+      });
+    });
+
+    group('setComment', () {
+      test('merges with an existing like', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, 'good');
+        final ItemMark mark = (await dao.getMarksForItem(itemId)).single;
+        expect(mark.isFavorite, isTrue);
+        expect(mark.userComment, 'good');
+      });
+
+      test('blank comment on a like-only mark keeps the like', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, '   ');
+        final ItemMark mark = (await dao.getMarksForItem(itemId)).single;
+        expect(mark.isFavorite, isTrue);
+        expect(mark.userComment, isNull);
+      });
+
+      test('clearing the note on a note-only mark deletes the row', () async {
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, 'temp');
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, null);
+        expect(await dao.getMarksForItem(itemId), isEmpty);
+      });
+
+      test('trims stored comments', () async {
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, '  spaced  ');
+        expect(
+          (await dao.getMarksForItem(itemId)).single.userComment,
+          'spaced',
+        );
+      });
+    });
+
+    group('deleteMark', () {
+      test('removes a mark unconditionally', () async {
+        await dao.setFavorite(itemId, kUnitSeason, 2, 0, isFavorite: true);
+        await dao.deleteMark(itemId, kUnitSeason, 2, 0);
+        expect(await dao.getMarksForItem(itemId), isEmpty);
+      });
+    });
+
+    group('unique key', () {
+      test('same coordinates upsert into one row', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, 'a');
+        await dao.setComment(itemId, kUnitEpisode, 1, 3, 'b');
+        final List<ItemMark> marks = await dao.getMarksForItem(itemId);
+        expect(marks, hasLength(1));
+        expect(marks.single.userComment, 'b');
+      });
+
+      test('different coordinates are distinct rows', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 4, isFavorite: true);
+        await dao.setFavorite(itemId, kUnitSeason, 1, 0, isFavorite: true);
+        expect(await dao.getMarksForItem(itemId), hasLength(3));
+      });
+    });
+
+    group('insertMarks', () {
+      test('inserts imported marks verbatim in one batch', () async {
+        final ItemMark mark = ItemMark(
+          id: 0,
+          itemId: itemId,
+          unitType: kUnitChapter,
+          parentNumber: 0,
+          unitNumber: 45,
+          isFavorite: true,
+          userComment: 'imported',
+          likedAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          updatedAt: DateTime.fromMillisecondsSinceEpoch(1700000005000),
+        );
+        await dao.insertMarks(<ItemMark>[mark]);
+        final ItemMark restored = (await dao.getMarksForItem(itemId)).single;
+        expect(restored.userComment, 'imported');
+        expect(restored.unitNumber, 45);
+        expect(restored.likedAt,
+            DateTime.fromMillisecondsSinceEpoch(1700000000000));
+      });
+
+      test('empty list is a no-op', () async {
+        await dao.insertMarks(const <ItemMark>[]);
+        expect(await dao.getMarksForItem(itemId), isEmpty);
+      });
+    });
+
+    group('getMarksForItems', () {
+      test('returns marks only for the requested items', () async {
+        await dao.setFavorite(1, kUnitEpisode, 1, 1, isFavorite: true);
+        await dao.setFavorite(2, kUnitEpisode, 1, 1, isFavorite: true);
+        await dao.setFavorite(3, kUnitEpisode, 1, 1, isFavorite: true);
+        final List<ItemMark> marks =
+            await dao.getMarksForItems(<int>[1, 2]);
+        expect(marks, hasLength(2));
+        expect(
+          marks.map((ItemMark m) => m.itemId),
+          unorderedEquals(<int>[1, 2]),
+        );
+      });
+
+      test('empty id list returns empty without querying', () async {
+        expect(await dao.getMarksForItems(const <int>[]), isEmpty);
+      });
+
+      test('handles id lists larger than one query chunk', () async {
+        await dao.insertMarks(<ItemMark>[
+          for (int i = 1; i <= 600; i++)
+            ItemMark(
+              id: 0,
+              itemId: i,
+              unitType: kUnitEpisode,
+              parentNumber: 1,
+              unitNumber: 1,
+              isFavorite: true,
+              updatedAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+            ),
+        ]);
+        final List<ItemMark> marks = await dao.getMarksForItems(
+          <int>[for (int i = 1; i <= 600; i++) i],
+        );
+        expect(marks, hasLength(600));
+      });
+    });
+
+    group('setFavorite/setComment return value', () {
+      test('returns the merged mark on write', () async {
+        final ItemMark? merged =
+            await dao.setFavorite(itemId, kUnitEpisode, 1, 3,
+                isFavorite: true);
+        expect(merged, isNotNull);
+        expect(merged!.isFavorite, isTrue);
+        final ItemMark? withNote =
+            await dao.setComment(itemId, kUnitEpisode, 1, 3, 'good');
+        expect(withNote!.isFavorite, isTrue);
+        expect(withNote.userComment, 'good');
+      });
+
+      test('returns null when the row is deleted', () async {
+        await dao.setFavorite(itemId, kUnitEpisode, 1, 3, isFavorite: true);
+        final ItemMark? gone =
+            await dao.setFavorite(itemId, kUnitEpisode, 1, 3,
+                isFavorite: false);
+        expect(gone, isNull);
+      });
+    });
+
+    group('export/import round-trip', () {
+      test('marks survive serialization and re-anchor to a new item id',
+          () async {
+        const int oldItemId = 7;
+        const int newItemId = 12;
+        await dao.setFavorite(oldItemId, kUnitEpisode, 2, 5, isFavorite: true);
+        await dao.setComment(oldItemId, kUnitEpisode, 2, 5, 'loved it');
+        await dao.setComment(oldItemId, kUnitChapter, 0, 45, 'cliffhanger');
+
+        // Export (nested, no item_id) then import under a fresh id.
+        final List<Map<String, dynamic>> exported =
+            (await dao.getMarksForItem(oldItemId))
+                .map((ItemMark m) => m.toExport())
+                .toList();
+        await dao.insertMarks(<ItemMark>[
+          for (final Map<String, dynamic> json in exported)
+            ItemMark.fromExport(json, itemId: newItemId),
+        ]);
+
+        final List<ItemMark> restored = await dao.getMarksForItem(newItemId);
+        expect(restored, hasLength(2));
+        final ItemMark episode = restored
+            .firstWhere((ItemMark m) => m.unitType == kUnitEpisode);
+        expect(episode.itemId, newItemId);
+        expect(episode.isFavorite, isTrue);
+        expect(episode.userComment, 'loved it');
+        expect(episode.parentNumber, 2);
+        expect(episode.unitNumber, 5);
+      });
+    });
+  });
+}

--- a/test/core/database/migrations/migration_v53_test.dart
+++ b/test/core/database/migrations/migration_v53_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v53.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  /// A pre-v53 database with only a minimal `collection_items` table so the
+  /// new table's foreign key has a target.
+  Future<Database> openOldDb() async {
+    return factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 52,
+        onCreate: (Database db, int _) async {
+          await db.execute('''
+            CREATE TABLE collection_items (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              media_type TEXT NOT NULL,
+              external_id INTEGER NOT NULL
+            )
+          ''');
+        },
+      ),
+    );
+  }
+
+  Future<bool> hasTable(Database db, String table) async {
+    final List<Map<String, Object?>> rows = await db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+      <Object?>[table],
+    );
+    return rows.isNotEmpty;
+  }
+
+  Future<bool> hasIndex(Database db, String index) async {
+    final List<Map<String, Object?>> rows = await db.rawQuery(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+      <Object?>[index],
+    );
+    return rows.isNotEmpty;
+  }
+
+  group('MigrationV53', () {
+    late Database db;
+
+    setUp(() async {
+      db = await openOldDb();
+      await MigrationV53().migrate(db);
+    });
+
+    tearDown(() async => db.close());
+
+    test('creates the item_marks table and its index', () async {
+      expect(await hasTable(db, 'item_marks'), isTrue);
+      expect(await hasIndex(db, 'idx_item_marks_item'), isTrue);
+    });
+
+    test('is idempotent — re-running does not throw', () async {
+      await MigrationV53().migrate(db);
+      expect(await hasTable(db, 'item_marks'), isTrue);
+    });
+
+    test('enforces the unique unit key', () async {
+      await db.insert('item_marks', <String, Object?>{
+        'item_id': 1,
+        'unit_type': 'episode',
+        'parent_number': 1,
+        'unit_number': 3,
+        'is_favorite': 1,
+        'updated_at': 1700000000000,
+      });
+      expect(
+        () => db.insert('item_marks', <String, Object?>{
+          'item_id': 1,
+          'unit_type': 'episode',
+          'parent_number': 1,
+          'unit_number': 3,
+          'is_favorite': 0,
+          'updated_at': 1700000001000,
+        }, conflictAlgorithm: ConflictAlgorithm.fail),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('cascades deletes from collection_items', () async {
+      await db.execute('PRAGMA foreign_keys = ON');
+      await db.insert('collection_items', <String, Object?>{
+        'id': 1,
+        'media_type': 'tv_show',
+        'external_id': 100,
+      });
+      await db.insert('item_marks', <String, Object?>{
+        'item_id': 1,
+        'unit_type': 'episode',
+        'parent_number': 1,
+        'unit_number': 3,
+        'is_favorite': 1,
+        'updated_at': 1700000000000,
+      });
+      await db.delete('collection_items', where: 'id = ?', whereArgs: <Object?>[1]);
+      final List<Map<String, Object?>> marks = await db.query('item_marks');
+      expect(marks, isEmpty);
+    });
+  });
+}

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -12,6 +12,7 @@ import 'package:tonkatsu_box/shared/models/canvas_viewport.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/movie.dart';
@@ -1995,6 +1996,126 @@ void main() {
 
         expect(xcoll.media.containsKey('platforms'), isTrue);
         verify(() => mockGameDao.getPlatformsByIds(any())).called(1);
+      });
+    });
+
+    group('item marks in full export', () {
+      late MockCanvasRepository mockCanvasRepo;
+      late MockImageCacheService mockImageCache;
+      late MockDatabaseService mockDatabase;
+      late MockTvShowDao mockTvShowDao;
+      late MockItemMarkDao mockItemMarkDao;
+      late MockTierListDao mockTierListDao;
+      late MockTagDao mockTagDao;
+      late ExportService sutMarks;
+
+      setUp(() {
+        mockCanvasRepo = MockCanvasRepository();
+        mockImageCache = MockImageCacheService();
+        mockDatabase = MockDatabaseService();
+        mockTvShowDao = MockTvShowDao();
+        mockItemMarkDao = MockItemMarkDao();
+        mockTierListDao = MockTierListDao();
+        mockTagDao = MockTagDao();
+
+        when(() => mockDatabase.tvShowDao).thenReturn(mockTvShowDao);
+        when(() => mockDatabase.itemMarkDao).thenReturn(mockItemMarkDao);
+        when(() => mockDatabase.tierListDao).thenReturn(mockTierListDao);
+        when(() => mockDatabase.tagDao).thenReturn(mockTagDao);
+
+        when(() => mockCanvasRepo.getViewport(any()))
+            .thenAnswer((_) async => null);
+        when(() => mockCanvasRepo.getItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+        when(() => mockCanvasRepo.getConnections(any()))
+            .thenAnswer((_) async => <CanvasConnection>[]);
+        when(() => mockCanvasRepo.getGameCanvasItems(any()))
+            .thenAnswer((_) async => <CanvasItem>[]);
+        when(() => mockImageCache.readImageBytes(any(), any()))
+            .thenAnswer((_) async => null);
+        when(() => mockTvShowDao.getTvSeasonsByShowId(any()))
+            .thenAnswer((_) async => <TvSeason>[]);
+        when(() => mockTvShowDao.getEpisodesByShowId(any()))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        when(() => mockTierListDao.getTierListsByCollection(any()))
+            .thenAnswer((_) async => <TierList>[]);
+        when(() => mockTagDao.getTagsByCollection(any()))
+            .thenAnswer((_) async => <CollectionTag>[]);
+
+        sutMarks = ExportService(
+          canvasRepository: mockCanvasRepo,
+          imageCacheService: mockImageCache,
+          database: mockDatabase,
+        );
+      });
+
+      List<CollectionItem> twoTvItems() => <CollectionItem>[
+            createTestCollectionItem(
+              id: 1,
+              mediaType: MediaType.tvShow,
+              externalId: 1399,
+              platformId: null,
+              tvShow: const TvShow(tmdbId: 1399, title: 'GoT'),
+            ),
+            createTestCollectionItem(
+              id: 2,
+              mediaType: MediaType.tvShow,
+              externalId: 1400,
+              platformId: null,
+              tvShow: const TvShow(tmdbId: 1400, title: 'Other'),
+            ),
+          ];
+
+      test('should attach _marks only to items that have marks', () async {
+        when(() => mockItemMarkDao.getMarksForItems(any())).thenAnswer(
+          (_) async => <ItemMark>[
+            ItemMark(
+              id: 1,
+              itemId: 1,
+              unitType: kUnitEpisode,
+              parentNumber: 2,
+              unitNumber: 5,
+              isFavorite: true,
+              userComment: 'loved it',
+              likedAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              updatedAt: DateTime.fromMillisecondsSinceEpoch(1700000005000),
+            ),
+          ],
+        );
+
+        final XcollFile xcoll = await sutMarks.createFullExport(
+          createTestCollection(),
+          twoTvItems(),
+          1,
+          includeUserData: true,
+        );
+
+        // The DAO must be asked only for the exported items' ids.
+        verify(() => mockItemMarkDao.getMarksForItems(<int>[1, 2])).called(1);
+
+        final List<dynamic> marks =
+            xcoll.items[0]['_marks'] as List<dynamic>;
+        expect(marks, hasLength(1));
+        final Map<String, dynamic> mark = marks[0] as Map<String, dynamic>;
+        expect(mark['unit_type'], kUnitEpisode);
+        expect(mark['parent_number'], 2);
+        expect(mark['unit_number'], 5);
+        expect(mark['is_favorite'], 1);
+        expect(mark['user_comment'], 'loved it');
+        expect(mark['liked_at'], 1700000000);
+        expect(mark['updated_at'], 1700000005);
+        expect(xcoll.items[1].containsKey('_marks'), isFalse);
+      });
+
+      test('should skip marks when includeUserData is false', () async {
+        final XcollFile xcoll = await sutMarks.createFullExport(
+          createTestCollection(),
+          twoTvItems(),
+          1,
+        );
+
+        expect(xcoll.items[0].containsKey('_marks'), isFalse);
+        verifyNever(() => mockItemMarkDao.getMarksForItems(any()));
       });
     });
   });

--- a/test/core/services/import_service_test.dart
+++ b/test/core/services/import_service_test.dart
@@ -15,6 +15,7 @@ import 'package:tonkatsu_box/shared/models/canvas_viewport.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/movie.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
@@ -2714,6 +2715,156 @@ void main() {
         // Canvas should NOT be imported
         verifyNever(() => mockCanvas.createItem(any()));
         verifyNever(() => mockCanvas.createConnection(any()));
+      });
+    });
+
+    group('import item marks (_marks)', () {
+      late ImportService sutV2;
+      late MockItemMarkDao mockItemMarkDao;
+
+      const List<Map<String, dynamic>> itemsWithMarks =
+          <Map<String, dynamic>>[
+        <String, dynamic>{
+          'media_type': 'game',
+          'external_id': 100,
+          '_marks': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'unit_type': 'episode',
+              'parent_number': 2,
+              'unit_number': 5,
+              'is_favorite': 1,
+              'user_comment': 'loved it',
+              'liked_at': 1700000000,
+              'updated_at': 1700000005,
+            },
+            <String, dynamic>{
+              'unit_type': 'chapter',
+              'parent_number': 0,
+              'unit_number': 45,
+              'is_favorite': 0,
+              'user_comment': 'cliffhanger',
+              'updated_at': 1700000005,
+            },
+          ],
+        },
+      ];
+
+      setUp(() {
+        mockItemMarkDao = MockItemMarkDao();
+        when(() => mockDb.itemMarkDao).thenReturn(mockItemMarkDao);
+        when(() => mockItemMarkDao.insertMarks(any()))
+            .thenAnswer((_) async {});
+
+        when(() => mockApi.getGamesByIds(any()))
+            .thenAnswer((_) async => const <Game>[Game(id: 100, name: 'G')]);
+        when(() => mockGameDao.upsertGame(any())).thenAnswer((_) async {});
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+
+        sutV2 = ImportService(
+          repository: mockRepo,
+          igdbApi: mockApi,
+          tmdbApi: mockTmdb,
+          database: mockDb,
+          canvasRepository: mockCanvas,
+        );
+      });
+
+      XcollFile xcollWith({required bool userData}) => XcollFile(
+            version: 2,
+            format: ExportFormat.light,
+            name: 'Import',
+            author: 'Author',
+            created: testDate,
+            includesUserData: userData,
+            items: itemsWithMarks,
+          );
+
+      test('should re-anchor imported marks to the new item id', () async {
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        final List<ItemMark> inserted = verify(
+          () => mockItemMarkDao.insertMarks(captureAny()),
+        ).captured.single as List<ItemMark>;
+        expect(inserted, hasLength(2));
+        expect(inserted[0].itemId, 42);
+        expect(inserted[0].unitType, 'episode');
+        expect(inserted[0].parentNumber, 2);
+        expect(inserted[0].unitNumber, 5);
+        expect(inserted[0].isFavorite, isTrue);
+        expect(inserted[0].userComment, 'loved it');
+        expect(
+          inserted[0].likedAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+        );
+        expect(inserted[1].itemId, 42);
+        expect(inserted[1].unitType, 'chapter');
+        expect(inserted[1].isFavorite, isFalse);
+      });
+
+      test('should skip marks when the file has no user data', () async {
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              authorComment: any(named: 'authorComment'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: false),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verifyNever(() => mockItemMarkDao.insertMarks(any()));
+      });
+
+      test('should merge marks onto an existing duplicate item', () async {
+        // addItem returns null = duplicate; marks anchor to the existing id.
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => null);
+        when(() => mockRepo.findItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+            )).thenAnswer((_) async => createTestCollectionItem(
+              id: 77,
+              mediaType: MediaType.game,
+              externalId: 100,
+            ));
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        final List<ItemMark> inserted = verify(
+          () => mockItemMarkDao.insertMarks(captureAny()),
+        ).captured.single as List<ItemMark>;
+        expect(inserted, hasLength(2));
+        expect(inserted.every((ItemMark m) => m.itemId == 77), isTrue);
       });
     });
   });

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -142,6 +142,10 @@ void main() {
     mockDb = MockDatabaseService();
     mockTvShowDao = MockTvShowDao();
     when(() => mockDb.tvShowDao).thenReturn(mockTvShowDao);
+    // Eager cache load on build; default to no cached episodes so tests that
+    // don't care about it are unaffected.
+    when(() => mockTvShowDao.getEpisodesByShowId(any()))
+        .thenAnswer((_) async => <TvEpisode>[]);
     mockTmdbApi = MockTmdbApi();
     when(() => mockTmdbApi.getTvShow(any()))
         .thenAnswer((_) async => null);
@@ -344,6 +348,31 @@ void main() {
         expect(state.watchedEpisodes, watchedEpisodes);
         verify(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
             .called(1);
+      });
+
+      test('should eagerly load cached episodes grouped by season on build',
+          () async {
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+        when(() => mockTvShowDao.getEpisodesByShowId(testShowId)).thenAnswer(
+          (_) async => <TvEpisode>[
+            testEpisode1,
+            testEpisode2,
+            testEpisode2s1,
+          ],
+        );
+
+        final ProviderContainer container = createContainer();
+        container.read(episodeTrackerNotifierProvider(testArg));
+
+        await Future<void>.delayed(Duration.zero);
+
+        final EpisodeTrackerState state =
+            container.read(episodeTrackerNotifierProvider(testArg));
+
+        expect(state.episodesBySeason[1], hasLength(2));
+        expect(state.episodesBySeason[2], hasLength(1));
+        verify(() => mockTvShowDao.getEpisodesByShowId(testShowId)).called(1);
       });
 
       test('should handle ошибку загрузки просмотренных эпизодов',

--- a/test/features/collections/providers/item_marks_provider_test.dart
+++ b/test/features/collections/providers/item_marks_provider_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/features/collections/providers/item_marks_provider.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+ItemMark _mark({
+  int itemId = 1,
+  String unitType = kUnitEpisode,
+  int parent = 1,
+  int unit = 3,
+  bool fav = true,
+  String? note,
+}) {
+  return ItemMark(
+    id: 1,
+    itemId: itemId,
+    unitType: unitType,
+    parentNumber: parent,
+    unitNumber: unit,
+    isFavorite: fav,
+    userComment: note,
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+  );
+}
+
+void main() {
+  late MockDatabaseService mockDb;
+  late MockItemMarkDao mockDao;
+
+  setUp(() {
+    mockDb = MockDatabaseService();
+    mockDao = MockItemMarkDao();
+    when(() => mockDb.itemMarkDao).thenReturn(mockDao);
+  });
+
+  ProviderContainer makeContainer() {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        databaseServiceProvider.overrideWithValue(mockDb),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('ItemMarksNotifier', () {
+    test('build loads marks into a keyed map with counters', () async {
+      when(() => mockDao.getMarksForItem(1)).thenAnswer((_) async =>
+          <ItemMark>[
+            _mark(unit: 3, fav: true, note: 'a'),
+            _mark(unit: 4, fav: false, note: 'b'),
+          ]);
+
+      final ProviderContainer container = makeContainer();
+      container.read(itemMarksProvider(1));
+      await pumpEventQueue();
+
+      final ItemMarksState state = container.read(itemMarksProvider(1));
+      expect(state.isLiked(kUnitEpisode, 1, 3), isTrue);
+      expect(state.isLiked(kUnitEpisode, 1, 4), isFalse);
+      expect(state.likedCountOfType(kUnitEpisode), 1);
+      expect(state.commentedCountOfType(kUnitEpisode), 2);
+    });
+
+    test('toggleFavorite writes the negated value and applies the merged mark',
+        () async {
+      when(() => mockDao.getMarksForItem(1))
+          .thenAnswer((_) async => <ItemMark>[]);
+      when(() => mockDao.setFavorite(any(), any(), any(), any(),
+              isFavorite: any(named: 'isFavorite')))
+          .thenAnswer((_) async => _mark(fav: true));
+
+      final ProviderContainer container = makeContainer();
+      container.read(itemMarksProvider(1));
+      await pumpEventQueue();
+
+      await container
+          .read(itemMarksProvider(1).notifier)
+          .toggleFavorite(kUnitEpisode, 1, 3);
+
+      verify(() => mockDao.setFavorite(1, kUnitEpisode, 1, 3,
+          isFavorite: true)).called(1);
+      expect(
+        container.read(itemMarksProvider(1)).isLiked(kUnitEpisode, 1, 3),
+        isTrue,
+      );
+    });
+
+    test('setComment delegates to the dao', () async {
+      when(() => mockDao.getMarksForItem(1))
+          .thenAnswer((_) async => <ItemMark>[]);
+      when(() => mockDao.setComment(any(), any(), any(), any(), any()))
+          .thenAnswer((_) async => _mark(note: 'hi'));
+
+      final ProviderContainer container = makeContainer();
+      container.read(itemMarksProvider(1));
+      await pumpEventQueue();
+
+      await container
+          .read(itemMarksProvider(1).notifier)
+          .setComment(kUnitEpisode, 1, 3, 'hi');
+
+      verify(() => mockDao.setComment(1, kUnitEpisode, 1, 3, 'hi')).called(1);
+    });
+
+    test('a null DAO result removes the mark from state', () async {
+      when(() => mockDao.getMarksForItem(1)).thenAnswer(
+          (_) async => <ItemMark>[_mark(fav: false, note: 'old')]);
+      when(() => mockDao.setComment(any(), any(), any(), any(), any()))
+          .thenAnswer((_) async => null);
+
+      final ProviderContainer container = makeContainer();
+      container.read(itemMarksProvider(1));
+      await pumpEventQueue();
+      expect(
+        container.read(itemMarksProvider(1)).noteFor(kUnitEpisode, 1, 3),
+        'old',
+      );
+
+      await container
+          .read(itemMarksProvider(1).notifier)
+          .setComment(kUnitEpisode, 1, 3, '');
+
+      expect(
+        container.read(itemMarksProvider(1)).noteFor(kUnitEpisode, 1, 3),
+        isNull,
+      );
+    });
+
+    test('deleteMark delegates to the dao', () async {
+      when(() => mockDao.getMarksForItem(1))
+          .thenAnswer((_) async => <ItemMark>[]);
+      when(() => mockDao.deleteMark(any(), any(), any(), any()))
+          .thenAnswer((_) async {});
+
+      final ProviderContainer container = makeContainer();
+      container.read(itemMarksProvider(1));
+      await pumpEventQueue();
+
+      await container
+          .read(itemMarksProvider(1).notifier)
+          .deleteMark(kUnitSeason, 2, 0);
+
+      verify(() => mockDao.deleteMark(1, kUnitSeason, 2, 0)).called(1);
+    });
+  });
+}

--- a/test/features/collections/screens/item_detail_screen_test.dart
+++ b/test/features/collections/screens/item_detail_screen_test.dart
@@ -16,6 +16,8 @@ import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/movie.dart';
 import 'package:tonkatsu_box/shared/models/platform.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
 import 'package:tonkatsu_box/shared/widgets/media_detail_view.dart';
@@ -47,6 +49,12 @@ void main() {
         .thenAnswer((_) async => <TvSeason>[]);
     when(() => mockTvShowDao.getWatchedEpisodes(any(), any()))
         .thenAnswer((_) async => <(int, int), DateTime?>{});
+    when(() => mockTvShowDao.getEpisodesByShowId(any()))
+        .thenAnswer((_) async => <TvEpisode>[]);
+    final MockItemMarkDao mockItemMarkDao = MockItemMarkDao();
+    when(() => mockDb.itemMarkDao).thenReturn(mockItemMarkDao);
+    when(() => mockItemMarkDao.getMarksForItem(any()))
+        .thenAnswer((_) async => <ItemMark>[]);
     final MockGameDao mockGameDao = MockGameDao();
     when(() => mockDb.gameDao).thenReturn(mockGameDao);
     when(() => mockGameDao.getPlatformCount())

--- a/test/features/collections/widgets/item_mark_controls_test.dart
+++ b/test/features/collections/widgets/item_mark_controls_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/features/collections/widgets/item_mark_controls.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockDatabaseService mockDb;
+  late MockItemMarkDao mockDao;
+
+  setUp(() {
+    mockDb = MockDatabaseService();
+    mockDao = MockItemMarkDao();
+    when(() => mockDb.itemMarkDao).thenReturn(mockDao);
+    when(() => mockDao.getMarksForItem(any()))
+        .thenAnswer((_) async => <ItemMark>[]);
+    when(() => mockDao.setFavorite(any(), any(), any(), any(),
+        isFavorite: any(named: 'isFavorite'))).thenAnswer((_) async => null);
+    when(() => mockDao.setComment(any(), any(), any(), any(), any()))
+        .thenAnswer((_) async => null);
+  });
+
+  List<Override> overrides() => <Override>[
+        databaseServiceProvider.overrideWithValue(mockDb),
+      ];
+
+  group('ItemMarkControls', () {
+    testWidgets('renders both controls without exception', (WidgetTester tester) async {
+      await tester.pumpApp(
+        ItemMarkControls(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          onNotePressed: () {},
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(IconButton), findsNWidgets(2));
+    });
+
+    testWidgets('note-only mode hides the like button', (WidgetTester tester) async {
+      await tester.pumpApp(
+        ItemMarkControls(
+          itemId: 1,
+          unitType: kUnitSeason,
+          parentNumber: 2,
+          unitNumber: 0,
+          showLike: false,
+          onNotePressed: () {},
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      expect(find.byType(IconButton), findsOneWidget);
+    });
+
+    testWidgets('tapping the like button writes through the provider',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        ItemMarkControls(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          onNotePressed: () {},
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.byType(IconButton).first);
+      await tester.pumpAndSettle();
+
+      verify(() => mockDao.setFavorite(1, kUnitEpisode, 1, 3,
+          isFavorite: true)).called(1);
+    });
+
+    testWidgets('tapping the note button fires onNotePressed',
+        (WidgetTester tester) async {
+      int pressed = 0;
+      await tester.pumpApp(
+        ItemMarkControls(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          onNotePressed: () => pressed++,
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.byType(IconButton).last);
+      await tester.pumpAndSettle();
+
+      expect(pressed, 1);
+      verifyNever(() => mockDao.setComment(any(), any(), any(), any(), any()));
+    });
+  });
+
+  group('ItemMarkNoteEditor', () {
+    testWidgets('saves the entered text and calls onDone on the done button',
+        (WidgetTester tester) async {
+      int done = 0;
+      await tester.pumpApp(
+        ItemMarkNoteEditor(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          accentColor: Colors.teal,
+          onDone: () => done++,
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      await tester.enterText(find.byType(TextField), 'great one');
+      await tester.tap(find.byType(IconButton));
+      await tester.pumpAndSettle();
+
+      expect(done, 1);
+      verify(() => mockDao.setComment(1, kUnitEpisode, 1, 3, 'great one'))
+          .called(1);
+    });
+
+    testWidgets('autosaves after a pause without pressing done',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        ItemMarkNoteEditor(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          accentColor: Colors.teal,
+          onDone: () {},
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      await tester.enterText(find.byType(TextField), 'typed');
+      await tester.pump(const Duration(seconds: 2));
+
+      verify(() => mockDao.setComment(1, kUnitEpisode, 1, 3, 'typed'))
+          .called(1);
+    });
+
+    testWidgets('does not write anything on dispose when text is untouched',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        ItemMarkNoteEditor(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          accentColor: Colors.teal,
+          onDone: () {},
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+      await tester.pumpAndSettle();
+
+      // Replace the editor without touching the text — dispose must not save.
+      await tester.pumpApp(
+        const SizedBox.shrink(),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      verifyNever(() => mockDao.setComment(any(), any(), any(), any(), any()));
+    });
+
+    testWidgets('renders on a phone-sized viewport', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpApp(
+        ItemMarkNoteEditor(
+          itemId: 1,
+          unitType: kUnitEpisode,
+          parentNumber: 1,
+          unitNumber: 3,
+          accentColor: Colors.teal,
+          onDone: () {},
+        ),
+        overrides: overrides(),
+        wrapInScaffold: true,
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(TextField), findsOneWidget);
+    });
+  });
+}

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -7,6 +7,7 @@ import 'package:tonkatsu_box/shared/models/canvas_viewport.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
 import 'package:tonkatsu_box/shared/models/manga.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/movie.dart';
@@ -69,6 +70,8 @@ void registerAllFallbacks() {
     trackerGameId: '0',
     lastSyncedAt: 0,
   ));
+
+  registerFallbackValue(const <ItemMark>[]);
 
   registerFallbackValue(Uint8List(0));
   registerFallbackValue(DateTime(2024));

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -19,6 +19,7 @@ import 'package:tonkatsu_box/core/api/vndb_api.dart';
 import 'package:tonkatsu_box/core/database/dao/canvas_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/collection_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/game_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/item_mark_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/movie_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/tracked_release_dao.dart';
@@ -99,6 +100,8 @@ class MockGameDao extends Mock implements GameDao {}
 class MockMovieDao extends Mock implements MovieDao {}
 
 class MockTvShowDao extends Mock implements TvShowDao {}
+
+class MockItemMarkDao extends Mock implements ItemMarkDao {}
 
 class MockTrackedReleaseDao extends Mock implements TrackedReleaseDao {}
 

--- a/test/shared/models/item_mark_test.dart
+++ b/test/shared/models/item_mark_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/item_mark.dart';
+
+void main() {
+  group('ItemMark', () {
+    ItemMark buildMark({
+      int id = 5,
+      int itemId = 42,
+      String unitType = kUnitEpisode,
+      int parentNumber = 1,
+      int unitNumber = 3,
+      bool isFavorite = true,
+      String? userComment = 'great episode',
+      DateTime? likedAt,
+      DateTime? updatedAt,
+    }) {
+      return ItemMark(
+        id: id,
+        itemId: itemId,
+        unitType: unitType,
+        parentNumber: parentNumber,
+        unitNumber: unitNumber,
+        isFavorite: isFavorite,
+        userComment: userComment,
+        likedAt: likedAt ?? DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        updatedAt:
+            updatedAt ?? DateTime.fromMillisecondsSinceEpoch(1700000005000),
+      );
+    }
+
+    group('fromDb / toDb', () {
+      test('toDb omits id and encodes booleans/timestamps as ints', () {
+        final Map<String, dynamic> row = buildMark().toDb();
+        expect(row.containsKey('id'), isFalse);
+        expect(row['item_id'], 42);
+        expect(row['unit_type'], kUnitEpisode);
+        expect(row['parent_number'], 1);
+        expect(row['unit_number'], 3);
+        expect(row['is_favorite'], 1);
+        expect(row['user_comment'], 'great episode');
+        expect(row['liked_at'], 1700000000000);
+        expect(row['updated_at'], 1700000005000);
+      });
+
+      test('fromDb round-trips a persisted row', () {
+        final ItemMark original = buildMark();
+        final Map<String, dynamic> row = original.toDb()..['id'] = 5;
+        final ItemMark restored = ItemMark.fromDb(row);
+        expect(restored, original); // equality is identity-based
+        expect(restored.id, 5);
+        expect(restored.isFavorite, isTrue);
+        expect(restored.userComment, 'great episode');
+        expect(restored.likedAt, original.likedAt);
+        expect(restored.updatedAt, original.updatedAt);
+      });
+
+      test('fromDb tolerates null liked_at', () {
+        final Map<String, dynamic> row = buildMark(
+          isFavorite: false,
+          likedAt: null,
+        ).toDb()
+          ..['id'] = 1
+          ..['liked_at'] = null;
+        final ItemMark restored = ItemMark.fromDb(row);
+        expect(restored.likedAt, isNull);
+        expect(restored.isFavorite, isFalse);
+      });
+    });
+
+    group('export round-trip', () {
+      test('toExport uses seconds and drops id/item_id', () {
+        final Map<String, dynamic> json = buildMark().toExport();
+        expect(json.containsKey('id'), isFalse);
+        expect(json.containsKey('item_id'), isFalse);
+        expect(json['liked_at'], 1700000000);
+        expect(json['updated_at'], 1700000005);
+        expect(json['is_favorite'], 1);
+      });
+
+      test('fromExport re-anchors to the supplied itemId', () {
+        final Map<String, dynamic> json = buildMark().toExport();
+        final ItemMark restored = ItemMark.fromExport(json, itemId: 99);
+        expect(restored.itemId, 99);
+        expect(restored.unitType, kUnitEpisode);
+        expect(restored.parentNumber, 1);
+        expect(restored.unitNumber, 3);
+        expect(restored.isFavorite, isTrue);
+        expect(restored.userComment, 'great episode');
+        expect(
+          restored.likedAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        );
+      });
+    });
+
+    group('hasContent', () {
+      test('true when favorite', () {
+        expect(buildMark(isFavorite: true, userComment: null).hasContent,
+            isTrue);
+      });
+
+      test('true when non-empty note', () {
+        expect(buildMark(isFavorite: false, userComment: 'x').hasContent,
+            isTrue);
+      });
+
+      test('false when no like and blank note', () {
+        expect(buildMark(isFavorite: false, userComment: '   ').hasContent,
+            isFalse);
+        expect(buildMark(isFavorite: false, userComment: null).hasContent,
+            isFalse);
+      });
+    });
+
+    group('displayNumber', () {
+      test('uses unitNumber for episode/chapter', () {
+        expect(buildMark(unitType: kUnitEpisode).displayNumber, 3);
+        expect(
+          buildMark(unitType: kUnitChapter, unitNumber: 45).displayNumber,
+          45,
+        );
+      });
+
+      test('uses parentNumber for season/volume', () {
+        expect(
+          buildMark(unitType: kUnitSeason, parentNumber: 2, unitNumber: 0)
+              .displayNumber,
+          2,
+        );
+        expect(
+          buildMark(unitType: kUnitVolume, parentNumber: 7, unitNumber: 0)
+              .displayNumber,
+          7,
+        );
+      });
+    });
+
+    group('equality', () {
+      test('equal by (itemId, unitType, parent, unit), ignoring content', () {
+        final ItemMark a = buildMark(isFavorite: true, userComment: 'a');
+        final ItemMark b = buildMark(isFavorite: false, userComment: 'b');
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('differs when coordinates differ', () {
+        expect(buildMark(unitNumber: 3), isNot(buildMark(unitNumber: 4)));
+      });
+    });
+
+    group('copyWith', () {
+      test('clearUserComment / clearLikedAt null out fields', () {
+        final ItemMark m = buildMark();
+        final ItemMark cleared =
+            m.copyWith(clearUserComment: true, clearLikedAt: true);
+        expect(cleared.userComment, isNull);
+        expect(cleared.likedAt, isNull);
+      });
+    });
+  });
+
+  group('unitCoordsFor', () {
+    test('season/volume -> parent number', () {
+      expect(unitCoordsFor(kUnitSeason, 2), (parent: 2, unit: 0));
+      expect(unitCoordsFor(kUnitVolume, 7), (parent: 7, unit: 0));
+    });
+
+    test('everything else -> unit number', () {
+      expect(unitCoordsFor(kUnitEpisode, 5), (parent: 0, unit: 5));
+      expect(unitCoordsFor(kUnitChapter, 45), (parent: 0, unit: 45));
+      expect(unitCoordsFor('arc', 3), (parent: 0, unit: 3));
+    });
+  });
+}


### PR DESCRIPTION
Universal marks anchored on collection_items.id: a like and/or free-text note on an episode, season, chapter, volume, page, part or a custom unit. Inline controls + filter bar in the episode tracker; add-mark form for media without a unit list (anime, manga). Marks travel in .xcoll/.xcollx user-data exports and re-anchor on import. DB migration v53.