### PR TITLE
feat(import): custom cards import from JSON/CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,64 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Custom-card import from JSON/CSV files**
+
+  A new import source (Settings → Import → Custom cards) for loading cards
+  produced by the user's own scripts or parsers. One file per run: JSON (an
+  array of objects, or a single object) or CSV (RFC 4180, header-addressed
+  columns). Only `title` and `type` are required; the schema covers every
+  card field (alt title, description, year, genres, link, cover URL,
+  platform, manga/anime format, unit totals) and every personal field
+  (status, rating, note, rewatch counter, start/finish dates, time spent,
+  favorite, episode/season progress, global tags — missing tags are created
+  automatically). The file is parsed and validated up front without touching
+  the database; a preview screen shows "Recognized N · Errors M ·
+  Duplicates K" with a lazy checkbox list — invalid rows float to the top
+  with their reasons, duplicates (same title already in the target
+  collection, or repeated in the file) are unchecked by default. Covers
+  (http/https only) are downloaded into the image cache only after
+  confirmation and only for the imported rows. Two downloadable templates
+  document the format: a header-only CSV and a self-describing JSON whose
+  `_`-prefixed hint keys the parser ignores, so the template itself imports
+  cleanly. Platform text is matched against the platform catalog
+  case-insensitively (abbreviation or full name); unmatched text is kept as
+  a free-form platform name.
+
+  * lib/core/import/sources/custom_file/custom_card_entry.dart
+    (CustomCardFields, CustomCardEntry, CustomCardRow, CustomCardIssue,
+    CustomCardIssueCode, CustomCardsParseException,
+    CustomCardsParseErrorCode): New — schema constants, parsed-entry model,
+    per-row validation issues, whole-file parse errors.
+  * lib/core/import/sources/custom_file/custom_cards_parser.dart
+    (CustomCardsParser.parseBytes, CustomCardsParser.parseJson,
+    CustomCardsParser.parseCsv): New — format sniffing, UTF-8 BOM handling,
+    quote-aware CSV splitting over code units, full field validation.
+  * lib/core/import/sources/custom_file/custom_cards_template.dart
+    (CustomCardsTemplate.csv, CustomCardsTemplate.json): New — downloadable
+    templates.
+  * lib/core/import/sources/custom_file/custom_cards_import_service.dart
+    (CustomCardsImportService.parseFile,
+    CustomCardsImportService.duplicateRowIndexes,
+    CustomCardsImportService.importSelected,
+    customCardsImportServiceProvider): New — preview-driven two-phase
+    import: batch card creation, platform catalog matching, explicit dates
+    overriding status-derived ones, tag resolve-or-create and assignment,
+    post-import cover downloads with per-card failure notes.
+  * lib/core/database/dao/custom_media_dao.dart (CustomMediaDao.createAll):
+    New batch insert returning the new row ids in order.
+  * lib/features/settings/content/custom_cards_import_content.dart
+    (CustomCardsImportContent, localizedParseError): New — file pick,
+    template download buttons, target collection choice.
+  * lib/features/settings/screens/custom_cards_import_screen.dart
+    (CustomCardsImportScreen): New — title-bar wrapper.
+  * lib/features/settings/screens/custom_cards_preview_screen.dart
+    (CustomCardsPreviewScreen): New — summary, select all/none, lazy
+    checkbox list with problem rows first, import progress dialog.
+  * lib/features/settings/screens/settings_screen.dart: Custom cards tile
+    in the Import group.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb: customImport* /
+    settingsCustomCardsImport* keys.
+
 - **Replay status and a rewatch counter**
 
   A sixth item status for going through a finished title again: Replaying

--- a/lib/core/database/dao/custom_media_dao.dart
+++ b/lib/core/database/dao/custom_media_dao.dart
@@ -17,6 +17,24 @@ class CustomMediaDao {
     return db.insert('custom_items', data);
   }
 
+  /// Batch-inserts [items] in one transaction; returns the new row IDs in the
+  /// same order. Used by the custom-cards file import.
+  Future<List<int>> createAll(List<CustomMedia> items) async {
+    if (items.isEmpty) return const <int>[];
+    final Database db = await _getDatabase();
+    final List<Object?> results =
+        await db.transaction((Transaction txn) async {
+      final Batch batch = txn.batch();
+      for (final CustomMedia item in items) {
+        final Map<String, dynamic> data = item.toDb();
+        data.remove('id'); // autoincrement
+        batch.insert('custom_items', data);
+      }
+      return batch.commit();
+    });
+    return results.cast<int>();
+  }
+
   Future<void> update(CustomMedia item) async {
     final Database db = await _getDatabase();
     await db.update(

--- a/lib/core/import/sources/custom_file/custom_card_entry.dart
+++ b/lib/core/import/sources/custom_file/custom_card_entry.dart
@@ -1,0 +1,235 @@
+import '../../../../shared/models/item_status.dart';
+import '../../../../shared/models/media_type.dart';
+
+/// Field keys of the custom-cards import schema, shared by the JSON and CSV
+/// parsers and the downloadable templates.
+abstract final class CustomCardFields {
+  static const String title = 'title';
+  static const String type = 'type';
+  static const String altTitle = 'alt_title';
+  static const String description = 'description';
+  static const String year = 'year';
+  static const String genres = 'genres';
+  static const String link = 'link';
+  static const String cover = 'cover';
+  static const String platform = 'platform';
+  static const String format = 'format';
+  static const String unitTotal = 'unit_total';
+  static const String unitGroupTotal = 'unit_group_total';
+  static const String status = 'status';
+  static const String rating = 'rating';
+  static const String comment = 'comment';
+  static const String rewatchCount = 'rewatch_count';
+  static const String startedAt = 'started_at';
+  static const String completedAt = 'completed_at';
+  static const String timeSpentMinutes = 'time_spent_minutes';
+  static const String tags = 'tags';
+  static const String favorite = 'favorite';
+  static const String currentEpisode = 'current_episode';
+  static const String currentSeason = 'current_season';
+
+  /// Canonical column order for the CSV template and previews.
+  static const List<String> ordered = <String>[
+    title,
+    type,
+    altTitle,
+    description,
+    year,
+    genres,
+    link,
+    cover,
+    platform,
+    format,
+    unitTotal,
+    unitGroupTotal,
+    status,
+    rating,
+    comment,
+    rewatchCount,
+    startedAt,
+    completedAt,
+    timeSpentMinutes,
+    favorite,
+    currentEpisode,
+    currentSeason,
+    tags,
+  ];
+
+  /// Card types a file may declare. `custom` itself is not accepted: the card
+  /// is always stored as a custom item, `type` only picks how it masquerades.
+  static const List<MediaType> allowedTypes = <MediaType>[
+    MediaType.game,
+    MediaType.movie,
+    MediaType.tvShow,
+    MediaType.animation,
+    MediaType.visualNovel,
+    MediaType.manga,
+    MediaType.anime,
+    MediaType.book,
+  ];
+}
+
+/// Why a row (or the whole file) failed validation.
+enum CustomCardIssueCode {
+  /// A JSON array element is not an object.
+  notAnObject,
+
+  /// `title` is missing or blank.
+  missingTitle,
+
+  /// `type` is missing or blank.
+  missingType,
+
+  /// `type` is not one of [CustomCardFields.allowedTypes].
+  unknownType,
+
+  /// A numeric field does not parse or is out of its valid range.
+  invalidNumber,
+
+  /// `status` is not a known [ItemStatus] value.
+  unknownStatus,
+
+  /// `format` is not a known manga/anime format code.
+  unknownFormat,
+
+  /// `format` was given for a type that has no formats (not manga/anime).
+  formatNotApplicable,
+
+  /// `cover` is not an http(s) URL.
+  invalidCoverUrl,
+
+  /// A date field is not an ISO `YYYY-MM-DD` date.
+  invalidDate,
+
+  /// `favorite` is not a boolean (`true`/`false`/`1`/`0`).
+  invalidBool,
+}
+
+/// One validation problem of a parsed row: the [code] plus the offending
+/// [field]/[value] for the error message.
+class CustomCardIssue {
+  const CustomCardIssue(this.code, {this.field, this.value});
+
+  final CustomCardIssueCode code;
+  final String? field;
+  final String? value;
+}
+
+/// A fully validated card from the import file. Field semantics mirror
+/// `CustomMedia` plus the personal columns of `collection_items`.
+class CustomCardEntry {
+  const CustomCardEntry({
+    required this.title,
+    required this.type,
+    this.altTitle,
+    this.description,
+    this.year,
+    this.genres,
+    this.link,
+    this.coverUrl,
+    this.platform,
+    this.format,
+    this.unitTotal,
+    this.unitGroupTotal,
+    this.status,
+    this.rating,
+    this.comment,
+    this.rewatchCount,
+    this.startedAt,
+    this.completedAt,
+    this.timeSpentMinutes,
+    this.favorite,
+    this.currentEpisode,
+    this.currentSeason,
+    this.tags = const <String>[],
+  });
+
+  final String title;
+
+  /// Display type of the created custom card (never [MediaType.custom]).
+  final MediaType type;
+
+  final String? altTitle;
+  final String? description;
+  final int? year;
+
+  /// Comma-separated genre list, stored verbatim.
+  final String? genres;
+
+  /// External page URL (`external_url` on the card).
+  final String? link;
+
+  /// Remote cover URL, downloaded into the image cache after import.
+  final String? coverUrl;
+
+  /// Raw platform text; matched against the platform catalog at import time.
+  final String? platform;
+
+  /// Canonical (upper-cased) manga/anime format code.
+  final String? format;
+
+  final int? unitTotal;
+  final int? unitGroupTotal;
+
+  final ItemStatus? status;
+  final double? rating;
+
+  /// Personal note ("My Note", `user_comment` on the item).
+  final String? comment;
+
+  final int? rewatchCount;
+
+  /// Explicit activity dates; they win over the dates the status implies.
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+
+  final int? timeSpentMinutes;
+
+  final bool? favorite;
+
+  /// Progress positions against [unitTotal] / [unitGroupTotal].
+  final int? currentEpisode;
+  final int? currentSeason;
+
+  /// Global tag names; missing tags are created at import time.
+  final List<String> tags;
+}
+
+/// One row of the parsed file: either a valid [entry] or the [issues] that
+/// disqualified it. [index] is the 1-based data row / array element number.
+class CustomCardRow {
+  const CustomCardRow({
+    required this.index,
+    this.entry,
+    this.issues = const <CustomCardIssue>[],
+    this.sourceTitle,
+  });
+
+  final int index;
+  final CustomCardEntry? entry;
+  final List<CustomCardIssue> issues;
+
+  /// Raw title text for labeling invalid rows in the preview (may be null
+  /// when the row has no readable title at all).
+  final String? sourceTitle;
+
+  bool get isValid => entry != null;
+}
+
+/// Why the file as a whole cannot be parsed.
+enum CustomCardsParseErrorCode {
+  emptyFile,
+  invalidJson,
+  missingRequiredColumns,
+}
+
+/// Raised when the import file cannot be parsed at all (broken JSON, empty
+/// file, CSV without the required header columns).
+class CustomCardsParseException implements Exception {
+  const CustomCardsParseException(this.code);
+
+  final CustomCardsParseErrorCode code;
+
+  @override
+  String toString() => 'CustomCardsParseException: ${code.name}';
+}

--- a/lib/core/import/sources/custom_file/custom_cards_import_service.dart
+++ b/lib/core/import/sources/custom_file/custom_cards_import_service.dart
@@ -1,0 +1,341 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import '../../../../data/repositories/collection_repository.dart';
+import '../../../../shared/models/collection.dart';
+import '../../../../shared/models/collection_item.dart';
+import '../../../../shared/models/custom_media.dart';
+import '../../../../shared/models/item_status.dart';
+import '../../../../shared/models/item_status_logic.dart';
+import '../../../../shared/models/media_type.dart';
+import '../../../../shared/models/platform.dart';
+import '../../../../shared/models/tag.dart';
+import '../../../../shared/models/universal_import_result.dart';
+import '../../../database/database_service.dart';
+import '../../../services/image_cache_service.dart';
+import '../../../services/import_service.dart';
+import '../../import_columns.dart';
+import 'custom_card_entry.dart';
+import 'custom_cards_parser.dart';
+
+final Provider<CustomCardsImportService> customCardsImportServiceProvider =
+    Provider<CustomCardsImportService>((Ref ref) {
+  return CustomCardsImportService(
+    database: ref.watch(databaseServiceProvider),
+    repository: ref.watch(collectionRepositoryProvider),
+    imageCache: ref.watch(imageCacheServiceProvider),
+  );
+});
+
+/// Imports user-authored custom cards from a JSON/CSV file.
+///
+/// Unlike the one-shot [ImportSource] adapters this runs in two phases driven
+/// by the preview UI: [parseFile] validates the whole file without touching
+/// the database, then [importSelected] writes only the rows the user kept.
+/// Covers are downloaded after the rows are written, only for imported cards.
+class CustomCardsImportService {
+  CustomCardsImportService({
+    required DatabaseService database,
+    required CollectionRepository repository,
+    required ImageCacheService imageCache,
+  })  : _db = database,
+        _repository = repository,
+        _imageCache = imageCache;
+
+  static final Logger _log = Logger('CustomCardsImportService');
+
+  static const String sourceName = 'Custom cards';
+
+  final DatabaseService _db;
+  final CollectionRepository _repository;
+  final ImageCacheService _imageCache;
+
+  /// Parses and validates [filePath] without writing anything.
+  Future<List<CustomCardRow>> parseFile(String filePath) async {
+    final Uint8List bytes = await File(filePath).readAsBytes();
+    return const CustomCardsParser()
+        .parseBytes(bytes, fileName: filePath);
+  }
+
+  /// Indexes of rows that duplicate an item already in the target collection
+  /// (matched by title, case-insensitively) or an earlier row of the same
+  /// file. For a new collection ([collectionId] == null) only in-file
+  /// duplicates are reported.
+  Future<Set<int>> duplicateRowIndexes({
+    required int? collectionId,
+    required List<CustomCardRow> rows,
+  }) async {
+    final Set<String> seen = <String>{};
+    if (collectionId != null) {
+      final List<CollectionItem> existing =
+          await _repository.getItemsWithData(collectionId);
+      for (final CollectionItem item in existing) {
+        seen.add(item.itemName.trim().toLowerCase());
+      }
+    }
+
+    final Set<int> duplicates = <int>{};
+    for (final CustomCardRow row in rows) {
+      final CustomCardEntry? entry = row.entry;
+      if (entry == null) continue;
+      if (!seen.add(entry.title.trim().toLowerCase())) {
+        duplicates.add(row.index);
+      }
+    }
+    return duplicates;
+  }
+
+  /// Writes [entries] as custom cards into the target collection (created as
+  /// "Custom Import" when [collectionId] is null), then downloads the covers
+  /// of the written cards.
+  Future<UniversalImportResult> importSelected({
+    required int? collectionId,
+    required String author,
+    required List<CustomCardEntry> entries,
+    ImportProgressCallback? onProgress,
+  }) async {
+    try {
+      if (entries.isEmpty) {
+        return const UniversalImportResult.failure(
+          sourceName: sourceName,
+          error: 'Nothing selected to import',
+        );
+      }
+
+      onProgress?.call(const ImportProgress(
+        stage: ImportStage.creatingCollection,
+        current: 0,
+        total: 0,
+      ));
+
+      final Collection? collection = collectionId != null
+          ? await _repository.getById(collectionId)
+          : await _repository.create(name: 'Custom Import', author: author);
+      if (collection == null) {
+        return const UniversalImportResult.failure(
+          sourceName: sourceName,
+          error: 'Collection not found',
+        );
+      }
+
+      final Map<String, Platform> platformLookup = await _platformLookup();
+      final List<CustomMedia> cards = <CustomMedia>[
+        for (final CustomCardEntry entry in entries)
+          _card(entry, platformLookup),
+      ];
+
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.addingItems,
+        current: 0,
+        total: entries.length,
+      ));
+
+      final List<int> customIds = await _db.customMediaDao.createAll(cards);
+      final List<Map<String, dynamic>> rows = <Map<String, dynamic>>[];
+      for (int i = 0; i < entries.length; i++) {
+        rows.add(_insertRow(entries[i], customIds[i]));
+      }
+      final int inserted =
+          await _repository.addItemsBatch(collection.id, rows);
+      await _applyTags(collection.id, entries, customIds);
+
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.addingItems,
+        current: entries.length,
+        total: entries.length,
+        imported: inserted,
+      ));
+
+      final List<String> errors =
+          await _downloadCovers(entries, customIds, inserted, onProgress);
+
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.completed,
+        current: 1,
+        total: 1,
+        imported: inserted,
+      ));
+
+      return UniversalImportResult(
+        sourceName: sourceName,
+        success: true,
+        collection: collection,
+        importedByType: <MediaType, int>{MediaType.custom: inserted},
+        skipped: entries.length - inserted,
+        errors: errors,
+      );
+    } on Exception catch (e, stack) {
+      _log.severe('Custom cards import failed', e, stack);
+      return UniversalImportResult.failure(
+        sourceName: sourceName,
+        error: 'Import failed: $e',
+      );
+    }
+  }
+
+  /// Platform catalog keyed by lower-cased abbreviation and full name.
+  Future<Map<String, Platform>> _platformLookup() async {
+    final List<Platform> platforms = await _db.gameDao.getAllPlatforms();
+    final Map<String, Platform> lookup = <String, Platform>{};
+    for (final Platform platform in platforms) {
+      lookup[platform.name.trim().toLowerCase()] = platform;
+      final String? abbreviation = platform.abbreviation?.trim().toLowerCase();
+      if (abbreviation != null && abbreviation.isNotEmpty) {
+        lookup[abbreviation] = platform;
+      }
+    }
+    return lookup;
+  }
+
+  CustomMedia _card(
+    CustomCardEntry entry,
+    Map<String, Platform> platformLookup,
+  ) {
+    final Platform? matched = entry.platform == null
+        ? null
+        : platformLookup[entry.platform!.trim().toLowerCase()];
+    // The platform FK only exists for custom games (per the CustomMedia
+    // contract); other types keep the text as a free-form display name.
+    final bool isGame = entry.type == MediaType.game;
+    return CustomMedia(
+      id: 0,
+      title: entry.title,
+      displayType: entry.type,
+      altTitle: entry.altTitle,
+      description: entry.description,
+      coverUrl: entry.coverUrl,
+      year: entry.year,
+      genres: entry.genres,
+      platformName: matched?.displayName ?? entry.platform,
+      platformId: isGame ? matched?.id : null,
+      format: entry.format,
+      unitTotal: entry.unitTotal,
+      unitGroupTotal: entry.unitGroupTotal,
+      externalUrl: entry.link,
+    );
+  }
+
+  Map<String, dynamic> _insertRow(CustomCardEntry entry, int customId) {
+    final ItemStatus status = entry.status ?? ItemStatus.notStarted;
+    final Map<String, dynamic> row = <String, dynamic>{
+      'media_type': MediaType.custom.value,
+      'external_id': customId,
+      'status': status.value,
+      if (entry.rating != null) 'user_rating': entry.rating,
+      if (entry.comment != null) 'user_comment': entry.comment,
+      if (entry.rewatchCount != null) 'rewatch_count': entry.rewatchCount,
+      if (entry.timeSpentMinutes != null)
+        'time_spent_minutes': entry.timeSpentMinutes,
+      if (entry.favorite != null) 'is_favorite': entry.favorite! ? 1 : 0,
+      if (entry.currentEpisode != null)
+        'current_episode': entry.currentEpisode,
+      if (entry.currentSeason != null) 'current_season': entry.currentSeason,
+    };
+
+    if (status != ItemStatus.notStarted) {
+      final StatusDatesUpdate dates = computeDatesForStatus(
+        newStatus: status,
+        currentStartedAt: null,
+        currentCompletedAt: null,
+        now: DateTime.now(),
+      );
+      row['started_at'] = epochSeconds(dates.startedAt);
+      row['completed_at'] = epochSeconds(dates.completedAt);
+      row['last_activity_at'] = epochSeconds(dates.lastActivityAt);
+    }
+
+    // Explicit file dates win over the ones the status implies.
+    if (entry.startedAt != null) {
+      row['started_at'] = epochSeconds(entry.startedAt);
+    }
+    if (entry.completedAt != null) {
+      row['completed_at'] = epochSeconds(entry.completedAt);
+    }
+    if (entry.completedAt != null || entry.startedAt != null) {
+      row['last_activity_at'] =
+          epochSeconds(entry.completedAt ?? entry.startedAt);
+    }
+
+    return row;
+  }
+
+  /// Assigns global tags to the written items, creating tags that don't exist
+  /// yet (matched by name, case-insensitively).
+  Future<void> _applyTags(
+    int collectionId,
+    List<CustomCardEntry> entries,
+    List<int> customIds,
+  ) async {
+    if (!entries.any((CustomCardEntry e) => e.tags.isNotEmpty)) return;
+
+    final List<Tag> existing = await _db.globalTagDao.getAll();
+    final Map<String, int> tagIdByName = <String, int>{
+      for (final Tag tag in existing) tag.name.trim().toLowerCase(): tag.id,
+    };
+    for (final CustomCardEntry entry in entries) {
+      for (final String name in entry.tags) {
+        final String key = name.toLowerCase();
+        if (tagIdByName.containsKey(key)) continue;
+        final Tag created = await _db.globalTagDao.create(name);
+        tagIdByName[key] = created.id;
+      }
+    }
+
+    // Batch insert reports no row ids, so map items back via the unique
+    // (custom) external_id.
+    final Map<int, int> itemIdByExternal = <int, int>{
+      for (final CollectionItem item
+          in await _repository.getItemsWithData(collectionId))
+        if (item.mediaType == MediaType.custom) item.externalId: item.id,
+    };
+    for (int i = 0; i < entries.length; i++) {
+      if (entries[i].tags.isEmpty) continue;
+      final int? itemId = itemIdByExternal[customIds[i]];
+      if (itemId == null) continue;
+      await _db.globalTagDao.setItemTags(itemId, <int>{
+        for (final String name in entries[i].tags)
+          tagIdByName[name.toLowerCase()]!,
+      });
+    }
+  }
+
+  /// Downloads the covers of the written cards; returns per-card error notes
+  /// for covers that could not be fetched (the card keeps its remote URL, so
+  /// the UI can still resolve it later).
+  Future<List<String>> _downloadCovers(
+    List<CustomCardEntry> entries,
+    List<int> customIds,
+    int imported,
+    ImportProgressCallback? onProgress,
+  ) async {
+    final List<(int, CustomCardEntry)> withCovers = <(int, CustomCardEntry)>[
+      for (int i = 0; i < entries.length; i++)
+        if (entries[i].coverUrl != null) (customIds[i], entries[i]),
+    ];
+    if (withCovers.isEmpty) return const <String>[];
+
+    final List<String> errors = <String>[];
+    for (int i = 0; i < withCovers.length; i++) {
+      final (int customId, CustomCardEntry entry) = withCovers[i];
+      onProgress?.call(ImportProgress(
+        stage: ImportStage.importingImages,
+        current: i,
+        total: withCovers.length,
+        currentItem: entry.title,
+        imported: imported,
+      ));
+      final bool ok = await _imageCache.downloadImage(
+        type: ImageType.customCover,
+        imageId: customId.toString(),
+        remoteUrl: entry.coverUrl!,
+      );
+      if (!ok) {
+        errors.add('Cover download failed: ${entry.title}');
+      }
+    }
+    return errors;
+  }
+}

--- a/lib/core/import/sources/custom_file/custom_cards_parser.dart
+++ b/lib/core/import/sources/custom_file/custom_cards_parser.dart
@@ -1,0 +1,465 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../../../../shared/models/item_status.dart';
+import '../../../../shared/models/media_type.dart';
+import '../../../../shared/utils/media_format.dart';
+import 'custom_card_entry.dart';
+
+/// Parses a user-supplied JSON or CSV file into custom-card rows.
+///
+/// JSON: an array of objects (or one object = one card). Keys starting with
+/// `_` and unknown keys are ignored, so the downloadable template with its
+/// `_..._values` hint keys imports cleanly. CSV: UTF-8, comma-separated,
+/// RFC 4180 quoting; columns addressed by header name, unknown columns
+/// ignored. Rows are validated individually — a bad row becomes a
+/// [CustomCardRow] with issues, never a whole-file failure.
+class CustomCardsParser {
+  const CustomCardsParser();
+
+  static const int _yearMin = 1000;
+  static const int _yearMax = 9999;
+  static const double _ratingMax = 10;
+
+  /// Parses [bytes], picking the format from [fileName]'s extension and
+  /// falling back to content sniffing (`{`/`[` first → JSON, else CSV).
+  List<CustomCardRow> parseBytes(Uint8List bytes, {String? fileName}) {
+    final String content = _decode(bytes);
+    if (content.trim().isEmpty) {
+      throw const CustomCardsParseException(CustomCardsParseErrorCode.emptyFile);
+    }
+    final String lowerName = fileName?.toLowerCase() ?? '';
+    if (lowerName.endsWith('.json')) return parseJson(content);
+    if (lowerName.endsWith('.csv')) return parseCsv(content);
+    final String first = content.trimLeft()[0];
+    return (first == '{' || first == '[')
+        ? parseJson(content)
+        : parseCsv(content);
+  }
+
+  /// Parses JSON text: an array of card objects or a single card object.
+  List<CustomCardRow> parseJson(String content) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(content);
+    } on FormatException {
+      throw const CustomCardsParseException(
+        CustomCardsParseErrorCode.invalidJson,
+      );
+    }
+
+    final List<Object?> elements = switch (decoded) {
+      final List<Object?> list => list,
+      final Map<String, dynamic> single => <Object?>[single],
+      _ => throw const CustomCardsParseException(
+          CustomCardsParseErrorCode.invalidJson,
+        ),
+    };
+    if (elements.isEmpty) {
+      throw const CustomCardsParseException(CustomCardsParseErrorCode.emptyFile);
+    }
+
+    final List<CustomCardRow> rows = <CustomCardRow>[];
+    for (int i = 0; i < elements.length; i++) {
+      final Object? element = elements[i];
+      if (element is! Map<String, dynamic>) {
+        rows.add(CustomCardRow(
+          index: i + 1,
+          issues: const <CustomCardIssue>[
+            CustomCardIssue(CustomCardIssueCode.notAnObject),
+          ],
+        ));
+        continue;
+      }
+      rows.add(_validate(element, i + 1));
+    }
+    return rows;
+  }
+
+  /// Parses CSV text; the header must contain `title` and `type` columns.
+  List<CustomCardRow> parseCsv(String content) {
+    final List<List<String>> lines = _splitRows(content);
+    if (lines.isEmpty) {
+      throw const CustomCardsParseException(CustomCardsParseErrorCode.emptyFile);
+    }
+
+    final Map<String, int> index = <String, int>{};
+    final List<String> header = lines.first;
+    for (int i = 0; i < header.length; i++) {
+      index[header[i].trim().toLowerCase()] = i;
+    }
+    if (!index.containsKey(CustomCardFields.title) ||
+        !index.containsKey(CustomCardFields.type)) {
+      throw const CustomCardsParseException(
+        CustomCardsParseErrorCode.missingRequiredColumns,
+      );
+    }
+    if (lines.length == 1) {
+      throw const CustomCardsParseException(CustomCardsParseErrorCode.emptyFile);
+    }
+
+    final List<CustomCardRow> rows = <CustomCardRow>[];
+    for (int r = 1; r < lines.length; r++) {
+      final List<String> line = lines[r];
+      final Map<String, dynamic> raw = <String, dynamic>{};
+      for (final MapEntry<String, int> column in index.entries) {
+        if (line.length > column.value) {
+          raw[column.key] = line[column.value];
+        }
+      }
+      rows.add(_validate(raw, r));
+    }
+    return rows;
+  }
+
+  CustomCardRow _validate(Map<String, dynamic> raw, int index) {
+    final List<CustomCardIssue> issues = <CustomCardIssue>[];
+
+    final String? title = _string(raw, CustomCardFields.title);
+    if (title == null) {
+      issues.add(const CustomCardIssue(CustomCardIssueCode.missingTitle));
+    }
+
+    MediaType? type;
+    final String? typeText = _string(raw, CustomCardFields.type);
+    if (typeText == null) {
+      issues.add(const CustomCardIssue(CustomCardIssueCode.missingType));
+    } else {
+      type = _byValue(
+        CustomCardFields.allowedTypes,
+        typeText,
+        (MediaType t) => t.value,
+      );
+      if (type == null) {
+        issues.add(CustomCardIssue(
+          CustomCardIssueCode.unknownType,
+          field: CustomCardFields.type,
+          value: typeText,
+        ));
+      }
+    }
+
+    final int? year = _intInRange(
+      raw,
+      CustomCardFields.year,
+      issues,
+      min: _yearMin,
+      max: _yearMax,
+    );
+    final int? unitTotal =
+        _intInRange(raw, CustomCardFields.unitTotal, issues, min: 1);
+    final int? unitGroupTotal =
+        _intInRange(raw, CustomCardFields.unitGroupTotal, issues, min: 1);
+    final int? rewatchCount =
+        _intInRange(raw, CustomCardFields.rewatchCount, issues, min: 0);
+
+    double? rating;
+    final String? ratingText = _string(raw, CustomCardFields.rating);
+    if (ratingText != null) {
+      rating = double.tryParse(ratingText.replaceAll(',', '.'));
+      if (rating == null || rating < 0 || rating > _ratingMax) {
+        issues.add(CustomCardIssue(
+          CustomCardIssueCode.invalidNumber,
+          field: CustomCardFields.rating,
+          value: ratingText,
+        ));
+        rating = null;
+      }
+    }
+
+    ItemStatus? status;
+    final String? statusText = _string(raw, CustomCardFields.status);
+    if (statusText != null) {
+      status = _byValue(
+        ItemStatus.values,
+        statusText,
+        (ItemStatus s) => s.value,
+      );
+      if (status == null) {
+        issues.add(CustomCardIssue(
+          CustomCardIssueCode.unknownStatus,
+          field: CustomCardFields.status,
+          value: statusText,
+        ));
+      }
+    }
+
+    final DateTime? startedAt =
+        _date(raw, CustomCardFields.startedAt, issues);
+    final DateTime? completedAt =
+        _date(raw, CustomCardFields.completedAt, issues);
+    final int? timeSpentMinutes =
+        _intInRange(raw, CustomCardFields.timeSpentMinutes, issues, min: 0);
+    final int? currentEpisode =
+        _intInRange(raw, CustomCardFields.currentEpisode, issues, min: 0);
+    final int? currentSeason =
+        _intInRange(raw, CustomCardFields.currentSeason, issues, min: 0);
+    final bool? favorite = _bool(raw, CustomCardFields.favorite, issues);
+
+    String? format;
+    final String? formatText = _string(raw, CustomCardFields.format);
+    if (formatText != null) {
+      final String normalized = formatText.toUpperCase();
+      if (type == MediaType.manga || type == MediaType.anime) {
+        final List<String> allowed = type == MediaType.manga
+            ? MediaFormat.mangaOrder
+            : MediaFormat.animeOrder;
+        if (allowed.contains(normalized)) {
+          format = normalized;
+        } else {
+          issues.add(CustomCardIssue(
+            CustomCardIssueCode.unknownFormat,
+            field: CustomCardFields.format,
+            value: formatText,
+          ));
+        }
+      } else if (type != null) {
+        issues.add(CustomCardIssue(
+          CustomCardIssueCode.formatNotApplicable,
+          field: CustomCardFields.format,
+          value: formatText,
+        ));
+      }
+    }
+
+    String? cover = _string(raw, CustomCardFields.cover);
+    if (cover != null) {
+      final String lower = cover.toLowerCase();
+      if (!lower.startsWith('http://') && !lower.startsWith('https://')) {
+        issues.add(CustomCardIssue(
+          CustomCardIssueCode.invalidCoverUrl,
+          field: CustomCardFields.cover,
+          value: cover,
+        ));
+        cover = null;
+      }
+    }
+
+    if (issues.isNotEmpty || title == null || type == null) {
+      return CustomCardRow(index: index, issues: issues, sourceTitle: title);
+    }
+
+    return CustomCardRow(
+      index: index,
+      sourceTitle: title,
+      entry: CustomCardEntry(
+        title: title,
+        type: type,
+        altTitle: _string(raw, CustomCardFields.altTitle),
+        description: _string(raw, CustomCardFields.description),
+        year: year,
+        genres: _string(raw, CustomCardFields.genres),
+        link: _string(raw, CustomCardFields.link),
+        coverUrl: cover,
+        platform: _string(raw, CustomCardFields.platform),
+        format: format,
+        unitTotal: unitTotal,
+        unitGroupTotal: unitGroupTotal,
+        status: status,
+        rating: rating,
+        comment: _string(raw, CustomCardFields.comment),
+        rewatchCount: rewatchCount,
+        startedAt: startedAt,
+        completedAt: completedAt,
+        timeSpentMinutes: timeSpentMinutes,
+        favorite: favorite,
+        currentEpisode: currentEpisode,
+        currentSeason: currentSeason,
+        tags: _tags(raw),
+      ),
+    );
+  }
+
+  /// Case-insensitive lookup of an enum-like [values] entry by its stored
+  /// [value] string.
+  T? _byValue<T>(
+    Iterable<T> values,
+    String text,
+    String Function(T) value,
+  ) {
+    final String normalized = text.trim().toLowerCase();
+    for (final T candidate in values) {
+      if (value(candidate) == normalized) return candidate;
+    }
+    return null;
+  }
+
+  DateTime? _date(
+    Map<String, dynamic> raw,
+    String key,
+    List<CustomCardIssue> issues,
+  ) {
+    final String? text = _string(raw, key);
+    if (text == null) return null;
+    final DateTime? parsed = DateTime.tryParse(text);
+    if (parsed == null) {
+      issues.add(CustomCardIssue(
+        CustomCardIssueCode.invalidDate,
+        field: key,
+        value: text,
+      ));
+    }
+    return parsed;
+  }
+
+  bool? _bool(
+    Map<String, dynamic> raw,
+    String key,
+    List<CustomCardIssue> issues,
+  ) {
+    final Object? value = raw[key];
+    if (value is bool) return value;
+    final String? text = _string(raw, key);
+    if (text == null) return null;
+    switch (text.toLowerCase()) {
+      case 'true' || '1' || 'yes':
+        return true;
+      case 'false' || '0' || 'no':
+        return false;
+    }
+    issues.add(CustomCardIssue(
+      CustomCardIssueCode.invalidBool,
+      field: key,
+      value: text,
+    ));
+    return null;
+  }
+
+  /// Comma-separated tag names, trimmed and deduped case-insensitively
+  /// (first spelling wins). JSON may also pass a native string array.
+  List<String> _tags(Map<String, dynamic> raw) {
+    final Object? value = raw[CustomCardFields.tags];
+    final List<String> parts;
+    if (value is List<Object?>) {
+      parts = <String>[for (final Object? v in value) if (v != null) '$v'];
+    } else {
+      final String? text = _string(raw, CustomCardFields.tags);
+      if (text == null) return const <String>[];
+      parts = text.split(',');
+    }
+    final Set<String> seen = <String>{};
+    final List<String> tags = <String>[];
+    for (final String part in parts) {
+      final String name = part.trim();
+      if (name.isEmpty) continue;
+      if (seen.add(name.toLowerCase())) tags.add(name);
+    }
+    return tags;
+  }
+
+  /// Trimmed string value of [key]; empty and null collapse to null. Non-string
+  /// JSON scalars (numbers) are stringified so `"year": 1995` works.
+  String? _string(Map<String, dynamic> raw, String key) {
+    final Object? value = raw[key];
+    if (value == null) return null;
+    final String text = value is String ? value.trim() : value.toString();
+    return text.isEmpty ? null : text;
+  }
+
+  int? _intInRange(
+    Map<String, dynamic> raw,
+    String key,
+    List<CustomCardIssue> issues, {
+    int? min,
+    int? max,
+  }) {
+    final Object? value = raw[key];
+    if (value is int) {
+      if ((min != null && value < min) || (max != null && value > max)) {
+        issues.add(CustomCardIssue(
+          CustomCardIssueCode.invalidNumber,
+          field: key,
+          value: '$value',
+        ));
+        return null;
+      }
+      return value;
+    }
+    final String? text = _string(raw, key);
+    if (text == null) return null;
+    final int? parsed = int.tryParse(text);
+    if (parsed == null ||
+        (min != null && parsed < min) ||
+        (max != null && parsed > max)) {
+      issues.add(CustomCardIssue(
+        CustomCardIssueCode.invalidNumber,
+        field: key,
+        value: text,
+      ));
+      return null;
+    }
+    return parsed;
+  }
+
+  /// RFC 4180 row splitter: quoted fields may hold commas, newlines and `""`
+  /// escaped quotes; blank lines are skipped.
+  List<List<String>> _splitRows(String content) {
+    final List<List<String>> rows = <List<String>>[];
+    List<String> current = <String>[];
+    final StringBuffer field = StringBuffer();
+    bool inQuotes = false;
+
+    void endField() {
+      current.add(field.toString());
+      field.clear();
+    }
+
+    void endRow() {
+      endField();
+      final bool blank = current.length == 1 && current.first.trim().isEmpty;
+      if (!blank) rows.add(current);
+      current = <String>[];
+    }
+
+    // Code units, not String indexing: files run to thousands of rows and a
+    // per-character String allocation would drag the UI isolate.
+    const int quote = 0x22, comma = 0x2C, cr = 0x0D, lf = 0x0A;
+    for (int i = 0; i < content.length; i++) {
+      final int ch = content.codeUnitAt(i);
+
+      if (inQuotes) {
+        if (ch == quote) {
+          if (i + 1 < content.length && content.codeUnitAt(i + 1) == quote) {
+            field.writeCharCode(quote);
+            i++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          field.writeCharCode(ch);
+        }
+        continue;
+      }
+
+      switch (ch) {
+        case quote:
+          inQuotes = true;
+        case comma:
+          endField();
+        case cr:
+          // Consume a following \n so CRLF ends exactly one row.
+          if (i + 1 < content.length && content.codeUnitAt(i + 1) == lf) i++;
+          endRow();
+        case lf:
+          endRow();
+        default:
+          field.writeCharCode(ch);
+      }
+    }
+
+    // Flush the last row when the file has no trailing newline.
+    if (field.isNotEmpty || current.isNotEmpty) endRow();
+
+    return rows;
+  }
+
+  String _decode(Uint8List bytes) {
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xEF &&
+        bytes[1] == 0xBB &&
+        bytes[2] == 0xBF) {
+      return utf8.decode(bytes.sublist(3), allowMalformed: true);
+    }
+    return utf8.decode(bytes, allowMalformed: true);
+  }
+}

--- a/lib/core/import/sources/custom_file/custom_cards_template.dart
+++ b/lib/core/import/sources/custom_file/custom_cards_template.dart
@@ -1,0 +1,111 @@
+import 'custom_card_entry.dart';
+
+/// Downloadable templates for the custom-cards import: a header-only CSV and
+/// a JSON example documenting every field. Both import cleanly as-is — the
+/// parser ignores the `_`-prefixed hint keys of the JSON template.
+abstract final class CustomCardsTemplate {
+  static const String csvFileName = 'custom_cards_template.csv';
+  static const String jsonFileName = 'custom_cards_template.json';
+
+  /// CSV template: the full header row, no data rows.
+  static String csv() => '${CustomCardFields.ordered.join(',')}\n';
+
+  /// JSON template: two example cards (a game and an anime) with every field
+  /// filled, plus `_...` hint keys describing each field and its allowed
+  /// values.
+  static String json() => '''
+[
+  {
+    "_help": "Every key except title and type is optional. Keys starting with _ are hints and are ignored by the import.",
+
+    "_title": "REQUIRED. Card name.",
+    "title": "Chrono Trigger",
+
+    "_type": "REQUIRED. One of: game, movie, tv_show, animation, visual_novel, manga, anime, book.",
+    "type": "game",
+
+    "_alt_title": "Original or alternative name.",
+    "alt_title": "クロノ・トリガー",
+
+    "_description": "Free-form description shown on the card.",
+    "description": "Time-travel JRPG by the dream team.",
+
+    "_year": "Release year, number.",
+    "year": 1995,
+
+    "_genres": "Comma-separated genre list.",
+    "genres": "RPG, Adventure",
+
+    "_link": "External page URL opened from the card.",
+    "link": "https://example.com/games/chrono-trigger",
+
+    "_cover": "Cover image URL (http/https only); downloaded after import.",
+    "cover": "https://example.com/covers/chrono-trigger.jpg",
+
+    "_platform": "Abbreviation or name from the platform catalog (PS2, NES, SNES, ...); unmatched text is kept as free text.",
+    "platform": "SNES",
+
+    "_status": "One of: not_started, in_progress, completed, dropped, planned, replaying.",
+    "status": "completed",
+
+    "_rating": "Your rating, 0 to 10, decimals allowed.",
+    "rating": 9.5,
+
+    "_comment": "Personal note (the My Note field on the card).",
+    "comment": "All endings unlocked.",
+
+    "_rewatch_count": "How many times replayed / rewatched / reread.",
+    "rewatch_count": 2,
+
+    "_started_at": "Date you started, YYYY-MM-DD.",
+    "started_at": "2024-01-05",
+
+    "_completed_at": "Date you finished, YYYY-MM-DD.",
+    "completed_at": "2024-02-10",
+
+    "_time_spent_minutes": "Time spent, in minutes.",
+    "time_spent_minutes": 3600,
+
+    "_favorite": "true or false — the heart mark on the card.",
+    "favorite": true,
+
+    "_tags": "Comma-separated global tag names; missing tags are created automatically.",
+    "tags": "jrpg, classics",
+
+    "_current_episode": "Progress: episodes/chapters done (see the second example).",
+    "_current_season": "Progress: seasons/volumes done (see the second example)."
+  },
+  {
+    "title": "Fullmetal Alchemist: Brotherhood",
+    "type": "anime",
+    "alt_title": "鋼の錬金術師",
+    "description": "Two brothers search for the Philosopher's Stone.",
+    "year": 2009,
+    "genres": "Action, Adventure, Drama",
+    "link": "https://example.com/anime/fmab",
+    "cover": "https://example.com/covers/fmab.jpg",
+
+    "_format": "Only for manga/anime. Anime: TV, TV_SHORT, MOVIE, OVA, ONA, SPECIAL, MUSIC. Manga: MANGA, MANHWA, MANHUA, NOVEL, LIGHT_NOVEL, ONE_SHOT.",
+    "format": "TV",
+
+    "_unit_total": "Total episodes (anime/TV) or chapters (manga/book).",
+    "unit_total": 64,
+
+    "_unit_group_total": "Total seasons (TV) or volumes (manga).",
+    "unit_group_total": 1,
+
+    "_current_episode_example": "26 of 64 episodes watched:",
+    "current_episode": 26,
+    "current_season": 1,
+
+    "status": "in_progress",
+    "rating": 10,
+    "comment": "",
+    "rewatch_count": 0,
+    "started_at": "2026-06-01",
+    "favorite": false,
+    "tags": "anime night"
+  }
+]
+''';
+}

--- a/lib/features/settings/content/custom_cards_import_content.dart
+++ b/lib/features/settings/content/custom_cards_import_content.dart
@@ -1,0 +1,341 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/import/sources/custom_file/custom_card_entry.dart';
+import '../../../core/import/sources/custom_file/custom_cards_import_service.dart';
+import '../../../core/import/sources/custom_file/custom_cards_template.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/collection.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/collection_picker_field.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../providers/settings_provider.dart';
+import '../screens/custom_cards_preview_screen.dart';
+import '../widgets/settings_group.dart';
+
+/// Flow: JSON/CSV file pick → parse + validate → target collection →
+/// preview screen with per-row checkboxes → import.
+class CustomCardsImportContent extends ConsumerStatefulWidget {
+  const CustomCardsImportContent({super.key});
+
+  @override
+  ConsumerState<CustomCardsImportContent> createState() =>
+      _CustomCardsImportContentState();
+}
+
+class _CustomCardsImportContentState
+    extends ConsumerState<CustomCardsImportContent> {
+  String? _filePath;
+  List<CustomCardRow>? _rows;
+  bool _useNewCollection = true;
+  int? _selectedCollectionId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _buildFileSection(context),
+        if (_rows != null) ...<Widget>[
+          const SizedBox(height: AppSpacing.md),
+          _buildTargetSection(context),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildFileSection(BuildContext context) {
+    final S l = S.of(context);
+    return SettingsGroup(
+      title: l.customImportTitle,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.sm,
+          ),
+          child: Text(
+            l.customImportDescription,
+            style: AppTypography.bodySmall.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        if (_filePath != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.md,
+              vertical: AppSpacing.sm,
+            ),
+            child: Row(
+              children: <Widget>[
+                const Icon(
+                  Icons.check_circle,
+                  color: AppColors.statusCompleted,
+                  size: 20,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    _filePath!.split(Platform.pathSeparator).last,
+                    style: AppTypography.body,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                TextButton(
+                  onPressed: _pickFile,
+                  child: Text(l.change),
+                ),
+              ],
+            ),
+          )
+        else
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.md,
+              vertical: AppSpacing.sm,
+            ),
+            child: OutlinedButton.icon(
+              onPressed: _pickFile,
+              icon: const Icon(Icons.folder_open),
+              label: Text(l.customImportSelectFile),
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.md,
+            AppSpacing.xs,
+            AppSpacing.md,
+            AppSpacing.md,
+          ),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: OutlinedButton.icon(
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size(0, 40),
+                  ),
+                  onPressed: () => _saveTemplate(
+                    fileName: CustomCardsTemplate.csvFileName,
+                    content: CustomCardsTemplate.csv(),
+                    extension: 'csv',
+                  ),
+                  icon: const Icon(Icons.grid_on, size: 18),
+                  label: Text(l.customImportCsvTemplate),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: OutlinedButton.icon(
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size(0, 40),
+                  ),
+                  onPressed: () => _saveTemplate(
+                    fileName: CustomCardsTemplate.jsonFileName,
+                    content: CustomCardsTemplate.json(),
+                    extension: 'json',
+                  ),
+                  icon: const Icon(Icons.data_object, size: 18),
+                  label: Text(l.customImportJsonTemplate),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTargetSection(BuildContext context) {
+    final AsyncValue<List<Collection>> collectionsAsync =
+        ref.watch(collectionsProvider);
+    final S l = S.of(context);
+
+    return SettingsGroup(
+      title: l.customImportTargetCollection,
+      children: <Widget>[
+        RadioGroup<bool>(
+          groupValue: _useNewCollection,
+          onChanged: (bool? value) {
+            if (value == null) return;
+            setState(() {
+              _useNewCollection = value;
+              if (value) _selectedCollectionId = null;
+            });
+          },
+          child: Column(
+            children: <Widget>[
+              ListTile(
+                title: Text(l.customImportCreateNew),
+                leading: const Radio<bool>(value: true),
+                dense: true,
+                onTap: () => setState(() {
+                  _useNewCollection = true;
+                  _selectedCollectionId = null;
+                }),
+              ),
+              ListTile(
+                title: Text(l.customImportUseExisting),
+                leading: const Radio<bool>(value: false),
+                dense: true,
+                onTap: () => setState(() {
+                  _useNewCollection = false;
+                }),
+              ),
+            ],
+          ),
+        ),
+        if (!_useNewCollection)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              0,
+              AppSpacing.md,
+              AppSpacing.md,
+            ),
+            child: collectionsAsync.when(
+              data: (List<Collection> collections) {
+                if (collections.isEmpty) {
+                  return Text(
+                    l.customImportNoCollections,
+                    style: AppTypography.bodySmall.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                  );
+                }
+                final bool selectedExists = _selectedCollectionId != null &&
+                    collections.any(
+                      (Collection c) => c.id == _selectedCollectionId,
+                    );
+                return CollectionPickerField(
+                  value: selectedExists ? _selectedCollectionId : null,
+                  hint: l.customImportSelectCollection,
+                  title: l.customImportSelectCollection,
+                  onChanged: (int? id) =>
+                      setState(() => _selectedCollectionId = id),
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (Object e, StackTrace s) => Text(
+                l.customImportErrorLoadingCollections,
+                style: AppTypography.bodySmall.copyWith(
+                  color: AppColors.statusDropped,
+                ),
+              ),
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: FilledButton.icon(
+            onPressed: _canPreview ? _openPreview : null,
+            icon: const Icon(Icons.playlist_add_check),
+            label: Text(l.customImportPreviewButton),
+          ),
+        ),
+      ],
+    );
+  }
+
+  bool get _canPreview =>
+      _rows != null && (_useNewCollection || _selectedCollectionId != null);
+
+  Future<void> _pickFile() async {
+    final S l = S.of(context);
+    // Android's SAF does not reliably filter custom extensions.
+    final bool useAny = Platform.isAndroid;
+    final FilePickerResult? result = await FilePicker.platform.pickFiles(
+      dialogTitle: l.customImportSelectFile,
+      type: useAny ? FileType.any : FileType.custom,
+      allowedExtensions: useAny ? null : <String>['json', 'csv'],
+      allowMultiple: false,
+    );
+
+    if (result == null || result.files.isEmpty) return;
+    final String? path = result.files.single.path;
+    if (path == null || !mounted) return;
+
+    final CustomCardsImportService service =
+        ref.read(customCardsImportServiceProvider);
+    try {
+      final List<CustomCardRow> rows = await service.parseFile(path);
+      if (!mounted) return;
+      setState(() {
+        _filePath = path;
+        _rows = rows;
+      });
+    } on CustomCardsParseException catch (e) {
+      if (!mounted) return;
+      context.showSnack(
+        localizedParseError(S.of(context), e.code),
+        type: SnackType.error,
+      );
+    }
+  }
+
+  Future<void> _saveTemplate({
+    required String fileName,
+    required String content,
+    required String extension,
+  }) async {
+    final S l = S.of(context);
+    final String? path = await FilePicker.platform.saveFile(
+      dialogTitle: fileName,
+      fileName: fileName,
+      type: FileType.custom,
+      allowedExtensions: <String>[extension],
+      // On Android/iOS the picker writes the bytes itself.
+      bytes: utf8.encode(content),
+    );
+    if (path == null || !mounted) return;
+
+    // On desktop saveFile only returns the path; write the content ourselves.
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      await File(path).writeAsString(content);
+    }
+    if (!mounted) return;
+    context.showSnack(l.customImportTemplateSaved);
+  }
+
+  Future<void> _openPreview() async {
+    final List<CustomCardRow> rows = _rows!;
+    final int? collectionId = _useNewCollection ? null : _selectedCollectionId;
+    final CustomCardsImportService service =
+        ref.read(customCardsImportServiceProvider);
+    final Set<int> duplicates = await service.duplicateRowIndexes(
+      collectionId: collectionId,
+      rows: rows,
+    );
+    if (!mounted) return;
+
+    final String author = ref.read(settingsNotifierProvider).authorName;
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => CustomCardsPreviewScreen(
+          rows: rows,
+          duplicateIndexes: duplicates,
+          collectionId: collectionId,
+          author: author,
+        ),
+      ),
+    );
+  }
+}
+
+/// Localized message for a whole-file parse failure.
+String localizedParseError(S l, CustomCardsParseErrorCode code) {
+  switch (code) {
+    case CustomCardsParseErrorCode.emptyFile:
+      return l.customImportErrorEmptyFile;
+    case CustomCardsParseErrorCode.invalidJson:
+      return l.customImportErrorInvalidJson;
+    case CustomCardsParseErrorCode.missingRequiredColumns:
+      return l.customImportErrorMissingColumns;
+  }
+}

--- a/lib/features/settings/screens/custom_cards_import_screen.dart
+++ b/lib/features/settings/screens/custom_cards_import_screen.dart
@@ -1,0 +1,42 @@
+// Screen for importing custom cards from a user-supplied JSON/CSV file.
+
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/widgets/sub_screen_title_bar.dart';
+import '../content/custom_cards_import_content.dart';
+
+/// Thin [Scaffold]/title-bar wrapper around [CustomCardsImportContent].
+class CustomCardsImportScreen extends StatelessWidget {
+  const CustomCardsImportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final double width = MediaQuery.sizeOf(context).width;
+    final bool isWide = width >= 800;
+
+    return Column(
+      children: <Widget>[
+        SubScreenTitleBar(title: S.of(context).settingsCustomCardsImport),
+        Expanded(
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: isWide ? 600 : double.infinity,
+              ),
+              child: SingleChildScrollView(
+                padding: EdgeInsets.symmetric(
+                  horizontal: isWide ? AppSpacing.lg : AppSpacing.md,
+                  vertical: AppSpacing.sm,
+                ),
+                child: const CustomCardsImportContent(),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/screens/custom_cards_preview_screen.dart
+++ b/lib/features/settings/screens/custom_cards_preview_screen.dart
@@ -1,0 +1,381 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/import/sources/custom_file/custom_card_entry.dart';
+import '../../../core/import/sources/custom_file/custom_cards_import_service.dart';
+import '../../../core/services/import_service.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
+import '../../../shared/models/universal_import_result.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/sub_screen_title_bar.dart';
+import '../../collections/providers/canvas_provider.dart';
+import '../../collections/providers/collection_covers_provider.dart';
+import '../../collections/providers/collections_provider.dart';
+import '../../collections/providers/global_tags_provider.dart';
+import '../../collections/providers/item_tags_provider.dart';
+import '../../home/providers/all_items_provider.dart';
+import 'import_result_screen.dart';
+
+/// Preview of a parsed custom-cards file: a summary, select-all controls and
+/// a lazy checkbox list (problem rows first), ending in the import action.
+class CustomCardsPreviewScreen extends ConsumerStatefulWidget {
+  const CustomCardsPreviewScreen({
+    required this.rows,
+    required this.duplicateIndexes,
+    required this.collectionId,
+    required this.author,
+    super.key,
+  });
+
+  final List<CustomCardRow> rows;
+
+  /// Row indexes flagged as duplicates (unchecked by default).
+  final Set<int> duplicateIndexes;
+
+  /// Target collection; `null` means "create a new collection".
+  final int? collectionId;
+
+  final String author;
+
+  @override
+  ConsumerState<CustomCardsPreviewScreen> createState() =>
+      _CustomCardsPreviewScreenState();
+}
+
+class _CustomCardsPreviewScreenState
+    extends ConsumerState<CustomCardsPreviewScreen> {
+  /// Rows re-ordered for display: invalid first, then duplicates, then valid.
+  late final List<CustomCardRow> _sorted;
+  late final Set<int> _checked;
+  late final int _validCount;
+
+  @override
+  void initState() {
+    super.initState();
+    _validCount = widget.rows.where((CustomCardRow r) => r.isValid).length;
+    int rank(CustomCardRow row) {
+      if (!row.isValid) return 0;
+      return widget.duplicateIndexes.contains(row.index) ? 1 : 2;
+    }
+
+    _sorted = List<CustomCardRow>.of(widget.rows)
+      ..sort((CustomCardRow a, CustomCardRow b) {
+        final int byRank = rank(a).compareTo(rank(b));
+        return byRank != 0 ? byRank : a.index.compareTo(b.index);
+      });
+    _checked = <int>{
+      for (final CustomCardRow row in widget.rows)
+        if (row.isValid && !widget.duplicateIndexes.contains(row.index))
+          row.index,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    final int errorCount = widget.rows.length - _validCount;
+
+    return Column(
+      children: <Widget>[
+        SubScreenTitleBar(title: l.customImportPreviewTitle),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.md,
+            AppSpacing.sm,
+            AppSpacing.md,
+            0,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                l.customImportSummary(
+                  _validCount,
+                  errorCount,
+                  widget.duplicateIndexes.length,
+                ),
+                style: AppTypography.body,
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              // Wrap, not Row: on narrow screens the buttons plus the counter
+              // exceed the width and must flow onto a second line.
+              Wrap(
+                spacing: AppSpacing.sm,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: <Widget>[
+                  TextButton(
+                    onPressed: _selectAll,
+                    child: Text(l.customImportSelectAll),
+                  ),
+                  TextButton(
+                    onPressed:
+                        _checked.isEmpty ? null : () => setState(_checked.clear),
+                    child: Text(l.customImportSelectNone),
+                  ),
+                  Text(
+                    l.customImportSelectedCount(_checked.length, _validCount),
+                    style: AppTypography.bodySmall.copyWith(
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: ListView.builder(
+            itemCount: _sorted.length,
+            itemBuilder: (BuildContext context, int index) =>
+                _buildRow(context, _sorted[index]),
+          ),
+        ),
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: FilledButton.icon(
+            onPressed: _checked.isEmpty ? null : _startImport,
+            icon: const Icon(Icons.download),
+            label: Text(l.customImportStart),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRow(BuildContext context, CustomCardRow row) {
+    final S l = S.of(context);
+    final String title =
+        row.sourceTitle ?? l.customImportRowLabel(row.index);
+
+    if (!row.isValid) {
+      return ListTile(
+        dense: true,
+        leading: const Icon(
+          Icons.error_outline,
+          color: AppColors.statusDropped,
+        ),
+        title: Text(title, overflow: TextOverflow.ellipsis),
+        subtitle: Text(
+          row.issues
+              .map((CustomCardIssue issue) => _issueText(l, issue))
+              .join(' · '),
+          style: AppTypography.bodySmall.copyWith(
+            color: AppColors.statusDropped,
+          ),
+        ),
+      );
+    }
+
+    final CustomCardEntry entry = row.entry!;
+    final bool isDuplicate = widget.duplicateIndexes.contains(row.index);
+    return CheckboxListTile(
+      dense: true,
+      controlAffinity: ListTileControlAffinity.leading,
+      value: _checked.contains(row.index),
+      onChanged: (bool? checked) => setState(() {
+        if (checked ?? false) {
+          _checked.add(row.index);
+        } else {
+          _checked.remove(row.index);
+        }
+      }),
+      title: Text(entry.title, overflow: TextOverflow.ellipsis),
+      subtitle: isDuplicate
+          ? Text(
+              l.customImportDuplicate,
+              style: AppTypography.bodySmall.copyWith(
+                color: AppColors.statusPlanned,
+              ),
+            )
+          : Text(
+              entry.type.localizedLabel(l),
+              style: AppTypography.bodySmall.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            ),
+    );
+  }
+
+  void _selectAll() => setState(() {
+        for (final CustomCardRow row in widget.rows) {
+          if (row.isValid) _checked.add(row.index);
+        }
+      });
+
+  String _issueText(S l, CustomCardIssue issue) {
+    switch (issue.code) {
+      case CustomCardIssueCode.notAnObject:
+        return l.customImportIssueNotAnObject;
+      case CustomCardIssueCode.missingTitle:
+        return l.customImportIssueMissingTitle;
+      case CustomCardIssueCode.missingType:
+        return l.customImportIssueMissingType;
+      case CustomCardIssueCode.unknownType:
+        return l.customImportIssueUnknownType(issue.value ?? '');
+      case CustomCardIssueCode.invalidNumber:
+        return l.customImportIssueInvalidNumber(
+          issue.field ?? '',
+          issue.value ?? '',
+        );
+      case CustomCardIssueCode.unknownStatus:
+        return l.customImportIssueUnknownStatus(issue.value ?? '');
+      case CustomCardIssueCode.unknownFormat:
+        return l.customImportIssueUnknownFormat(issue.value ?? '');
+      case CustomCardIssueCode.formatNotApplicable:
+        return l.customImportIssueFormatNotApplicable;
+      case CustomCardIssueCode.invalidCoverUrl:
+        return l.customImportIssueInvalidCover;
+      case CustomCardIssueCode.invalidDate:
+        return l.customImportIssueInvalidDate(issue.field ?? '', issue.value ?? '');
+      case CustomCardIssueCode.invalidBool:
+        return l.customImportIssueInvalidBool(issue.value ?? '');
+    }
+  }
+
+  Future<void> _startImport() async {
+    final CustomCardsImportService service =
+        ref.read(customCardsImportServiceProvider);
+    final List<CustomCardEntry> entries = <CustomCardEntry>[
+      for (final CustomCardRow row in widget.rows)
+        if (row.entry != null && _checked.contains(row.index)) row.entry!,
+    ];
+
+    final ValueNotifier<ImportProgress?> progressNotifier =
+        ValueNotifier<ImportProgress?>(null);
+    UniversalImportResult? importResult;
+
+    final Future<UniversalImportResult> importFuture = service
+        .importSelected(
+      collectionId: widget.collectionId,
+      author: widget.author,
+      entries: entries,
+      onProgress: (ImportProgress progress) {
+        progressNotifier.value = progress;
+      },
+    )
+        .then((UniversalImportResult result) {
+      importResult = result;
+      return result;
+    });
+
+    await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext dialogContext) => _ImportProgressDialog(
+        progressNotifier: progressNotifier,
+        importFuture: importFuture,
+      ),
+    );
+
+    progressNotifier.dispose();
+    if (importResult == null || !mounted) return;
+
+    final UniversalImportResult result = importResult!;
+    if (result.success) {
+      ref.invalidate(collectionsProvider);
+      final int? cid = result.effectiveCollectionId;
+      if (cid != null) {
+        ref.invalidate(collectionStatsProvider(cid));
+        ref.invalidate(collectionCoversProvider(cid));
+        ref.invalidate(collectionItemsNotifierProvider(cid));
+        ref.invalidate(canvasNotifierProvider(cid));
+      }
+      ref.invalidate(allItemsNotifierProvider);
+      // Tags may have been created and assigned by the import.
+      ref.invalidate(globalTagsProvider);
+      ref.invalidate(itemTagsProvider);
+
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => ImportResultScreen(result: result),
+        ),
+      );
+    } else if (result.fatalError != null) {
+      context.showSnack(result.fatalError!, type: SnackType.error);
+    }
+  }
+}
+
+class _ImportProgressDialog extends StatelessWidget {
+  const _ImportProgressDialog({
+    required this.progressNotifier,
+    required this.importFuture,
+  });
+
+  final ValueNotifier<ImportProgress?> progressNotifier;
+  final Future<UniversalImportResult> importFuture;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      scrollable: true,
+      title: Text(S.of(context).customImportImporting),
+      content: ValueListenableBuilder<ImportProgress?>(
+        valueListenable: progressNotifier,
+        builder:
+            (BuildContext context, ImportProgress? progress, Widget? child) {
+          if (progress == null) {
+            return const SizedBox(
+              height: 100,
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                progress.stage.description,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              if (progress.currentItem != null) ...<Widget>[
+                const SizedBox(height: 4),
+                Text(
+                  progress.currentItem!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ],
+              const SizedBox(height: 16),
+              LinearProgressIndicator(
+                value: progress.total > 0 ? progress.progress : null,
+              ),
+              if (progress.total > 0) ...<Widget>[
+                const SizedBox(height: 8),
+                Text(
+                  '${progress.current} / ${progress.total}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ],
+          );
+        },
+      ),
+      actions: <Widget>[
+        FutureBuilder<UniversalImportResult>(
+          future: importFuture,
+          builder: (BuildContext context,
+              AsyncSnapshot<UniversalImportResult> snapshot) {
+            if (snapshot.connectionState == ConnectionState.done) {
+              return FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: Text(S.of(context).done),
+              );
+            }
+            return const SizedBox.shrink();
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -41,6 +41,7 @@ import '../../releases/providers/releases_provider.dart';
 import '../../wishlist/providers/wishlist_provider.dart';
 import 'browse_collections_screen.dart';
 import 'anilist_import_screen.dart';
+import 'custom_cards_import_screen.dart';
 import 'igdb_list_import_screen.dart';
 import 'mal_import_screen.dart';
 import 'ra_import_screen.dart';
@@ -307,6 +308,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: l.settingsAniListImport,
             subtitle: l.settingsAniListImportSubtitle,
             onTap: () => _pushScreen(const AniListImportScreen()),
+          ),
+          SettingsTile(
+            leadingIcon: Icons.upload_file,
+            title: l.settingsCustomCardsImport,
+            subtitle: l.settingsCustomCardsImportSubtitle,
+            onTap: () => _pushScreen(const CustomCardsImportScreen()),
           ),
         ],
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2344,6 +2344,95 @@
   "aniListImportEmptyUsername": "Enter your AniList username",
   "aniListImportSelectAtLeastOne": "Select anime or manga to import",
 
+  "settingsCustomCardsImport": "Custom cards",
+  "settingsCustomCardsImportSubtitle": "Import cards from a JSON or CSV file",
+  "customImportTitle": "Import custom cards",
+  "customImportDescription": "Load a JSON or CSV file produced by your own script or parser — every row becomes a custom card. Download a template to see all supported fields and values.",
+  "customImportSelectFile": "Select JSON/CSV file",
+  "customImportCsvTemplate": "CSV template",
+  "customImportJsonTemplate": "JSON template",
+  "customImportTemplateSaved": "Template saved",
+  "customImportTargetCollection": "Target collection",
+  "customImportCreateNew": "Create new collection",
+  "customImportUseExisting": "Add to existing collection",
+  "customImportSelectCollection": "Select collection",
+  "customImportNoCollections": "No collections yet",
+  "customImportErrorLoadingCollections": "Failed to load collections",
+  "customImportPreviewButton": "Preview and import",
+  "customImportPreviewTitle": "Import preview",
+  "customImportSummary": "Recognized {valid} · Errors {errors} · Duplicates {duplicates}",
+  "@customImportSummary": {
+    "placeholders": {
+      "valid": {"type": "int"},
+      "errors": {"type": "int"},
+      "duplicates": {"type": "int"}
+    }
+  },
+  "customImportSelectAll": "Select all",
+  "customImportSelectNone": "Deselect all",
+  "customImportSelectedCount": "{selected} of {total} selected",
+  "@customImportSelectedCount": {
+    "placeholders": {
+      "selected": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "customImportDuplicate": "Duplicate — already in the collection",
+  "customImportRowLabel": "Row {index}",
+  "@customImportRowLabel": {
+    "placeholders": {
+      "index": {"type": "int"}
+    }
+  },
+  "customImportStart": "Import selected",
+  "customImportImporting": "Importing custom cards...",
+  "customImportErrorEmptyFile": "The file is empty",
+  "customImportErrorInvalidJson": "Broken JSON — the file could not be parsed",
+  "customImportErrorMissingColumns": "CSV must have \"title\" and \"type\" columns",
+  "customImportIssueNotAnObject": "Not a JSON object",
+  "customImportIssueMissingTitle": "Missing \"title\"",
+  "customImportIssueMissingType": "Missing \"type\"",
+  "customImportIssueUnknownType": "Unknown type: {value}",
+  "@customImportIssueUnknownType": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueInvalidNumber": "Invalid value in \"{field}\": {value}",
+  "@customImportIssueInvalidNumber": {
+    "placeholders": {
+      "field": {"type": "String"},
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueUnknownStatus": "Unknown status: {value}",
+  "@customImportIssueUnknownStatus": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueUnknownFormat": "Unknown format: {value}",
+  "@customImportIssueUnknownFormat": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueFormatNotApplicable": "\"format\" is only for manga and anime",
+  "customImportIssueInvalidCover": "\"cover\" must be an http(s) URL",
+  "customImportIssueInvalidDate": "Invalid date in \"{field}\": {value} (expected YYYY-MM-DD)",
+  "@customImportIssueInvalidDate": {
+    "placeholders": {
+      "field": {"type": "String"},
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueInvalidBool": "\"favorite\" must be true/false: {value}",
+  "@customImportIssueInvalidBool": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+
   "moodGridCreate": "Create Mood Grid",
   "moodGridCreateTitle": "New Mood Grid",
   "moodGridName": "Name",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9084,6 +9084,234 @@ abstract class S {
   /// **'Select anime or manga to import'**
   String get aniListImportSelectAtLeastOne;
 
+  /// No description provided for @settingsCustomCardsImport.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom cards'**
+  String get settingsCustomCardsImport;
+
+  /// No description provided for @settingsCustomCardsImportSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import cards from a JSON or CSV file'**
+  String get settingsCustomCardsImportSubtitle;
+
+  /// No description provided for @customImportTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import custom cards'**
+  String get customImportTitle;
+
+  /// No description provided for @customImportDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Load a JSON or CSV file produced by your own script or parser — every row becomes a custom card. Download a template to see all supported fields and values.'**
+  String get customImportDescription;
+
+  /// No description provided for @customImportSelectFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Select JSON/CSV file'**
+  String get customImportSelectFile;
+
+  /// No description provided for @customImportCsvTemplate.
+  ///
+  /// In en, this message translates to:
+  /// **'CSV template'**
+  String get customImportCsvTemplate;
+
+  /// No description provided for @customImportJsonTemplate.
+  ///
+  /// In en, this message translates to:
+  /// **'JSON template'**
+  String get customImportJsonTemplate;
+
+  /// No description provided for @customImportTemplateSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Template saved'**
+  String get customImportTemplateSaved;
+
+  /// No description provided for @customImportTargetCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Target collection'**
+  String get customImportTargetCollection;
+
+  /// No description provided for @customImportCreateNew.
+  ///
+  /// In en, this message translates to:
+  /// **'Create new collection'**
+  String get customImportCreateNew;
+
+  /// No description provided for @customImportUseExisting.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to existing collection'**
+  String get customImportUseExisting;
+
+  /// No description provided for @customImportSelectCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Select collection'**
+  String get customImportSelectCollection;
+
+  /// No description provided for @customImportNoCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'No collections yet'**
+  String get customImportNoCollections;
+
+  /// No description provided for @customImportErrorLoadingCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to load collections'**
+  String get customImportErrorLoadingCollections;
+
+  /// No description provided for @customImportPreviewButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview and import'**
+  String get customImportPreviewButton;
+
+  /// No description provided for @customImportPreviewTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import preview'**
+  String get customImportPreviewTitle;
+
+  /// No description provided for @customImportSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Recognized {valid} · Errors {errors} · Duplicates {duplicates}'**
+  String customImportSummary(int valid, int errors, int duplicates);
+
+  /// No description provided for @customImportSelectAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Select all'**
+  String get customImportSelectAll;
+
+  /// No description provided for @customImportSelectNone.
+  ///
+  /// In en, this message translates to:
+  /// **'Deselect all'**
+  String get customImportSelectNone;
+
+  /// No description provided for @customImportSelectedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{selected} of {total} selected'**
+  String customImportSelectedCount(int selected, int total);
+
+  /// No description provided for @customImportDuplicate.
+  ///
+  /// In en, this message translates to:
+  /// **'Duplicate — already in the collection'**
+  String get customImportDuplicate;
+
+  /// No description provided for @customImportRowLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Row {index}'**
+  String customImportRowLabel(int index);
+
+  /// No description provided for @customImportStart.
+  ///
+  /// In en, this message translates to:
+  /// **'Import selected'**
+  String get customImportStart;
+
+  /// No description provided for @customImportImporting.
+  ///
+  /// In en, this message translates to:
+  /// **'Importing custom cards...'**
+  String get customImportImporting;
+
+  /// No description provided for @customImportErrorEmptyFile.
+  ///
+  /// In en, this message translates to:
+  /// **'The file is empty'**
+  String get customImportErrorEmptyFile;
+
+  /// No description provided for @customImportErrorInvalidJson.
+  ///
+  /// In en, this message translates to:
+  /// **'Broken JSON — the file could not be parsed'**
+  String get customImportErrorInvalidJson;
+
+  /// No description provided for @customImportErrorMissingColumns.
+  ///
+  /// In en, this message translates to:
+  /// **'CSV must have \"title\" and \"type\" columns'**
+  String get customImportErrorMissingColumns;
+
+  /// No description provided for @customImportIssueNotAnObject.
+  ///
+  /// In en, this message translates to:
+  /// **'Not a JSON object'**
+  String get customImportIssueNotAnObject;
+
+  /// No description provided for @customImportIssueMissingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing \"title\"'**
+  String get customImportIssueMissingTitle;
+
+  /// No description provided for @customImportIssueMissingType.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing \"type\"'**
+  String get customImportIssueMissingType;
+
+  /// No description provided for @customImportIssueUnknownType.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown type: {value}'**
+  String customImportIssueUnknownType(String value);
+
+  /// No description provided for @customImportIssueInvalidNumber.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid value in \"{field}\": {value}'**
+  String customImportIssueInvalidNumber(String field, String value);
+
+  /// No description provided for @customImportIssueUnknownStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown status: {value}'**
+  String customImportIssueUnknownStatus(String value);
+
+  /// No description provided for @customImportIssueUnknownFormat.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown format: {value}'**
+  String customImportIssueUnknownFormat(String value);
+
+  /// No description provided for @customImportIssueFormatNotApplicable.
+  ///
+  /// In en, this message translates to:
+  /// **'\"format\" is only for manga and anime'**
+  String get customImportIssueFormatNotApplicable;
+
+  /// No description provided for @customImportIssueInvalidCover.
+  ///
+  /// In en, this message translates to:
+  /// **'\"cover\" must be an http(s) URL'**
+  String get customImportIssueInvalidCover;
+
+  /// No description provided for @customImportIssueInvalidDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid date in \"{field}\": {value} (expected YYYY-MM-DD)'**
+  String customImportIssueInvalidDate(String field, String value);
+
+  /// No description provided for @customImportIssueInvalidBool.
+  ///
+  /// In en, this message translates to:
+  /// **'\"favorite\" must be true/false: {value}'**
+  String customImportIssueInvalidBool(String value);
+
   /// No description provided for @moodGridCreate.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5063,6 +5063,145 @@ class SEn extends S {
   String get aniListImportSelectAtLeastOne => 'Select anime or manga to import';
 
   @override
+  String get settingsCustomCardsImport => 'Custom cards';
+
+  @override
+  String get settingsCustomCardsImportSubtitle =>
+      'Import cards from a JSON or CSV file';
+
+  @override
+  String get customImportTitle => 'Import custom cards';
+
+  @override
+  String get customImportDescription =>
+      'Load a JSON or CSV file produced by your own script or parser — every row becomes a custom card. Download a template to see all supported fields and values.';
+
+  @override
+  String get customImportSelectFile => 'Select JSON/CSV file';
+
+  @override
+  String get customImportCsvTemplate => 'CSV template';
+
+  @override
+  String get customImportJsonTemplate => 'JSON template';
+
+  @override
+  String get customImportTemplateSaved => 'Template saved';
+
+  @override
+  String get customImportTargetCollection => 'Target collection';
+
+  @override
+  String get customImportCreateNew => 'Create new collection';
+
+  @override
+  String get customImportUseExisting => 'Add to existing collection';
+
+  @override
+  String get customImportSelectCollection => 'Select collection';
+
+  @override
+  String get customImportNoCollections => 'No collections yet';
+
+  @override
+  String get customImportErrorLoadingCollections =>
+      'Failed to load collections';
+
+  @override
+  String get customImportPreviewButton => 'Preview and import';
+
+  @override
+  String get customImportPreviewTitle => 'Import preview';
+
+  @override
+  String customImportSummary(int valid, int errors, int duplicates) {
+    return 'Recognized $valid · Errors $errors · Duplicates $duplicates';
+  }
+
+  @override
+  String get customImportSelectAll => 'Select all';
+
+  @override
+  String get customImportSelectNone => 'Deselect all';
+
+  @override
+  String customImportSelectedCount(int selected, int total) {
+    return '$selected of $total selected';
+  }
+
+  @override
+  String get customImportDuplicate => 'Duplicate — already in the collection';
+
+  @override
+  String customImportRowLabel(int index) {
+    return 'Row $index';
+  }
+
+  @override
+  String get customImportStart => 'Import selected';
+
+  @override
+  String get customImportImporting => 'Importing custom cards...';
+
+  @override
+  String get customImportErrorEmptyFile => 'The file is empty';
+
+  @override
+  String get customImportErrorInvalidJson =>
+      'Broken JSON — the file could not be parsed';
+
+  @override
+  String get customImportErrorMissingColumns =>
+      'CSV must have \"title\" and \"type\" columns';
+
+  @override
+  String get customImportIssueNotAnObject => 'Not a JSON object';
+
+  @override
+  String get customImportIssueMissingTitle => 'Missing \"title\"';
+
+  @override
+  String get customImportIssueMissingType => 'Missing \"type\"';
+
+  @override
+  String customImportIssueUnknownType(String value) {
+    return 'Unknown type: $value';
+  }
+
+  @override
+  String customImportIssueInvalidNumber(String field, String value) {
+    return 'Invalid value in \"$field\": $value';
+  }
+
+  @override
+  String customImportIssueUnknownStatus(String value) {
+    return 'Unknown status: $value';
+  }
+
+  @override
+  String customImportIssueUnknownFormat(String value) {
+    return 'Unknown format: $value';
+  }
+
+  @override
+  String get customImportIssueFormatNotApplicable =>
+      '\"format\" is only for manga and anime';
+
+  @override
+  String get customImportIssueInvalidCover =>
+      '\"cover\" must be an http(s) URL';
+
+  @override
+  String customImportIssueInvalidDate(String field, String value) {
+    return 'Invalid date in \"$field\": $value (expected YYYY-MM-DD)';
+  }
+
+  @override
+  String customImportIssueInvalidBool(String value) {
+    return '\"favorite\" must be true/false: $value';
+  }
+
+  @override
   String get moodGridCreate => 'Create Mood Grid';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -5152,6 +5152,145 @@ class SRu extends S {
       'Выберите хотя бы один тип: аниме или манга';
 
   @override
+  String get settingsCustomCardsImport => 'Кастомные карточки';
+
+  @override
+  String get settingsCustomCardsImportSubtitle =>
+      'Импорт карточек из JSON или CSV файла';
+
+  @override
+  String get customImportTitle => 'Импорт кастомных карточек';
+
+  @override
+  String get customImportDescription =>
+      'Загрузите JSON или CSV файл, собранный вашим скриптом или парсером — каждая строка станет кастомной карточкой. Скачайте шаблон, чтобы увидеть все поддерживаемые поля и значения.';
+
+  @override
+  String get customImportSelectFile => 'Выбрать JSON/CSV файл';
+
+  @override
+  String get customImportCsvTemplate => 'Шаблон CSV';
+
+  @override
+  String get customImportJsonTemplate => 'Шаблон JSON';
+
+  @override
+  String get customImportTemplateSaved => 'Шаблон сохранён';
+
+  @override
+  String get customImportTargetCollection => 'Целевая коллекция';
+
+  @override
+  String get customImportCreateNew => 'Создать новую коллекцию';
+
+  @override
+  String get customImportUseExisting => 'Добавить в существующую';
+
+  @override
+  String get customImportSelectCollection => 'Выберите коллекцию';
+
+  @override
+  String get customImportNoCollections => 'Коллекций пока нет';
+
+  @override
+  String get customImportErrorLoadingCollections =>
+      'Не удалось загрузить коллекции';
+
+  @override
+  String get customImportPreviewButton => 'Предпросмотр и импорт';
+
+  @override
+  String get customImportPreviewTitle => 'Предпросмотр импорта';
+
+  @override
+  String customImportSummary(int valid, int errors, int duplicates) {
+    return 'Распознано $valid · Ошибок $errors · Дублей $duplicates';
+  }
+
+  @override
+  String get customImportSelectAll => 'Выбрать все';
+
+  @override
+  String get customImportSelectNone => 'Снять все';
+
+  @override
+  String customImportSelectedCount(int selected, int total) {
+    return 'Выбрано $selected из $total';
+  }
+
+  @override
+  String get customImportDuplicate => 'Дубль — уже есть в коллекции';
+
+  @override
+  String customImportRowLabel(int index) {
+    return 'Строка $index';
+  }
+
+  @override
+  String get customImportStart => 'Импортировать отмеченные';
+
+  @override
+  String get customImportImporting => 'Импорт кастомных карточек...';
+
+  @override
+  String get customImportErrorEmptyFile => 'Файл пуст';
+
+  @override
+  String get customImportErrorInvalidJson =>
+      'Битый JSON — файл не удалось разобрать';
+
+  @override
+  String get customImportErrorMissingColumns =>
+      'В CSV должны быть колонки \"title\" и \"type\"';
+
+  @override
+  String get customImportIssueNotAnObject => 'Не JSON-объект';
+
+  @override
+  String get customImportIssueMissingTitle => 'Нет \"title\"';
+
+  @override
+  String get customImportIssueMissingType => 'Нет \"type\"';
+
+  @override
+  String customImportIssueUnknownType(String value) {
+    return 'Неизвестный тип: $value';
+  }
+
+  @override
+  String customImportIssueInvalidNumber(String field, String value) {
+    return 'Неверное значение в \"$field\": $value';
+  }
+
+  @override
+  String customImportIssueUnknownStatus(String value) {
+    return 'Неизвестный статус: $value';
+  }
+
+  @override
+  String customImportIssueUnknownFormat(String value) {
+    return 'Неизвестный формат: $value';
+  }
+
+  @override
+  String get customImportIssueFormatNotApplicable =>
+      '\"format\" только для манги и аниме';
+
+  @override
+  String get customImportIssueInvalidCover =>
+      '\"cover\" должен быть http(s) URL';
+
+  @override
+  String customImportIssueInvalidDate(String field, String value) {
+    return 'Неверная дата в \"$field\": $value (нужен формат YYYY-MM-DD)';
+  }
+
+  @override
+  String customImportIssueInvalidBool(String value) {
+    return '\"favorite\" должен быть true/false: $value';
+  }
+
+  @override
   String get moodGridCreate => 'Создать mood-сетку';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -2010,6 +2010,95 @@
   "aniListImportEmptyUsername": "Введите имя пользователя AniList",
   "aniListImportSelectAtLeastOne": "Выберите хотя бы один тип: аниме или манга",
 
+  "settingsCustomCardsImport": "Кастомные карточки",
+  "settingsCustomCardsImportSubtitle": "Импорт карточек из JSON или CSV файла",
+  "customImportTitle": "Импорт кастомных карточек",
+  "customImportDescription": "Загрузите JSON или CSV файл, собранный вашим скриптом или парсером — каждая строка станет кастомной карточкой. Скачайте шаблон, чтобы увидеть все поддерживаемые поля и значения.",
+  "customImportSelectFile": "Выбрать JSON/CSV файл",
+  "customImportCsvTemplate": "Шаблон CSV",
+  "customImportJsonTemplate": "Шаблон JSON",
+  "customImportTemplateSaved": "Шаблон сохранён",
+  "customImportTargetCollection": "Целевая коллекция",
+  "customImportCreateNew": "Создать новую коллекцию",
+  "customImportUseExisting": "Добавить в существующую",
+  "customImportSelectCollection": "Выберите коллекцию",
+  "customImportNoCollections": "Коллекций пока нет",
+  "customImportErrorLoadingCollections": "Не удалось загрузить коллекции",
+  "customImportPreviewButton": "Предпросмотр и импорт",
+  "customImportPreviewTitle": "Предпросмотр импорта",
+  "customImportSummary": "Распознано {valid} · Ошибок {errors} · Дублей {duplicates}",
+  "@customImportSummary": {
+    "placeholders": {
+      "valid": {"type": "int"},
+      "errors": {"type": "int"},
+      "duplicates": {"type": "int"}
+    }
+  },
+  "customImportSelectAll": "Выбрать все",
+  "customImportSelectNone": "Снять все",
+  "customImportSelectedCount": "Выбрано {selected} из {total}",
+  "@customImportSelectedCount": {
+    "placeholders": {
+      "selected": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "customImportDuplicate": "Дубль — уже есть в коллекции",
+  "customImportRowLabel": "Строка {index}",
+  "@customImportRowLabel": {
+    "placeholders": {
+      "index": {"type": "int"}
+    }
+  },
+  "customImportStart": "Импортировать отмеченные",
+  "customImportImporting": "Импорт кастомных карточек...",
+  "customImportErrorEmptyFile": "Файл пуст",
+  "customImportErrorInvalidJson": "Битый JSON — файл не удалось разобрать",
+  "customImportErrorMissingColumns": "В CSV должны быть колонки \"title\" и \"type\"",
+  "customImportIssueNotAnObject": "Не JSON-объект",
+  "customImportIssueMissingTitle": "Нет \"title\"",
+  "customImportIssueMissingType": "Нет \"type\"",
+  "customImportIssueUnknownType": "Неизвестный тип: {value}",
+  "@customImportIssueUnknownType": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueInvalidNumber": "Неверное значение в \"{field}\": {value}",
+  "@customImportIssueInvalidNumber": {
+    "placeholders": {
+      "field": {"type": "String"},
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueUnknownStatus": "Неизвестный статус: {value}",
+  "@customImportIssueUnknownStatus": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueUnknownFormat": "Неизвестный формат: {value}",
+  "@customImportIssueUnknownFormat": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueFormatNotApplicable": "\"format\" только для манги и аниме",
+  "customImportIssueInvalidCover": "\"cover\" должен быть http(s) URL",
+  "customImportIssueInvalidDate": "Неверная дата в \"{field}\": {value} (нужен формат YYYY-MM-DD)",
+  "@customImportIssueInvalidDate": {
+    "placeholders": {
+      "field": {"type": "String"},
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueInvalidBool": "\"favorite\" должен быть true/false: {value}",
+  "@customImportIssueInvalidBool": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+
   "moodGridCreate": "Создать mood-сетку",
   "moodGridCreateTitle": "Новая mood-сетка",
   "moodGridName": "Название",

--- a/test/core/import/sources/custom_file/custom_cards_import_service_test.dart
+++ b/test/core/import/sources/custom_file/custom_cards_import_service_test.dart
@@ -1,0 +1,466 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_card_entry.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_cards_import_service.dart';
+import 'package:tonkatsu_box/core/services/image_cache_service.dart';
+import 'package:tonkatsu_box/core/services/import_service.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/custom_media.dart';
+import 'package:tonkatsu_box/shared/models/item_status.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+import 'package:tonkatsu_box/shared/models/platform.dart' as model;
+import 'package:tonkatsu_box/shared/models/tag.dart';
+import 'package:tonkatsu_box/shared/models/universal_import_result.dart';
+
+import '../../../../helpers/test_helpers.dart';
+
+void main() {
+  late CustomCardsImportService sut;
+  late MockDatabaseService mockDb;
+  late MockCustomMediaDao mockCustomDao;
+  late MockGameDao mockGameDao;
+  late MockGlobalTagDao mockTagDao;
+  late MockCollectionRepository mockRepo;
+  late MockImageCacheService mockImageCache;
+
+  late Directory tempDir;
+
+  setUpAll(() {
+    registerAllFallbacks();
+    registerFallbackValue(<CustomMedia>[]);
+    registerFallbackValue(<Map<String, dynamic>>[]);
+    registerFallbackValue(<int>{});
+  });
+
+  setUp(() {
+    mockDb = MockDatabaseService();
+    mockCustomDao = MockCustomMediaDao();
+    mockGameDao = MockGameDao();
+    mockTagDao = MockGlobalTagDao();
+    mockRepo = MockCollectionRepository();
+    mockImageCache = MockImageCacheService();
+    when(() => mockDb.customMediaDao).thenReturn(mockCustomDao);
+    when(() => mockDb.gameDao).thenReturn(mockGameDao);
+    when(() => mockDb.globalTagDao).thenReturn(mockTagDao);
+    when(() => mockTagDao.getAll()).thenAnswer((_) async => <Tag>[]);
+    when(() => mockTagDao.setItemTags(any(), any())).thenAnswer((_) async {});
+
+    sut = CustomCardsImportService(
+      database: mockDb,
+      repository: mockRepo,
+      imageCache: mockImageCache,
+    );
+
+    tempDir = Directory.systemTemp.createTempSync('custom_cards_test');
+
+    when(() => mockGameDao.getAllPlatforms()).thenAnswer(
+      (_) async => <model.Platform>[
+        const model.Platform(
+          id: 19,
+          name: 'Super Nintendo Entertainment System',
+          abbreviation: 'SNES',
+        ),
+        const model.Platform(id: 6, name: 'PC (Microsoft Windows)'),
+      ],
+    );
+    when(() => mockRepo.create(
+          name: any(named: 'name'),
+          author: any(named: 'author'),
+        )).thenAnswer((_) async => createTestCollection(id: 7));
+    when(() => mockRepo.getById(any()))
+        .thenAnswer((_) async => createTestCollection(id: 1));
+    when(() => mockCustomDao.createAll(any())).thenAnswer(
+        (Invocation inv) async => List<int>.generate(
+            (inv.positionalArguments[0] as List<CustomMedia>).length,
+            (int i) => 100 + i));
+    when(() => mockRepo.addItemsBatch(any(), any())).thenAnswer(
+        (Invocation inv) async =>
+            (inv.positionalArguments[1] as List<dynamic>).length);
+    when(() => mockImageCache.downloadImage(
+          type: any(named: 'type'),
+          imageId: any(named: 'imageId'),
+          remoteUrl: any(named: 'remoteUrl'),
+        )).thenAnswer((_) async => true);
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  CustomCardEntry entry({
+    String title = 'Card',
+    MediaType type = MediaType.game,
+    String? platform,
+    String? coverUrl,
+    ItemStatus? status,
+    double? rating,
+    String? comment,
+    int? rewatchCount,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    int? timeSpentMinutes,
+    bool? favorite,
+    int? currentEpisode,
+    int? currentSeason,
+    List<String> tags = const <String>[],
+  }) {
+    return CustomCardEntry(
+      title: title,
+      type: type,
+      platform: platform,
+      coverUrl: coverUrl,
+      status: status,
+      rating: rating,
+      comment: comment,
+      rewatchCount: rewatchCount,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      timeSpentMinutes: timeSpentMinutes,
+      favorite: favorite,
+      currentEpisode: currentEpisode,
+      currentSeason: currentSeason,
+      tags: tags,
+    );
+  }
+
+  group('CustomCardsImportService', () {
+    group('parseFile', () {
+      test('parses a JSON file from disk', () async {
+        final String path = '${tempDir.path}/cards.json';
+        File(path).writeAsStringSync('[{"title": "A", "type": "game"}]');
+
+        final List<CustomCardRow> rows = await sut.parseFile(path);
+
+        expect(rows.single.isValid, isTrue);
+      });
+
+      test('parses a CSV file from disk', () async {
+        final String path = '${tempDir.path}/cards.csv';
+        File(path).writeAsStringSync('title,type\nA,book\n');
+
+        final List<CustomCardRow> rows = await sut.parseFile(path);
+
+        expect(rows.single.entry!.type, MediaType.book);
+      });
+    });
+
+    group('duplicateRowIndexes', () {
+      List<CustomCardRow> rowsFor(List<String> titles) => <CustomCardRow>[
+            for (int i = 0; i < titles.length; i++)
+              CustomCardRow(
+                index: i + 1,
+                sourceTitle: titles[i],
+                entry: entry(title: titles[i]),
+              ),
+          ];
+
+      test('flags case-insensitive title matches in the target collection',
+          () async {
+        when(() => mockRepo.getItemsWithData(any())).thenAnswer(
+          (_) async => <CollectionItem>[
+            createTestCollectionItem(overrideName: 'chrono trigger'),
+          ],
+        );
+
+        final Set<int> duplicates = await sut.duplicateRowIndexes(
+          collectionId: 1,
+          rows: rowsFor(<String>['Chrono Trigger', 'Dune']),
+        );
+
+        expect(duplicates, <int>{1});
+      });
+
+      test('flags in-file repeats of the same title', () async {
+        final Set<int> duplicates = await sut.duplicateRowIndexes(
+          collectionId: null,
+          rows: rowsFor(<String>['Dune', 'DUNE', 'Other']),
+        );
+
+        expect(duplicates, <int>{2});
+      });
+
+      test('skips invalid rows and existing lookup for a new collection',
+          () async {
+        final Set<int> duplicates = await sut.duplicateRowIndexes(
+          collectionId: null,
+          rows: <CustomCardRow>[
+            const CustomCardRow(
+              index: 1,
+              issues: <CustomCardIssue>[
+                CustomCardIssue(CustomCardIssueCode.missingTitle),
+              ],
+            ),
+          ],
+        );
+
+        expect(duplicates, isEmpty);
+        verifyNever(() => mockRepo.getItemsWithData(any()));
+      });
+    });
+
+    group('importSelected', () {
+      test('fails on an empty selection', () async {
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: const <CustomCardEntry>[],
+        );
+
+        expect(result.success, isFalse);
+        expect(result.fatalError, isNotNull);
+      });
+
+      test('fails when the target collection does not exist', () async {
+        when(() => mockRepo.getById(any())).thenAnswer((_) async => null);
+
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: 42,
+          author: 'me',
+          entries: <CustomCardEntry>[entry()],
+        );
+
+        expect(result.success, isFalse);
+        verifyNever(() => mockCustomDao.createAll(any()));
+      });
+
+      test('creates a new collection when collectionId is null', () async {
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: null,
+          author: 'me',
+          entries: <CustomCardEntry>[entry()],
+        );
+
+        expect(result.success, isTrue);
+        expect(result.collection?.id, 7);
+        verify(() => mockRepo.create(name: 'Custom Import', author: 'me'))
+            .called(1);
+      });
+
+      test('maps entries to custom cards with platform catalog matching',
+          () async {
+        await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[
+            entry(title: 'Matched', platform: 'snes'),
+            entry(title: 'Free text', platform: 'Famiclone'),
+            entry(
+              title: 'Not a game',
+              type: MediaType.anime,
+              platform: 'SNES',
+            ),
+          ],
+        );
+
+        final List<CustomMedia> cards = verify(
+                () => mockCustomDao.createAll(captureAny()))
+            .captured
+            .single as List<CustomMedia>;
+        expect(cards[0].platformId, 19);
+        expect(cards[0].platformName, 'SNES');
+        expect(cards[0].displayType, MediaType.game);
+        expect(cards[1].platformId, isNull);
+        expect(cards[1].platformName, 'Famiclone');
+        // The platform FK is a custom-games-only field.
+        expect(cards[2].platformId, isNull);
+        expect(cards[2].platformName, 'SNES');
+        expect(cards[2].displayType, MediaType.anime);
+      });
+
+      test('writes items with user fields and status dates', () async {
+        await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[
+            entry(
+              status: ItemStatus.completed,
+              rating: 8.5,
+              comment: 'note',
+              rewatchCount: 3,
+            ),
+            entry(title: 'Untouched'),
+          ],
+        );
+
+        final List<Map<String, dynamic>> rows = (verify(
+                () => mockRepo.addItemsBatch(1, captureAny()))
+            .captured
+            .single as List<dynamic>)
+            .cast<Map<String, dynamic>>();
+
+        expect(rows[0]['media_type'], 'custom');
+        expect(rows[0]['external_id'], 100);
+        expect(rows[0]['status'], 'completed');
+        expect(rows[0]['user_rating'], 8.5);
+        expect(rows[0]['user_comment'], 'note');
+        expect(rows[0]['rewatch_count'], 3);
+        expect(rows[0]['completed_at'], isNotNull);
+        expect(rows[0]['last_activity_at'], isNotNull);
+
+        expect(rows[1]['external_id'], 101);
+        expect(rows[1]['status'], 'not_started');
+        expect(rows[1].containsKey('user_rating'), isFalse);
+        expect(rows[1].containsKey('started_at'), isFalse);
+      });
+
+      test('explicit dates and remaining user fields override status defaults',
+          () async {
+        final DateTime started = DateTime(2024, 1, 5);
+        final DateTime completed = DateTime(2024, 2, 10);
+
+        await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[
+            entry(
+              status: ItemStatus.completed,
+              startedAt: started,
+              completedAt: completed,
+              timeSpentMinutes: 300,
+              favorite: true,
+              currentEpisode: 12,
+              currentSeason: 2,
+            ),
+          ],
+        );
+
+        final Map<String, dynamic> row = (verify(
+                () => mockRepo.addItemsBatch(1, captureAny()))
+            .captured
+            .single as List<dynamic>)
+            .cast<Map<String, dynamic>>()
+            .single;
+
+        int epoch(DateTime d) => d.millisecondsSinceEpoch ~/ 1000;
+        expect(row['started_at'], epoch(started));
+        expect(row['completed_at'], epoch(completed));
+        expect(row['last_activity_at'], epoch(completed));
+        expect(row['time_spent_minutes'], 300);
+        expect(row['is_favorite'], 1);
+        expect(row['current_episode'], 12);
+        expect(row['current_season'], 2);
+      });
+
+      test('resolves existing tags, creates missing ones and assigns them',
+          () async {
+        when(() => mockTagDao.getAll()).thenAnswer(
+          (_) async => <Tag>[
+            const Tag(id: 5, name: 'JRPG', createdAt: 0),
+          ],
+        );
+        when(() => mockTagDao.create(any())).thenAnswer(
+          (_) async => const Tag(id: 9, name: 'new tag', createdAt: 0),
+        );
+        when(() => mockRepo.getItemsWithData(any())).thenAnswer(
+          (_) async => <CollectionItem>[
+            createTestCollectionItem(
+              id: 71,
+              mediaType: MediaType.custom,
+              externalId: 100,
+            ),
+          ],
+        );
+
+        await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[
+            entry(tags: <String>['jrpg', 'new tag']),
+          ],
+        );
+
+        verify(() => mockTagDao.create('new tag')).called(1);
+        verify(() => mockTagDao.setItemTags(71, <int>{5, 9})).called(1);
+      });
+
+      test('skips the tag machinery entirely when no entry has tags',
+          () async {
+        await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[entry()],
+        );
+
+        verifyNever(() => mockTagDao.getAll());
+        verifyNever(() => mockTagDao.setItemTags(any(), any()));
+      });
+
+      test('downloads covers only for entries that have one', () async {
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[
+            entry(title: 'No cover'),
+            entry(title: 'Covered', coverUrl: 'https://e.com/c.jpg'),
+          ],
+        );
+
+        expect(result.success, isTrue);
+        verify(() => mockImageCache.downloadImage(
+              type: ImageType.customCover,
+              imageId: '101',
+              remoteUrl: 'https://e.com/c.jpg',
+            )).called(1);
+        verifyNoMoreInteractions(mockImageCache);
+      });
+
+      test('reports failed cover downloads without failing the import',
+          () async {
+        when(() => mockImageCache.downloadImage(
+              type: any(named: 'type'),
+              imageId: any(named: 'imageId'),
+              remoteUrl: any(named: 'remoteUrl'),
+            )).thenAnswer((_) async => false);
+
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[
+            entry(title: 'Covered', coverUrl: 'https://e.com/c.jpg'),
+          ],
+        );
+
+        expect(result.success, isTrue);
+        expect(result.errors, hasLength(1));
+        expect(result.errors.single, contains('Covered'));
+      });
+
+      test('counts inserted vs skipped and reports progress stages', () async {
+        when(() => mockRepo.addItemsBatch(any(), any()))
+            .thenAnswer((_) async => 1);
+        final List<ImportStage> stages = <ImportStage>[];
+
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[entry(), entry(title: 'Second')],
+          onProgress: (ImportProgress progress) => stages.add(progress.stage),
+        );
+
+        expect(result.importedByType, <MediaType, int>{MediaType.custom: 1});
+        expect(result.skipped, 1);
+        expect(stages.first, ImportStage.creatingCollection);
+        expect(stages, contains(ImportStage.addingItems));
+        expect(stages.last, ImportStage.completed);
+      });
+
+      test('turns an unexpected exception into a failure result', () async {
+        when(() => mockCustomDao.createAll(any()))
+            .thenThrow(Exception('db locked'));
+
+        final UniversalImportResult result = await sut.importSelected(
+          collectionId: 1,
+          author: 'me',
+          entries: <CustomCardEntry>[entry()],
+        );
+
+        expect(result.success, isFalse);
+        expect(result.fatalError, contains('db locked'));
+      });
+    });
+  });
+}

--- a/test/core/import/sources/custom_file/custom_cards_parser_test.dart
+++ b/test/core/import/sources/custom_file/custom_cards_parser_test.dart
@@ -1,0 +1,631 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_card_entry.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_cards_parser.dart';
+import 'package:tonkatsu_box/shared/models/item_status.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+void main() {
+  const CustomCardsParser sut = CustomCardsParser();
+
+  bool hasIssue(CustomCardRow row, CustomCardIssueCode code, {String? field}) =>
+      row.issues.any((CustomCardIssue issue) =>
+          issue.code == code && (field == null || issue.field == field));
+
+  group('CustomCardsParser', () {
+    group('parseJson', () {
+      test('parses an array of objects into valid entries', () {
+        final List<CustomCardRow> rows = sut.parseJson('''
+[
+  {"title": "Chrono Trigger", "type": "game", "year": 1995,
+   "genres": "RPG, Adventure", "link": "https://e.com/ct",
+   "cover": "https://e.com/ct.jpg", "platform": "SNES",
+   "status": "completed", "rating": 9.5, "comment": "Great",
+   "rewatch_count": 2, "alt_title": "CT", "description": "JRPG"}
+]
+''');
+
+        expect(rows, hasLength(1));
+        final CustomCardEntry entry = rows.first.entry!;
+        expect(entry.title, 'Chrono Trigger');
+        expect(entry.type, MediaType.game);
+        expect(entry.year, 1995);
+        expect(entry.genres, 'RPG, Adventure');
+        expect(entry.link, 'https://e.com/ct');
+        expect(entry.coverUrl, 'https://e.com/ct.jpg');
+        expect(entry.platform, 'SNES');
+        expect(entry.status, ItemStatus.completed);
+        expect(entry.rating, 9.5);
+        expect(entry.comment, 'Great');
+        expect(entry.rewatchCount, 2);
+        expect(entry.altTitle, 'CT');
+        expect(entry.description, 'JRPG');
+      });
+
+      test('accepts a single object as one card', () {
+        final List<CustomCardRow> rows =
+            sut.parseJson('{"title": "Solo", "type": "movie"}');
+
+        expect(rows, hasLength(1));
+        expect(rows.first.entry!.type, MediaType.movie);
+      });
+
+      test('throws invalidJson on broken JSON', () {
+        expect(
+          () => sut.parseJson('[{"title": '),
+          throwsA(isA<CustomCardsParseException>().having(
+            (CustomCardsParseException e) => e.code,
+            'code',
+            CustomCardsParseErrorCode.invalidJson,
+          )),
+        );
+      });
+
+      test('throws invalidJson when the root is a scalar', () {
+        expect(
+          () => sut.parseJson('"just a string"'),
+          throwsA(isA<CustomCardsParseException>().having(
+            (CustomCardsParseException e) => e.code,
+            'code',
+            CustomCardsParseErrorCode.invalidJson,
+          )),
+        );
+      });
+
+      test('throws emptyFile on an empty array', () {
+        expect(
+          () => sut.parseJson('[]'),
+          throwsA(isA<CustomCardsParseException>().having(
+            (CustomCardsParseException e) => e.code,
+            'code',
+            CustomCardsParseErrorCode.emptyFile,
+          )),
+        );
+      });
+
+      test('flags a non-object array element', () {
+        final List<CustomCardRow> rows =
+            sut.parseJson('[{"title": "A", "type": "game"}, 42]');
+
+        expect(rows, hasLength(2));
+        expect(rows[0].isValid, isTrue);
+        expect(rows[1].isValid, isFalse);
+        expect(hasIssue(rows[1], CustomCardIssueCode.notAnObject), isTrue);
+        expect(rows[1].index, 2);
+      });
+
+      test('ignores underscore-prefixed and unknown keys', () {
+        final List<CustomCardRow> rows = sut.parseJson('''
+[{"title": "A", "type": "game",
+  "_type_values": "game, movie", "some_extra": "x"}]
+''');
+
+        expect(rows.single.isValid, isTrue);
+      });
+
+      test('accepts native JSON numbers and numeric strings', () {
+        final List<CustomCardRow> rows = sut.parseJson('''
+[{"title": "A", "type": "anime", "year": "2009",
+  "unit_total": 64, "unit_group_total": "1", "rating": 10}]
+''');
+
+        final CustomCardEntry entry = rows.single.entry!;
+        expect(entry.year, 2009);
+        expect(entry.unitTotal, 64);
+        expect(entry.unitGroupTotal, 1);
+        expect(entry.rating, 10);
+      });
+    });
+
+    group('validation', () {
+      CustomCardRow one(Map<String, Object?> card) =>
+          sut.parseJson(jsonEncode(<Object?>[card])).single;
+
+      test('missing or blank title', () {
+        expect(
+          hasIssue(
+            one(<String, Object?>{'type': 'game'}),
+            CustomCardIssueCode.missingTitle,
+          ),
+          isTrue,
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{'title': '  ', 'type': 'game'}),
+            CustomCardIssueCode.missingTitle,
+          ),
+          isTrue,
+        );
+      });
+
+      test('missing type', () {
+        expect(
+          hasIssue(
+            one(<String, Object?>{'title': 'A'}),
+            CustomCardIssueCode.missingType,
+          ),
+          isTrue,
+        );
+      });
+
+      test('unknown type, including the reserved "custom"', () {
+        expect(
+          hasIssue(
+            one(<String, Object?>{'title': 'A', 'type': 'podcast'}),
+            CustomCardIssueCode.unknownType,
+          ),
+          isTrue,
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{'title': 'A', 'type': 'custom'}),
+            CustomCardIssueCode.unknownType,
+          ),
+          isTrue,
+        );
+      });
+
+      test('type matching is case-insensitive', () {
+        final CustomCardRow row =
+            one(<String, Object?>{'title': 'A', 'type': 'Tv_Show'});
+        expect(row.entry!.type, MediaType.tvShow);
+      });
+
+      test('all eight allowed types resolve', () {
+        const Map<String, MediaType> expected = <String, MediaType>{
+          'game': MediaType.game,
+          'movie': MediaType.movie,
+          'tv_show': MediaType.tvShow,
+          'animation': MediaType.animation,
+          'visual_novel': MediaType.visualNovel,
+          'manga': MediaType.manga,
+          'anime': MediaType.anime,
+          'book': MediaType.book,
+        };
+        for (final MapEntry<String, MediaType> pair in expected.entries) {
+          final CustomCardRow row =
+              one(<String, Object?>{'title': 'A', 'type': pair.key});
+          expect(row.entry!.type, pair.value, reason: pair.key);
+        }
+      });
+
+      test('year out of range or non-numeric', () {
+        for (final Object bad in <Object>[999, 10000, 'soon']) {
+          expect(
+            hasIssue(
+              one(<String, Object?>{'title': 'A', 'type': 'game', 'year': bad}),
+              CustomCardIssueCode.invalidNumber,
+              field: 'year',
+            ),
+            isTrue,
+            reason: '$bad',
+          );
+        }
+      });
+
+      test('unit totals must be positive integers', () {
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'anime',
+              'unit_total': 0,
+            }),
+            CustomCardIssueCode.invalidNumber,
+            field: 'unit_total',
+          ),
+          isTrue,
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'anime',
+              'unit_group_total': -1,
+            }),
+            CustomCardIssueCode.invalidNumber,
+            field: 'unit_group_total',
+          ),
+          isTrue,
+        );
+      });
+
+      test('rewatch_count allows zero but not negatives', () {
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'movie',
+            'rewatch_count': 0,
+          }).entry!.rewatchCount,
+          0,
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'movie',
+              'rewatch_count': -1,
+            }),
+            CustomCardIssueCode.invalidNumber,
+            field: 'rewatch_count',
+          ),
+          isTrue,
+        );
+      });
+
+      test('rating bounds and decimal comma', () {
+        expect(
+          one(<String, Object?>{'title': 'A', 'type': 'game', 'rating': '7,5'})
+              .entry!
+              .rating,
+          7.5,
+        );
+        for (final Object bad in <Object>[-1, 10.5, 'great']) {
+          expect(
+            hasIssue(
+              one(<String, Object?>{
+                'title': 'A',
+                'type': 'game',
+                'rating': bad,
+              }),
+              CustomCardIssueCode.invalidNumber,
+              field: 'rating',
+            ),
+            isTrue,
+            reason: '$bad',
+          );
+        }
+      });
+
+      test('status matching is case-insensitive; unknown flagged', () {
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'game',
+            'status': 'REPLAYING',
+          }).entry!.status,
+          ItemStatus.replaying,
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'game',
+              'status': 'finished',
+            }),
+            CustomCardIssueCode.unknownStatus,
+          ),
+          isTrue,
+        );
+      });
+
+      test('format normalizes case for manga and anime', () {
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'manga',
+            'format': 'manhwa',
+          }).entry!.format,
+          'MANHWA',
+        );
+        expect(
+          one(<String, Object?>{'title': 'A', 'type': 'anime', 'format': 'ova'})
+              .entry!
+              .format,
+          'OVA',
+        );
+      });
+
+      test('format from the other list is unknown for this type', () {
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'anime',
+              'format': 'MANGA',
+            }),
+            CustomCardIssueCode.unknownFormat,
+          ),
+          isTrue,
+        );
+      });
+
+      test('format on a non-manga/anime type is not applicable', () {
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'game',
+              'format': 'TV',
+            }),
+            CustomCardIssueCode.formatNotApplicable,
+          ),
+          isTrue,
+        );
+      });
+
+      test('cover must be an http(s) URL', () {
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'game',
+            'cover': 'HTTPS://e.com/a.jpg',
+          }).entry!.coverUrl,
+          'HTTPS://e.com/a.jpg',
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'game',
+              'cover': 'file:///c/a.jpg',
+            }),
+            CustomCardIssueCode.invalidCoverUrl,
+          ),
+          isTrue,
+        );
+      });
+
+      test('a row collects every issue it has', () {
+        final CustomCardRow row = one(<String, Object?>{
+          'year': 'abc',
+          'rating': 99,
+        });
+        expect(row.isValid, isFalse);
+        expect(hasIssue(row, CustomCardIssueCode.missingTitle), isTrue);
+        expect(hasIssue(row, CustomCardIssueCode.missingType), isTrue);
+        expect(hasIssue(row, CustomCardIssueCode.invalidNumber, field: 'year'),
+            isTrue);
+        expect(
+            hasIssue(row, CustomCardIssueCode.invalidNumber, field: 'rating'),
+            isTrue);
+      });
+
+      test('parses ISO dates and flags non-ISO ones', () {
+        final CustomCardEntry ok = one(<String, Object?>{
+          'title': 'A',
+          'type': 'game',
+          'started_at': '2024-01-05',
+          'completed_at': '2024-02-10',
+        }).entry!;
+        expect(ok.startedAt, DateTime(2024, 1, 5));
+        expect(ok.completedAt, DateTime(2024, 2, 10));
+
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'game',
+              'started_at': '31.12.2020',
+            }),
+            CustomCardIssueCode.invalidDate,
+            field: 'started_at',
+          ),
+          isTrue,
+        );
+      });
+
+      test('time_spent_minutes and progress positions allow zero, not negatives',
+          () {
+        final CustomCardEntry ok = one(<String, Object?>{
+          'title': 'A',
+          'type': 'anime',
+          'time_spent_minutes': 0,
+          'current_episode': 0,
+          'current_season': 0,
+        }).entry!;
+        expect(ok.timeSpentMinutes, 0);
+        expect(ok.currentEpisode, 0);
+        expect(ok.currentSeason, 0);
+
+        for (final String field in <String>[
+          'time_spent_minutes',
+          'current_episode',
+          'current_season',
+        ]) {
+          expect(
+            hasIssue(
+              one(<String, Object?>{'title': 'A', 'type': 'anime', field: -1}),
+              CustomCardIssueCode.invalidNumber,
+              field: field,
+            ),
+            isTrue,
+            reason: field,
+          );
+        }
+      });
+
+      test('favorite accepts booleans and common string spellings', () {
+        expect(
+          one(<String, Object?>{'title': 'A', 'type': 'game', 'favorite': true})
+              .entry!
+              .favorite,
+          isTrue,
+        );
+        expect(
+          one(<String, Object?>{'title': 'A', 'type': 'game', 'favorite': '0'})
+              .entry!
+              .favorite,
+          isFalse,
+        );
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'game',
+            'favorite': 'YES',
+          }).entry!.favorite,
+          isTrue,
+        );
+        expect(
+          hasIssue(
+            one(<String, Object?>{
+              'title': 'A',
+              'type': 'game',
+              'favorite': 'да',
+            }),
+            CustomCardIssueCode.invalidBool,
+          ),
+          isTrue,
+        );
+      });
+
+      test('tags parse from a comma string or a JSON array, deduped', () {
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'game',
+            'tags': ' jrpg, Classics ,JRPG,, ',
+          }).entry!.tags,
+          <String>['jrpg', 'Classics'],
+        );
+        expect(
+          one(<String, Object?>{
+            'title': 'A',
+            'type': 'game',
+            'tags': <Object?>['one', 'two', 'ONE'],
+          }).entry!.tags,
+          <String>['one', 'two'],
+        );
+        expect(
+          one(<String, Object?>{'title': 'A', 'type': 'game'}).entry!.tags,
+          isEmpty,
+        );
+      });
+
+      test('keeps the raw title on invalid rows for preview labels', () {
+        final CustomCardRow row =
+            one(<String, Object?>{'title': 'Broken', 'type': 'nope'});
+        expect(row.isValid, isFalse);
+        expect(row.sourceTitle, 'Broken');
+      });
+    });
+
+    group('parseCsv', () {
+      test('parses rows addressed by header name', () {
+        final List<CustomCardRow> rows = sut.parseCsv(
+          'type,title,year\n'
+          'game,"Mario, Lost Levels",1986\n'
+          'book,Dune,1965\n',
+        );
+
+        expect(rows, hasLength(2));
+        expect(rows[0].entry!.title, 'Mario, Lost Levels');
+        expect(rows[0].entry!.year, 1986);
+        expect(rows[1].entry!.type, MediaType.book);
+      });
+
+      test('handles CRLF, quoted quotes and short rows', () {
+        final List<CustomCardRow> rows = sut.parseCsv(
+          'title,type,description\r\n'
+          '"He said ""hi""",game\r\n',
+        );
+
+        expect(rows.single.entry!.title, 'He said "hi"');
+        expect(rows.single.entry!.description, isNull);
+      });
+
+      test('ignores unknown columns', () {
+        final List<CustomCardRow> rows = sut.parseCsv(
+          'title,type,shelf\nA,game,top\n',
+        );
+
+        expect(rows.single.isValid, isTrue);
+      });
+
+      test('empty field values collapse to null', () {
+        final List<CustomCardRow> rows = sut.parseCsv(
+          'title,type,year,status\nA,game,,\n',
+        );
+
+        final CustomCardEntry entry = rows.single.entry!;
+        expect(entry.year, isNull);
+        expect(entry.status, isNull);
+      });
+
+      test('throws when title or type column is missing', () {
+        expect(
+          () => sut.parseCsv('name,type\nA,game\n'),
+          throwsA(isA<CustomCardsParseException>().having(
+            (CustomCardsParseException e) => e.code,
+            'code',
+            CustomCardsParseErrorCode.missingRequiredColumns,
+          )),
+        );
+      });
+
+      test('throws emptyFile when only the header is present', () {
+        expect(
+          () => sut.parseCsv('title,type\n'),
+          throwsA(isA<CustomCardsParseException>().having(
+            (CustomCardsParseException e) => e.code,
+            'code',
+            CustomCardsParseErrorCode.emptyFile,
+          )),
+        );
+      });
+
+      test('row indexes are 1-based data rows', () {
+        final List<CustomCardRow> rows = sut.parseCsv(
+          'title,type\nA,game\nB,game\n',
+        );
+        expect(rows[0].index, 1);
+        expect(rows[1].index, 2);
+      });
+    });
+
+    group('parseBytes', () {
+      Uint8List bytes(String s) => Uint8List.fromList(utf8.encode(s));
+
+      test('throws emptyFile on a blank file', () {
+        expect(
+          () => sut.parseBytes(bytes('  \n')),
+          throwsA(isA<CustomCardsParseException>().having(
+            (CustomCardsParseException e) => e.code,
+            'code',
+            CustomCardsParseErrorCode.emptyFile,
+          )),
+        );
+      });
+
+      test('picks the parser from the file extension', () {
+        final List<CustomCardRow> json = sut.parseBytes(
+          bytes('[{"title": "A", "type": "game"}]'),
+          fileName: 'cards.JSON',
+        );
+        final List<CustomCardRow> csv = sut.parseBytes(
+          bytes('title,type\nA,game\n'),
+          fileName: 'cards.csv',
+        );
+        expect(json.single.isValid, isTrue);
+        expect(csv.single.isValid, isTrue);
+      });
+
+      test('sniffs JSON content without an extension hint', () {
+        final List<CustomCardRow> rows = sut.parseBytes(
+          bytes('  {"title": "A", "type": "game"}'),
+          fileName: 'export.txt',
+        );
+        expect(rows.single.isValid, isTrue);
+      });
+
+      test('falls back to CSV for non-JSON content', () {
+        final List<CustomCardRow> rows =
+            sut.parseBytes(bytes('title,type\nA,game\n'));
+        expect(rows.single.isValid, isTrue);
+      });
+
+      test('strips a UTF-8 BOM', () {
+        final Uint8List withBom = Uint8List.fromList(<int>[
+          0xEF,
+          0xBB,
+          0xBF,
+          ...utf8.encode('title,type\nA,game\n'),
+        ]);
+        final List<CustomCardRow> rows = sut.parseBytes(withBom);
+        expect(rows.single.entry!.title, 'A');
+      });
+    });
+  });
+}

--- a/test/core/import/sources/custom_file/custom_cards_template_test.dart
+++ b/test/core/import/sources/custom_file/custom_cards_template_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_card_entry.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_cards_parser.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_cards_template.dart';
+
+void main() {
+  group('CustomCardsTemplate', () {
+    test('CSV template is exactly the full header row', () {
+      expect(
+        CustomCardsTemplate.csv(),
+        '${CustomCardFields.ordered.join(',')}\n',
+      );
+    });
+
+    test('CSV template mentions every schema field once', () {
+      final List<String> header =
+          CustomCardsTemplate.csv().trim().split(',');
+      expect(header.toSet(), CustomCardFields.ordered.toSet());
+      expect(header.length, CustomCardFields.ordered.length);
+    });
+
+    test('JSON template round-trips through the parser without issues', () {
+      final List<CustomCardRow> rows =
+          const CustomCardsParser().parseJson(CustomCardsTemplate.json());
+
+      expect(rows, isNotEmpty);
+      for (final CustomCardRow row in rows) {
+        expect(row.isValid, isTrue,
+            reason: row.issues
+                .map((CustomCardIssue i) => '${i.code} ${i.field}')
+                .join(', '));
+      }
+    });
+
+    test('JSON template examples cover every schema field', () {
+      final String json = CustomCardsTemplate.json();
+      for (final String field in CustomCardFields.ordered) {
+        expect(json.contains('"$field"'), isTrue, reason: field);
+      }
+    });
+  });
+}

--- a/test/features/settings/screens/custom_cards_preview_screen_test.dart
+++ b/test/features/settings/screens/custom_cards_preview_screen_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/core/import/sources/custom_file/custom_card_entry.dart';
+import 'package:tonkatsu_box/features/settings/screens/custom_cards_preview_screen.dart';
+import 'package:tonkatsu_box/l10n/app_localizations.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  CustomCardRow valid(int index, String title) => CustomCardRow(
+        index: index,
+        sourceTitle: title,
+        entry: CustomCardEntry(title: title, type: MediaType.game),
+      );
+
+  CustomCardRow invalid(int index) => CustomCardRow(
+        index: index,
+        issues: const <CustomCardIssue>[
+          CustomCardIssue(CustomCardIssueCode.missingTitle),
+        ],
+      );
+
+  Widget screen({
+    required List<CustomCardRow> rows,
+    Set<int> duplicates = const <int>{},
+  }) {
+    return Scaffold(
+      body: CustomCardsPreviewScreen(
+        rows: rows,
+        duplicateIndexes: duplicates,
+        collectionId: 1,
+        author: 'me',
+      ),
+    );
+  }
+
+  group('CustomCardsPreviewScreen', () {
+    testWidgets('renders without exception on a phone-sized screen',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpApp(screen(
+        rows: <CustomCardRow>[valid(1, 'Valid'), valid(2, 'Dup'), invalid(3)],
+        duplicates: <int>{2},
+      ));
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('checks valid rows by default and leaves duplicates unchecked',
+        (WidgetTester tester) async {
+      await tester.pumpApp(screen(
+        rows: <CustomCardRow>[valid(1, 'Valid'), valid(2, 'Dup')],
+        duplicates: <int>{2},
+      ));
+
+      final List<CheckboxListTile> tiles = tester
+          .widgetList<CheckboxListTile>(find.byType(CheckboxListTile))
+          .toList();
+      expect(tiles, hasLength(2));
+      final Map<bool?, int> byValue = <bool?, int>{};
+      for (final CheckboxListTile tile in tiles) {
+        byValue[tile.value] = (byValue[tile.value] ?? 0) + 1;
+      }
+      expect(byValue[true], 1);
+      expect(byValue[false], 1);
+    });
+
+    testWidgets('invalid rows come first and get no checkbox',
+        (WidgetTester tester) async {
+      await tester.pumpApp(screen(
+        rows: <CustomCardRow>[valid(1, 'Valid'), invalid(2)],
+      ));
+
+      expect(find.byType(CheckboxListTile), findsOneWidget);
+      final Offset invalidRow =
+          tester.getTopLeft(find.byIcon(Icons.error_outline));
+      final Offset validRow =
+          tester.getTopLeft(find.byType(CheckboxListTile));
+      expect(invalidRow.dy, lessThan(validRow.dy));
+    });
+
+    testWidgets('select none disables import, select all re-enables it',
+        (WidgetTester tester) async {
+      await tester.pumpApp(screen(
+        rows: <CustomCardRow>[valid(1, 'Valid'), valid(2, 'Other')],
+      ));
+
+      FilledButton importButton() => tester.widget<FilledButton>(
+            find.ancestor(
+              of: find.byIcon(Icons.download),
+              matching: find.byType(FilledButton),
+            ),
+          );
+      expect(importButton().onPressed, isNotNull);
+
+      final S l = await S.delegate.load(const Locale('en'));
+      await tester.tap(find.text(l.customImportSelectNone));
+      await tester.pump();
+      expect(importButton().onPressed, isNull);
+
+      await tester.tap(find.text(l.customImportSelectAll));
+      await tester.pump();
+      expect(importButton().onPressed, isNotNull);
+    });
+
+    testWidgets('toggling a row checkbox updates the selection',
+        (WidgetTester tester) async {
+      await tester.pumpApp(screen(
+        rows: <CustomCardRow>[valid(1, 'Only')],
+      ));
+
+      expect(
+        tester
+            .widget<CheckboxListTile>(find.byType(CheckboxListTile))
+            .value,
+        isTrue,
+      );
+
+      await tester.tap(find.byType(CheckboxListTile));
+      await tester.pump();
+
+      expect(
+        tester
+            .widget<CheckboxListTile>(find.byType(CheckboxListTile))
+            .value,
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
New import source for cards produced by the user's own scripts: JSON (array or single object) or CSV (RFC 4180). Only title and type are required; the schema covers all card fields plus every personal field (status, rating, note, rewatch count, start/finish dates, time spent, favorite, episode/season progress, global tags with auto-creation). Validation happens up front; a preview screen lists problem rows first and unchecks duplicates; covers (http/https URLs) download only for the imported rows. Downloadable CSV/JSON templates document every field and import cleanly as-is.

#340 