### PR TITLE
fix(books): build Google Books covers from the thumbnail, upscaled via fife

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,21 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Fixed
 
+- **Google Books: keep the real cover when adding a book to a collection**
+
+  Search showed the correct cover, but adding the book (and "Refresh from
+  source") swapped it for an interior page scan: the volume-detail
+  `imageLinks` sizes (`small`..`extraLarge`) are page scans for scanned
+  volumes despite `printsec=frontcover`, and the largest size was preferred.
+  The cover is now always built from the thumbnail — the only size that
+  reliably carries the cover — upscaled to 800px width via Google's `fife`
+  parameter, which also sharpens Google Books covers in search results.
+  Existing items pick the fix up via the item's "Refresh from source" button.
+
+  * lib/shared/models/book.dart (Book._googleCover): Use only `thumbnail` /
+    `smallThumbnail`, strip `&edge=curl`, upgrade to HTTPS, append
+    `&fife=w800`.
+
 - **Stop the app-wide slowdown after visiting Personalization**
 
   The Personalization screen used to stay mounted forever after its first

--- a/lib/shared/models/book.dart
+++ b/lib/shared/models/book.dart
@@ -729,24 +729,21 @@ class Book {
     return (isbn10, isbn13);
   }
 
-  /// Largest available cover from a Google Books `imageLinks` object, with
-  /// Google's curled-corner overlay (`&edge=curl`) removed and the scheme
-  /// upgraded to HTTPS.
+  /// Cover from a Google Books `imageLinks` object. Only the thumbnail zoom
+  /// levels reliably carry the cover — the volume-detail sizes
+  /// (`small`..`extraLarge`, zoom 2-6) are interior page scans for scanned
+  /// volumes despite `printsec=frontcover` — so the thumbnail is upscaled via
+  /// Google's `fife` width parameter instead. The curled-corner overlay
+  /// (`&edge=curl`) is removed and the scheme upgraded to HTTPS.
   static String? _googleCover(Object? imageLinks) {
     if (imageLinks is! Map<String, dynamic>) return null;
-    for (final String key in const <String>[
-      'extraLarge',
-      'large',
-      'medium',
-      'small',
-      'thumbnail',
-      'smallThumbnail',
-    ]) {
+    for (final String key in const <String>['thumbnail', 'smallThumbnail']) {
       final String? url = _nonEmpty(imageLinks[key]);
       if (url != null) {
-        return url
+        final String clean = url
             .replaceAll('&edge=curl', '')
             .replaceFirst('http://', 'https://');
+        return '$clean&fife=w800';
       }
     }
     return null;

--- a/test/core/api/google_books_api_test.dart
+++ b/test/core/api/google_books_api_test.dart
@@ -104,8 +104,9 @@ void main() {
       expect(b.isbn13, '9780441013593');
       expect(b.isbn10, '0441013597');
       expect(b.description, 'A desert planet.');
-      // Largest variant, curled-corner overlay removed, scheme upgraded.
-      expect(b.coverUrl, 'https://books.google.com/large?zoom=1');
+      // Thumbnail variant (larger sizes can be page scans), curled-corner
+      // overlay removed, scheme upgraded, fife upscale appended.
+      expect(b.coverUrl, 'https://books.google.com/thumb?zoom=1&fife=w800');
       expect(hasMore, isFalse);
     });
 

--- a/test/shared/models/book_google_books_test.dart
+++ b/test/shared/models/book_google_books_test.dart
@@ -104,16 +104,30 @@ void main() {
       expect(b.pageCount, isNull);
     });
 
-    test('picks the largest cover, strips edge=curl and upgrades to https', () {
+    test(
+        'builds the cover from the thumbnail (never the page-scan sizes), '
+        'strips edge=curl, upgrades to https and upscales via fife', () {
       final Book b = Book.fromGoogleBooksVolume(volume(<String, dynamic>{
         'title': 'Dune',
         'imageLinks': <String, dynamic>{
           'smallThumbnail': 'http://x/small',
-          'thumbnail': 'http://x/thumb?zoom=5&edge=curl',
-          'large': 'http://books.google.com/large?zoom=1&edge=curl',
+          'thumbnail': 'http://x/thumb?zoom=1&edge=curl',
+          // Interior page scan on scanned volumes — must be ignored.
+          'large': 'http://books.google.com/large?zoom=4&edge=curl',
+          'extraLarge': 'http://books.google.com/xl?zoom=6&edge=curl',
         },
       }));
-      expect(b.coverUrl, 'https://books.google.com/large?zoom=1');
+      expect(b.coverUrl, 'https://x/thumb?zoom=1&fife=w800');
+    });
+
+    test('falls back to smallThumbnail when thumbnail is absent', () {
+      final Book b = Book.fromGoogleBooksVolume(volume(<String, dynamic>{
+        'title': 'Dune',
+        'imageLinks': <String, dynamic>{
+          'smallThumbnail': 'http://x/small?zoom=5',
+        },
+      }));
+      expect(b.coverUrl, 'https://x/small?zoom=5&fife=w800');
     });
 
     test('falls back to canonicalVolumeLink for the external url', () {


### PR DESCRIPTION
The volume-detail imageLinks sizes (small..extraLarge, zoom 2-6) are interior page scans for scanned volumes despite printsec=frontcover, so preferring the largest swapped the real cover for a page scan when a book was added to a collection (search only ever sees the thumbnail). Build the cover from thumbnail/smallThumbnail upscaled to 800px via Google's fife parameter — correct everywhere and sharper in search. Existing items recover via "Refresh from source" (it already purges the cached image and re-parses the volume).