### PR TITLE
feat(tier-lists): positional card drops, tier reordering, stable sort…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,32 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (lanSyncImportConfig,
     lanSyncImportConfigSubtitle, lanSyncReceivingSettings): New.
 
+- **Tier list: drop a card at an exact position and reorder whole tiers**
+
+  Dropping a card onto another card now inserts it right before that card —
+  while hovering, a gap with a bright insertion bar opens at the exact target
+  position; hovering empty row space shows the bar after the last card and
+  appends to the end. A whole tier — with its contents — can be moved up or
+  down: on desktop by dragging its colored label onto another tier row, and
+  everywhere via new "Move up" / "Move down" actions in the tier options
+  sheet. Plain Draggable is used instead of ReorderableListView, whose
+  GlobalKey reparenting crashes with card tooltips (OverlayPortal) inside
+  the screen's LayoutBuilder.
+
+  * lib/features/tier_lists/widgets/tier_row.dart (TierRow.onDrop,
+    TierRow._handleSlotDrop, TierRow.tierDraggable, TierRow._labelBox,
+    _TierCardSlot, _InsertionBar): Per-card drop slots opening an animated
+    insertion-bar gap on hover; the label becomes a Draggable with the tier
+    key as payload.
+  * lib/features/tier_lists/widgets/tier_list_view.dart (_TierRowDropTarget,
+    _TierListViewState._showTierOptions): Per-row drop target for tier keys;
+    move up/down entries in the options sheet.
+  * lib/features/tier_lists/providers/tier_list_detail_provider.dart
+    (TierListDetailNotifier.moveTier): Reorder definitions and persist
+    renumbered sort orders.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb (tierListMoveUp,
+    tierListMoveDown): New.
+
 ### Changed
 
 - **Show the item cover as the Discord Rich Presence large image**
@@ -333,6 +359,25 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     sortLastActivityOldest): New.
 
 ### Fixed
+
+- **Tier list: card order no longer shuffles after an app restart**
+
+  Placing a card assigned it a sort order equal to the tier's current size
+  while removals left gaps, so different cards could end up with the same
+  sort order — and the load query returned them in unspecified (rowid)
+  order, reshuffling the tier between sessions. Every move now rewrites the
+  whole target tier with contiguous sort orders in one transaction, and
+  tiers already broken by older builds are renumbered once on load,
+  freezing the currently visible order.
+
+  * lib/core/database/dao/tier_list_dao.dart (TierListDao.setItemTierOrdered,
+    TierListDao._writeContiguousOrders): New transactional move that
+    renumbers the target tier; reorderTierItems shares the renumber pass.
+  * lib/features/tier_lists/providers/tier_list_detail_provider.dart
+    (TierListDetailNotifier.moveToTier,
+    TierListDetailNotifier._normalizeSortOrders): Insert at index with
+    clamping and full-tier renumber; one-time self-heal of gaps and
+    duplicates on load.
 
 - **Google Books: keep the real cover when adding a book to a collection**
 

--- a/lib/core/database/dao/tier_list_dao.dart
+++ b/lib/core/database/dao/tier_list_dao.dart
@@ -146,6 +146,35 @@ class TierListDao {
     );
   }
 
+  /// Moves an item into [tierKey], rewriting the whole tier's sort orders
+  /// contiguously in one transaction so removals can't leave collisions.
+  Future<void> setItemTierOrdered(
+    int tierListId,
+    int collectionItemId,
+    String tierKey,
+    List<int> orderedItemIds,
+  ) async {
+    final Database db = await _getDatabase();
+    await db.transaction((Transaction txn) async {
+      await txn.delete(
+        'tier_list_entries',
+        where: 'tier_list_id = ? AND collection_item_id = ?',
+        whereArgs: <Object?>[tierListId, collectionItemId],
+      );
+      // Placeholder order; the renumber pass below assigns the real value.
+      await txn.insert(
+        'tier_list_entries',
+        <String, dynamic>{
+          'tier_list_id': tierListId,
+          'collection_item_id': collectionItemId,
+          'tier_key': tierKey,
+          'sort_order': 0,
+        },
+      );
+      await _writeContiguousOrders(txn, tierListId, tierKey, orderedItemIds);
+    });
+  }
+
   Future<void> removeItemFromTier(
     int tierListId,
     int collectionItemId,
@@ -165,16 +194,24 @@ class TierListDao {
   ) async {
     final Database db = await _getDatabase();
     await db.transaction((Transaction txn) async {
-      for (int i = 0; i < itemIds.length; i++) {
-        await txn.update(
-          'tier_list_entries',
-          <String, dynamic>{'sort_order': i},
-          where:
-              'tier_list_id = ? AND collection_item_id = ? AND tier_key = ?',
-          whereArgs: <Object?>[tierListId, itemIds[i], tierKey],
-        );
-      }
+      await _writeContiguousOrders(txn, tierListId, tierKey, itemIds);
     });
+  }
+
+  Future<void> _writeContiguousOrders(
+    DatabaseExecutor txn,
+    int tierListId,
+    String tierKey,
+    List<int> itemIds,
+  ) async {
+    for (int i = 0; i < itemIds.length; i++) {
+      await txn.update(
+        'tier_list_entries',
+        <String, dynamic>{'sort_order': i},
+        where: 'tier_list_id = ? AND collection_item_id = ? AND tier_key = ?',
+        whereArgs: <Object?>[tierListId, itemIds[i], tierKey],
+      );
+    }
   }
 
   Future<void> clearTierListEntries(int tierListId) async {

--- a/lib/features/tier_lists/providers/tier_list_detail_provider.dart
+++ b/lib/features/tier_lists/providers/tier_list_detail_provider.dart
@@ -185,8 +185,9 @@ class TierListDetailNotifier
         definitions = TierDefinition.defaults;
       }
 
-      final List<TierListEntry> entries =
-          await _tierListDao.getTierListEntries(arg);
+      final List<TierListEntry> entries = await _normalizeSortOrders(
+        await _tierListDao.getTierListEntries(arg),
+      );
 
       state = TierListDetailState(
         tierList: tierList,
@@ -204,28 +205,87 @@ class TierListDetailNotifier
     await _load();
   }
 
+  /// One-time repair of gaps/duplicates left by older builds — duplicate
+  /// sort orders made `ORDER BY sort_order` unstable across restarts.
+  Future<List<TierListEntry>> _normalizeSortOrders(
+    List<TierListEntry> entries,
+  ) async {
+    final Map<String, List<TierListEntry>> byTier =
+        <String, List<TierListEntry>>{};
+    for (final TierListEntry entry in entries) {
+      byTier.putIfAbsent(entry.tierKey, () => <TierListEntry>[]).add(entry);
+    }
+
+    final Map<int, int> fixedOrders = <int, int>{};
+    for (final MapEntry<String, List<TierListEntry>> group in byTier.entries) {
+      final List<TierListEntry> tierEntries = group.value;
+      bool contiguous = true;
+      for (int i = 0; i < tierEntries.length; i++) {
+        if (tierEntries[i].sortOrder != i) {
+          contiguous = false;
+          break;
+        }
+      }
+      if (contiguous) continue;
+
+      await _tierListDao.reorderTierItems(
+        arg,
+        group.key,
+        <int>[
+          for (final TierListEntry e in tierEntries) e.collectionItemId,
+        ],
+      );
+      for (int i = 0; i < tierEntries.length; i++) {
+        fixedOrders[tierEntries[i].collectionItemId] = i;
+      }
+    }
+
+    if (fixedOrders.isEmpty) return entries;
+    return <TierListEntry>[
+      for (final TierListEntry entry in entries)
+        fixedOrders.containsKey(entry.collectionItemId)
+            ? entry.copyWith(sortOrder: fixedOrders[entry.collectionItemId])
+            : entry,
+    ];
+  }
+
+  /// Inserts the item at [index] within [tierKey]; null appends to the end.
   Future<void> moveToTier(
     int collectionItemId,
     String tierKey, {
     int? index,
   }) async {
-    final Map<String, List<TierListEntry>> byTier = state.entriesByTier;
-    final List<TierListEntry> tierEntries =
-        byTier[tierKey] ?? <TierListEntry>[];
-    final int sortOrder = index ?? tierEntries.length;
+    final List<TierListEntry> target = List<TierListEntry>.of(
+      state.entriesByTier[tierKey] ?? const <TierListEntry>[],
+    )..removeWhere(
+        (TierListEntry e) => e.collectionItemId == collectionItemId,
+      );
 
-    await _tierListDao.setItemTier(arg, collectionItemId, tierKey, sortOrder);
-
-    final List<TierListEntry> newEntries = state.entries
-        .where((TierListEntry e) => e.collectionItemId != collectionItemId)
-        .toList()
-      ..add(TierListEntry(
+    int insertAt = index ?? target.length;
+    if (insertAt < 0) insertAt = 0;
+    if (insertAt > target.length) insertAt = target.length;
+    target.insert(
+      insertAt,
+      TierListEntry(
         collectionItemId: collectionItemId,
         tierKey: tierKey,
-        sortOrder: sortOrder,
-      ));
+        sortOrder: insertAt,
+      ),
+    );
 
-    state = state.copyWith(entries: newEntries);
+    await _tierListDao.setItemTierOrdered(
+      arg,
+      collectionItemId,
+      tierKey,
+      <int>[for (final TierListEntry e in target) e.collectionItemId],
+    );
+
+    state = state.copyWith(entries: <TierListEntry>[
+      for (final TierListEntry e in state.entries)
+        if (e.tierKey != tierKey && e.collectionItemId != collectionItemId) e,
+      for (int i = 0; i < target.length; i++)
+        target[i].copyWith(sortOrder: i),
+    ]);
   }
 
   Future<void> removeFromTier(int collectionItemId) async {
@@ -267,8 +327,8 @@ class TierListDetailNotifier
     state = state.copyWith(entries: updatedEntries);
   }
 
-  /// Single setItemTier handles DELETE+INSERT — one DB write, one state update,
-  /// avoids the double rebuild a remove+add pair would cause.
+  /// One moveToTier write instead of a remove+add pair — avoids a double
+  /// state rebuild.
   Future<void> moveBetweenTiers(
     int collectionItemId,
     String fromTierKey,
@@ -305,6 +365,28 @@ class TierListDetailNotifier
         color: color,
         sortOrder: state.definitions.length,
       ));
+
+    await _tierListDao.saveTierDefinitions(arg, updated);
+    state = state.copyWith(definitions: updated);
+  }
+
+  /// Moves a whole tier (with its contents) to [newIndex] in the tier stack.
+  Future<void> moveTier(int oldIndex, int newIndex) async {
+    if (oldIndex < 0 ||
+        oldIndex >= state.definitions.length ||
+        newIndex < 0 ||
+        newIndex >= state.definitions.length ||
+        oldIndex == newIndex) {
+      return;
+    }
+
+    final List<TierDefinition> updated =
+        List<TierDefinition>.of(state.definitions);
+    final TierDefinition moved = updated.removeAt(oldIndex);
+    updated.insert(newIndex, moved);
+    for (int i = 0; i < updated.length; i++) {
+      updated[i] = updated[i].copyWith(sortOrder: i);
+    }
 
     await _tierListDao.saveTierDefinitions(arg, updated);
     state = state.copyWith(definitions: updated);

--- a/lib/features/tier_lists/widgets/tier_list_view.dart
+++ b/lib/features/tier_lists/widgets/tier_list_view.dart
@@ -96,27 +96,27 @@ class _TierListViewState extends ConsumerState<TierListView> {
                 child: ListView(
                   padding: EdgeInsets.zero,
                   children: <Widget>[
-                    for (final TierDefinition def in state.definitions)
+                    for (int i = 0; i < state.definitions.length; i++)
                       Padding(
-                        key: ValueKey<String>('tier_${def.tierKey}'),
+                        key: ValueKey<String>(
+                          'tier_${state.definitions[i].tierKey}',
+                        ),
                         padding: const EdgeInsets.only(bottom: AppSpacing.xs),
-                        child: TierRow(
+                        child: _TierRowDropTarget(
                           tierListId: tierListId,
-                          definition: def,
-                          entries: entriesByTier[def.tierKey] ??
-                              const <TierListEntry>[],
+                          index: i,
+                          definitions: state.definitions,
+                          entries:
+                              entriesByTier[state.definitions[i].tierKey] ??
+                                  const <TierListEntry>[],
                           itemsMap: itemsMap,
                           titleLanguage: titleLanguage,
                           overlayResolver: overlayResolver,
-                          onDrop: (int collectionItemId) {
-                            ref
-                                .read(
-                                  tierListDetailProvider(tierListId).notifier,
-                                )
-                                .moveToTier(collectionItemId, def.tierKey);
-                          },
-                          onDefinitionTap: () =>
-                              _showTierOptions(context, ref, def),
+                          onDefinitionTap: () => _showTierOptions(
+                            context,
+                            ref,
+                            state.definitions[i],
+                          ),
                         ),
                       ),
                   ],
@@ -150,6 +150,10 @@ class _TierListViewState extends ConsumerState<TierListView> {
     TierDefinition def,
   ) {
     final S l = S.of(context);
+    final int tierIndex = widget.state.definitions.indexWhere(
+      (TierDefinition d) => d.tierKey == def.tierKey,
+    );
+    final int tierCount = widget.state.definitions.length;
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: AppColors.surface,
@@ -166,6 +170,32 @@ class _TierListViewState extends ConsumerState<TierListView> {
                   _renameTier(context, ref, def);
                 },
               ),
+              if (tierIndex > 0)
+                ListTile(
+                  leading: const Icon(Icons.arrow_upward),
+                  title: Text(l.tierListMoveUp),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    ref
+                        .read(
+                          tierListDetailProvider(widget.tierListId).notifier,
+                        )
+                        .moveTier(tierIndex, tierIndex - 1);
+                  },
+                ),
+              if (tierIndex >= 0 && tierIndex < tierCount - 1)
+                ListTile(
+                  leading: const Icon(Icons.arrow_downward),
+                  title: Text(l.tierListMoveDown),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    ref
+                        .read(
+                          tierListDetailProvider(widget.tierListId).notifier,
+                        )
+                        .moveTier(tierIndex, tierIndex + 1);
+                  },
+                ),
               ListTile(
                 leading: const Icon(Icons.palette),
                 title: Text(l.tierListChangeColor),
@@ -250,6 +280,81 @@ class _TierListViewState extends ConsumerState<TierListView> {
     }
   }
 
+}
+
+/// Tier row wrapped in a drop target for whole-tier (String key) drags.
+class _TierRowDropTarget extends ConsumerWidget {
+  const _TierRowDropTarget({
+    required this.tierListId,
+    required this.index,
+    required this.definitions,
+    required this.entries,
+    required this.itemsMap,
+    required this.titleLanguage,
+    required this.overlayResolver,
+    required this.onDefinitionTap,
+  });
+
+  final int tierListId;
+  final int index;
+  final List<TierDefinition> definitions;
+  final List<TierListEntry> entries;
+  final Map<int, CollectionItem> itemsMap;
+  final String titleLanguage;
+  final String? Function(CollectionItem) overlayResolver;
+  final VoidCallback onDefinitionTap;
+
+  TierDefinition get _definition => definitions[index];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return DragTarget<String>(
+      onWillAcceptWithDetails: (DragTargetDetails<String> details) =>
+          details.data != _definition.tierKey,
+      onAcceptWithDetails: (DragTargetDetails<String> details) {
+        final int from = definitions.indexWhere(
+          (TierDefinition t) => t.tierKey == details.data,
+        );
+        if (from == -1) return;
+        ref
+            .read(tierListDetailProvider(tierListId).notifier)
+            .moveTier(from, index);
+      },
+      builder: (BuildContext context, List<String?> candidateData,
+          List<dynamic> rejectedData) {
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: candidateData.isNotEmpty
+                  ? AppColors.brand
+                  : Colors.transparent,
+              width: 2,
+            ),
+            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          ),
+          child: TierRow(
+            tierListId: tierListId,
+            definition: _definition,
+            entries: entries,
+            itemsMap: itemsMap,
+            titleLanguage: titleLanguage,
+            overlayResolver: overlayResolver,
+            tierDraggable: true,
+            onDrop: (int collectionItemId, int? dropIndex) {
+              ref
+                  .read(tierListDetailProvider(tierListId).notifier)
+                  .moveToTier(
+                    collectionItemId,
+                    _definition.tierKey,
+                    index: dropIndex,
+                  );
+            },
+            onDefinitionTap: onDefinitionTap,
+          ),
+        );
+      },
+    );
+  }
 }
 
 class _UnrankedPool extends ConsumerWidget {

--- a/lib/features/tier_lists/widgets/tier_row.dart
+++ b/lib/features/tier_lists/widgets/tier_row.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../shared/constants/platform_features.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/tier_definition.dart';
 import '../../../shared/models/tier_list_entry.dart';
@@ -62,6 +63,7 @@ class TierRow extends StatelessWidget {
     required this.titleLanguage,
     required this.onDrop,
     required this.onDefinitionTap,
+    this.tierDraggable = false,
     this.overlayResolver,
     super.key,
   });
@@ -74,9 +76,25 @@ class TierRow extends StatelessWidget {
   /// Resolved once in the parent so each card doesn't subscribe to settings.
   final String titleLanguage;
 
-  final void Function(int collectionItemId) onDrop;
+  /// Insert the dragged item at [index]; null appends to the end.
+  final void Function(int collectionItemId, int? index) onDrop;
+
   final VoidCallback onDefinitionTap;
+
+  /// Desktop-only drag of the whole tier by its label.
+  final bool tierDraggable;
+
   final String? Function(CollectionItem item)? overlayResolver;
+
+  void _handleSlotDrop(int draggedId, int slotIndex) {
+    // A same-tier move from an earlier slot shifts the anchor one left.
+    int insertAt = slotIndex;
+    final int oldIndex = entries.indexWhere(
+      (TierListEntry e) => e.collectionItemId == draggedId,
+    );
+    if (oldIndex != -1 && oldIndex < slotIndex) insertAt -= 1;
+    onDrop(draggedId, insertAt);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -85,35 +103,11 @@ class TierRow extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-        GestureDetector(
-          onTap: onDefinitionTap,
-          onLongPress: onDefinitionTap,
-          child: Container(
-            width: m.tierLabelWidth,
-            constraints: BoxConstraints(minHeight: m.rowMinHeight),
-            decoration: BoxDecoration(
-              color: definition.color,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(AppSpacing.radiusSm),
-                bottomLeft: Radius.circular(AppSpacing.radiusSm),
-              ),
-            ),
-            alignment: Alignment.center,
-            child: Text(
-              definition.label,
-              style: AppTypography.h2.copyWith(
-                color: _textColorFor(definition.color),
-                fontWeight: FontWeight.bold,
-                fontSize: m.tierLabelFont,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
+        _buildLabel(m),
         Expanded(
           child: DragTarget<int>(
             onAcceptWithDetails: (DragTargetDetails<int> details) =>
-                onDrop(details.data),
+                onDrop(details.data, null),
             builder: (BuildContext context, List<int?> candidateData,
                 List<dynamic> rejectedData) {
               return Container(
@@ -143,20 +137,35 @@ class TierRow extends StatelessWidget {
                         spacing: AppSpacing.xs,
                         runSpacing: AppSpacing.xs,
                         children: <Widget>[
-                          for (final TierListEntry entry in entries)
-                            if (itemsMap[entry.collectionItemId] != null)
-                              TierItemCard(
-                                key: ValueKey<int>(entry.collectionItemId),
-                                item: itemsMap[entry.collectionItemId]!,
-                                displayName: itemsMap[entry.collectionItemId]!
-                                    .displayName(titleLanguage),
-                                isDraggable: true,
-                                width: m.cardWidth,
-                                height: m.cardImageHeight,
-                                labelHeight: m.cardLabelMinHeight,
-                                platformOverlayAsset: overlayResolver
-                                    ?.call(itemsMap[entry.collectionItemId]!),
+                          for (int i = 0; i < entries.length; i++)
+                            if (itemsMap[entries[i].collectionItemId] != null)
+                              _TierCardSlot(
+                                key: ValueKey<int>(
+                                  entries[i].collectionItemId,
+                                ),
+                                indicatorHeight: m.cardTotalHeight,
+                                onDrop: (int draggedId) =>
+                                    _handleSlotDrop(draggedId, i),
+                                child: TierItemCard(
+                                  item: itemsMap[entries[i].collectionItemId]!,
+                                  displayName:
+                                      itemsMap[entries[i].collectionItemId]!
+                                          .displayName(titleLanguage),
+                                  isDraggable: true,
+                                  width: m.cardWidth,
+                                  height: m.cardImageHeight,
+                                  labelHeight: m.cardLabelMinHeight,
+                                  platformOverlayAsset: overlayResolver?.call(
+                                    itemsMap[entries[i].collectionItemId]!,
+                                  ),
+                                ),
                               ),
+                          // Empty-space hover appends — mark the end slot.
+                          if (candidateData.isNotEmpty)
+                            _InsertionBar(
+                              visible: true,
+                              height: m.cardTotalHeight,
+                            ),
                         ],
                       ),
               );
@@ -168,8 +177,130 @@ class TierRow extends StatelessWidget {
     );
   }
 
+  Widget _buildLabel(TierRowMetrics m) {
+    final Widget label = GestureDetector(
+      onTap: onDefinitionTap,
+      onLongPress: onDefinitionTap,
+      child: _labelBox(
+        m,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(AppSpacing.radiusSm),
+          bottomLeft: Radius.circular(AppSpacing.radiusSm),
+        ),
+      ),
+    );
+    // Mobile long-press is taken by the options sheet. Plain Draggable, not
+    // ReorderableListView: its GlobalKey reparenting during layout crashes
+    // the card Tooltips (OverlayPortal) under the screen's LayoutBuilder.
+    if (!tierDraggable || kIsMobile) return label;
+    return Draggable<String>(
+      data: definition.tierKey,
+      feedback: Material(
+        color: Colors.transparent,
+        child: Opacity(
+          opacity: 0.85,
+          child: _labelBox(
+            m,
+            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+            height: m.rowMinHeight,
+          ),
+        ),
+      ),
+      childWhenDragging: Opacity(opacity: 0.3, child: label),
+      child: label,
+    );
+  }
+
+  Widget _labelBox(
+    TierRowMetrics m, {
+    required BorderRadius borderRadius,
+    double? height,
+  }) {
+    return Container(
+      width: m.tierLabelWidth,
+      height: height,
+      constraints:
+          height == null ? BoxConstraints(minHeight: m.rowMinHeight) : null,
+      decoration: BoxDecoration(
+        color: definition.color,
+        borderRadius: borderRadius,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        definition.label,
+        style: AppTypography.h2.copyWith(
+          color: _textColorFor(definition.color),
+          fontWeight: FontWeight.bold,
+          fontSize: m.tierLabelFont,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+
   Color _textColorFor(Color background) {
     final double luminance = background.computeLuminance();
     return luminance > 0.5 ? Colors.black : Colors.white;
+  }
+}
+
+/// Drop zone over a card: a drop inserts before it; hover opens an
+/// insertion-bar gap at that spot.
+class _TierCardSlot extends StatelessWidget {
+  const _TierCardSlot({
+    required this.indicatorHeight,
+    required this.onDrop,
+    required this.child,
+    super.key,
+  });
+
+  final double indicatorHeight;
+  final void Function(int draggedId) onDrop;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<int>(
+      onAcceptWithDetails: (DragTargetDetails<int> details) =>
+          onDrop(details.data),
+      builder: (BuildContext context, List<int?> candidateData,
+          List<dynamic> rejectedData) {
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            _InsertionBar(
+              visible: candidateData.isNotEmpty,
+              height: indicatorHeight,
+            ),
+            child,
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Marks where a dragged card will land; collapses to zero width when hidden.
+class _InsertionBar extends StatelessWidget {
+  const _InsertionBar({
+    required this.visible,
+    required this.height,
+  });
+
+  final bool visible;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      width: visible ? 6 : 0,
+      height: height,
+      margin: EdgeInsets.only(right: visible ? AppSpacing.xs : 0),
+      decoration: BoxDecoration(
+        color: AppColors.brand,
+        borderRadius: BorderRadius.circular(3),
+      ),
+    );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1724,6 +1724,8 @@
   "tierListImageSaved": "Tier list saved as image",
   "tierListRename": "Rename tier",
   "tierListChangeColor": "Change color",
+  "tierListMoveUp": "Move up",
+  "tierListMoveDown": "Move down",
   "tierListDeleteTier": "Delete tier",
   "tierListAddTier": "Add tier",
   "tierListClearAll": "Clear all",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7056,6 +7056,18 @@ abstract class S {
   /// **'Change color'**
   String get tierListChangeColor;
 
+  /// No description provided for @tierListMoveUp.
+  ///
+  /// In en, this message translates to:
+  /// **'Move up'**
+  String get tierListMoveUp;
+
+  /// No description provided for @tierListMoveDown.
+  ///
+  /// In en, this message translates to:
+  /// **'Move down'**
+  String get tierListMoveDown;
+
   /// No description provided for @tierListDeleteTier.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3899,6 +3899,12 @@ class SEn extends S {
   String get tierListChangeColor => 'Change color';
 
   @override
+  String get tierListMoveUp => 'Move up';
+
+  @override
+  String get tierListMoveDown => 'Move down';
+
+  @override
   String get tierListDeleteTier => 'Delete tier';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3948,6 +3948,12 @@ class SRu extends S {
   String get tierListChangeColor => 'Изменить цвет';
 
   @override
+  String get tierListMoveUp => 'Переместить выше';
+
+  @override
+  String get tierListMoveDown => 'Переместить ниже';
+
+  @override
   String get tierListDeleteTier => 'Удалить тир';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1442,6 +1442,8 @@
   "tierListImageSaved": "Тир-лист сохранён как изображение",
   "tierListRename": "Переименовать тир",
   "tierListChangeColor": "Изменить цвет",
+  "tierListMoveUp": "Переместить выше",
+  "tierListMoveDown": "Переместить ниже",
   "tierListDeleteTier": "Удалить тир",
   "tierListAddTier": "Добавить тир",
   "tierListClearAll": "Очистить всё",

--- a/test/core/database/dao/tier_list_dao_test.dart
+++ b/test/core/database/dao/tier_list_dao_test.dart
@@ -344,6 +344,61 @@ void main() {
       });
     });
 
+    group('setItemTierOrdered', () {
+      test('replaces entry and renumbers the whole tier in a transaction',
+          () async {
+        final TransactionMockDatabase txnDb = TransactionMockDatabase();
+        final MockTransaction mockTxn = MockTransaction();
+        txnDb.stubTransaction(mockTxn);
+
+        final TierListDao txnDao = TierListDao(() async => txnDb);
+
+        when(
+          () => mockTxn.delete(
+            'tier_list_entries',
+            where: 'tier_list_id = ? AND collection_item_id = ?',
+            whereArgs: <Object?>[1, 42],
+          ),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockTxn.insert('tier_list_entries', any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockTxn.update(
+            'tier_list_entries',
+            any(),
+            where: any(named: 'where'),
+            whereArgs: any(named: 'whereArgs'),
+          ),
+        ).thenAnswer((_) async => 1);
+
+        await txnDao.setItemTierOrdered(1, 42, 'S', <int>[10, 42, 20]);
+
+        verify(
+          () => mockTxn.delete(
+            'tier_list_entries',
+            where: 'tier_list_id = ? AND collection_item_id = ?',
+            whereArgs: <Object?>[1, 42],
+          ),
+        ).called(1);
+
+        final Map<String, dynamic> inserted = verify(
+          () => mockTxn.insert('tier_list_entries', captureAny()),
+        ).captured.single as Map<String, dynamic>;
+        expect(inserted['collection_item_id'], 42);
+        expect(inserted['tier_key'], 'S');
+
+        verify(
+          () => mockTxn.update(
+            'tier_list_entries',
+            any(),
+            where: any(named: 'where'),
+            whereArgs: any(named: 'whereArgs'),
+          ),
+        ).called(3);
+      });
+    });
+
     group('removeItemFromTier', () {
       test('deletes entry', () async {
         when(

--- a/test/features/tier_lists/providers/tier_list_detail_provider_test.dart
+++ b/test/features/tier_lists/providers/tier_list_detail_provider_test.dart
@@ -501,7 +501,7 @@ void main() {
           items: items,
         );
 
-        when(() => mockTierListDao.setItemTier(1, 1, 'S', any()))
+        when(() => mockTierListDao.setItemTierOrdered(1, 1, 'S', any()))
             .thenAnswer((_) async {});
 
         await listenAndWait(1);
@@ -537,7 +537,7 @@ void main() {
           items: items,
         );
 
-        when(() => mockTierListDao.setItemTier(1, 20, 'S', 0))
+        when(() => mockTierListDao.setItemTierOrdered(1, 20, 'S', any()))
             .thenAnswer((_) async {});
 
         await listenAndWait(1);
@@ -549,7 +549,66 @@ void main() {
         final TierListDetailState state =
             container.read(tierListDetailProvider(1));
         expect(state.entries, hasLength(2));
-        verify(() => mockTierListDao.setItemTier(1, 20, 'S', 0)).called(1);
+        final List<TierListEntry> sTier = state.entriesByTier['S']!;
+        expect(sTier[0].collectionItemId, 20);
+        expect(sTier[0].sortOrder, 0);
+        expect(sTier[1].collectionItemId, 10);
+        expect(sTier[1].sortOrder, 1);
+        final List<int> orderedIds = verify(
+          () => mockTierListDao.setItemTierOrdered(1, 20, 'S', captureAny()),
+        ).captured.single as List<int>;
+        expect(orderedIds, <int>[20, 10]);
+      });
+
+      test('should assign contiguous sort orders after gaps from removals',
+          () async {
+        // Regression: gaps + append-by-length used to create duplicate
+        // sort orders, reshuffling the tier on restart.
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S'),
+        ];
+        final List<TierListEntry> entries = <TierListEntry>[
+          createTestTierListEntry(
+              collectionItemId: 10, tierKey: 'S', sortOrder: 0),
+          createTestTierListEntry(
+              collectionItemId: 20, tierKey: 'S', sortOrder: 1),
+        ];
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestCollectionItem(id: 10),
+          createTestCollectionItem(id: 20),
+          createTestCollectionItem(id: 30),
+        ];
+
+        stubLoadCollectionScoped(
+          definitions: defs,
+          entries: entries,
+          items: items,
+        );
+
+        when(() => mockTierListDao.removeItemFromTier(1, 10))
+            .thenAnswer((_) async {});
+        when(() => mockTierListDao.setItemTierOrdered(1, 30, 'S', any()))
+            .thenAnswer((_) async {});
+
+        await listenAndWait(1);
+
+        final TierListDetailNotifier notifier =
+            container.read(tierListDetailProvider(1).notifier);
+        await notifier.removeFromTier(10);
+        await notifier.moveToTier(30, 'S');
+
+        final List<int> orderedIds = verify(
+          () => mockTierListDao.setItemTierOrdered(1, 30, 'S', captureAny()),
+        ).captured.single as List<int>;
+        expect(orderedIds, <int>[20, 30]);
+
+        final List<TierListEntry> sTier = container
+            .read(tierListDetailProvider(1))
+            .entriesByTier['S']!;
+        expect(
+          <int>[for (final TierListEntry e in sTier) e.sortOrder],
+          <int>[0, 1],
+        );
       });
 
       test('should replace existing entry when moving already placed item',
@@ -572,7 +631,7 @@ void main() {
           items: items,
         );
 
-        when(() => mockTierListDao.setItemTier(1, 1, 'A', 0))
+        when(() => mockTierListDao.setItemTierOrdered(1, 1, 'A', any()))
             .thenAnswer((_) async {});
 
         await listenAndWait(1);
@@ -840,7 +899,7 @@ void main() {
 
         when(() => mockTierListDao.removeItemFromTier(1, 1))
             .thenAnswer((_) async {});
-        when(() => mockTierListDao.setItemTier(1, 1, 'A', any()))
+        when(() => mockTierListDao.setItemTierOrdered(1, 1, 'A', any()))
             .thenAnswer((_) async {});
 
         await listenAndWait(1);
@@ -878,7 +937,7 @@ void main() {
           items: items,
         );
 
-        when(() => mockTierListDao.setItemTier(1, 1, 'A', 0))
+        when(() => mockTierListDao.setItemTierOrdered(1, 1, 'A', any()))
             .thenAnswer((_) async {});
 
         await listenAndWait(1);
@@ -887,10 +946,197 @@ void main() {
             container.read(tierListDetailProvider(1).notifier);
         await notifier.moveBetweenTiers(1, 'S', 'A', index: 0);
 
-        // moveBetweenTiers collapses to a single setItemTier — the DELETE+INSERT
-        // lives inside setItemTier itself, to avoid a double state rebuild.
+        // Collapses to a single setItemTierOrdered — no separate remove call.
         verifyNever(() => mockTierListDao.removeItemFromTier(1, 1));
-        verify(() => mockTierListDao.setItemTier(1, 1, 'A', 0)).called(1);
+        final List<int> orderedIds = verify(
+          () => mockTierListDao.setItemTierOrdered(1, 1, 'A', captureAny()),
+        ).captured.single as List<int>;
+        expect(orderedIds, <int>[1, 2]);
+      });
+    });
+
+    group('sort order normalization on load', () {
+      test('renumbers tiers with duplicate sort orders and persists', () async {
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S'),
+        ];
+        final List<TierListEntry> entries = <TierListEntry>[
+          createTestTierListEntry(
+              collectionItemId: 1, tierKey: 'S', sortOrder: 0),
+          createTestTierListEntry(
+              collectionItemId: 2, tierKey: 'S', sortOrder: 2),
+          createTestTierListEntry(
+              collectionItemId: 3, tierKey: 'S', sortOrder: 2),
+        ];
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestCollectionItem(id: 1),
+          createTestCollectionItem(id: 2),
+          createTestCollectionItem(id: 3),
+        ];
+
+        stubLoadCollectionScoped(
+          definitions: defs,
+          entries: entries,
+          items: items,
+        );
+
+        when(() => mockTierListDao.reorderTierItems(1, 'S', any()))
+            .thenAnswer((_) async {});
+
+        final TierListDetailState state = await listenAndWait(1);
+
+        final List<int> orderedIds = verify(
+          () => mockTierListDao.reorderTierItems(1, 'S', captureAny()),
+        ).captured.single as List<int>;
+        expect(orderedIds, <int>[1, 2, 3]);
+
+        final List<TierListEntry> sTier = state.entriesByTier['S']!;
+        expect(
+          <int>[for (final TierListEntry e in sTier) e.sortOrder],
+          <int>[0, 1, 2],
+        );
+      });
+
+      test('does not touch tiers with contiguous sort orders', () async {
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S'),
+          createTestTierDefinition(tierKey: 'A'),
+        ];
+        final List<TierListEntry> entries = <TierListEntry>[
+          createTestTierListEntry(
+              collectionItemId: 1, tierKey: 'S', sortOrder: 0),
+          createTestTierListEntry(
+              collectionItemId: 2, tierKey: 'S', sortOrder: 1),
+          createTestTierListEntry(
+              collectionItemId: 3, tierKey: 'A', sortOrder: 0),
+        ];
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestCollectionItem(id: 1),
+          createTestCollectionItem(id: 2),
+          createTestCollectionItem(id: 3),
+        ];
+
+        stubLoadCollectionScoped(
+          definitions: defs,
+          entries: entries,
+          items: items,
+        );
+
+        await listenAndWait(1);
+
+        verifyNever(
+          () => mockTierListDao.reorderTierItems(any(), any(), any()),
+        );
+      });
+
+      test('renumbers only the broken tier', () async {
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S'),
+          createTestTierDefinition(tierKey: 'A'),
+        ];
+        final List<TierListEntry> entries = <TierListEntry>[
+          createTestTierListEntry(
+              collectionItemId: 1, tierKey: 'S', sortOrder: 0),
+          createTestTierListEntry(
+              collectionItemId: 2, tierKey: 'A', sortOrder: 1),
+        ];
+        final List<CollectionItem> items = <CollectionItem>[
+          createTestCollectionItem(id: 1),
+          createTestCollectionItem(id: 2),
+        ];
+
+        stubLoadCollectionScoped(
+          definitions: defs,
+          entries: entries,
+          items: items,
+        );
+
+        when(() => mockTierListDao.reorderTierItems(1, 'A', any()))
+            .thenAnswer((_) async {});
+
+        await listenAndWait(1);
+
+        verify(() => mockTierListDao.reorderTierItems(1, 'A', any()))
+            .called(1);
+        verifyNever(() => mockTierListDao.reorderTierItems(1, 'S', any()));
+      });
+    });
+
+    group('moveTier', () {
+      test('should move tier to new index and renumber sort orders', () async {
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S', sortOrder: 0),
+          createTestTierDefinition(tierKey: 'A', sortOrder: 1),
+          createTestTierDefinition(tierKey: 'B', sortOrder: 2),
+        ];
+
+        stubLoadCollectionScoped(definitions: defs);
+
+        await listenAndWait(1);
+
+        final TierListDetailNotifier notifier =
+            container.read(tierListDetailProvider(1).notifier);
+        await notifier.moveTier(0, 2);
+
+        final TierListDetailState state =
+            container.read(tierListDetailProvider(1));
+        expect(
+          <String>[for (final TierDefinition d in state.definitions) d.tierKey],
+          <String>['A', 'B', 'S'],
+        );
+        expect(
+          <int>[for (final TierDefinition d in state.definitions) d.sortOrder],
+          <int>[0, 1, 2],
+        );
+        verify(() => mockTierListDao.saveTierDefinitions(1, any())).called(1);
+      });
+
+      test('should move tier up', () async {
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S', sortOrder: 0),
+          createTestTierDefinition(tierKey: 'A', sortOrder: 1),
+        ];
+
+        stubLoadCollectionScoped(definitions: defs);
+
+        await listenAndWait(1);
+
+        final TierListDetailNotifier notifier =
+            container.read(tierListDetailProvider(1).notifier);
+        await notifier.moveTier(1, 0);
+
+        final TierListDetailState state =
+            container.read(tierListDetailProvider(1));
+        expect(
+          <String>[for (final TierDefinition d in state.definitions) d.tierKey],
+          <String>['A', 'S'],
+        );
+      });
+
+      test('should be no-op when indices are out of bounds or equal',
+          () async {
+        final List<TierDefinition> defs = <TierDefinition>[
+          createTestTierDefinition(tierKey: 'S', sortOrder: 0),
+          createTestTierDefinition(tierKey: 'A', sortOrder: 1),
+        ];
+
+        stubLoadCollectionScoped(definitions: defs);
+
+        await listenAndWait(1);
+
+        final TierListDetailNotifier notifier =
+            container.read(tierListDetailProvider(1).notifier);
+        await notifier.moveTier(0, 5);
+        await notifier.moveTier(-1, 0);
+        await notifier.moveTier(1, 1);
+
+        final TierListDetailState state =
+            container.read(tierListDetailProvider(1));
+        expect(
+          <String>[for (final TierDefinition d in state.definitions) d.tierKey],
+          <String>['S', 'A'],
+        );
+        verifyNever(() => mockTierListDao.saveTierDefinitions(1, any()));
       });
     });
 

--- a/test/features/tier_lists/widgets/tier_list_view_test.dart
+++ b/test/features/tier_lists/widgets/tier_list_view_test.dart
@@ -1,4 +1,8 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/features/tier_lists/providers/tier_list_detail_provider.dart';
 import 'package:tonkatsu_box/features/tier_lists/widgets/tier_item_card.dart';
 import 'package:tonkatsu_box/features/tier_lists/widgets/tier_list_view.dart';
@@ -170,6 +174,124 @@ void main() {
       await tester.pump();
 
       expect(find.byType(TierItemCard), findsNWidgets(2));
+    });
+
+    group('tier reorder via options sheet', () {
+      late MockTierListDao mockTierListDao;
+      late MockCollectionDao mockCollectionDao;
+
+      setUp(() {
+        mockTierListDao = MockTierListDao();
+        mockCollectionDao = MockCollectionDao();
+        when(() => mockTierListDao.getTierListById(1)).thenAnswer(
+          (_) async => createTestTierList(id: 1, collectionId: 10),
+        );
+        when(() => mockCollectionDao.getCollectionItemsWithData(10))
+            .thenAnswer((_) async => <CollectionItem>[]);
+        when(() => mockTierListDao.getTierDefinitions(1))
+            .thenAnswer((_) async => state.definitions);
+        when(() => mockTierListDao.getTierListEntries(1))
+            .thenAnswer((_) async => <TierListEntry>[]);
+        when(() => mockTierListDao.saveTierDefinitions(1, any()))
+            .thenAnswer((_) async {});
+      });
+
+      Future<void> pumpView(WidgetTester tester) async {
+        // The tiers pane is a third of the viewport — keep both rows tappable.
+        tester.view.physicalSize = const Size(800, 1400);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+        await tester.pumpApp(
+          TierListView(tierListId: 1, state: state),
+          overrides: <Override>[
+            tierListDaoProvider.overrideWithValue(mockTierListDao),
+            collectionDaoProvider.overrideWithValue(mockCollectionDao),
+          ],
+          settle: false,
+        );
+        // The real screen watches (and loads) the provider; warm it up so
+        // sheet actions see loaded state.
+        ProviderScope.containerOf(
+          tester.element(find.byType(TierListView)),
+        ).read(tierListDetailProvider(1));
+        await tester.pump();
+      }
+
+      testWidgets('move down persists swapped definitions',
+          (WidgetTester tester) async {
+        await pumpView(tester);
+
+        await tester.tap(find.text('S'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        await tester.tap(find.byIcon(Icons.arrow_downward));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        final List<TierDefinition> saved = verify(
+          () => mockTierListDao.saveTierDefinitions(1, captureAny()),
+        ).captured.single as List<TierDefinition>;
+        expect(
+          <String>[for (final TierDefinition d in saved) d.tierKey],
+          <String>['A', 'S'],
+        );
+      });
+
+      testWidgets('move up persists swapped definitions',
+          (WidgetTester tester) async {
+        await pumpView(tester);
+
+        await tester.tap(find.text('A'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        await tester.tap(find.byIcon(Icons.arrow_upward));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        final List<TierDefinition> saved = verify(
+          () => mockTierListDao.saveTierDefinitions(1, captureAny()),
+        ).captured.single as List<TierDefinition>;
+        expect(
+          <String>[for (final TierDefinition d in saved) d.tierKey],
+          <String>['A', 'S'],
+        );
+      });
+
+      testWidgets('dragging a tier label onto another tier persists reorder',
+          (WidgetTester tester) async {
+        await pumpView(tester);
+
+        final TestGesture gesture = await tester.startGesture(
+          tester.getCenter(find.text('S')),
+        );
+        await tester.pump(const Duration(milliseconds: 100));
+        await gesture.moveTo(tester.getCenter(find.text('A')));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+
+        final List<TierDefinition> saved = verify(
+          () => mockTierListDao.saveTierDefinitions(1, captureAny()),
+        ).captured.single as List<TierDefinition>;
+        expect(
+          <String>[for (final TierDefinition d in saved) d.tierKey],
+          <String>['A', 'S'],
+        );
+      });
+
+      testWidgets('first tier has no move-up action, last has no move-down',
+          (WidgetTester tester) async {
+        await pumpView(tester);
+
+        await tester.tap(find.text('S'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.byIcon(Icons.arrow_upward), findsNothing);
+        expect(find.byIcon(Icons.arrow_downward), findsOneWidget);
+      });
     });
   });
 }

--- a/test/features/tier_lists/widgets/tier_row_test.dart
+++ b/test/features/tier_lists/widgets/tier_row_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/tier_lists/widgets/tier_item_card.dart';
 import 'package:tonkatsu_box/features/tier_lists/widgets/tier_row.dart';
@@ -44,7 +45,7 @@ void main() {
           entries: const <TierListEntry>[],
           itemsMap: const <int, CollectionItem>{},
           titleLanguage: '',
-          onDrop: (_) {},
+          onDrop: (_, _) {},
           onDefinitionTap: () {},
         ),
         settle: false,
@@ -63,7 +64,7 @@ void main() {
           entries: const <TierListEntry>[],
           itemsMap: const <int, CollectionItem>{},
           titleLanguage: '',
-          onDrop: (_) {},
+          onDrop: (_, _) {},
           onDefinitionTap: () {},
         ),
         settle: false,
@@ -82,7 +83,7 @@ void main() {
           entries: const <TierListEntry>[],
           itemsMap: const <int, CollectionItem>{},
           titleLanguage: '',
-          onDrop: (_) {},
+          onDrop: (_, _) {},
           onDefinitionTap: () {},
         ),
         settle: false,
@@ -111,7 +112,7 @@ void main() {
           entries: entries,
           itemsMap: itemsMap,
           titleLanguage: '',
-          onDrop: (_) {},
+          onDrop: (_, _) {},
           onDefinitionTap: () {},
         ),
         settle: false,
@@ -132,7 +133,7 @@ void main() {
           entries: const <TierListEntry>[],
           itemsMap: const <int, CollectionItem>{},
           titleLanguage: '',
-          onDrop: (_) {},
+          onDrop: (_, _) {},
           onDefinitionTap: () => tapped = true,
         ),
         settle: false,
@@ -167,7 +168,7 @@ void main() {
           entries: entries,
           itemsMap: itemsMap,
           titleLanguage: '',
-          onDrop: (_) {},
+          onDrop: (_, _) {},
           onDefinitionTap: () {},
         ),
         settle: false,
@@ -175,6 +176,112 @@ void main() {
       await tester.pump();
 
       expect(find.byType(TierItemCard), findsOneWidget);
+    });
+
+    group('intra-tier drop slots', () {
+      late CollectionItem item3;
+
+      setUp(() {
+        item3 = createTestCollectionItem(
+          id: 3,
+          externalId: 300,
+          game: createTestGame(id: 300, name: 'Game Three'),
+        );
+      });
+
+      Future<void> dragCard(
+        WidgetTester tester,
+        int fromIndex,
+        int toIndex,
+      ) async {
+        final Finder cards = find.byType(TierItemCard);
+        final TestGesture gesture = await tester.startGesture(
+          tester.getCenter(cards.at(fromIndex)),
+        );
+        await tester.pump(const Duration(milliseconds: 100));
+        await gesture.moveTo(tester.getCenter(cards.at(toIndex)));
+        await tester.pump();
+        await gesture.up();
+        await tester.pump();
+      }
+
+      Widget buildRow(
+        List<TierListEntry> entries,
+        Map<int, CollectionItem> itemsMap,
+        void Function(int, int?) onDrop,
+      ) {
+        return TierRow(
+          tierListId: 1,
+          definition: definition,
+          entries: entries,
+          itemsMap: itemsMap,
+          titleLanguage: '',
+          onDrop: onDrop,
+          onDefinitionTap: () {},
+        );
+      }
+
+      testWidgets('dropping a card onto an earlier card inserts before it',
+          (WidgetTester tester) async {
+        final List<TierListEntry> entries = <TierListEntry>[
+          createTestTierListEntry(
+              collectionItemId: 1, tierKey: 'S', sortOrder: 0),
+          createTestTierListEntry(
+              collectionItemId: 2, tierKey: 'S', sortOrder: 1),
+        ];
+        final Map<int, CollectionItem> itemsMap = <int, CollectionItem>{
+          1: item1,
+          2: item2,
+        };
+        final List<(int, int?)> drops = <(int, int?)>[];
+
+        await tester.pumpApp(
+          buildRow(
+            entries,
+            itemsMap,
+            (int id, int? index) => drops.add((id, index)),
+          ),
+          settle: false,
+        );
+        await tester.pump();
+
+        await dragCard(tester, 1, 0);
+
+        expect(drops, <(int, int?)>[(2, 0)]);
+      });
+
+      testWidgets(
+          'dropping a card onto a later card adjusts index for its removal',
+          (WidgetTester tester) async {
+        final List<TierListEntry> entries = <TierListEntry>[
+          createTestTierListEntry(
+              collectionItemId: 1, tierKey: 'S', sortOrder: 0),
+          createTestTierListEntry(
+              collectionItemId: 2, tierKey: 'S', sortOrder: 1),
+          createTestTierListEntry(
+              collectionItemId: 3, tierKey: 'S', sortOrder: 2),
+        ];
+        final Map<int, CollectionItem> itemsMap = <int, CollectionItem>{
+          1: item1,
+          2: item2,
+          3: item3,
+        };
+        final List<(int, int?)> drops = <(int, int?)>[];
+
+        await tester.pumpApp(
+          buildRow(
+            entries,
+            itemsMap,
+            (int id, int? index) => drops.add((id, index)),
+          ),
+          settle: false,
+        );
+        await tester.pump();
+
+        await dragCard(tester, 0, 2);
+
+        expect(drops, <(int, int?)>[(1, 1)]);
+      });
     });
   });
 }


### PR DESCRIPTION
… order

- drop a card at an exact position, with an animated insertion-bar marker
- drag a whole tier by its label (desktop) or move it via the options sheet
- rewrite tier sort orders transactionally and self-heal gaps/duplicates on load, fixing the order reshuffle after app restarts