### PR TITLE
feat(release-39): import error details, card progress, cover size slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,136 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     cached cover URL onto the refetched work; showFantlabEditionPicker is
     now actually wired up.
 
+- **Cover size slider in Settings → Appearance**
+
+  A 70–160% slider scales the item cards in every grid: the collection
+  grid, "All items" and Browse. Desktop scales the max card width;
+  phones and tablets recalculate the column count (2–8). The grid
+  updates live while dragging; the value is saved on release.
+
+  * lib/features/settings/providers/settings_provider.dart
+    (SettingsKeys.cardScale, SettingsState.cardScale,
+    SettingsNotifier.setCardScale): New setting, clamped to 0.7–1.6,
+    persisted in SharedPreferences; reset by clearSettings.
+  * lib/features/settings/screens/settings_screen.dart (_CardScaleSlider):
+    New — slider tile with live preview (persist: false while dragging).
+  * lib/shared/theme/app_spacing.dart (AppSpacing.desktopMaxCardWidth,
+    AppSpacing.scaledColumns): New — the 170px desktop card width moved
+    here from three copies; column-count helper for fixed-count grids.
+  * lib/features/collections/widgets/collection_items_view.dart
+    (CollectionItemsView._buildGridView),
+    lib/features/home/screens/all_items_screen.dart
+    (_AllItemsScreenState._buildGridView),
+    lib/features/search/widgets/browse_grid.dart
+    (_BrowseGridState._buildGridDelegate): Apply the scale to grid
+    delegates.
+
+- **Readable import errors with copyable details**
+
+  A failed import no longer shows a raw exception dump. Error snacks
+  grow a "Details" action opening a dialog with the full message and a
+  copyable debug block (request, status code, cause). The import result
+  screen lists per-item errors in an expandable card with copy-all and
+  adds a copy button for the fatal error.
+
+  * lib/shared/widgets/error_details_dialog.dart (showErrorDetailsDialog,
+    copyErrorDetails): New — copyable error dialog and clipboard helper.
+  * lib/shared/extensions/snackbar_extension.dart
+    (SnackBarExtension.showErrorSnack): New — error snack with the
+    "Details" action.
+  * lib/shared/models/universal_import_result.dart
+    (UniversalImportResult.fatalDetail): New — debug detail carried next
+    to fatalError.
+  * lib/core/api/api_error_extract.dart (extractApiError): Also unwraps
+    GoogleBooksApiException, HardcoverApiException, FantlabApiException,
+    KodiApiException, ScreenScraperApiException.
+  * lib/core/import/sources/steam/steam_import_service.dart,
+    lib/core/import/sources/trakt/trakt_import_service.dart,
+    lib/core/import/sources/igdb_list/igdb_list_import_service.dart,
+    lib/core/import/sources/kinorium/kinorium_import_service.dart:
+    Route unexpected exceptions through extractApiError and attach the
+    detail to the failure result.
+  * lib/core/import/sources/custom_file/custom_cards_import_service.dart:
+    Attach the stack trace as the failure detail.
+  * lib/features/settings/content/anilist_import_content.dart,
+    hardcover_import_content.dart, mal_import_content.dart,
+    ra_import_content.dart, steam_import_content.dart,
+    trakt_import_content.dart, igdb_list_import_content.dart,
+    kinorium_import_content.dart, custom_cards_import_content.dart,
+    lib/features/settings/screens/custom_cards_preview_screen.dart,
+    lib/features/collections/screens/home_screen.dart: Show failures via
+    showErrorSnack with the detail attached.
+  * lib/features/settings/screens/import_result_screen.dart (_ErrorsCard):
+    New — expandable per-item error list with copy-all; copy button for
+    the fatal error.
+  * lib/shared/utils/custom_cards_parse_error_l10n.dart
+    (localizedParseError): Moved out of custom_cards_import_content.dart
+    so the create-item dialog can reuse it.
+
+- **Reading/watching progress on item cards and in the table**
+
+  Anime, manga, books and custom items show their progress right on the
+  poster: a pill next to the status dot (`12/24`, `V2 · 45/120`) and a
+  thin bar along the bottom edge when the total is known. The collection
+  table gains a read-only Progress column. The All Items list is patched
+  in place on every progress change, so the pill stays fresh without a
+  full reload.
+
+  * lib/shared/utils/item_card_progress.dart (ItemCardProgress,
+    itemCardProgress): New — builds the label and 0..1 fraction per
+    media type.
+  * lib/shared/widgets/media_poster_card.dart (MediaPosterCard.progress):
+    New — progress pill and bottom-edge bar on grid/compact cards.
+  * lib/features/collections/widgets/collection_items_view.dart,
+    lib/features/home/screens/all_items_screen.dart: Pass the item's
+    progress to the card.
+  * lib/features/collections/widgets/collection_table/table_fields.dart,
+    table_columns.dart, table_rows.dart (TableFields.progress): New
+    read-only Progress column.
+  * lib/features/home/providers/all_items_provider.dart
+    (AllItemsNotifier.updateProgressLocally): New — in-place patch,
+    mirrors updateStatusLocally.
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier.updateProgress): Sync the All Items copy
+    via the local patch.
+
+- **Prefill the custom item form from a JSON/CSV file**
+
+  The create-item dialog gets an upload button that runs the bulk-import
+  parser on a picked file and fills the form from the first valid row.
+  Only fields present in the file overwrite current values; personal
+  fields (status, rating, dates) are ignored.
+
+  * lib/features/collections/widgets/create_custom_item_dialog.dart
+    (_CreateCustomItemDialogState._fillFromFile, _applyEntry,
+    _resolvePlatformId): New.
+
 ### Changed
+
+- **TMDB content language list expanded from 3 to 45 locales**
+
+  The content language picker now covers TMDB's primary translations
+  (sorted by code, named in their own language), with Chinese split into
+  Simplified and Traditional. On first run the welcome wizard also
+  derives the AniList title mode from the chosen content language
+  (English → english, Japanese → native, otherwise romaji).
+
+  * lib/shared/constants/tmdb_content_languages.dart
+    (kTmdbContentLanguages, anilistTitleLanguageForContent): Expanded
+    list; new content-to-AniList mapping.
+  * lib/features/welcome/widgets/welcome_step_language.dart
+    (_WelcomeStepLanguageState._applyContentLanguage): Apply both TMDB
+    and AniList title language on first-run selection.
+
+- **Gamepad debug log export goes through the system save dialog**
+
+  On Android the log was silently written into the app documents folder;
+  now every platform shows a save dialog (SAF on Android) so the user
+  picks the destination.
+
+  * lib/features/settings/screens/gamepad_debug_screen.dart
+    (_GamepadDebugScreenState._exportLog): Unified FilePicker.saveFile
+    path with bytes payload; manual write kept for desktop.
 
 - **Localization strings deduplicated: 262 duplicate keys collapsed**
 

--- a/lib/core/api/api_error_extract.dart
+++ b/lib/core/api/api_error_extract.dart
@@ -1,9 +1,14 @@
 import 'anilist_api.dart';
 import 'comicvine_api.dart';
+import 'fantlab_api.dart';
+import 'google_books_api.dart';
+import 'hardcover_api.dart';
 import 'igdb_api.dart';
+import 'kodi_api.dart';
 import 'mangabaka_api.dart';
 import 'openlibrary_api.dart';
 import 'ra_api.dart';
+import 'screenscraper_api.dart';
 import 'steam_api.dart';
 import 'steamgriddb_api.dart';
 import 'tmdb_api.dart';
@@ -36,6 +41,16 @@ ApiError extractApiError(Exception e) {
       (message: message, detail: detail),
     RaApiException(:final String message, :final String? detail) =>
       (message: message, detail: detail),
+    GoogleBooksApiException(:final String message, :final String? detail) =>
+      (message: message, detail: detail),
+    HardcoverApiException(:final String message, :final String? detail) =>
+      (message: message, detail: detail),
+    FantlabApiException(:final String message, :final String? detail) =>
+      (message: message, detail: detail),
+    KodiApiException(:final String message, :final String? detail) =>
+      (message: message, detail: detail),
+    ScreenScraperApiException(:final String message) =>
+      (message: message, detail: null),
     _ => (message: e.toString(), detail: null),
   };
 }

--- a/lib/core/import/sources/custom_file/custom_cards_import_service.dart
+++ b/lib/core/import/sources/custom_file/custom_cards_import_service.dart
@@ -173,6 +173,7 @@ class CustomCardsImportService {
       return UniversalImportResult.failure(
         sourceName: sourceName,
         error: 'Import failed: $e',
+        detail: stack.toString(),
       );
     }
   }

--- a/lib/core/import/sources/igdb_list/igdb_list_import_service.dart
+++ b/lib/core/import/sources/igdb_list/igdb_list_import_service.dart
@@ -14,6 +14,7 @@ import '../../../../shared/models/item_status_logic.dart';
 import '../../../../shared/models/media_type.dart';
 import '../../../../shared/models/universal_import_result.dart';
 import '../../../../shared/models/wishlist_tag.dart';
+import '../../../api/api_error_extract.dart';
 import '../../../api/igdb_api.dart';
 import '../../../database/database_service.dart';
 import '../../../services/import_service.dart';
@@ -206,6 +207,7 @@ class IgdbListImportService implements ImportSource {
       return UniversalImportResult.failure(
         sourceName: 'IGDB',
         error: e.message,
+        detail: e.detail,
       );
     } on IgdbListParseException catch (e) {
       return UniversalImportResult.failure(
@@ -213,9 +215,11 @@ class IgdbListImportService implements ImportSource {
         error: e.message,
       );
     } on Exception catch (e) {
+      final ApiError err = extractApiError(e);
       return UniversalImportResult.failure(
         sourceName: 'IGDB',
-        error: 'Import failed: $e',
+        error: 'Import failed: ${err.message}',
+        detail: err.detail,
       );
     }
   }

--- a/lib/core/import/sources/kinorium/kinorium_import_service.dart
+++ b/lib/core/import/sources/kinorium/kinorium_import_service.dart
@@ -14,6 +14,7 @@ import '../../../../shared/models/movie.dart';
 import '../../../../shared/models/tv_show.dart';
 import '../../../../shared/models/universal_import_result.dart';
 import '../../../../shared/models/wishlist_tag.dart';
+import '../../../api/api_error_extract.dart';
 import '../../../api/tmdb_api.dart';
 import '../../../database/database_service.dart';
 import '../../../services/import_service.dart';
@@ -295,9 +296,11 @@ class KinoriumImportService implements ImportSource {
         error: e.message,
       );
     } on Exception catch (e) {
+      final ApiError err = extractApiError(e);
       return UniversalImportResult.failure(
         sourceName: 'Kinorium',
-        error: 'Import failed: $e',
+        error: 'Import failed: ${err.message}',
+        detail: err.detail,
       );
     }
   }

--- a/lib/core/import/sources/steam/steam_import_service.dart
+++ b/lib/core/import/sources/steam/steam_import_service.dart
@@ -11,6 +11,7 @@ import '../../../../shared/models/item_status_logic.dart';
 import '../../../../shared/models/media_type.dart';
 import '../../../../shared/models/universal_import_result.dart';
 import '../../../../shared/models/wishlist_tag.dart';
+import '../../../api/api_error_extract.dart';
 import '../../../api/igdb_api.dart';
 import '../../../api/steam_api.dart';
 import '../../../database/database_service.dart';
@@ -201,11 +202,14 @@ class SteamImportService implements ImportSource {
       return UniversalImportResult.failure(
         sourceName: 'Steam',
         error: e.message,
+        detail: e.detail,
       );
     } on Exception catch (e) {
+      final ApiError err = extractApiError(e);
       return UniversalImportResult.failure(
         sourceName: 'Steam',
-        error: 'Import failed: $e',
+        error: 'Import failed: ${err.message}',
+        detail: err.detail,
       );
     }
   }

--- a/lib/core/import/sources/trakt/trakt_import_service.dart
+++ b/lib/core/import/sources/trakt/trakt_import_service.dart
@@ -16,6 +16,7 @@ import '../../../../shared/models/movie.dart';
 import '../../../../shared/models/tv_show.dart';
 import '../../../../shared/models/universal_import_result.dart';
 import '../../../../shared/models/wishlist_tag.dart';
+import '../../../api/api_error_extract.dart';
 import '../../../api/tmdb_api.dart';
 import '../../../database/database_service.dart';
 import '../../../services/import_service.dart';
@@ -615,9 +616,11 @@ class TraktImportService implements ImportSource {
         skipped: skipped,
       );
     } on Exception catch (e) {
+      final ApiError err = extractApiError(e);
       return UniversalImportResult.failure(
         sourceName: 'Trakt',
-        error: 'Import failed: $e',
+        error: 'Import failed: ${err.message}',
+        detail: err.detail,
       );
     }
   }

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -966,6 +966,14 @@ class CollectionItemsNotifier
         ),
         affects: const <CollectionSortMode>{CollectionSortMode.lastActivity},
       );
+      // The all-items screen renders progress on cards from its own copy;
+      // patch it in place — invalidating would reload every item per tick.
+      ref.read(allItemsNotifierProvider.notifier).updateProgressLocally(
+            id,
+            currentSeason: currentSeason,
+            currentEpisode: currentEpisode,
+            lastActivityAt: now,
+          );
 
       await _autoUpdateMangaStatus(id, currentEpisode, currentSeason);
       await _autoUpdateAnimeStatus(id, currentEpisode);

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -626,10 +626,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       xcoll = await importService.pickAndParseFile();
     } on FormatException catch (e) {
       if (!context.mounted) return;
-      context.showSnack(
-        '${S.of(context).settingsError}: ${e.message}',
-        type: SnackType.error,
-      );
+      context.showErrorSnack('${S.of(context).settingsError}: ${e.message}');
       return;
     }
     if (xcoll == null) return;
@@ -706,7 +703,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       context.showSnack(message.toString(), type: SnackType.success);
       _navigateToCollection(context, result.collection!);
     } else if (!result.isCancelled && result.error != null) {
-      context.showSnack(result.error!, type: SnackType.error);
+      context.showErrorSnack(result.error!);
     }
   }
 }

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -13,6 +13,7 @@ import '../../../shared/models/tag.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/utils/item_card_progress.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../settings/providers/settings_provider.dart';
 import '../helpers/collection_actions.dart';
@@ -74,8 +75,6 @@ class CollectionItemsView extends ConsumerWidget {
   /// Mirrors the table's status column filter outward so chevron counts in
   /// the outer filter bar can react to in-table cycling.
   final ValueChanged<ItemStatus?>? onTableFilterStatusChanged;
-
-  static const double _desktopMaxCardWidth = 170;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -229,32 +228,32 @@ class CollectionItemsView extends ConsumerWidget {
     final double crossSpacing = isLandscape ? AppSpacing.sm : AppSpacing.gridGap;
     final double mainSpacing = isLandscape ? AppSpacing.sm : AppSpacing.lg;
 
+    final SettingsState settings = ref.watch(settingsNotifierProvider);
+
     final SliverGridDelegate gridDelegate;
     if (isDesktop) {
       gridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
-        maxCrossAxisExtent: _desktopMaxCardWidth,
+        maxCrossAxisExtent: AppSpacing.desktopMaxCardWidth * settings.cardScale,
         crossAxisSpacing: crossSpacing,
         mainAxisSpacing: mainSpacing,
         childAspectRatio: 0.55,
       );
     } else {
-      final int crossAxisCount;
+      final int baseCount;
       if (isLandscape) {
-        crossAxisCount = AppSpacing.gridColumnsDesktop;
+        baseCount = AppSpacing.gridColumnsDesktop;
       } else if (screenWidth >= 500) {
-        crossAxisCount = AppSpacing.gridColumnsTablet;
+        baseCount = AppSpacing.gridColumnsTablet;
       } else {
-        crossAxisCount = AppSpacing.gridColumnsMobile;
+        baseCount = AppSpacing.gridColumnsMobile;
       }
       gridDelegate = SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: crossAxisCount,
+        crossAxisCount: AppSpacing.scaledColumns(baseCount, settings.cardScale),
         crossAxisSpacing: crossSpacing,
         mainAxisSpacing: mainSpacing,
         childAspectRatio: 0.55,
       );
     }
-
-    final SettingsState settings = ref.watch(settingsNotifierProvider);
 
     if (!_hasTagGroups) {
       return _buildFlatGridView(
@@ -371,6 +370,7 @@ class CollectionItemsView extends ConsumerWidget {
         : const <int>{};
     final bool selectionActive = selection.isNotEmpty;
     final bool isSelected = selection.contains(item.id);
+    final ItemCardProgress? progress = itemCardProgress(item);
 
     final Widget card = MediaPosterCard(
       key: ValueKey<int>(item.id),
@@ -391,6 +391,7 @@ class CollectionItemsView extends ConsumerWidget {
       mediaType: item.displayMediaType,
       typeLabelOverride: item.formatLabel,
       status: item.status,
+      progress: progress,
       isFavorite: item.isFavorite,
       showFavorite: canEdit,
       enableHoverScale: !isSelected,

--- a/lib/features/collections/widgets/collection_table/table_columns.dart
+++ b/lib/features/collections/widgets/collection_table/table_columns.dart
@@ -179,6 +179,28 @@ List<TrinaColumn> buildCollectionTableColumns({
       },
     ),
     TrinaColumn(
+      title: l.progress.toUpperCase(),
+      field: TableFields.progress,
+      type: TrinaColumnType.text(),
+      width: 96,
+      minWidth: 64,
+      readOnly: true,
+      enableEditingMode: false,
+      enableContextMenu: false,
+      enableSorting: sortable,
+      titleTextAlign: TrinaColumnTextAlign.center,
+      renderer: (TrinaColumnRendererContext ctx) => Center(
+        child: Text(
+          ctx.cell.value as String,
+          style: AppTypography.caption.copyWith(
+            color: AppColors.textSecondary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    ),
+    TrinaColumn(
       title: l.favorite.toUpperCase(),
       field: TableFields.favorite,
       type: TrinaColumnType.number(),

--- a/lib/features/collections/widgets/collection_table/table_fields.dart
+++ b/lib/features/collections/widgets/collection_table/table_fields.dart
@@ -8,6 +8,7 @@ abstract final class TableFields {
   static const String platform = 'platform';
   static const String type = 'type';
   static const String status = 'status';
+  static const String progress = 'progress';
   static const String favorite = 'favorite';
   static const String rating = 'rating';
   static const String externalRating = 'externalRating';
@@ -22,6 +23,7 @@ Map<String, String> tableColumnLabels(S l) => <String, String>{
   TableFields.platform: l.platform,
   TableFields.type: l.type,
   TableFields.status: l.status,
+  TableFields.progress: l.progress,
   TableFields.favorite: l.favorite,
   TableFields.rating: l.rating,
   TableFields.externalRating: l.collectionTableExternalRating,

--- a/lib/features/collections/widgets/collection_table/table_rows.dart
+++ b/lib/features/collections/widgets/collection_table/table_rows.dart
@@ -4,6 +4,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../../shared/models/collection_item.dart';
 import '../../../../shared/models/media_type.dart';
 import '../../../../shared/models/tag.dart';
+import '../../../../shared/utils/item_card_progress.dart';
 import 'table_fields.dart';
 
 /// Builds grid rows for the collection table. Cell values are the plain
@@ -29,6 +30,8 @@ List<TrinaRow<dynamic>> buildCollectionTableRows({
         TableFields.platform: TrinaCell(value: _platformLabel(item)),
         TableFields.type: TrinaCell(value: item.mediaType.localizedLabel(l)),
         TableFields.status: TrinaCell(value: item.status.genericLabel(l)),
+        TableFields.progress:
+            TrinaCell(value: itemCardProgress(item)?.label ?? ''),
         TableFields.favorite: TrinaCell(value: item.isFavorite ? 1 : 0),
         TableFields.rating: TrinaCell(value: item.userRating ?? 0),
         TableFields.externalRating: TrinaCell(value: item.apiRating ?? 0),

--- a/lib/features/collections/widgets/create_custom_item_dialog.dart
+++ b/lib/features/collections/widgets/create_custom_item_dialog.dart
@@ -1,19 +1,24 @@
 import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/database/database_service.dart';
+import '../../../core/import/sources/custom_file/custom_card_entry.dart';
+import '../../../core/import/sources/custom_file/custom_cards_import_service.dart';
 import '../../../core/services/image_cache_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/constants/media_type_theme.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/custom_media.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/platform.dart' as model;
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/utils/custom_cards_parse_error_l10n.dart';
 import '../../../shared/utils/custom_progress_units.dart';
 import '../../../shared/utils/media_format.dart';
 import 'custom_item/cover_image_picker.dart';
@@ -199,6 +204,125 @@ class _CreateCustomItemDialogState
     ));
   }
 
+  /// Prefills the form from a JSON/CSV file via the bulk-import parser;
+  /// with several entries the first valid one is used.
+  Future<void> _fillFromFile() async {
+    final S l = S.of(context);
+    // Mobile pickers don't reliably filter custom extensions (SAF/UTI).
+    final bool useAny = Platform.isAndroid || Platform.isIOS;
+    final FilePickerResult? picked = await FilePicker.platform.pickFiles(
+      dialogTitle: l.customItemFillFromFile,
+      type: useAny ? FileType.any : FileType.custom,
+      allowedExtensions: useAny ? null : <String>['json', 'csv'],
+      allowMultiple: false,
+    );
+    if (picked == null || picked.files.isEmpty) return;
+    final String? path = picked.files.single.path;
+    if (path == null || !mounted) return;
+
+    final List<CustomCardRow> rows;
+    try {
+      rows = await ref
+          .read(customCardsImportServiceProvider)
+          .parseFile(path);
+    } on CustomCardsParseException catch (e) {
+      if (!mounted) return;
+      context.showErrorSnack(localizedParseError(S.of(context), e.code));
+      return;
+    }
+    if (!mounted) return;
+
+    CustomCardEntry? entry;
+    for (final CustomCardRow row in rows) {
+      if (row.entry != null) {
+        entry = row.entry;
+        break;
+      }
+    }
+    if (entry == null) {
+      context.showErrorSnack(S.of(context).customItemFileNoValidRows);
+      return;
+    }
+
+    _applyEntry(entry);
+    if (rows.length > 1) {
+      context.showSnack(
+        S.of(context).customItemFileMultipleRows(rows.length),
+        type: SnackType.info,
+      );
+    }
+  }
+
+  /// Only fields present in the file overwrite current values; personal
+  /// fields (status, rating, dates…) are ignored — they belong to the item.
+  void _applyEntry(CustomCardEntry entry) {
+    setState(() {
+      _selectedType = entry.type;
+      _titleController.text = entry.title;
+      _titleError = null;
+      if (entry.altTitle != null) {
+        _altTitleController.text = entry.altTitle!;
+      }
+      if (entry.description != null) {
+        _descriptionController.text = entry.description!;
+      }
+      if (entry.year != null) {
+        _selectedYear = entry.year;
+      }
+      if (entry.genres != null) {
+        _genresController.text = entry.genres!;
+      }
+      if (entry.coverUrl != null) {
+        _coverUrlController.text = entry.coverUrl!;
+        _localCoverPath = null;
+      }
+      if (entry.link != null) {
+        _externalUrlController.text = entry.link!;
+      }
+      if (entry.unitTotal != null) {
+        _unitTotalController.text = entry.unitTotal!.toString();
+      }
+      if (entry.unitGroupTotal != null) {
+        _unitGroupTotalController.text = entry.unitGroupTotal!.toString();
+      }
+
+      if (entry.type == MediaType.game) {
+        if (entry.platform != null) {
+          _platformController.text = entry.platform!;
+          _selectedPlatformId = _resolvePlatformId(entry.platform!);
+        }
+      } else {
+        _selectedPlatformId = null;
+        _platformController.clear();
+      }
+
+      final List<String>? formatCodes = switch (entry.type) {
+        MediaType.manga => MediaFormat.mangaOrder,
+        MediaType.anime => MediaFormat.animeOrder,
+        _ => null,
+      };
+      if (formatCodes == null) {
+        _selectedFormat = null;
+      } else if (entry.format != null && formatCodes.contains(entry.format)) {
+        _selectedFormat = entry.format;
+      } else if (!formatCodes.contains(_selectedFormat)) {
+        _selectedFormat = null;
+      }
+    });
+  }
+
+  // Same rule as the bulk importer: name or abbreviation, case-insensitive.
+  int? _resolvePlatformId(String name) {
+    final String needle = name.trim().toLowerCase();
+    for (final model.Platform p in _platforms) {
+      if (p.name.trim().toLowerCase() == needle ||
+          p.abbreviation?.trim().toLowerCase() == needle) {
+        return p.id;
+      }
+    }
+    return null;
+  }
+
   Color get _accentColor => MediaTypeTheme.colorFor(_selectedType);
 
   @override
@@ -216,6 +340,11 @@ class _CreateCustomItemDialogState
           style: AppTypography.h2,
         ),
         actions: <Widget>[
+          IconButton(
+            onPressed: _fillFromFile,
+            icon: const Icon(Icons.upload_file),
+            tooltip: l.customItemFillFromFile,
+          ),
           Padding(
             padding: const EdgeInsets.only(right: AppSpacing.sm),
             child: TextButton(

--- a/lib/features/home/providers/all_items_provider.dart
+++ b/lib/features/home/providers/all_items_provider.dart
@@ -182,6 +182,31 @@ class AllItemsNotifier extends Notifier<AsyncValue<List<CollectionItem>>> {
     ref.invalidate(collectionItemsNotifierProvider(target.collectionId));
   }
 
+  /// Patches an item's progress locally without re-querying the DB.
+  ///
+  /// Called from `CollectionItemsNotifier.updateProgress` so the progress
+  /// pill on All Items cards stays in sync without a full reload.
+  void updateProgressLocally(
+    int id, {
+    int? currentSeason,
+    int? currentEpisode,
+    DateTime? lastActivityAt,
+  }) {
+    final List<CollectionItem>? items = state.valueOrNull;
+    if (items == null) return;
+    state = AsyncData<List<CollectionItem>>(
+      items
+          .map((CollectionItem i) => i.id == id
+              ? i.copyWith(
+                  currentSeason: currentSeason ?? i.currentSeason,
+                  currentEpisode: currentEpisode ?? i.currentEpisode,
+                  lastActivityAt: lastActivityAt ?? i.lastActivityAt,
+                )
+              : i)
+          .toList(),
+    );
+  }
+
   /// Patches an item's favorite flag locally without re-querying the DB.
   void updateFavoriteLocally(int id, {required bool isFavorite}) {
     final List<CollectionItem>? items = state.valueOrNull;

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -16,6 +16,7 @@ import '../../../shared/navigation/search_providers.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/utils/item_card_progress.dart';
 import '../../../shared/utils/media_format.dart';
 import '../../../shared/widgets/chevron_filter_bar.dart';
 import '../../../shared/widgets/filter_subfilter_bar.dart';
@@ -47,8 +48,6 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
   final Set<int> _selectedPlatformIds = <int>{};
   final Set<String> _selectedMangaFormats = <String>{};
   final Set<String> _selectedAnimeFormats = <String>{};
-
-  static const double _desktopMaxCardWidth = 170;
 
   /// Below this width the segments show icons instead of text.
   static const double _compactBreakpoint = 700;
@@ -454,25 +453,29 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     final double crossSpacing = isLandscape ? AppSpacing.sm : AppSpacing.gridGap;
     final double mainSpacing = isLandscape ? AppSpacing.sm : AppSpacing.lg;
 
+    final double cardScale = ref.watch(
+      settingsNotifierProvider.select((SettingsState s) => s.cardScale),
+    );
+
     final SliverGridDelegate gridDelegate;
     if (isDesktop) {
       gridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
-        maxCrossAxisExtent: _desktopMaxCardWidth,
+        maxCrossAxisExtent: AppSpacing.desktopMaxCardWidth * cardScale,
         crossAxisSpacing: crossSpacing,
         mainAxisSpacing: mainSpacing,
         childAspectRatio: 0.55,
       );
     } else {
-      final int crossAxisCount;
+      final int baseCount;
       if (isLandscape) {
-        crossAxisCount = AppSpacing.gridColumnsDesktop;
+        baseCount = AppSpacing.gridColumnsDesktop;
       } else if (screenWidth >= 500) {
-        crossAxisCount = AppSpacing.gridColumnsTablet;
+        baseCount = AppSpacing.gridColumnsTablet;
       } else {
-        crossAxisCount = AppSpacing.gridColumnsMobile;
+        baseCount = AppSpacing.gridColumnsMobile;
       }
       gridDelegate = SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: crossAxisCount,
+        crossAxisCount: AppSpacing.scaledColumns(baseCount, cardScale),
         crossAxisSpacing: crossSpacing,
         mainAxisSpacing: mainSpacing,
         childAspectRatio: 0.55,
@@ -516,6 +519,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                     final Set<int> selection =
                         ref.watch(allItemsSelectionProvider);
                     final bool isSelected = selection.contains(item.id);
+                    final ItemCardProgress? progress = itemCardProgress(item);
                     final MediaPosterCard card = MediaPosterCard(
                       key: ValueKey<int>(item.id),
                       variant: isLandscape ||
@@ -541,6 +545,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                       mediaType: item.displayMediaType,
                       typeLabelOverride: item.formatLabel,
                       status: item.status,
+                      progress: progress,
                       isFavorite: item.isFavorite,
                       showFavorite: true,
                       enableHoverScale: !isSelected,

--- a/lib/features/search/widgets/browse_grid.dart
+++ b/lib/features/search/widgets/browse_grid.dart
@@ -456,27 +456,27 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
     return '';
   }
 
-  /// Max card width on desktop; kept in sync with collection_screen.
-  static const double _desktopMaxCardWidth = 170;
-
   /// Card aspect ratio; kept in sync with collection_screen.
   static const double _cardAspectRatio = 0.55;
 
   SliverGridDelegate _buildGridDelegate(BuildContext context) {
     final double width = MediaQuery.sizeOf(context).width;
+    final double cardScale = ref.watch(
+      settingsNotifierProvider.select((SettingsState s) => s.cardScale),
+    );
     if (width >= 800) {
-      return const SliverGridDelegateWithMaxCrossAxisExtent(
-        maxCrossAxisExtent: _desktopMaxCardWidth,
+      return SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: AppSpacing.desktopMaxCardWidth * cardScale,
         childAspectRatio: _cardAspectRatio,
         crossAxisSpacing: AppSpacing.sm,
         mainAxisSpacing: AppSpacing.sm,
       );
     }
-    final int crossAxisCount = width >= 500
+    final int baseCount = width >= 500
         ? AppSpacing.gridColumnsTablet
         : AppSpacing.gridColumnsMobile;
     return SliverGridDelegateWithFixedCrossAxisCount(
-      crossAxisCount: crossAxisCount,
+      crossAxisCount: AppSpacing.scaledColumns(baseCount, cardScale),
       childAspectRatio: _cardAspectRatio,
       crossAxisSpacing: AppSpacing.sm,
       mainAxisSpacing: AppSpacing.sm,

--- a/lib/features/settings/content/anilist_import_content.dart
+++ b/lib/features/settings/content/anilist_import_content.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../core/api/anilist_api.dart';
+import '../../../core/api/api_error_extract.dart';
 import '../../../core/import/sources/anilist/anilist_import_service.dart';
 import '../../../core/services/import_service.dart';
 import '../../../l10n/app_localizations.dart';
@@ -463,7 +464,7 @@ class _AniListImportContentState extends ConsumerState<AniListImportContent> {
       if (!result.success) {
         setState(() => _isImporting = false);
         if (result.fatalError != null) {
-          context.showSnack(result.fatalError!, type: SnackType.error);
+          context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
         }
         return;
       }
@@ -505,10 +506,8 @@ class _AniListImportContentState extends ConsumerState<AniListImportContent> {
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() => _isImporting = false);
-      context.showSnack(
-        l.importFailed(e.toString()),
-        type: SnackType.error,
-      );
+      final ApiError err = extractApiError(e);
+      context.showErrorSnack(l.importFailed(err.message), detail: err.detail);
     }
   }
 }

--- a/lib/features/settings/content/custom_cards_import_content.dart
+++ b/lib/features/settings/content/custom_cards_import_content.dart
@@ -14,6 +14,7 @@ import '../../../shared/models/collection.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/utils/custom_cards_parse_error_l10n.dart';
 import '../../../shared/widgets/collection_picker_field.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../providers/settings_provider.dart';
@@ -272,10 +273,7 @@ class _CustomCardsImportContentState
       });
     } on CustomCardsParseException catch (e) {
       if (!mounted) return;
-      context.showSnack(
-        localizedParseError(S.of(context), e.code),
-        type: SnackType.error,
-      );
+      context.showErrorSnack(localizedParseError(S.of(context), e.code));
     }
   }
 
@@ -325,17 +323,5 @@ class _CustomCardsImportContentState
         ),
       ),
     );
-  }
-}
-
-/// Localized message for a whole-file parse failure.
-String localizedParseError(S l, CustomCardsParseErrorCode code) {
-  switch (code) {
-    case CustomCardsParseErrorCode.emptyFile:
-      return l.customImportErrorEmptyFile;
-    case CustomCardsParseErrorCode.invalidJson:
-      return l.customImportErrorInvalidJson;
-    case CustomCardsParseErrorCode.missingRequiredColumns:
-      return l.customImportErrorMissingColumns;
   }
 }

--- a/lib/features/settings/content/hardcover_import_content.dart
+++ b/lib/features/settings/content/hardcover_import_content.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../core/api/api_error_extract.dart';
 import '../../../core/api/hardcover_api.dart';
 import '../../../core/import/sources/anilist/anilist_import_service.dart'
     show ImportMode;
@@ -440,7 +441,7 @@ class _HardcoverImportContentState
       if (!result.success) {
         setState(() => _isImporting = false);
         if (result.fatalError != null) {
-          context.showSnack(result.fatalError!, type: SnackType.error);
+          context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
         }
         return;
       }
@@ -480,10 +481,8 @@ class _HardcoverImportContentState
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() => _isImporting = false);
-      context.showSnack(
-        l.importFailed(e.toString()),
-        type: SnackType.error,
-      );
+      final ApiError err = extractApiError(e);
+      context.showErrorSnack(l.importFailed(err.message), detail: err.detail);
     }
   }
 }

--- a/lib/features/settings/content/igdb_list_import_content.dart
+++ b/lib/features/settings/content/igdb_list_import_content.dart
@@ -466,7 +466,7 @@ class _IgdbListImportContentState extends ConsumerState<IgdbListImportContent> {
         ),
       );
     } else if (result.fatalError != null) {
-      context.showSnack(result.fatalError!, type: SnackType.error);
+      context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
     }
   }
 

--- a/lib/features/settings/content/kinorium_import_content.dart
+++ b/lib/features/settings/content/kinorium_import_content.dart
@@ -357,7 +357,7 @@ class _KinoriumImportContentState extends ConsumerState<KinoriumImportContent> {
         ),
       );
     } else if (result.fatalError != null) {
-      context.showSnack(result.fatalError!, type: SnackType.error);
+      context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
     }
   }
 }

--- a/lib/features/settings/content/mal_import_content.dart
+++ b/lib/features/settings/content/mal_import_content.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/api/api_error_extract.dart';
 import '../../../core/import/sources/mal/mal_import_service.dart';
 import '../../../core/services/import_service.dart';
 import '../../../l10n/app_localizations.dart';
@@ -467,7 +468,7 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
       if (!result.success) {
         setState(() => _isImporting = false);
         if (result.fatalError != null) {
-          context.showSnack(result.fatalError!, type: SnackType.error);
+          context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
         }
         return;
       }
@@ -496,10 +497,8 @@ class _MalImportContentState extends ConsumerState<MalImportContent> {
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() => _isImporting = false);
-      context.showSnack(
-        l.importFailed(e.toString()),
-        type: SnackType.error,
-      );
+      final ApiError err = extractApiError(e);
+      context.showErrorSnack(l.importFailed(err.message), detail: err.detail);
     }
   }
 }

--- a/lib/features/settings/content/ra_import_content.dart
+++ b/lib/features/settings/content/ra_import_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../core/api/api_error_extract.dart';
 import '../../../core/api/ra_api.dart';
 import '../../../core/import/sources/ra/ra_import_service.dart';
 import '../../../core/services/import_service.dart';
@@ -434,9 +435,10 @@ class _RaImportContentState extends ConsumerState<RaImportContent> {
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() => _isCheckingProfile = false);
-      context.showSnack(
-        S.of(context).raConnectionFailed('$e'),
-        type: SnackType.error,
+      final ApiError err = extractApiError(e);
+      context.showErrorSnack(
+        S.of(context).raConnectionFailed(err.message),
+        detail: err.detail,
       );
     }
   }
@@ -548,7 +550,7 @@ class _RaImportContentState extends ConsumerState<RaImportContent> {
       if (!result.success) {
         setState(() => _isImporting = false);
         if (result.fatalError != null) {
-          context.showSnack(result.fatalError!, type: SnackType.error);
+          context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
         }
         return;
       }
@@ -577,9 +579,10 @@ class _RaImportContentState extends ConsumerState<RaImportContent> {
     } on Exception catch (e) {
       if (!mounted) return;
       setState(() => _isImporting = false);
-      context.showSnack(
-        S.of(context).importFailed('$e'),
-        type: SnackType.error,
+      final ApiError err = extractApiError(e);
+      context.showErrorSnack(
+        S.of(context).importFailed(err.message),
+        detail: err.detail,
       );
     }
   }

--- a/lib/features/settings/content/steam_import_content.dart
+++ b/lib/features/settings/content/steam_import_content.dart
@@ -476,7 +476,7 @@ class _SteamImportContentState extends ConsumerState<SteamImportContent> {
     if (!result.success) {
       setState(() => _isImporting = false);
       if (result.fatalError != null) {
-        context.showSnack(result.fatalError!, type: SnackType.error);
+        context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
       }
       return;
     }

--- a/lib/features/settings/content/trakt_import_content.dart
+++ b/lib/features/settings/content/trakt_import_content.dart
@@ -490,7 +490,7 @@ class _TraktImportContentState extends ConsumerState<TraktImportContent> {
         ),
       );
     } else if (result.fatalError != null) {
-      context.showSnack(result.fatalError!, type: SnackType.error);
+      context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
     }
   }
 }

--- a/lib/features/settings/providers/settings_provider.dart
+++ b/lib/features/settings/providers/settings_provider.dart
@@ -103,6 +103,15 @@ abstract class SettingsKeys {
   static const String animeMangaTitleLanguage = 'anime_manga_title_language';
 
   static const String animeMangaTitleLanguageDefault = 'romaji';
+
+  /// Grid card size multiplier.
+  static const String cardScale = 'card_scale';
+
+  static const double cardScaleDefault = 1.0;
+
+  static const double cardScaleMin = 0.7;
+
+  static const double cardScaleMax = 1.6;
 }
 
 class SettingsState {
@@ -135,6 +144,7 @@ class SettingsState {
     this.alwaysShowSubcategories = false,
     this.dateFormat = SettingsKeys.dateFormatDefault,
     this.animeMangaTitleLanguage = SettingsKeys.animeMangaTitleLanguageDefault,
+    this.cardScale = SettingsKeys.cardScaleDefault,
   });
 
   final String? clientId;
@@ -206,6 +216,9 @@ class SettingsState {
 
   /// AniList title language preference.
   final String animeMangaTitleLanguage;
+
+  /// Grid card size multiplier (1.0 = default size).
+  final double cardScale;
 
   String? resolveOverlay({
     String? platformOverlay,
@@ -301,6 +314,7 @@ class SettingsState {
     bool? alwaysShowSubcategories,
     String? dateFormat,
     String? animeMangaTitleLanguage,
+    double? cardScale,
   }) {
     return SettingsState(
       clientId: clientId ?? this.clientId,
@@ -336,6 +350,7 @@ class SettingsState {
       dateFormat: dateFormat ?? this.dateFormat,
       animeMangaTitleLanguage:
           animeMangaTitleLanguage ?? this.animeMangaTitleLanguage,
+      cardScale: cardScale ?? this.cardScale,
     );
   }
 }
@@ -480,6 +495,9 @@ class SettingsNotifier extends Notifier<SettingsState> {
     final String animeMangaTitleLanguage =
         _prefs.getString(SettingsKeys.animeMangaTitleLanguage) ??
             SettingsKeys.animeMangaTitleLanguageDefault;
+    final double cardScale = (_prefs.getDouble(SettingsKeys.cardScale) ??
+            SettingsKeys.cardScaleDefault)
+        .clamp(SettingsKeys.cardScaleMin, SettingsKeys.cardScaleMax);
 
     // Valid token → connected immediately (skip verify);
     // expired with credentials → trigger auto-verify below.
@@ -516,6 +534,7 @@ class SettingsNotifier extends Notifier<SettingsState> {
       alwaysShowSubcategories: alwaysShowSubcategories,
       dateFormat: dateFormat,
       animeMangaTitleLanguage: animeMangaTitleLanguage,
+      cardScale: cardScale,
     );
 
     // API keys already wired by apiKeysProvider; only the request-time language param is set here.
@@ -820,6 +839,17 @@ class SettingsNotifier extends Notifier<SettingsState> {
     state = state.copyWith(animeMangaTitleLanguage: lang);
   }
 
+  /// Set [persist] to false for live slider preview; the final value must be
+  /// saved with a persisting call.
+  Future<void> setCardScale(double scale, {bool persist = true}) async {
+    final double clamped =
+        scale.clamp(SettingsKeys.cardScaleMin, SettingsKeys.cardScaleMax);
+    state = state.copyWith(cardScale: clamped);
+    if (persist) {
+      await _prefs.setDouble(SettingsKeys.cardScale, clamped);
+    }
+  }
+
   /// Falls back to built-in key if available, otherwise clears.
   Future<void> resetTmdbApiKeyToDefault() async {
     await _prefs.remove(SettingsKeys.tmdbApiKey);
@@ -951,6 +981,7 @@ class SettingsNotifier extends Notifier<SettingsState> {
     await _prefs.remove(SettingsKeys.alwaysShowSubcategories);
     await _prefs.remove(SettingsKeys.dateFormat);
     await _prefs.remove(SettingsKeys.animeMangaTitleLanguage);
+    await _prefs.remove(SettingsKeys.cardScale);
     await _prefs.remove(SettingsKeys.raUsername);
     await _prefs.remove(SettingsKeys.raApiKey);
 

--- a/lib/features/settings/screens/custom_cards_preview_screen.dart
+++ b/lib/features/settings/screens/custom_cards_preview_screen.dart
@@ -311,7 +311,7 @@ class _CustomCardsPreviewScreenState
         ),
       );
     } else if (result.fatalError != null) {
-      context.showSnack(result.fatalError!, type: SnackType.error);
+      context.showErrorSnack(result.fatalError!, detail: result.fatalDetail);
     }
   }
 }

--- a/lib/features/settings/screens/gamepad_debug_screen.dart
+++ b/lib/features/settings/screens/gamepad_debug_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
@@ -7,7 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gamepads/gamepads.dart';
 import 'package:logging/logging.dart';
-import 'package:path_provider/path_provider.dart';
 
 import '../../../core/services/gamepad_service.dart';
 import '../../../l10n/app_localizations.dart';
@@ -159,40 +159,30 @@ class _GamepadDebugScreenState extends ConsumerState<GamepadDebugScreen> {
     final String content = buffer.toString();
 
     try {
-      if (Platform.isAndroid) {
-        final Directory dir = await getApplicationDocumentsDirectory();
-        final String timestamp = DateTime.now()
-            .toIso8601String()
-            .replaceAll(':', '-')
-            .split('.')
-            .first;
-        final String filePath = '${dir.path}/gamepad_log_$timestamp.txt';
-        await File(filePath).writeAsString(content);
-        if (mounted) {
-          context.showSnack(
-            l.debugLogExported(filePath),
-            type: SnackType.success,
-          );
-        }
-      } else {
-        final String? outputPath = await FilePicker.platform.saveFile(
-          dialogTitle: l.debugExportLog,
-          fileName: 'gamepad_log.txt',
-          type: FileType.custom,
-          allowedExtensions: <String>['txt'],
-        );
-        if (outputPath == null) return;
+      // On Android FileType.custom doesn't support custom extensions.
+      final bool useAny = Platform.isAndroid || Platform.isIOS;
+      final String? outputPath = await FilePicker.platform.saveFile(
+        dialogTitle: l.debugExportLog,
+        fileName: 'gamepad_log.txt',
+        type: useAny ? FileType.any : FileType.custom,
+        allowedExtensions: useAny ? null : <String>['txt'],
+        bytes: utf8.encode(content),
+      );
+      if (outputPath == null) return;
+      // On Android/iOS file_picker writes the bytes via SAF;
+      // on desktop the file must be written manually.
+      if (!Platform.isAndroid && !Platform.isIOS) {
         await File(outputPath).writeAsString(content);
-        if (mounted) {
-          context.showSnack(
-            l.debugLogExported(outputPath),
-            type: SnackType.success,
-          );
-        }
+      }
+      if (mounted) {
+        context.showSnack(
+          l.debugLogExported(outputPath),
+          type: SnackType.success,
+        );
       }
     } on Exception catch (e) {
       if (mounted) {
-        context.showSnack(e.toString(), type: SnackType.error);
+        context.showErrorSnack(e.toString());
       }
     }
   }

--- a/lib/features/settings/screens/import_result_screen.dart
+++ b/lib/features/settings/screens/import_result_screen.dart
@@ -1,14 +1,15 @@
-// Экран результатов импорта — единый для всех импортёров.
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/constants/media_type_theme.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/universal_import_result.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/error_details_dialog.dart';
 import '../../../shared/widgets/sub_screen_title_bar.dart';
 import '../../collections/screens/collection_screen.dart';
 
@@ -87,6 +88,10 @@ class ImportResultScreen extends StatelessWidget {
                     color: AppColors.textTertiary,
                     text: l.importResultSkipped(result.skipped),
                   ),
+                if (result.errors.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: AppSpacing.md),
+                  _ErrorsCard(errors: result.errors),
+                ],
                 const SizedBox(height: AppSpacing.xl),
                 _buildActions(context, l),
               ],
@@ -115,10 +120,23 @@ class ImportResultScreen extends StatelessWidget {
         ),
         if (result.fatalError != null) ...<Widget>[
           const SizedBox(height: AppSpacing.sm),
-          Text(
+          SelectableText(
             result.fatalError!,
             style: AppTypography.body.copyWith(color: AppColors.error),
             textAlign: TextAlign.center,
+          ),
+          TextButton.icon(
+            onPressed: () => copyErrorDetails(
+              context,
+              message: result.fatalError!,
+              detail: result.fatalDetail,
+            ),
+            icon: const Icon(Icons.copy, size: 16),
+            label: Text(l.copyErrorDetails),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.textSecondary,
+              textStyle: AppTypography.bodySmall,
+            ),
           ),
         ],
       ],
@@ -250,7 +268,93 @@ class _ResultCard extends StatelessWidget {
   }
 }
 
-/// Одиночная строка статистики.
+/// Per-item import errors: expandable list with a copy-all button.
+class _ErrorsCard extends StatefulWidget {
+  const _ErrorsCard({required this.errors});
+
+  final List<String> errors;
+
+  @override
+  State<_ErrorsCard> createState() => _ErrorsCardState();
+}
+
+class _ErrorsCardState extends State<_ErrorsCard> {
+  static const int _collapsedCount = 5;
+
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final S l = S.of(context);
+    final List<String> visible = _expanded
+        ? widget.errors
+        : widget.errors.take(_collapsedCount).toList();
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+        border: Border.all(color: AppColors.error.withAlpha(128)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              const Icon(Icons.error_outline, size: 20, color: AppColors.error),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text(
+                  l.importResultErrors(widget.errors.length),
+                  style: AppTypography.body.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: () {
+                  Clipboard.setData(
+                    ClipboardData(text: widget.errors.join('\n')),
+                  );
+                  context.showSnack(
+                    l.importResultErrorsCopied,
+                    type: SnackType.info,
+                  );
+                },
+                icon: const Icon(Icons.copy, size: 16),
+                tooltip: l.copyErrorDetails,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const Divider(height: 1),
+          const SizedBox(height: AppSpacing.sm),
+          for (final String error in visible)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: SelectableText(
+                error,
+                style: AppTypography.bodySmall.copyWith(
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ),
+          if (widget.errors.length > _collapsedCount)
+            TextButton(
+              onPressed: () => setState(() => _expanded = !_expanded),
+              style: TextButton.styleFrom(
+                textStyle: AppTypography.bodySmall,
+              ),
+              child: Text(_expanded ? l.showLess : l.showMore),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Single stat row.
 class _StatRow extends StatelessWidget {
   const _StatRow({
     required this.icon,

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -481,6 +481,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               },
             ),
           ),
+          SettingsTile(
+            leadingIcon: Icons.photo_size_select_large_outlined,
+            leadingColor: _kAppearanceColor,
+            title: l.settingsCardScale,
+            subtitle: l.settingsCardScaleSubtitle,
+            showChevron: false,
+            trailing: _CardScaleSlider(scale: settings.cardScale),
+          ),
         ],
       ),
       gap,
@@ -1193,4 +1201,51 @@ class _RestoreOptions {
 
   final bool restoreWishlist;
   final bool restoreSettings;
+}
+
+/// Compact slider for the grid card scale; previews live, persists on release.
+class _CardScaleSlider extends ConsumerWidget {
+  const _CardScaleSlider({required this.scale});
+
+  final double scale;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bool compact = isCompactScreen(context);
+    final SettingsNotifier notifier =
+        ref.read(settingsNotifierProvider.notifier);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        SizedBox(
+          width: compact ? 120 : 170,
+          child: Slider(
+            value: scale.clamp(
+              SettingsKeys.cardScaleMin,
+              SettingsKeys.cardScaleMax,
+            ),
+            min: SettingsKeys.cardScaleMin,
+            max: SettingsKeys.cardScaleMax,
+            divisions:
+                ((SettingsKeys.cardScaleMax - SettingsKeys.cardScaleMin) / 0.1)
+                    .round(),
+            onChanged: (double value) =>
+                notifier.setCardScale(value, persist: false),
+            onChangeEnd: notifier.setCardScale,
+          ),
+        ),
+        SizedBox(
+          width: 38,
+          child: Text(
+            '${(scale * 100).round()}%',
+            textAlign: TextAlign.end,
+            style: TextStyle(
+              fontSize: compact ? 11 : 12,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/features/welcome/widgets/welcome_step_language.dart
+++ b/lib/features/welcome/widgets/welcome_step_language.dart
@@ -30,13 +30,22 @@ class _WelcomeStepLanguageState extends ConsumerState<WelcomeStepLanguage> {
         ref.read(settingsNotifierProvider.notifier);
     notifier.setAppLanguage(uiCode);
     if (!_contentLangTouched) {
-      notifier.setTmdbLanguage(defaultContentLanguageForUi(uiCode));
+      _applyContentLanguage(defaultContentLanguageForUi(uiCode));
     }
   }
 
   void _onContentLanguageSelected(String code) {
     setState(() => _contentLangTouched = true);
-    ref.read(settingsNotifierProvider.notifier).setTmdbLanguage(code);
+    _applyContentLanguage(code);
+  }
+
+  /// First-run only: besides TMDB, derive the AniList title mode from the
+  /// content language (en → english, ja → native, otherwise romaji).
+  void _applyContentLanguage(String code) {
+    final SettingsNotifier notifier =
+        ref.read(settingsNotifierProvider.notifier);
+    notifier.setTmdbLanguage(code);
+    notifier.setAnimeMangaTitleLanguage(anilistTitleLanguageForContent(code));
   }
 
   @override

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -211,7 +211,7 @@
   "settingsAppearance": "Appearance",
   "settingsAppearanceSubtitle": "Language, display and content",
   "settingsAppLanguageSubtitle": "Interface language",
-  "settingsContentLanguageSubtitle": "Language for movie and TV show descriptions",
+  "settingsContentLanguageSubtitle": "For now TMDB only (movies and TV shows)",
   "settingsDataSources": "Data Sources",
   "settingsDataSourcesSubtitle": "IGDB, TMDB, SteamGridDB",
   "settingsApiKeysSubtitle": "Configure connections to databases",
@@ -759,6 +759,14 @@
   "customItemDescriptionHint": "Brief description or notes",
   "customItemOptionalFields": "More fields",
   "customItemEdit": "Edit Custom Item",
+  "customItemFillFromFile": "Fill from file",
+  "customItemFileMultipleRows": "{count} entries in the file — the first one was used",
+  "@customItemFileMultipleRows": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "customItemFileNoValidRows": "No valid entries in this file",
   "customItemAddCover": "Add cover",
   "customItemCoverSource": "Cover source",
   "customItemCoverRatio": "Recommended aspect ratio: 2:3 (e.g. 600×900)",
@@ -1098,6 +1106,8 @@
   "searchCheckConnection": "Check your internet connection and try again.",
   "copyErrorDetails": "Copy error details",
   "errorDetailsCopied": "Error details copied",
+  "errorDetailsTitle": "Error details",
+  "errorDetailsShow": "Details",
   "showMore": "More…",
   "showLess": "Collapse",
 
@@ -1512,6 +1522,8 @@
   "settingsShowBlurayOverlaySubtitle": "Show Blu-ray overlay on movie and TV show posters",
   "settingsRichCollections": "Rich collection view",
   "settingsRichCollectionsSubtitle": "Personalize collections with a cover image and description",
+  "settingsCardScale": "Cover size",
+  "settingsCardScaleSubtitle": "Card size in collection grids",
   "collectionEditHeroImage": "Cover image",
   "collectionEditHeroImageHint": "Recommended 2560×1080 (21:9). Main subject on the right — the left side is covered by the title, the bottom fades into the background",
   "collectionEditHeroPick": "Choose image",
@@ -1774,6 +1786,13 @@
   "importResultImported": "Imported",
   "importResultWishlisted": "Added to Wishlist",
   "importResultUpdated": "Updated",
+  "importResultErrors": "Errors ({count})",
+  "@importResultErrors": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importResultErrorsCopied": "Errors copied",
   "importResultSkipped": "{count} skipped",
   "@importResultSkipped": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -978,7 +978,7 @@ abstract class S {
   /// No description provided for @settingsContentLanguageSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Language for movie and TV show descriptions'**
+  /// **'For now TMDB only (movies and TV shows)'**
   String get settingsContentLanguageSubtitle;
 
   /// No description provided for @settingsDataSources.
@@ -3002,6 +3002,24 @@ abstract class S {
   /// **'Edit Custom Item'**
   String get customItemEdit;
 
+  /// No description provided for @customItemFillFromFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Fill from file'**
+  String get customItemFillFromFile;
+
+  /// No description provided for @customItemFileMultipleRows.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} entries in the file — the first one was used'**
+  String customItemFileMultipleRows(int count);
+
+  /// No description provided for @customItemFileNoValidRows.
+  ///
+  /// In en, this message translates to:
+  /// **'No valid entries in this file'**
+  String get customItemFileNoValidRows;
+
   /// No description provided for @customItemAddCover.
   ///
   /// In en, this message translates to:
@@ -4153,6 +4171,18 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Error details copied'**
   String get errorDetailsCopied;
+
+  /// No description provided for @errorDetailsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Error details'**
+  String get errorDetailsTitle;
+
+  /// No description provided for @errorDetailsShow.
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get errorDetailsShow;
 
   /// No description provided for @showMore.
   ///
@@ -5798,6 +5828,18 @@ abstract class S {
   /// **'Personalize collections with a cover image and description'**
   String get settingsRichCollectionsSubtitle;
 
+  /// No description provided for @settingsCardScale.
+  ///
+  /// In en, this message translates to:
+  /// **'Cover size'**
+  String get settingsCardScale;
+
+  /// No description provided for @settingsCardScaleSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Card size in collection grids'**
+  String get settingsCardScaleSubtitle;
+
   /// No description provided for @collectionEditHeroImage.
   ///
   /// In en, this message translates to:
@@ -6901,6 +6943,18 @@ abstract class S {
   /// In en, this message translates to:
   /// **'Updated'**
   String get importResultUpdated;
+
+  /// No description provided for @importResultErrors.
+  ///
+  /// In en, this message translates to:
+  /// **'Errors ({count})'**
+  String importResultErrors(int count);
+
+  /// No description provided for @importResultErrorsCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Errors copied'**
+  String get importResultErrorsCopied;
 
   /// No description provided for @importResultSkipped.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -503,7 +503,7 @@ class SEn extends S {
 
   @override
   String get settingsContentLanguageSubtitle =>
-      'Language for movie and TV show descriptions';
+      'For now TMDB only (movies and TV shows)';
 
   @override
   String get settingsDataSources => 'Data Sources';
@@ -1675,6 +1675,17 @@ class SEn extends S {
   String get customItemEdit => 'Edit Custom Item';
 
   @override
+  String get customItemFillFromFile => 'Fill from file';
+
+  @override
+  String customItemFileMultipleRows(int count) {
+    return '$count entries in the file — the first one was used';
+  }
+
+  @override
+  String get customItemFileNoValidRows => 'No valid entries in this file';
+
+  @override
   String get customItemAddCover => 'Add cover';
 
   @override
@@ -2321,6 +2332,12 @@ class SEn extends S {
 
   @override
   String get errorDetailsCopied => 'Error details copied';
+
+  @override
+  String get errorDetailsTitle => 'Error details';
+
+  @override
+  String get errorDetailsShow => 'Details';
 
   @override
   String get showMore => 'More…';
@@ -3272,6 +3289,12 @@ class SEn extends S {
       'Personalize collections with a cover image and description';
 
   @override
+  String get settingsCardScale => 'Cover size';
+
+  @override
+  String get settingsCardScaleSubtitle => 'Card size in collection grids';
+
+  @override
   String get collectionEditHeroImage => 'Cover image';
 
   @override
@@ -3869,6 +3892,14 @@ class SEn extends S {
 
   @override
   String get importResultUpdated => 'Updated';
+
+  @override
+  String importResultErrors(int count) {
+    return 'Errors ($count)';
+  }
+
+  @override
+  String get importResultErrorsCopied => 'Errors copied';
 
   @override
   String importResultSkipped(int count) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -513,7 +513,7 @@ class SRu extends S {
 
   @override
   String get settingsContentLanguageSubtitle =>
-      'Язык описаний фильмов и сериалов';
+      'Пока только для TMDB (фильмы и сериалы)';
 
   @override
   String get settingsDataSources => 'Источники данных';
@@ -1714,6 +1714,17 @@ class SRu extends S {
   String get customItemEdit => 'Редактировать тайтл';
 
   @override
+  String get customItemFillFromFile => 'Заполнить из файла';
+
+  @override
+  String customItemFileMultipleRows(int count) {
+    return 'Записей в файле: $count — взята первая';
+  }
+
+  @override
+  String get customItemFileNoValidRows => 'В файле нет корректных записей';
+
+  @override
   String get customItemAddCover => 'Добавить обложку';
 
   @override
@@ -2363,6 +2374,12 @@ class SRu extends S {
 
   @override
   String get errorDetailsCopied => 'Детали ошибки скопированы';
+
+  @override
+  String get errorDetailsTitle => 'Детали ошибки';
+
+  @override
+  String get errorDetailsShow => 'Подробнее';
 
   @override
   String get showMore => 'Ещё…';
@@ -3335,6 +3352,12 @@ class SRu extends S {
       'Обложка и описание вместо мозаики';
 
   @override
+  String get settingsCardScale => 'Размер обложек';
+
+  @override
+  String get settingsCardScaleSubtitle => 'Размер карточек в сетках коллекций';
+
+  @override
   String get collectionEditHeroImage => 'Обложка';
 
   @override
@@ -3933,6 +3956,14 @@ class SRu extends S {
 
   @override
   String get importResultUpdated => 'Обновлено';
+
+  @override
+  String importResultErrors(int count) {
+    return 'Ошибки ($count)';
+  }
+
+  @override
+  String get importResultErrorsCopied => 'Ошибки скопированы';
 
   @override
   String importResultSkipped(int count) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -467,7 +467,7 @@ class SZh extends S {
   String get settingsAppLanguageSubtitle => '界面语言';
 
   @override
-  String get settingsContentLanguageSubtitle => '电影和电视剧简介的语言';
+  String get settingsContentLanguageSubtitle => '目前仅适用于 TMDB（电影和剧集）';
 
   @override
   String get settingsDataSources => '数据源';
@@ -1573,6 +1573,17 @@ class SZh extends S {
   String get customItemEdit => '编辑自定义项目';
 
   @override
+  String get customItemFillFromFile => '从文件填充';
+
+  @override
+  String customItemFileMultipleRows(int count) {
+    return '文件中有 $count 条记录，已使用第一条';
+  }
+
+  @override
+  String get customItemFileNoValidRows => '文件中没有有效记录';
+
+  @override
   String get customItemAddCover => '添加封面';
 
   @override
@@ -2201,6 +2212,12 @@ class SZh extends S {
 
   @override
   String get errorDetailsCopied => '错误详情已复制';
+
+  @override
+  String get errorDetailsTitle => '错误详情';
+
+  @override
+  String get errorDetailsShow => '详情';
 
   @override
   String get showMore => '更多…';
@@ -3083,6 +3100,12 @@ class SZh extends S {
   String get settingsRichCollectionsSubtitle => '使用封面图片和描述个性化收藏';
 
   @override
+  String get settingsCardScale => '封面大小';
+
+  @override
+  String get settingsCardScaleSubtitle => '收藏网格中卡片的大小';
+
+  @override
   String get collectionEditHeroImage => '封面图片';
 
   @override
@@ -3664,6 +3687,14 @@ class SZh extends S {
 
   @override
   String get importResultUpdated => '已更新';
+
+  @override
+  String importResultErrors(int count) {
+    return '错误（$count）';
+  }
+
+  @override
+  String get importResultErrorsCopied => '错误已复制';
 
   @override
   String importResultSkipped(int count) {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -211,7 +211,7 @@
   "settingsAppearance": "Оформление",
   "settingsAppearanceSubtitle": "Язык, отображение и контент",
   "settingsAppLanguageSubtitle": "Язык интерфейса",
-  "settingsContentLanguageSubtitle": "Язык описаний фильмов и сериалов",
+  "settingsContentLanguageSubtitle": "Пока только для TMDB (фильмы и сериалы)",
   "settingsDataSources": "Источники данных",
   "settingsDataSourcesSubtitle": "IGDB, TMDB, SteamGridDB",
   "settingsApiKeysSubtitle": "Настройка подключений к базам данных",
@@ -664,6 +664,14 @@
   "customItemDescriptionHint": "Краткое описание или заметки",
   "customItemOptionalFields": "Дополнительные поля",
   "customItemEdit": "Редактировать тайтл",
+  "customItemFillFromFile": "Заполнить из файла",
+  "customItemFileMultipleRows": "Записей в файле: {count} — взята первая",
+  "@customItemFileMultipleRows": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "customItemFileNoValidRows": "В файле нет корректных записей",
   "customItemAddCover": "Добавить обложку",
   "customItemCoverSource": "Источник обложки",
   "customItemCoverRatio": "Рекомендуемое соотношение: 2:3 (напр. 600×900)",
@@ -885,6 +893,8 @@
   "searchCheckConnection": "Проверьте подключение к интернету и попробуйте снова.",
   "copyErrorDetails": "Скопировать детали ошибки",
   "errorDetailsCopied": "Детали ошибки скопированы",
+  "errorDetailsTitle": "Детали ошибки",
+  "errorDetailsShow": "Подробнее",
   "showMore": "Ещё…",
   "showLess": "Свернуть",
 
@@ -1236,6 +1246,8 @@
   "settingsShowBlurayOverlaySubtitle": "Оверлей Blu-ray на постерах фильмов и сериалов",
   "settingsRichCollections": "Персонализация коллекций",
   "settingsRichCollectionsSubtitle": "Обложка и описание вместо мозаики",
+  "settingsCardScale": "Размер обложек",
+  "settingsCardScaleSubtitle": "Размер карточек в сетках коллекций",
   "collectionEditHeroImage": "Обложка",
   "collectionEditHeroImageHint": "Рекомендуется 2560×1080 (21:9). Главный объект справа — слева его закроет заголовок, снизу края растворятся в фоне",
   "collectionEditHeroPick": "Выбрать картинку",
@@ -1487,6 +1499,13 @@
   "importResultImported": "Импортировано",
   "importResultWishlisted": "В список желаний",
   "importResultUpdated": "Обновлено",
+  "importResultErrors": "Ошибки ({count})",
+  "@importResultErrors": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importResultErrorsCopied": "Ошибки скопированы",
   "importResultSkipped": "{count} пропущено",
   "@importResultSkipped": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -211,7 +211,7 @@
   "settingsAppearance": "外观",
   "settingsAppearanceSubtitle": "语言、显示和内容",
   "settingsAppLanguageSubtitle": "界面语言",
-  "settingsContentLanguageSubtitle": "电影和电视剧简介的语言",
+  "settingsContentLanguageSubtitle": "目前仅适用于 TMDB（电影和剧集）",
   "settingsDataSources": "数据源",
   "settingsDataSourcesSubtitle": "IGDB、TMDB、SteamGridDB",
   "settingsApiKeysSubtitle": "配置数据库连接",
@@ -759,6 +759,14 @@
   "customItemDescriptionHint": "简要描述或备注",
   "customItemOptionalFields": "更多字段",
   "customItemEdit": "编辑自定义项目",
+  "customItemFillFromFile": "从文件填充",
+  "customItemFileMultipleRows": "文件中有 {count} 条记录，已使用第一条",
+  "@customItemFileMultipleRows": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "customItemFileNoValidRows": "文件中没有有效记录",
   "customItemAddCover": "添加封面",
   "customItemCoverSource": "封面来源",
   "customItemCoverRatio": "推荐宽高比：2:3（例如 600×900）",
@@ -1098,6 +1106,8 @@
   "searchCheckConnection": "请检查网络连接后重试。",
   "copyErrorDetails": "复制错误详情",
   "errorDetailsCopied": "错误详情已复制",
+  "errorDetailsTitle": "错误详情",
+  "errorDetailsShow": "详情",
   "showMore": "更多…",
   "showLess": "收起",
 
@@ -1507,6 +1517,8 @@
   "settingsShowBlurayOverlaySubtitle": "在电影和电视剧海报上显示蓝光标识",
   "settingsRichCollections": "富文本收藏视图",
   "settingsRichCollectionsSubtitle": "使用封面图片和描述个性化收藏",
+  "settingsCardScale": "封面大小",
+  "settingsCardScaleSubtitle": "收藏网格中卡片的大小",
   "collectionEditHeroImage": "封面图片",
   "collectionEditHeroImageHint": "推荐 2560×1080（21:9）。主体靠右——左侧被标题覆盖，底部融入背景",
   "collectionEditHeroPick": "选择图片",
@@ -1769,6 +1781,13 @@
   "importResultImported": "已导入",
   "importResultWishlisted": "已加入愿望单",
   "importResultUpdated": "已更新",
+  "importResultErrors": "错误（{count}）",
+  "@importResultErrors": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importResultErrorsCopied": "错误已复制",
   "importResultSkipped": "跳过 {count} 个",
   "@importResultSkipped": {
     "placeholders": {

--- a/lib/shared/constants/tmdb_content_languages.dart
+++ b/lib/shared/constants/tmdb_content_languages.dart
@@ -1,50 +1,88 @@
-// Список поддерживаемых языков контента TMDB.
-
 import 'package:flutter/foundation.dart';
 
-/// Локаль контента TMDB (`primary_translations`).
-///
-/// Используется для запросов `language=<code>` к TMDB API и
-/// в UI выбора языка описаний фильмов/сериалов.
+/// TMDB content locale: the `language=` request value and its native name.
 @immutable
 class TmdbContentLanguage {
-  /// Создаёт [TmdbContentLanguage].
   const TmdbContentLanguage({
     required this.code,
     required this.nativeName,
   });
 
-  /// Код локали в формате IETF BCP 47, например `ru-RU`.
+  /// IETF BCP 47 locale code, e.g. `ru-RU`.
   final String code;
 
-  /// Название языка на самом этом языке (например, `Русский`, `English`).
+  /// Language name in that language itself (`Русский`, `English`).
   final String nativeName;
 }
 
-/// Поддерживаемые языки контента TMDB.
-///
-/// Расширяется параллельно с локализацией интерфейса — пара локалей
-/// (UI ↔ TMDB) обычно добавляется одним патчем.
+/// Curated from TMDB `/configuration/primary_translations`, sorted by code.
 const List<TmdbContentLanguage> kTmdbContentLanguages = <TmdbContentLanguage>[
+  TmdbContentLanguage(code: 'ar-SA', nativeName: 'العربية'),
+  TmdbContentLanguage(code: 'be-BY', nativeName: 'Беларуская'),
+  TmdbContentLanguage(code: 'bg-BG', nativeName: 'Български'),
+  TmdbContentLanguage(code: 'ca-ES', nativeName: 'Català'),
+  TmdbContentLanguage(code: 'cs-CZ', nativeName: 'Čeština'),
+  TmdbContentLanguage(code: 'da-DK', nativeName: 'Dansk'),
+  TmdbContentLanguage(code: 'de-DE', nativeName: 'Deutsch'),
+  TmdbContentLanguage(code: 'el-GR', nativeName: 'Ελληνικά'),
   TmdbContentLanguage(code: 'en-US', nativeName: 'English'),
+  TmdbContentLanguage(code: 'es-ES', nativeName: 'Español (España)'),
+  TmdbContentLanguage(code: 'es-MX', nativeName: 'Español (México)'),
+  TmdbContentLanguage(code: 'et-EE', nativeName: 'Eesti'),
+  TmdbContentLanguage(code: 'fa-IR', nativeName: 'فارسی'),
+  TmdbContentLanguage(code: 'fi-FI', nativeName: 'Suomi'),
+  TmdbContentLanguage(code: 'fr-FR', nativeName: 'Français'),
+  TmdbContentLanguage(code: 'he-IL', nativeName: 'עברית'),
+  TmdbContentLanguage(code: 'hi-IN', nativeName: 'हिन्दी'),
+  TmdbContentLanguage(code: 'hr-HR', nativeName: 'Hrvatski'),
+  TmdbContentLanguage(code: 'hu-HU', nativeName: 'Magyar'),
+  TmdbContentLanguage(code: 'id-ID', nativeName: 'Bahasa Indonesia'),
+  TmdbContentLanguage(code: 'it-IT', nativeName: 'Italiano'),
+  TmdbContentLanguage(code: 'ja-JP', nativeName: '日本語'),
+  TmdbContentLanguage(code: 'ka-GE', nativeName: 'ქართული'),
+  TmdbContentLanguage(code: 'kk-KZ', nativeName: 'Қазақша'),
+  TmdbContentLanguage(code: 'ko-KR', nativeName: '한국어'),
+  TmdbContentLanguage(code: 'lt-LT', nativeName: 'Lietuvių'),
+  TmdbContentLanguage(code: 'lv-LV', nativeName: 'Latviešu'),
+  TmdbContentLanguage(code: 'ms-MY', nativeName: 'Bahasa Melayu'),
+  TmdbContentLanguage(code: 'nb-NO', nativeName: 'Norsk (Bokmål)'),
+  TmdbContentLanguage(code: 'nl-NL', nativeName: 'Nederlands'),
+  TmdbContentLanguage(code: 'pl-PL', nativeName: 'Polski'),
+  TmdbContentLanguage(code: 'pt-BR', nativeName: 'Português (Brasil)'),
+  TmdbContentLanguage(code: 'pt-PT', nativeName: 'Português (Portugal)'),
+  TmdbContentLanguage(code: 'ro-RO', nativeName: 'Română'),
   TmdbContentLanguage(code: 'ru-RU', nativeName: 'Русский'),
-  TmdbContentLanguage(code: 'zh-CN', nativeName: '中文'),
+  TmdbContentLanguage(code: 'sk-SK', nativeName: 'Slovenčina'),
+  TmdbContentLanguage(code: 'sl-SI', nativeName: 'Slovenščina'),
+  TmdbContentLanguage(code: 'sr-RS', nativeName: 'Српски'),
+  TmdbContentLanguage(code: 'sv-SE', nativeName: 'Svenska'),
+  TmdbContentLanguage(code: 'th-TH', nativeName: 'ไทย'),
+  TmdbContentLanguage(code: 'tr-TR', nativeName: 'Türkçe'),
+  TmdbContentLanguage(code: 'uk-UA', nativeName: 'Українська'),
+  TmdbContentLanguage(code: 'vi-VN', nativeName: 'Tiếng Việt'),
+  TmdbContentLanguage(code: 'zh-CN', nativeName: '简体中文'),
+  TmdbContentLanguage(code: 'zh-TW', nativeName: '繁體中文'),
 ];
 
-/// Маппинг кода UI-локали → код языка контента TMDB по умолчанию.
-///
-/// Используется, чтобы при первом выборе UI-языка в визарде
-/// автоматически выставить парный язык контента. Если UI-локали нет
-/// в карте — возвращаем `en-US` как нейтральный fallback.
 const Map<String, String> _kUiToContentLanguage = <String, String>{
   'en': 'en-US',
   'ru': 'ru-RU',
   'zh': 'zh-CN',
 };
 
-/// Возвращает дефолтный TMDB-код для UI-локали.
-///
-/// Расширяется одновременно с [kTmdbContentLanguages].
+/// Default TMDB code for a UI locale; unknown locales fall back to `en-US`.
 String defaultContentLanguageForUi(String uiLanguageCode) {
   return _kUiToContentLanguage[uiLanguageCode] ?? 'en-US';
+}
+
+/// Closest AniList title mode (romaji / english / native): everything
+/// except English and Japanese degrades to romaji.
+String anilistTitleLanguageForContent(String contentCode) {
+  if (contentCode.startsWith('en-')) {
+    return 'english';
+  }
+  if (contentCode == 'ja-JP') {
+    return 'native';
+  }
+  return 'romaji';
 }

--- a/lib/shared/extensions/snackbar_extension.dart
+++ b/lib/shared/extensions/snackbar_extension.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/app_localizations.dart';
 import '../constants/platform_features.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_spacing.dart';
+import '../widgets/error_details_dialog.dart';
 
 enum SnackType {
   success,
@@ -94,5 +96,23 @@ extension SnackBarExtension on BuildContext {
 
   void hideSnack() {
     ScaffoldMessenger.of(this).hideCurrentSnackBar();
+  }
+
+  /// Error snack with a «Details» action opening a copyable dialog with the
+  /// full [message] and optional debug [detail].
+  void showErrorSnack(String message, {String? detail}) {
+    showSnack(
+      message,
+      type: SnackType.error,
+      duration: const Duration(seconds: 6),
+      action: SnackBarAction(
+        label: S.of(this).errorDetailsShow,
+        textColor: AppColors.brand,
+        onPressed: () {
+          if (!mounted) return;
+          showErrorDetailsDialog(this, message: message, detail: detail);
+        },
+      ),
+    );
   }
 }

--- a/lib/shared/models/universal_import_result.dart
+++ b/lib/shared/models/universal_import_result.dart
@@ -15,11 +15,13 @@ class UniversalImportResult {
     this.skipped = 0,
     this.errors = const <String>[],
     this.fatalError,
+    this.fatalDetail,
   });
 
   const UniversalImportResult.failure({
     required this.sourceName,
     required String error,
+    String? detail,
   })  : success = false,
         collection = null,
         collectionId = null,
@@ -30,7 +32,8 @@ class UniversalImportResult {
         untypedUpdated = 0,
         skipped = 0,
         errors = const <String>[],
-        fatalError = error;
+        fatalError = error,
+        fatalDetail = detail;
 
   /// Import source name: 'Steam', 'Trakt', 'Collection File'.
   final String sourceName;
@@ -60,6 +63,9 @@ class UniversalImportResult {
   final List<String> errors;
 
   final String? fatalError;
+
+  /// Copyable debug detail for [fatalError] (request, status code, cause).
+  final String? fatalDetail;
 
   int get totalImported => _sumValues(importedByType) + untypedImported;
 

--- a/lib/shared/theme/app_spacing.dart
+++ b/lib/shared/theme/app_spacing.dart
@@ -74,4 +74,12 @@ abstract final class AppSpacing {
 
   /// Grid column count on mobile (< 500px).
   static const int gridColumnsMobile = 3;
+
+  /// Max card width on desktop grids at 100% card scale.
+  static const double desktopMaxCardWidth = 170;
+
+  /// Column count for fixed-count grids adjusted by the card scale setting:
+  /// larger cards → fewer columns.
+  static int scaledColumns(int base, double scale) =>
+      (base / scale).round().clamp(2, 8);
 }

--- a/lib/shared/utils/custom_cards_parse_error_l10n.dart
+++ b/lib/shared/utils/custom_cards_parse_error_l10n.dart
@@ -1,0 +1,14 @@
+import '../../core/import/sources/custom_file/custom_card_entry.dart';
+import '../../l10n/app_localizations.dart';
+
+/// Localized message for a whole-file parse failure.
+String localizedParseError(S l, CustomCardsParseErrorCode code) {
+  switch (code) {
+    case CustomCardsParseErrorCode.emptyFile:
+      return l.customImportErrorEmptyFile;
+    case CustomCardsParseErrorCode.invalidJson:
+      return l.customImportErrorInvalidJson;
+    case CustomCardsParseErrorCode.missingRequiredColumns:
+      return l.customImportErrorMissingColumns;
+  }
+}

--- a/lib/shared/utils/item_card_progress.dart
+++ b/lib/shared/utils/item_card_progress.dart
@@ -1,0 +1,70 @@
+import '../models/collection_item.dart';
+import '../models/media_type.dart';
+
+/// Card progress: [label] like `12/24` / `V2 · 12/24`, [fraction] 0..1
+/// for the bar (null when the total is unknown).
+class ItemCardProgress {
+  const ItemCardProgress({required this.label, this.fraction});
+
+  final String label;
+
+  final double? fraction;
+}
+
+/// Null for untracked types and empty progress. TMDB shows are excluded for
+/// now: their marks live in `watched_episodes`, not on the item.
+ItemCardProgress? itemCardProgress(CollectionItem item) {
+  final int current = item.currentEpisode;
+  final int group = item.currentSeason;
+  if (current <= 0 && group <= 0) return null;
+
+  final MediaType type = item.displayMediaType;
+
+  int? fineTotal;
+  // S = seasons, V = volumes, null = no coarse axis.
+  String? groupMark;
+
+  if (item.mediaType == MediaType.custom) {
+    fineTotal = item.customUnitTotal;
+    groupMark = switch (type) {
+      MediaType.manga => 'V',
+      MediaType.tvShow || MediaType.animation => 'S',
+      _ => null,
+    };
+  } else {
+    switch (type) {
+      case MediaType.anime:
+        fineTotal = item.anime?.episodes;
+      case MediaType.manga:
+        fineTotal = item.manga?.chapters;
+        groupMark = 'V';
+      case MediaType.book:
+        fineTotal = item.book?.pageCount;
+      case MediaType.tvShow:
+      case MediaType.animation:
+      case MediaType.game:
+      case MediaType.movie:
+      case MediaType.visualNovel:
+      case MediaType.custom:
+        return null;
+    }
+  }
+
+  final StringBuffer buf = StringBuffer();
+  if (group > 0 && groupMark != null) {
+    buf.write('$groupMark$group');
+  }
+  if (current > 0) {
+    if (buf.isNotEmpty) buf.write(' · ');
+    buf.write(
+      fineTotal != null && fineTotal > 0 ? '$current/$fineTotal' : '$current',
+    );
+  }
+  if (buf.isEmpty) return null;
+
+  final double? fraction = current > 0 && fineTotal != null && fineTotal > 0
+      ? (current / fineTotal).clamp(0.0, 1.0)
+      : null;
+
+  return ItemCardProgress(label: buf.toString(), fraction: fraction);
+}

--- a/lib/shared/widgets/error_details_dialog.dart
+++ b/lib/shared/widgets/error_details_dialog.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../extensions/snackbar_extension.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_spacing.dart';
+import '../theme/app_typography.dart';
+
+/// Copies `message\n\ndetail` to the clipboard and confirms with a snack.
+void copyErrorDetails(
+  BuildContext context, {
+  required String message,
+  String? detail,
+}) {
+  final String text =
+      (detail == null || detail.isEmpty) ? message : '$message\n\n$detail';
+  Clipboard.setData(ClipboardData(text: text));
+  context.showSnack(S.of(context).errorDetailsCopied, type: SnackType.info);
+}
+
+/// Full error [message] + optional debug [detail], nothing truncated,
+/// one button copies both.
+Future<void> showErrorDetailsDialog(
+  BuildContext context, {
+  required String message,
+  String? detail,
+  String? title,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (BuildContext dialogContext) {
+      final S l = S.of(dialogContext);
+      return AlertDialog(
+        title: Row(
+          children: <Widget>[
+            const Icon(Icons.error_outline, color: AppColors.error, size: 22),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(child: Text(title ?? l.errorDetailsTitle)),
+          ],
+        ),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              SelectableText(message, style: AppTypography.body),
+              if (detail != null && detail.isNotEmpty) ...<Widget>[
+                const SizedBox(height: AppSpacing.md),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(AppSpacing.sm),
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+                    border: Border.all(color: AppColors.surfaceBorder),
+                  ),
+                  child: SelectableText(
+                    detail,
+                    style: AppTypography.caption.copyWith(
+                      color: AppColors.textSecondary,
+                      fontFamily: 'monospace',
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton.icon(
+            onPressed: () => copyErrorDetails(
+              dialogContext,
+              message: message,
+              detail: detail,
+            ),
+            icon: const Icon(Icons.copy, size: 16),
+            label: Text(l.copyErrorDetails),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(l.close),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/lib/shared/widgets/media_poster_card.dart
+++ b/lib/shared/widgets/media_poster_card.dart
@@ -5,6 +5,7 @@ import '../../l10n/app_localizations.dart';
 import '../constants/media_type_theme.dart';
 import '../models/item_status.dart';
 import '../models/media_type.dart';
+import '../utils/item_card_progress.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_durations.dart';
 import '../theme/app_spacing.dart';
@@ -50,6 +51,7 @@ class MediaPosterCard extends StatefulWidget {
     this.platformColor,
     this.platformOverlayAsset,
     this.timeToBeatHours,
+    this.progress,
     this.isFavorite = false,
     this.showFavorite = false,
     this.onToggleFavorite,
@@ -111,6 +113,10 @@ class MediaPosterCard extends StatefulWidget {
   /// Average time-to-beat in whole hours (IGDB). When set, a small clock
   /// badge is drawn over the poster. Grid/compact only; used on search cards.
   final int? timeToBeatHours;
+
+  /// Progress pill next to the status dot (`12/24`) plus the bottom-edge
+  /// bar when the fraction is known. Grid/compact only.
+  final ItemCardProgress? progress;
 
   /// Whether this item is marked favorite. Grid/compact only; drives the
   /// heart toggle's filled/broken state.
@@ -314,6 +320,8 @@ class _MediaPosterCardState extends State<MediaPosterCard>
 
     final bool showFavoriteBadge =
         widget.onToggleFavorite != null || widget.showFavorite;
+    final bool showStatusDot =
+        widget.status != null && widget.status != ItemStatus.notStarted;
     final bool showPlatformBadge = widget.platformOverlayAsset == null &&
         widget.platformLabel != null &&
         widget.platformColor != null;
@@ -466,29 +474,54 @@ class _MediaPosterCardState extends State<MediaPosterCard>
               ),
             ),
 
-            if (widget.status != null &&
-                widget.status != ItemStatus.notStarted)
+            if (showStatusDot || widget.progress != null)
               Positioned(
                 bottom: _isCompact ? 2 : AppSpacing.xs,
                 left: _isCompact ? 2 : AppSpacing.xs,
-                child: Container(
-                  padding: EdgeInsets.all(_isCompact ? 2 : 4),
-                  decoration: BoxDecoration(
-                    color: widget.status!.color,
-                    shape: BoxShape.circle,
-                  ),
-                  child: Icon(
-                    widget.status!.materialIcon,
-                    size: _isCompact ? 8 : 12,
-                    color: Colors.white,
-                  ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    if (showStatusDot)
+                      Container(
+                        padding: EdgeInsets.all(_isCompact ? 2 : 4),
+                        decoration: BoxDecoration(
+                          color: widget.status!.color,
+                          shape: BoxShape.circle,
+                        ),
+                        child: Icon(
+                          widget.status!.materialIcon,
+                          size: _isCompact ? 8 : 12,
+                          color: Colors.white,
+                        ),
+                      ),
+                    if (widget.progress != null) ...<Widget>[
+                      if (showStatusDot) SizedBox(width: _isCompact ? 2 : 4),
+                      Container(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: _isCompact ? 3 : 5,
+                          vertical: _isCompact ? 1 : 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withAlpha(170),
+                          borderRadius:
+                              BorderRadius.circular(AppSpacing.radiusXs),
+                        ),
+                        child: Text(
+                          widget.progress!.label,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: _isCompact ? 7 : 9,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
               ),
 
             // Average time-to-beat (bottom-left) — search cards only.
-            if (widget.timeToBeatHours != null &&
-                !(widget.status != null &&
-                    widget.status != ItemStatus.notStarted))
+            if (widget.timeToBeatHours != null && !showStatusDot)
               Positioned(
                 bottom: _isCompact ? 2 : AppSpacing.xs,
                 left: _isCompact ? 2 : AppSpacing.xs,
@@ -535,6 +568,27 @@ class _MediaPosterCardState extends State<MediaPosterCard>
                   moreCount: widget.tagMoreCount,
                   compact: _isCompact,
                   onTap: widget.onTagTap,
+                ),
+              ),
+
+            // Watch/read progress bar along the poster's bottom edge.
+            if (widget.progress?.fraction != null)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: _isCompact ? 2 : 3,
+                child: ColoredBox(
+                  color: Colors.black.withAlpha(120),
+                  child: FractionallySizedBox(
+                    alignment: Alignment.centerLeft,
+                    widthFactor: widget.progress!.fraction,
+                    child: ColoredBox(
+                      color: widget.mediaType != null
+                          ? MediaTypeTheme.colorFor(widget.mediaType!)
+                          : AppColors.brand,
+                    ),
+                  ),
                 ),
               ),
           ],

--- a/test/core/api/api_error_extract_test.dart
+++ b/test/core/api/api_error_extract_test.dart
@@ -2,8 +2,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/core/api/anilist_api.dart';
 import 'package:tonkatsu_box/core/api/api_error_extract.dart';
 import 'package:tonkatsu_box/core/api/comicvine_api.dart';
+import 'package:tonkatsu_box/core/api/fantlab_api.dart';
+import 'package:tonkatsu_box/core/api/google_books_api.dart';
+import 'package:tonkatsu_box/core/api/hardcover_api.dart';
 import 'package:tonkatsu_box/core/api/igdb_api.dart';
+import 'package:tonkatsu_box/core/api/kodi_api.dart';
 import 'package:tonkatsu_box/core/api/ra_api.dart';
+import 'package:tonkatsu_box/core/api/screenscraper_api.dart';
 import 'package:tonkatsu_box/core/api/steam_api.dart';
 import 'package:tonkatsu_box/core/api/steamgriddb_api.dart';
 import 'package:tonkatsu_box/core/api/tmdb_api.dart';
@@ -21,6 +26,10 @@ void main() {
         (const SteamApiException('steam', detail: 'd6'), 'steam'),
         (const RaApiException('ra', detail: 'd7'), 'ra'),
         (const ComicVineApiException('comicvine', detail: 'd8'), 'comicvine'),
+        (const GoogleBooksApiException('gbooks', detail: 'd9'), 'gbooks'),
+        (const HardcoverApiException('hardcover', detail: 'd10'), 'hardcover'),
+        (const FantlabApiException('fantlab', detail: 'd11'), 'fantlab'),
+        (const KodiApiException('kodi', detail: 'd12'), 'kodi'),
       ];
 
       for (final (Exception e, String msg) in cases) {
@@ -33,6 +42,12 @@ void main() {
     test('keeps a null detail when the exception carries none', () {
       final ApiError r = extractApiError(const TmdbApiException('boom'));
       expect(r.message, 'boom');
+      expect(r.detail, isNull);
+    });
+
+    test('maps ScreenScraper message without a detail', () {
+      final ApiError r = extractApiError(ScreenScraperApiException('ss'));
+      expect(r.message, 'ss');
       expect(r.detail, isNull);
     });
 

--- a/test/features/home/providers/all_items_provider_test.dart
+++ b/test/features/home/providers/all_items_provider_test.dart
@@ -441,6 +441,62 @@ void main() {
       );
     });
 
+    test('updateProgressLocally патчит прогресс только у нужного элемента',
+        () async {
+      final List<CollectionItem> items = <CollectionItem>[
+        _makeItem(id: 1),
+        _makeItem(id: 2),
+      ];
+      when(() => mockRepo.getAllItemsWithData())
+          .thenAnswer((_) async => items);
+
+      final ProviderContainer container = createContainer();
+      container.read(allItemsNotifierProvider);
+      await _pump();
+
+      final DateTime now = DateTime(2026, 7, 15);
+      container.read(allItemsNotifierProvider.notifier).updateProgressLocally(
+            1,
+            currentEpisode: 12,
+            currentSeason: 2,
+            lastActivityAt: now,
+          );
+
+      final List<CollectionItem>? state =
+          container.read(allItemsNotifierProvider).valueOrNull;
+      final CollectionItem patched =
+          state!.firstWhere((CollectionItem i) => i.id == 1);
+      expect(patched.currentEpisode, equals(12));
+      expect(patched.currentSeason, equals(2));
+      expect(patched.lastActivityAt, equals(now));
+      final CollectionItem untouched =
+          state.firstWhere((CollectionItem i) => i.id == 2);
+      expect(untouched.currentEpisode, equals(0));
+      expect(untouched.currentSeason, equals(0));
+    });
+
+    test('updateProgressLocally с null-полями сохраняет текущие значения',
+        () async {
+      when(() => mockRepo.getAllItemsWithData()).thenAnswer(
+          (_) async => <CollectionItem>[_makeItem(id: 1)]);
+
+      final ProviderContainer container = createContainer();
+      container.read(allItemsNotifierProvider);
+      await _pump();
+
+      final AllItemsNotifier notifier =
+          container.read(allItemsNotifierProvider.notifier);
+      notifier.updateProgressLocally(1, currentEpisode: 5);
+      notifier.updateProgressLocally(1, currentSeason: 3);
+
+      final CollectionItem patched = container
+          .read(allItemsNotifierProvider)
+          .valueOrNull!
+          .firstWhere((CollectionItem i) => i.id == 1);
+      expect(patched.currentEpisode, equals(5));
+      expect(patched.currentSeason, equals(3));
+    });
+
     test('toggleFavorite пишет в БД и обновляет состояние', () async {
       final List<CollectionItem> items = <CollectionItem>[
         _makeItem(id: 1, collectionId: 1),

--- a/test/features/settings/providers/settings_provider_card_scale_test.dart
+++ b/test/features/settings/providers/settings_provider_card_scale_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tonkatsu_box/core/api/igdb_api.dart';
+import 'package:tonkatsu_box/core/api/steamgriddb_api.dart';
+import 'package:tonkatsu_box/core/api/tmdb_api.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/core/services/api_key_initializer.dart';
+import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockIgdbApi mockIgdbApi;
+  late MockSteamGridDbApi mockSteamGridDbApi;
+  late MockTmdbApi mockTmdbApi;
+  late MockDatabaseService mockDbService;
+  late MockGameDao mockGameDao;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    mockIgdbApi = MockIgdbApi();
+    mockSteamGridDbApi = MockSteamGridDbApi();
+    mockTmdbApi = MockTmdbApi();
+    mockDbService = MockDatabaseService();
+    mockGameDao = MockGameDao();
+    when(() => mockDbService.gameDao).thenReturn(mockGameDao);
+
+    when(() => mockGameDao.getPlatformCount()).thenAnswer((_) async => 0);
+  });
+
+  Future<ProviderContainer> createContainer({
+    Map<String, Object> initialPrefs = const <String, Object>{},
+  }) async {
+    SharedPreferences.setMockInitialValues(initialPrefs);
+    prefs = await SharedPreferences.getInstance();
+
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        apiKeysProvider.overrideWithValue(const ApiKeys()),
+        igdbApiProvider.overrideWithValue(mockIgdbApi),
+        steamGridDbApiProvider.overrideWithValue(mockSteamGridDbApi),
+        tmdbApiProvider.overrideWithValue(mockTmdbApi),
+        databaseServiceProvider.overrideWithValue(mockDbService),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SettingsNotifier — cardScale', () {
+    group('значение по умолчанию', () {
+      test('cardScale == 1.0 по умолчанию', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(SettingsKeys.cardScaleDefault));
+      });
+    });
+
+    group('setCardScale', () {
+      test('сохраняет в prefs и обновляет состояние', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setCardScale(1.3);
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(1.3));
+        expect(prefs.getDouble('card_scale'), equals(1.3));
+      });
+
+      test('persist: false обновляет состояние без записи в prefs', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setCardScale(0.8, persist: false);
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(0.8));
+        expect(prefs.getDouble('card_scale'), isNull);
+      });
+
+      test('значение выше максимума ограничивается', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setCardScale(5.0);
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(SettingsKeys.cardScaleMax));
+        expect(prefs.getDouble('card_scale'), equals(SettingsKeys.cardScaleMax));
+      });
+
+      test('значение ниже минимума ограничивается', () async {
+        final ProviderContainer container = await createContainer();
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.setCardScale(0.1);
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(SettingsKeys.cardScaleMin));
+      });
+    });
+
+    group('_loadFromPrefs', () {
+      test('загружает сохранённое значение из prefs', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{'card_scale': 1.4},
+        );
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(1.4));
+      });
+
+      test('некорректное значение из prefs ограничивается диапазоном',
+          () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{'card_scale': 9.0},
+        );
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(SettingsKeys.cardScaleMax));
+      });
+    });
+
+    group('clearSettings', () {
+      test('сбрасывает cardScale к значению по умолчанию', () async {
+        final ProviderContainer container = await createContainer(
+          initialPrefs: <String, Object>{'card_scale': 1.4},
+        );
+
+        final SettingsNotifier notifier =
+            container.read(settingsNotifierProvider.notifier);
+
+        await notifier.clearSettings();
+
+        final SettingsState state = container.read(settingsNotifierProvider);
+
+        expect(state.cardScale, equals(SettingsKeys.cardScaleDefault));
+        expect(prefs.getDouble('card_scale'), isNull);
+      });
+    });
+
+    group('copyWith', () {
+      test('cardScale обновляется через copyWith', () {
+        const SettingsState original = SettingsState();
+        final SettingsState updated = original.copyWith(cardScale: 1.2);
+
+        expect(updated.cardScale, equals(1.2));
+        expect(original.cardScale, equals(1.0));
+      });
+
+      test('copyWith без cardScale сохраняет текущее значение', () {
+        const SettingsState original = SettingsState(cardScale: 1.5);
+        final SettingsState updated = original.copyWith(tmdbApiKey: 'key');
+
+        expect(updated.cardScale, equals(1.5));
+      });
+    });
+  });
+}

--- a/test/features/settings/screens/import_result_screen_test.dart
+++ b/test/features/settings/screens/import_result_screen_test.dart
@@ -168,6 +168,41 @@ void main() {
         expect(find.text('Connection timeout'), findsOneWidget);
       });
 
+      testWidgets('shows copy button for fatal error', (
+        WidgetTester tester,
+      ) async {
+        const UniversalImportResult result = UniversalImportResult.failure(
+          sourceName: 'Trakt',
+          error: 'Connection timeout',
+          detail: 'GET /sync/watched → 504',
+        );
+
+        await tester.pumpApp(
+          const ImportResultScreen(result: result),
+        );
+
+        expect(find.byIcon(Icons.copy), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('shows per-item errors card with error texts', (
+        WidgetTester tester,
+      ) async {
+        const UniversalImportResult result = UniversalImportResult(
+          success: true,
+          sourceName: 'Steam',
+          errors: <String>['Game A: not found', 'Game B: rate limited'],
+        );
+
+        await tester.pumpApp(
+          const ImportResultScreen(result: result),
+        );
+
+        expect(find.text('Game A: not found'), findsOneWidget);
+        expect(find.text('Game B: rate limited'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
       testWidgets('does not show Open Collection button on failure', (
         WidgetTester tester,
       ) async {

--- a/test/shared/constants/tmdb_content_languages_test.dart
+++ b/test/shared/constants/tmdb_content_languages_test.dart
@@ -37,6 +37,22 @@ void main() {
     });
   });
 
+  group('anilistTitleLanguageForContent', () {
+    test('en-* → english', () {
+      expect(anilistTitleLanguageForContent('en-US'), 'english');
+    });
+
+    test('ja-JP → native', () {
+      expect(anilistTitleLanguageForContent('ja-JP'), 'native');
+    });
+
+    test('остальные деградируют в romaji', () {
+      expect(anilistTitleLanguageForContent('ru-RU'), 'romaji');
+      expect(anilistTitleLanguageForContent('zh-TW'), 'romaji');
+      expect(anilistTitleLanguageForContent(''), 'romaji');
+    });
+  });
+
   group('defaultContentLanguageForUi', () {
     test('en → en-US', () {
       expect(defaultContentLanguageForUi('en'), 'en-US');

--- a/test/shared/theme/app_spacing_test.dart
+++ b/test/shared/theme/app_spacing_test.dart
@@ -63,5 +63,30 @@ void main() {
         expect(AppSpacing.gridColumnsMobile, equals(3));
       });
     });
+
+    group('scaledColumns', () {
+      test('масштаб 1.0 возвращает базовое число колонок', () {
+        expect(AppSpacing.scaledColumns(3, 1.0), equals(3));
+        expect(AppSpacing.scaledColumns(4, 1.0), equals(4));
+        expect(AppSpacing.scaledColumns(6, 1.0), equals(6));
+      });
+
+      test('крупные карточки уменьшают число колонок', () {
+        expect(AppSpacing.scaledColumns(3, 1.5), equals(2));
+        expect(AppSpacing.scaledColumns(4, 1.3), equals(3));
+        expect(AppSpacing.scaledColumns(6, 1.6), equals(4));
+      });
+
+      test('мелкие карточки увеличивают число колонок', () {
+        expect(AppSpacing.scaledColumns(3, 0.7), equals(4));
+        expect(AppSpacing.scaledColumns(4, 0.8), equals(5));
+        expect(AppSpacing.scaledColumns(6, 0.7), equals(8));
+      });
+
+      test('результат ограничен диапазоном 2..8', () {
+        expect(AppSpacing.scaledColumns(3, 10.0), equals(2));
+        expect(AppSpacing.scaledColumns(8, 0.1), equals(8));
+      });
+    });
   });
 }

--- a/test/shared/utils/item_card_progress_test.dart
+++ b/test/shared/utils/item_card_progress_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/custom_media.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
+import 'package:tonkatsu_box/shared/utils/item_card_progress.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('itemCardProgress', () {
+    test('null без записанного прогресса', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.anime,
+        anime: createTestAnime(episodes: 24),
+      );
+      expect(itemCardProgress(item), isNull);
+    });
+
+    test('null для типов без прогресса даже с ненулевыми полями', () {
+      for (final MediaType type in <MediaType>[
+        MediaType.game,
+        MediaType.movie,
+        MediaType.visualNovel,
+      ]) {
+        final CollectionItem item = createTestCollectionItem(
+          mediaType: type,
+          currentEpisode: 5,
+        );
+        expect(itemCardProgress(item), isNull, reason: type.name);
+      }
+    });
+
+    test('аниме: эпизод/всего и доля', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.anime,
+        currentEpisode: 12,
+        anime: createTestAnime(episodes: 24),
+      );
+      final ItemCardProgress? p = itemCardProgress(item);
+      expect(p!.label, '12/24');
+      expect(p.fraction, closeTo(0.5, 0.001));
+    });
+
+    test('аниме без известного тотала: только текущий, без доли', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.anime,
+        currentEpisode: 7,
+        anime: createTestAnime(),
+      );
+      final ItemCardProgress? p = itemCardProgress(item);
+      expect(p!.label, '7');
+      expect(p.fraction, isNull);
+    });
+
+    test('манга: том и главы', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.manga,
+        currentEpisode: 45,
+        currentSeason: 5,
+        manga: createTestManga(chapters: 100),
+      );
+      expect(itemCardProgress(item)!.label, 'V5 · 45/100');
+    });
+
+    test('манга: только том без глав', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.manga,
+        currentSeason: 3,
+        manga: createTestManga(),
+      );
+      final ItemCardProgress? p = itemCardProgress(item);
+      expect(p!.label, 'V3');
+      expect(p.fraction, isNull);
+    });
+
+    test('сериалы (TMDB) пока исключены — метки живут в watched_episodes', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.tvShow,
+        currentEpisode: 12,
+        currentSeason: 2,
+        tvShow: createTestTvShow(totalEpisodes: 62),
+      );
+      expect(itemCardProgress(item), isNull);
+    });
+
+    test('книга: страницы', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.book,
+        currentEpisode: 150,
+        book: createTestBook(pageCount: 300),
+      );
+      final ItemCardProgress? p = itemCardProgress(item);
+      expect(p!.label, '150/300');
+      expect(p.fraction, closeTo(0.5, 0.001));
+    });
+
+    test('кастомный элемент берёт тоталы и ось из customMedia', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.custom,
+        currentEpisode: 4,
+        currentSeason: 1,
+        customMedia: const CustomMedia(
+          id: 1,
+          title: 'X',
+          displayType: MediaType.tvShow,
+          unitTotal: 10,
+        ),
+      );
+      expect(itemCardProgress(item)!.label, 'S1 · 4/10');
+    });
+
+    test('кастомный элемент без displayType: без оси сезонов', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.custom,
+        currentEpisode: 2,
+        currentSeason: 3,
+        customMedia: const CustomMedia(id: 1, title: 'X', unitTotal: 8),
+      );
+      expect(itemCardProgress(item)!.label, '2/8');
+    });
+
+    test('доля ограничена 1.0 при перевыполнении', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.anime,
+        currentEpisode: 30,
+        anime: createTestAnime(episodes: 24),
+      );
+      expect(itemCardProgress(item)!.fraction, 1.0);
+    });
+  });
+}

--- a/test/shared/widgets/error_details_dialog_test.dart
+++ b/test/shared/widgets/error_details_dialog_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/extensions/snackbar_extension.dart';
+import 'package:tonkatsu_box/shared/widgets/error_details_dialog.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('showErrorDetailsDialog', () {
+    testWidgets('should show message и detail без исключений',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () => showErrorDetailsDialog(
+              context,
+              message: 'Import failed: timeout',
+              detail: 'GET /sync → 504',
+            ),
+            child: const Text('open'),
+          ),
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed: timeout'), findsOneWidget);
+      expect(find.text('GET /sync → 504'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('should hide блок detail когда detail == null',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () => showErrorDetailsDialog(
+              context,
+              message: 'Import failed: timeout',
+            ),
+            child: const Text('open'),
+          ),
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed: timeout'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('копирование не бросает исключений',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () => showErrorDetailsDialog(
+              context,
+              message: 'boom',
+              detail: 'stack',
+            ),
+            child: const Text('open'),
+          ),
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.copy));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('showErrorSnack', () {
+    testWidgets('открывает диалог деталей по действию снека',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () => context.showErrorSnack(
+              'Import failed: timeout',
+              detail: 'GET /sync → 504',
+            ),
+            child: const Text('fail'),
+          ),
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.text('fail'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed: timeout'), findsOneWidget);
+
+      await tester.tap(find.byType(SnackBarAction));
+      await tester.pumpAndSettle();
+
+      expect(find.text('GET /sync → 504'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/shared/widgets/media_poster_card_test.dart
+++ b/test/shared/widgets/media_poster_card_test.dart
@@ -4,6 +4,7 @@ import 'package:tonkatsu_box/core/services/image_cache_service.dart';
 import 'package:tonkatsu_box/l10n/app_localizations.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
+import 'package:tonkatsu_box/shared/utils/item_card_progress.dart';
 import 'package:tonkatsu_box/shared/widgets/dual_rating_badge.dart';
 import 'package:tonkatsu_box/shared/widgets/media_poster_card.dart';
 
@@ -23,6 +24,7 @@ void main() {
     MediaType? mediaType,
     IconData? placeholderIcon,
     int? timeToBeatHours,
+    ItemCardProgress? progress,
     bool isFavorite = false,
     bool showFavorite = false,
     VoidCallback? onTap,
@@ -52,6 +54,7 @@ void main() {
             mediaType: mediaType,
             placeholderIcon: placeholderIcon,
             timeToBeatHours: timeToBeatHours,
+            progress: progress,
             isFavorite: isFavorite,
             showFavorite: showFavorite,
             onTap: onTap,
@@ -185,6 +188,37 @@ void main() {
           matching: find.byType(Focus),
         );
         expect(focusWidgets, findsOneWidget);
+      });
+    });
+
+    group('progress', () {
+      testWidgets('should show метку прогресса когда progress задан',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard(
+          status: ItemStatus.inProgress,
+          progress: const ItemCardProgress(label: '12/24', fraction: 0.5),
+        ));
+
+        expect(find.text('12/24'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('should show метку без бара когда fraction == null',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard(
+          progress: const ItemCardProgress(label: 'V2 · 12'),
+        ));
+
+        expect(find.text('V2 · 12'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('не should show метку без progress',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildCard(status: ItemStatus.inProgress));
+
+        expect(find.text('12/24'), findsNothing);
+        expect(tester.takeException(), isNull);
       });
     });
 


### PR DESCRIPTION
- Import errors: showErrorSnack with a copyable details dialog, per-item errors card on the import result screen, extractApiError covers GoogleBooks/Hardcover/Fantlab/Kodi/ScreenScraper, fatalDetail on UniversalImportResult
- Progress pill + bottom-edge bar on item cards (anime/manga/books/custom), read-only Progress column in the collection table, All Items patched in place on progress ticks (updateProgressLocally)
- Cover size slider (70-160%) in Settings > Appearance, applied to the collection grid, All Items and Browse
- TMDB content languages expanded from 3 to 45 locales; welcome wizard derives the AniList title mode from the content language
- Create-item dialog: prefill the form from a JSON/CSV file
- Gamepad debug log export via the system save dialog (SAF on Android)