### PR TITLE
fix(gamepads): stub out the Windows plugin to stop USB hotplug crash

### DIFF
--- a/packages/gamepads_windows_stub/lib/gamepads_windows.dart
+++ b/packages/gamepads_windows_stub/lib/gamepads_windows.dart
@@ -1,0 +1,5 @@
+// Intentionally empty. This package exists only so that the pub resolver
+// picks it instead of the real gamepads_windows, whose native device
+// listener crashes on USB connect/disconnect. Nothing imports this library:
+// the real package is native-only and the app's Dart side never subscribes
+// to gamepad events on Windows.

--- a/packages/gamepads_windows_stub/pubspec.yaml
+++ b/packages/gamepads_windows_stub/pubspec.yaml
@@ -1,0 +1,17 @@
+name: gamepads_windows
+description: >-
+  Local stub replacing the native Windows implementation of the gamepads
+  plugin. The app never listens to gamepads on Windows (kGamepadSupported
+  excludes it), yet the real plugin's USB device listener crashes the app
+  (0xc0000005 in gamepads_windows_plugin.dll). Overriding with this stub
+  keeps the DLL out of the Windows build entirely.
+version: 0.3.0+1
+publish_to: none
+
+environment:
+  sdk: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"
+
+dependencies:
+  flutter:
+    sdk: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,12 +350,11 @@ packages:
     source: hosted
     version: "0.1.1+1"
   gamepads_windows:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: gamepads_windows
-      sha256: "650b68a4bc5d729abf12f0d2d3a53c05e4070a288c7e5575edfd485774550d8c"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/gamepads_windows_stub"
+      relative: true
+    source: path
     version: "0.3.0+1"
   glob:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,6 +85,14 @@ dependencies:
   sensors_plus: ^6.1.1
   calendar_view: ^2.0.0
 
+# The real gamepads_windows is native-only and its USB device listener
+# crashes the app (0xc0000005) even though the Dart side never subscribes
+# on Windows. The stub keeps the DLL out of the Windows build; Android
+# keeps the real implementation.
+dependency_overrides:
+  gamepads_windows:
+    path: packages/gamepads_windows_stub
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
The native gamepads_windows DLL listens to device changes even though the Dart side never subscribes on Windows, and crashes the app (0xc0000005) when a non-gamepad USB device is plugged or unplugged. Override the package with a local Dart-only stub so the DLL is not built or shipped; Android keeps the real implementation.