### PR TITLE
fix(personalization): unload on leave, defer cloud layout, mute hidden-tab tickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,41 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Fixed
 
+- **Stop the app-wide slowdown after visiting Personalization**
+
+  The Personalization screen used to stay mounted forever after its first
+  open: the genre cloud re-aggregated the whole library on every change (plus
+  an always-mounted offscreen export copy re-running the full word placement),
+  and the recommendations pipeline with its posters stayed alive too — on
+  mobile this dragged the entire app, snackbars included. The screen now
+  unmounts on leave and builds only the selected view; the expensive cloud
+  placement is deferred behind a progress indicator instead of freezing the
+  first frame for seconds; the export copy mounts only while saving the PNG.
+  Fetched recommendations are pinned in their provider, so a revisit shows
+  them instantly without re-fetching. Hidden shell tabs no longer run their
+  animations (tag glow, shimmer), and the tag-glow border repaints without
+  re-rasterizing the whole card — both smooth every animation on mobile.
+
+  * lib/shared/navigation/app_shell.dart (_openPreferenceCloud, _buildContent):
+    Drop the keep-alive `_personalizationEverOpened` flag — the screen is in
+    the IndexedStack only while open; wrap hidden tab navigators in
+    `TickerMode(enabled: false)`.
+  * lib/features/personalization/screens/personalization_screen.dart
+    (_PersonalizationScreenState.build): Build only the selected view instead
+    of an IndexedStack keeping both alive.
+  * lib/features/genre_cloud/widgets/genre_cloud_view.dart
+    (_GenreCloudViewState._scheduleLayout, _cachedLayout, _computeWithGrowth):
+    Defer the placement past the first frame; show a progress indicator until
+    it lands.
+  * lib/features/genre_cloud/screens/genre_cloud_screen.dart
+    (_GenreCloudScreenState._exportAsImage, _exporting): Mount the offscreen
+    export view only for the duration of an export.
+  * lib/features/recommendations/providers/recommendations_provider.dart
+    (recommendationsProvider): `ref.keepAlive()` after the network fetch so
+    results survive the screen unmounting; refresh still invalidates.
+  * lib/shared/widgets/media_poster_card.dart (_TagGlowWrapperState.build):
+    RepaintBoundary around the card so the animated border repaints alone.
+
 - **API Keys counter no longer counts built-in default keys**
 
   In production builds with TMDB / SteamGridDB / IGDB keys baked in via

--- a/lib/features/genre_cloud/screens/genre_cloud_screen.dart
+++ b/lib/features/genre_cloud/screens/genre_cloud_screen.dart
@@ -44,6 +44,10 @@ class _GenreCloudScreenState extends ConsumerState<GenreCloudScreen> {
 
   final GlobalKey _exportKey = GlobalKey();
 
+  // The offscreen export poster re-runs the full cloud layout on every build,
+  // so it is mounted only for the duration of an export.
+  bool _exporting = false;
+
   // "Broad strokes" filters: hidden facet dimensions and hidden media types.
   final Set<Facet> _hiddenFacets = <Facet>{};
   final Set<MediaType> _hiddenTypes = <MediaType>{};
@@ -86,7 +90,7 @@ class _GenreCloudScreenState extends ConsumerState<GenreCloudScreen> {
               Expanded(child: _buildBody(l, itemsAsync, words)),
             ],
           ),
-          if (hasWords)
+          if (hasWords && _exporting)
             Positioned(
               left: -10000,
               top: -10000,
@@ -239,7 +243,8 @@ class _GenreCloudScreenState extends ConsumerState<GenreCloudScreen> {
     List<FacetValue> words,
   ) async {
     final S l = S.of(context);
-    // Wait for the current frame so the offscreen export view is rendered.
+    // Mount the offscreen export view and wait for it to render.
+    setState(() => _exporting = true);
     await WidgetsBinding.instance.endOfFrame;
 
     final String safeBase = sanitizeFileName(l.genreCloudTitle);
@@ -251,6 +256,7 @@ class _GenreCloudScreenState extends ConsumerState<GenreCloudScreen> {
       suggestedFileName: fileName,
       saveDialogTitle: l.genreCloudExportImage,
     );
+    if (mounted) setState(() => _exporting = false);
     if (!context.mounted) return;
 
     switch (result.status) {

--- a/lib/features/genre_cloud/widgets/genre_cloud_view.dart
+++ b/lib/features/genre_cloud/widgets/genre_cloud_view.dart
@@ -125,6 +125,10 @@ class _GenreCloudViewState extends State<GenreCloudView> {
   List<FacetValue>? _laidOutWords;
   Size? _laidOutViewport;
 
+  // Deferred (post-frame) layout bookkeeping; see _scheduleLayout.
+  bool _layoutPending = false;
+  Size? _pendingViewport;
+
   // Canvas the view is currently centred for; re-centre only when it changes so
   // the user's own panning survives rebuilds.
   Size? _centeredFor;
@@ -155,16 +159,18 @@ class _GenreCloudViewState extends State<GenreCloudView> {
         maxFontSize: widget.maxFontSize,
       );
 
-  GenreCloudLayout _resolveLayout(Size viewport) {
-    if (!widget.interactive) return _compute(viewport);
-
+  /// The cached layout when it still matches the current words + viewport.
+  GenreCloudLayout? _cachedLayout(Size viewport) {
     if (_layout != null &&
         _laidOutViewport == viewport &&
         _laidOutWords != null &&
         listEquals(_laidOutWords, widget.words)) {
-      return _layout!;
+      return _layout;
     }
+    return null;
+  }
 
+  GenreCloudLayout _computeWithGrowth(Size viewport) {
     Size canvas = viewport;
     GenreCloudLayout layout = _compute(canvas);
     // Grow the canvas (keeping fonts readable) until everything fits, so the
@@ -175,11 +181,33 @@ class _GenreCloudViewState extends State<GenreCloudView> {
       layout = _compute(canvas);
       pass++;
     }
-
-    _layout = layout;
-    _laidOutWords = List<FacetValue>.of(widget.words);
-    _laidOutViewport = viewport;
     return layout;
+  }
+
+  /// Defers the expensive placement past the current frame so the screen
+  /// paints (with a progress indicator) before the layout blocks the UI
+  /// thread, instead of freezing navigation for the whole computation.
+  void _scheduleLayout() {
+    if (_layoutPending) return;
+    _layoutPending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        _layoutPending = false;
+        return;
+      }
+      final Size? viewport = _pendingViewport;
+      if (viewport == null) {
+        _layoutPending = false;
+        return;
+      }
+      final GenreCloudLayout layout = _computeWithGrowth(viewport);
+      setState(() {
+        _layout = layout;
+        _laidOutWords = List<FacetValue>.of(widget.words);
+        _laidOutViewport = viewport;
+        _layoutPending = false;
+      });
+    });
   }
 
   void _maybeRecenter(Size viewport, Size canvas) {
@@ -200,7 +228,22 @@ class _GenreCloudViewState extends State<GenreCloudView> {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final Size viewport = Size(constraints.maxWidth, constraints.maxHeight);
-        final GenreCloudLayout layout = _resolveLayout(viewport);
+
+        final GenreCloudLayout layout;
+        if (widget.interactive) {
+          // Export views compute synchronously (they are captured right after
+          // the frame); the interactive cloud defers so the screen opens
+          // instantly with a spinner instead of a frozen frame.
+          final GenreCloudLayout? cached = _cachedLayout(viewport);
+          if (cached == null) {
+            _pendingViewport = viewport;
+            _scheduleLayout();
+            return const Center(child: CircularProgressIndicator());
+          }
+          layout = cached;
+        } else {
+          layout = _compute(viewport);
+        }
 
         final Widget content;
         if (widget.interactive) {

--- a/lib/features/personalization/screens/personalization_screen.dart
+++ b/lib/features/personalization/screens/personalization_screen.dart
@@ -2,8 +2,9 @@
 // whole library — the genre cloud (a taste *picture*) and recommendations
 // (taste *acted on*). The two are switched with a segmented pill (the same
 // switcher style as the item-detail status row); it does not touch the app's
-// primary navigation. An IndexedStack keeps both alive so the cloud's pan/zoom
-// and the recs' fetched state survive a switch.
+// primary navigation. Only the selected view is built — both subtrees are
+// heavy, so the hidden one must not cost layout/memory; fetched
+// recommendations survive the switch in their provider, not in the widget.
 
 import 'package:flutter/material.dart';
 
@@ -67,13 +68,12 @@ class _PersonalizationScreenState extends State<PersonalizationScreen> {
             ),
           ),
           Expanded(
-            child: IndexedStack(
-              index: _view.index,
-              children: const <Widget>[
-                GenreCloudScreen(showTitle: false),
-                RecommendationsScreen(),
-              ],
-            ),
+            child: switch (_view) {
+              _PersonalizationView.cloud =>
+                const GenreCloudScreen(showTitle: false),
+              _PersonalizationView.recommendations =>
+                const RecommendationsScreen(),
+            },
           ),
         ],
       ),

--- a/lib/features/recommendations/providers/recommendations_provider.dart
+++ b/lib/features/recommendations/providers/recommendations_provider.dart
@@ -262,6 +262,13 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
     pool: pool,
   );
 
+  // The expensive network work is done — pin the result so it survives the
+  // screen unmounting (Personalization unloads on leave) and a revisit shows
+  // it instantly instead of re-fetching. The refresh button and the watched
+  // TMDB settings still invalidate it. Cheap pre-fetch states above stay
+  // uncached on purpose: they recompute per visit, picking up library changes.
+  ref.keepAlive();
+
   // 4. Vectorize candidates and score them.
   final Map<String, TasteTitle> candidateById = <String, TasteTitle>{};
   final Map<String, RecommendedItem Function(double score, double? predicted)>

--- a/lib/shared/navigation/app_shell.dart
+++ b/lib/shared/navigation/app_shell.dart
@@ -225,19 +225,12 @@ class _AppShellState extends ConsumerState<AppShell> {
   /// area and highlighting the centre nav button like a selected tab).
   bool _personalizationOpen = false;
 
-  /// Whether Personalization has been opened at least once, so its IndexedStack
-  /// child is built lazily on first open rather than on every app start.
-  bool _personalizationEverOpened = false;
-
   /// Shows the preference cloud as a shell-level destination — a sibling of the
   /// tab navigators, not a route pushed onto one — so switching tabs simply
   /// hides it instead of leaving it on a tab's navigator stack.
   void _openPreferenceCloud() {
     if (_personalizationOpen) return;
-    setState(() {
-      _personalizationEverOpened = true;
-      _personalizationOpen = true;
-    });
+    setState(() => _personalizationOpen = true);
   }
 
   /// Captures printable characters from the global Focus and redirects them to
@@ -295,16 +288,24 @@ class _AppShellState extends ConsumerState<AppShell> {
       index: _personalizationOpen ? _tabCount : _selectedIndex,
       children: <Widget>[
         for (int index = 0; index < _tabCount; index++)
-          if (_initializedTabs.contains(index))
-            _buildTabNavigator(index)
-          else
-            const SizedBox.shrink(),
+          // Hidden tabs keep their state but must not keep animating:
+          // IndexedStack alone leaves tickers running in invisible children
+          // (repeating glow/shimmer controllers), so the app never goes
+          // frame-idle and every visible animation competes with them.
+          TickerMode(
+            enabled: !_personalizationOpen && index == _selectedIndex,
+            child: _initializedTabs.contains(index)
+                ? _buildTabNavigator(index)
+                : const SizedBox.shrink(),
+          ),
         // Personalization is a shell-level destination, not a tab: it lives as
         // an extra IndexedStack child rather than a route pushed onto a tab's
         // navigator, so switching tabs hides it instead of leaving it glued to
-        // a tab's stack with the highlight pointing elsewhere. Built lazily on
-        // first open, then kept alive alongside the tabs.
-        if (_personalizationEverOpened)
+        // a tab's stack with the highlight pointing elsewhere. Unlike the tabs
+        // it is NOT kept alive: the genre cloud + recommendations subtree is
+        // heavy (large canvas, many posters), so it unmounts on leave and its
+        // data layers (providers) carry the state between visits.
+        if (_personalizationOpen)
           const PersonalizationScreen()
         else
           const SizedBox.shrink(),

--- a/lib/shared/widgets/media_poster_card.dart
+++ b/lib/shared/widgets/media_poster_card.dart
@@ -795,7 +795,9 @@ class _TagGlowWrapperState extends State<_TagGlowWrapper>
           child: child,
         );
       },
-      child: widget.child,
+      // The border repaints every frame; the boundary keeps that repaint from
+      // re-rasterizing the whole card (poster image, badges) each tick.
+      child: RepaintBoundary(child: widget.child),
     );
   }
 }

--- a/test/features/genre_cloud/genre_cloud_screen_test.dart
+++ b/test/features/genre_cloud/genre_cloud_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/genre_cloud/providers/genre_cloud_provider.dart';
 import 'package:tonkatsu_box/features/genre_cloud/screens/genre_cloud_screen.dart';
+import 'package:tonkatsu_box/features/genre_cloud/widgets/genre_cloud_export_view.dart';
 import 'package:tonkatsu_box/features/genre_cloud/widgets/genre_cloud_view.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
@@ -39,7 +40,13 @@ void main() {
       );
 
       expect(tester.takeException(), isNull);
-      expect(find.byType(GenreCloudView), findsWidgets);
+      expect(find.byType(GenreCloudView), findsOneWidget);
+      // The offscreen export poster re-runs the full layout, so it must not
+      // be mounted outside an export.
+      expect(
+        find.byType(GenreCloudExportView, skipOffstage: false),
+        findsNothing,
+      );
     });
 
     testWidgets('should show the empty state when no item carries a facet', (

--- a/test/features/genre_cloud/genre_cloud_view_test.dart
+++ b/test/features/genre_cloud/genre_cloud_view_test.dart
@@ -68,6 +68,30 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets(
+        'should show a progress indicator until the deferred layout lands', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpApp(
+        SizedBox(
+          width: 360,
+          height: 560,
+          child: GenreCloudView(words: _sample()),
+        ),
+        mediaQuerySize: const Size(360, 640),
+        settle: false,
+      );
+
+      // First frame: the expensive placement is deferred past it.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(InteractiveViewer), findsNothing);
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(InteractiveViewer), findsOneWidget);
+    });
+
     testWidgets('is pannable/zoomable by default (interactive)', (
       WidgetTester tester,
     ) async {

--- a/test/features/personalization/personalization_screen_test.dart
+++ b/test/features/personalization/personalization_screen_test.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/genre_cloud/providers/genre_cloud_provider.dart';
+import 'package:tonkatsu_box/features/genre_cloud/screens/genre_cloud_screen.dart';
 import 'package:tonkatsu_box/features/personalization/screens/personalization_screen.dart';
 import 'package:tonkatsu_box/features/recommendations/providers/recommendations_provider.dart';
+import 'package:tonkatsu_box/features/recommendations/screens/recommendations_screen.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/widgets/segmented_pill.dart';
 
@@ -24,9 +26,6 @@ void main() {
               .overrideWith((Ref ref) async => <String>{}),
         ];
 
-    int? viewIndex(WidgetTester tester) =>
-        tester.widget<IndexedStack>(find.byType(IndexedStack).first).index;
-
     Finder segments() => find.descendant(
           of: find.byWidgetPredicate((Widget w) => w is SegmentedPill),
           matching: find.byType(GestureDetector),
@@ -41,7 +40,9 @@ void main() {
       );
 
       expect(tester.takeException(), isNull);
-      expect(viewIndex(tester), 0);
+      expect(find.byType(GenreCloudScreen), findsOneWidget);
+      // The hidden view must not be built at all (lazy tabs).
+      expect(find.byType(RecommendationsScreen), findsNothing);
     });
 
     testWidgets('switches to recommendations and back via the pill', (
@@ -54,11 +55,13 @@ void main() {
 
       await tester.tap(segments().at(1));
       await tester.pumpAndSettle();
-      expect(viewIndex(tester), 1);
+      expect(find.byType(RecommendationsScreen), findsOneWidget);
+      expect(find.byType(GenreCloudScreen), findsNothing);
 
       await tester.tap(segments().at(0));
       await tester.pumpAndSettle();
-      expect(viewIndex(tester), 0);
+      expect(find.byType(GenreCloudScreen), findsOneWidget);
+      expect(find.byType(RecommendationsScreen), findsNothing);
     });
   });
 }

--- a/test/shared/navigation/app_shell_personalization_test.dart
+++ b/test/shared/navigation/app_shell_personalization_test.dart
@@ -9,6 +9,8 @@ import 'package:tonkatsu_box/core/services/update_service.dart';
 import 'package:tonkatsu_box/data/repositories/collection_repository.dart';
 import 'package:tonkatsu_box/features/genre_cloud/providers/genre_cloud_provider.dart';
 import 'package:tonkatsu_box/features/genre_cloud/screens/genre_cloud_screen.dart';
+import 'package:tonkatsu_box/features/home/screens/all_items_screen.dart';
+import 'package:tonkatsu_box/features/personalization/screens/personalization_screen.dart';
 import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
 import 'package:tonkatsu_box/features/welcome/screens/welcome_screen.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
@@ -91,6 +93,53 @@ void main() {
       await tester.tap(find.byType(NavIconButton).at(0));
       await tester.pumpAndSettle();
       expect(find.byType(GenreCloudScreen), findsNothing);
+    });
+
+    testWidgets('should fully unmount Personalization after leaving', (
+      WidgetTester tester,
+    ) async {
+      await pumpShell(tester);
+
+      await tester.tap(find.byType(NavCenterButton));
+      await tester.pumpAndSettle();
+      expect(find.byType(PersonalizationScreen), findsOneWidget);
+
+      await tester.tap(find.byType(NavIconButton).at(1));
+      await tester.pumpAndSettle();
+      // Unmounted, not merely offstage — the heavy subtree must not survive.
+      expect(
+        find.byType(PersonalizationScreen, skipOffstage: false),
+        findsNothing,
+      );
+      expect(
+        find.byType(GenreCloudScreen, skipOffstage: false),
+        findsNothing,
+      );
+    });
+
+    testWidgets('should mute tickers of hidden tabs', (
+      WidgetTester tester,
+    ) async {
+      await pumpShell(tester);
+
+      final Element homeTab =
+          tester.element(find.byType(AllItemsScreen, skipOffstage: false));
+      expect(TickerMode.valuesOf(homeTab).enabled, isTrue);
+
+      // Opening Personalization hides the tab — its animations must stop.
+      await tester.tap(find.byType(NavCenterButton));
+      await tester.pumpAndSettle();
+      expect(TickerMode.valuesOf(homeTab).enabled, isFalse);
+
+      // Switching to another tab keeps the home tab muted too.
+      await tester.tap(find.byType(NavIconButton).at(1));
+      await tester.pumpAndSettle();
+      expect(TickerMode.valuesOf(homeTab).enabled, isFalse);
+
+      // Returning re-enables it.
+      await tester.tap(find.byType(NavIconButton).at(0));
+      await tester.pumpAndSettle();
+      expect(TickerMode.valuesOf(homeTab).enabled, isTrue);
     });
 
     testWidgets('should reopen the cloud from the centre button', (


### PR DESCRIPTION
Personalization stayed mounted forever after first open, re-aggregating the genre cloud (plus an offscreen export copy) on every library change and keeping the recommendations pipeline alive — dragging the whole app on mobile. It now unmounts on leave and builds only the selected view; the expensive cloud placement is deferred behind a progress indicator; the export copy mounts only while saving; fetched recommendations are pinned so a revisit doesn't re-fetch. Hidden shell tabs no longer run their animations, and the tag-glow border repaints behind a RepaintBoundary instead of re-rasterizing the whole card.