### PR TITLE
feat(tags): manual per-item tag order in card, picker search + create row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,83 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     (_CreateCustomItemDialogState._fillFromFile, _applyEntry,
     _resolvePlatformId): New.
 
+- **Drag tag chips into a manual per-item order in the item card**
+
+  Tag chips in the item detail card can be dragged into a custom order —
+  immediate drag on desktop, long-press drag on Android. The order is
+  per item: until a chip is dragged, the item keeps following the global
+  tag order from the tag manager, and newly attached tags go to the end
+  of a manually ordered item. The first tag by that order is what item
+  cards and the table's primary-tag sort show. The arrangement survives
+  export/import (`tag_names` is written in display order and restored as
+  explicit positions only when it differs from the global order) and is
+  carried along when an item is cloned to another collection.
+
+  * lib/core/database/migrations/migration_v56.dart (MigrationV56): New —
+    nullable `item_tags.position` column via addColumnIfAbsent.
+  * lib/core/database/migrations/migration_registry.dart (MigrationRegistry.all),
+    lib/core/database/database_service.dart (_initDatabase): Register v56,
+    bump version to 56.
+  * lib/core/database/dao/global_tag_dao.dart (GlobalTagDao.getTagIdsByItem,
+    GlobalTagDao.getTagIdsForItems, GlobalTagDao.getAllItemTags): Return
+    ordered lists via a JOIN — manual positions first, NULLs after in
+    global order (shared _linkOrderBy clause).
+  * lib/core/database/dao/global_tag_dao.dart (GlobalTagDao.setItemTags):
+    No longer deletes-and-reinserts every link; surviving links keep their
+    manual position, new links get NULL.
+  * lib/core/database/dao/global_tag_dao.dart (GlobalTagDao.setItemTagPositions,
+    GlobalTagDao.copyItemTags): New — persist a per-item reorder; copy links
+    with positions when cloning an item.
+  * lib/features/collections/providers/item_tags_provider.dart
+    (ItemTagsNotifier): State is now Map<int, List<int>> in display order;
+    new reorderItemTags and refreshFromDb; setItemTags re-reads the item's
+    order from the DAO.
+  * lib/features/collections/providers/global_tags_provider.dart
+    (GlobalTagsNotifier.reorder): Refresh the cached per-item lists after a
+    global reorder so fallback-ordered items follow it.
+  * lib/shared/models/tag.dart (TagListProjection.orderedFor,
+    TagListProjection.primaryFor, TagListProjection.byId, TagMapProjection):
+    Projections follow the ids order (the item's display order); map-based
+    overloads let eager loops hoist the id → tag map.
+  * lib/features/collections/widgets/item_tags_section.dart (ItemTagsSection,
+    _TagDragData): Chips are Draggable/LongPressDraggable drop targets with a
+    hover highlight; the drag payload is scoped to the owning item.
+  * lib/core/services/export_service.dart (ExportService._collectTagData):
+    Write `tag_names` in the item's display order.
+  * lib/core/services/import_service.dart (ImportService._importTags): Restore
+    explicit positions when the imported order differs from the global one.
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier.cloneItem),
+    lib/features/collections/helpers/bulk_operations.dart (cloneItemsToCollection):
+    Clone tags via copyItemTags so the manual order travels with the copy.
+  * lib/features/collections/screens/collection_screen.dart,
+    lib/features/collections/widgets/collection_items_view.dart,
+    lib/features/collections/widgets/collection_table/collection_table_view.dart,
+    lib/features/collections/widgets/collection_table/table_rows.dart,
+    lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart,
+    lib/features/collections/widgets/copy_as_text_dialog.dart,
+    lib/features/collections/widgets/tag_management_dialog.dart,
+    lib/features/collections/helpers/collection_filters.dart,
+    lib/features/home/screens/all_items_screen.dart: Consume the ordered
+    Map<int, List<int>> item-tag map.
+  * docs/RCOLL_FORMAT.md: Document the `tag_names` order semantics.
+
+- **Tag picker: search field and an explicit "Create" row**
+
+  The tag picker's text field now searches: typing filters the tag list
+  as you type, with a clear button. When the query matches no existing
+  tag exactly, a highlighted "Create «query»" row with a plus icon
+  appears at the top of the list — tapping it (or pressing Enter)
+  creates the tag and selects it; Enter on an exact match just selects
+  it. Replaces the old bare name field whose plus button users didn't
+  recognise as "add new tag".
+
+  * lib/features/collections/widgets/tag_picker_dialog.dart
+    (_TagPickerDialogState._submitQuery, _buildCreateTile): Search-driven
+    list, create row, Enter handling.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb, lib/l10n/app_zh.arb
+    (tagCreateNamed): New key.
+
 ### Changed
 
 - **TMDB content language list expanded from 3 to 45 locales**

--- a/docs/RCOLL_FORMAT.md
+++ b/docs/RCOLL_FORMAT.md
@@ -163,7 +163,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 | comment | string | no | Author's comment |
 | user_rating | number | no | User rating (1.0–10.0, one decimal). Integers from v2 files load as doubles |
 | _canvas | object | no | Per-item canvas data (full only) |
-| tag_names | array | no | Names of all assigned tags in display order (full only, resolved into the global tag set on import) |
+| tag_names | array | no | Names of all assigned tags in the item's display order — manual per-item order when set, global tag order otherwise (full only, resolved into the global tag set on import) |
 | tag_name | string | no | First assigned tag name (full only). Legacy single-tag field kept for older app versions; readers prefer `tag_names` |
 | _marks | array | no | Per-unit likes/notes. Present only when `user_data` is `true`; re-anchored to the new item id on import (see Item Marks) |
 
@@ -268,7 +268,7 @@ Contains the global tag definitions used by the exported collection's items. Onl
 | text_color | int? | Tag label text color (0xAARRGGBB int), null for default |
 | sort_order | int | Display order |
 
-Item-tag assignments are stored per-item via the `tag_names` array (see Item Object); the legacy single `tag_name` field is still written and accepted. On import, names are resolved case-insensitively into the global tag set (missing tags are created with the exported colors), then item links are written into the `item_tags` junction.
+Item-tag assignments are stored per-item via the `tag_names` array (see Item Object); the legacy single `tag_name` field is still written and accepted. On import, names are resolved case-insensitively into the global tag set (missing tags are created with the exported colors), then item links are written into the `item_tags` junction. The `tag_names` order carries the item's manual tag arrangement: when it differs from the global tag order, explicit per-item positions are written on import, otherwise the item keeps following the global sort.
 
 ### Tracker Data Object
 

--- a/lib/core/database/dao/global_tag_dao.dart
+++ b/lib/core/database/dao/global_tag_dao.dart
@@ -135,59 +135,84 @@ class GlobalTagDao {
     return byKey;
   }
 
-  Future<Set<int>> getTagIdsByItem(int itemId) async {
+  /// Per-item display order: manual positions first (`NULL` = no manual
+  /// order → after the positioned ones, in global tag order).
+  static const String _linkOrderBy =
+      'it.position IS NULL, it.position, t.sort_order, t.name';
+
+  Future<List<int>> getTagIdsByItem(int itemId) async {
     final Database db = await _getDatabase();
-    final List<Map<String, Object?>> rows = await db.query(
-      'item_tags',
-      columns: <String>['tag_id'],
-      where: 'item_id = ?',
-      whereArgs: <Object?>[itemId],
+    final List<Map<String, Object?>> rows = await db.rawQuery(
+      'SELECT it.tag_id FROM item_tags it '
+      'JOIN tags t ON t.id = it.tag_id '
+      'WHERE it.item_id = ? '
+      'ORDER BY $_linkOrderBy',
+      <Object?>[itemId],
     );
-    return rows.map((Map<String, Object?> r) => r['tag_id']! as int).toSet();
+    return rows
+        .map((Map<String, Object?> r) => r['tag_id']! as int)
+        .toList();
   }
 
-  /// Tag ids for many items at once (list rendering / filtering).
-  /// Items without tags are absent from the map.
-  Future<Map<int, Set<int>>> getTagIdsForItems(List<int> itemIds) async {
+  /// Tag ids for many items at once (list rendering / filtering), each list
+  /// in the item's display order. Items without tags are absent from the map.
+  Future<Map<int, List<int>>> getTagIdsForItems(List<int> itemIds) async {
     final Database db = await _getDatabase();
     final List<Map<String, Object?>> rows = await queryByIdsInChunks(
       itemIds,
-      (List<int> chunk) => db.query(
-        'item_tags',
-        where: 'item_id IN (${List<String>.filled(chunk.length, '?').join(', ')})',
-        whereArgs: chunk,
+      (List<int> chunk) => db.rawQuery(
+        'SELECT it.item_id, it.tag_id FROM item_tags it '
+        'JOIN tags t ON t.id = it.tag_id '
+        'WHERE it.item_id IN '
+        '(${List<String>.filled(chunk.length, '?').join(', ')}) '
+        'ORDER BY it.item_id, $_linkOrderBy',
+        chunk,
       ),
     );
-    final Map<int, Set<int>> result = <int, Set<int>>{};
-    for (final Map<String, Object?> row in rows) {
-      result
-          .putIfAbsent(row['item_id']! as int, () => <int>{})
-          .add(row['tag_id']! as int);
-    }
-    return result;
+    return _groupByItem(rows);
   }
 
-  /// The whole junction as a map — items without tags are absent.
-  Future<Map<int, Set<int>>> getAllItemTags() async {
+  /// The whole junction as a map — items without tags are absent; each list
+  /// is in the item's display order.
+  Future<Map<int, List<int>>> getAllItemTags() async {
     final Database db = await _getDatabase();
-    final List<Map<String, Object?>> rows = await db.query('item_tags');
-    final Map<int, Set<int>> result = <int, Set<int>>{};
+    final List<Map<String, Object?>> rows = await db.rawQuery(
+      'SELECT it.item_id, it.tag_id FROM item_tags it '
+      'JOIN tags t ON t.id = it.tag_id '
+      'ORDER BY it.item_id, $_linkOrderBy',
+    );
+    return _groupByItem(rows);
+  }
+
+  static Map<int, List<int>> _groupByItem(List<Map<String, Object?>> rows) {
+    final Map<int, List<int>> result = <int, List<int>>{};
     for (final Map<String, Object?> row in rows) {
       result
-          .putIfAbsent(row['item_id']! as int, () => <int>{})
+          .putIfAbsent(row['item_id']! as int, () => <int>[])
           .add(row['tag_id']! as int);
     }
     return result;
   }
 
-  /// Replaces the item's tag set with [tagIds].
+  /// Replaces the item's tag set with [tagIds]. Links that survive keep
+  /// their manual position; new links get `NULL` (global-order fallback,
+  /// displayed after the positioned ones).
   Future<void> setItemTags(int itemId, Set<int> tagIds) async {
     final Database db = await _getDatabase();
     await db.transaction((Transaction txn) async {
+      if (tagIds.isEmpty) {
+        await txn.delete(
+          'item_tags',
+          where: 'item_id = ?',
+          whereArgs: <Object?>[itemId],
+        );
+        return;
+      }
       await txn.delete(
         'item_tags',
-        where: 'item_id = ?',
-        whereArgs: <Object?>[itemId],
+        where: 'item_id = ? AND tag_id NOT IN '
+            '(${List<String>.filled(tagIds.length, '?').join(', ')})',
+        whereArgs: <Object?>[itemId, ...tagIds],
       );
       for (final int tagId in tagIds) {
         await txn.rawInsert(
@@ -196,6 +221,39 @@ class GlobalTagDao {
         );
       }
     });
+  }
+
+  /// Persists a manual per-item reorder: [orderedTagIds] in their new
+  /// display order. Only existing links are touched.
+  Future<void> setItemTagPositions(int itemId, List<int> orderedTagIds) async {
+    if (orderedTagIds.isEmpty) return;
+    final Database db = await _getDatabase();
+    final Batch batch = db.batch();
+    for (int i = 0; i < orderedTagIds.length; i++) {
+      batch.update(
+        'item_tags',
+        <String, Object?>{'position': i},
+        where: 'item_id = ? AND tag_id = ?',
+        whereArgs: <Object?>[itemId, orderedTagIds[i]],
+      );
+    }
+    await batch.commit(noResult: true);
+  }
+
+  /// Copies every tag link (with its manual position) from one item to
+  /// another. Returns the number of links on the copy.
+  Future<int> copyItemTags(int fromItemId, int toItemId) async {
+    final Database db = await _getDatabase();
+    await db.rawInsert(
+      'INSERT OR IGNORE INTO item_tags (item_id, tag_id, position) '
+      'SELECT ?, tag_id, position FROM item_tags WHERE item_id = ?',
+      <Object?>[toItemId, fromItemId],
+    );
+    final List<Map<String, Object?>> count = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM item_tags WHERE item_id = ?',
+      <Object?>[toItemId],
+    );
+    return count.first['c'] as int? ?? 0;
   }
 
   /// Links [tagId] to every item in [itemIds] in one batch. Additive —

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -248,7 +248,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 55,
+        version: 56,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -54,6 +54,7 @@ import 'migration_v52.dart';
 import 'migration_v53.dart';
 import 'migration_v54.dart';
 import 'migration_v55.dart';
+import 'migration_v56.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
@@ -112,6 +113,7 @@ abstract final class MigrationRegistry {
     MigrationV53(),
     MigrationV54(),
     MigrationV55(),
+    MigrationV56(),
   ];
 
   /// Schema version this build can open; newer databases must be rejected.

--- a/lib/core/database/migrations/migration_v56.dart
+++ b/lib/core/database/migrations/migration_v56.dart
@@ -1,0 +1,27 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Adds `item_tags.position` — manual per-item tag order.
+///
+/// `NULL` means "no manual order yet": such links keep following the global
+/// tag sort. Reordering chips in the item card writes positions for all of
+/// the item's links; newly attached tags stay `NULL` and display after the
+/// positioned ones.
+class MigrationV56 extends Migration {
+  @override
+  int get version => 56;
+
+  @override
+  String get description => 'Item tags: per-item manual position';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await Migration.addColumnIfAbsent(
+      db,
+      'item_tags',
+      'position',
+      'position INTEGER',
+    );
+  }
+}

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -716,7 +716,7 @@ class ExportService {
   ) async {
     final DatabaseService db = _database!;
     final List<Tag> allTags = await db.globalTagDao.getAll();
-    final Map<int, Set<int>> links = await db.globalTagDao
+    final Map<int, List<int>> links = await db.globalTagDao
         .getTagIdsForItems(items.map((CollectionItem i) => i.id).toList());
 
     if (allTags.isEmpty || links.isEmpty) {
@@ -730,17 +730,22 @@ class ExportService {
     }
 
     final Set<int> usedIds = <int>{
-      for (final Set<int> ids in links.values) ...ids,
+      for (final List<int> ids in links.values) ...ids,
     };
     final List<Tag> usedTags =
         allTags.where((Tag t) => usedIds.contains(t.id)).toList();
 
+    // tag_names keeps the item's display order — that's how the manual
+    // per-item order survives export/import.
+    final Map<int, String> nameById = <int, String>{
+      for (final Tag tag in usedTags) tag.id: tag.name,
+    };
     final List<List<String>> itemTagNames = items.map((CollectionItem item) {
-      final Set<int>? ids = links[item.id];
+      final List<int>? ids = links[item.id];
       if (ids == null || ids.isEmpty) return const <String>[];
       return <String>[
-        for (final Tag tag in usedTags)
-          if (ids.contains(tag.id)) tag.name,
+        for (final int id in ids)
+          if (nameById[id] case final String name) name,
       ];
     }).toList();
 

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
@@ -28,6 +28,7 @@ import '../../shared/models/tv_show.dart';
 import '../../shared/models/anime.dart';
 import '../../shared/models/book.dart';
 import '../../shared/models/manga.dart';
+import '../../shared/models/tag.dart';
 import '../../shared/models/tracker_game_data.dart';
 import '../../shared/models/visual_novel.dart';
 import '../api/anilist_api.dart';
@@ -1409,6 +1410,8 @@ class ImportService {
         ),
     ]);
 
+    final List<Tag> allTags = await _database.globalTagDao.getAll();
+
     for (final Map<String, dynamic> itemData in exportedItems) {
       final List<String> tagNames = switch (itemData['tag_names']) {
         final List<dynamic> names => names.cast<String>(),
@@ -1419,11 +1422,13 @@ class ImportService {
       };
       if (tagNames.isEmpty) continue;
 
+      // tag_names comes in the item's display order; keep it.
       final Set<int> tagIds = <int>{
         for (final String name in tagNames)
           if (tagNameToId[GlobalTagDao.nameKey(name)] case final int id) id,
       };
       if (tagIds.isEmpty) continue;
+      final List<int> orderedIds = tagIds.toList();
 
       final String? mediaType = itemData['media_type'] as String?;
       final int? externalId = itemData['external_id'] as int?;
@@ -1440,6 +1445,17 @@ class ImportService {
       // Imported items are freshly created, so a replace-set write is safe
       // and avoids one INSERT round-trip per link.
       await _database.globalTagDao.setItemTags(itemId, tagIds);
+
+      // Explicit positions only when the exported order differs from the
+      // global fallback — otherwise the item keeps following the global sort.
+      final List<int> globalOrder = <int>[
+        for (final Tag tag in allTags)
+          if (tagIds.contains(tag.id)) tag.id,
+      ];
+      if (!listEquals(orderedIds, globalOrder)) {
+        await _database.globalTagDao
+            .setItemTagPositions(itemId, orderedIds);
+      }
     }
   }
 

--- a/lib/features/collections/helpers/bulk_operations.dart
+++ b/lib/features/collections/helpers/bulk_operations.dart
@@ -136,12 +136,9 @@ class BulkOperations {
         skipped++;
         continue;
       }
-      // Tags are global — the copy simply carries the same links.
-      final Set<int> tagIds = await tagDao.getTagIdsByItem(item.id);
-      if (tagIds.isNotEmpty) {
-        await tagDao.setItemTags(newId, tagIds);
-        tagsCopiedAny = true;
-      }
+      // Tags are global — the copy carries the links with their manual order.
+      final int copiedTags = await tagDao.copyItemTags(item.id, newId);
+      if (copiedTags > 0) tagsCopiedAny = true;
       affectedTypes.add(item.mediaType);
       cloned++;
     }

--- a/lib/features/collections/helpers/collection_filters.dart
+++ b/lib/features/collections/helpers/collection_filters.dart
@@ -33,7 +33,7 @@ class CollectionFilters {
   List<CollectionItem> apply(
     List<CollectionItem> items,
     List<Tag> tags,
-    Map<int, Set<int>> itemTags, {
+    Map<int, List<int>> itemTags, {
     String animeMangaTitleLanguage = 'romaji',
   }) {
     List<CollectionItem> result = items;
@@ -84,7 +84,7 @@ class CollectionFilters {
       for (final Tag tag in tags) tag.id: tag.name.toLowerCase(),
     };
     bool matchesTagName(CollectionItem item) {
-      final Set<int>? ids = itemTags[item.id];
+      final List<int>? ids = itemTags[item.id];
       if (ids == null) return false;
       return ids.any((int id) => tagNames[id]?.contains(query) ?? false);
     }

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -660,11 +660,10 @@ class CollectionItemsNotifier
     );
     if (newId == null) return false;
 
-    // Tags are global — the copy simply carries the same links.
+    // Tags are global — the copy carries the links with their manual order.
     final GlobalTagDao tagDao = ref.read(globalTagDaoProvider);
-    final Set<int> tagIds = await tagDao.getTagIdsByItem(itemId);
-    if (tagIds.isNotEmpty) {
-      await tagDao.setItemTags(newId, tagIds);
+    final int copiedTags = await tagDao.copyItemTags(itemId, newId);
+    if (copiedTags > 0) {
       ref.invalidate(itemTagsProvider);
     }
 

--- a/lib/features/collections/providers/global_tags_provider.dart
+++ b/lib/features/collections/providers/global_tags_provider.dart
@@ -72,6 +72,9 @@ class GlobalTagsNotifier extends AsyncNotifier<List<Tag>> {
   Future<void> reorder(List<int> orderedIds) async {
     final GlobalTagDao dao = ref.read(globalTagDaoProvider);
     await dao.setSortOrders(orderedIds);
+    // Items without a manual per-item order follow the global sort, and
+    // itemTagsProvider caches resolved per-item lists — refresh them.
+    await ref.read(itemTagsProvider.notifier).refreshFromDb();
     final Map<int, Tag> byId = <int, Tag>{
       for (final Tag t in state.valueOrNull ?? <Tag>[]) t.id: t,
     };

--- a/lib/features/collections/providers/item_tags_provider.dart
+++ b/lib/features/collections/providers/item_tags_provider.dart
@@ -3,53 +3,75 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/database/dao/global_tag_dao.dart';
 import '../../../core/database/database_service.dart';
 
-/// Item → global tag ids map for the whole database.
+/// Item → global tag ids for the whole database, each list in the item's
+/// display order (manual positions first, global-order fallback for the
+/// rest — the DAO bakes that in).
 ///
 /// The junction is small (one row per link), so keeping the full map in
 /// memory lets filters, cards and the table resolve an item's tags
 /// synchronously without per-item queries.
-final AsyncNotifierProvider<ItemTagsNotifier, Map<int, Set<int>>>
+final AsyncNotifierProvider<ItemTagsNotifier, Map<int, List<int>>>
     itemTagsProvider =
-    AsyncNotifierProvider<ItemTagsNotifier, Map<int, Set<int>>>(
+    AsyncNotifierProvider<ItemTagsNotifier, Map<int, List<int>>>(
   ItemTagsNotifier.new,
 );
 
-class ItemTagsNotifier extends AsyncNotifier<Map<int, Set<int>>> {
+class ItemTagsNotifier extends AsyncNotifier<Map<int, List<int>>> {
   @override
-  Future<Map<int, Set<int>>> build() async {
+  Future<Map<int, List<int>>> build() async {
     final GlobalTagDao dao = ref.watch(globalTagDaoProvider);
     return dao.getAllItemTags();
   }
 
-  /// Replaces the item's tag set.
+  /// Replaces the item's tag set; surviving links keep their manual order.
+  ///
+  /// The item's list is re-read from the DAO: only it knows whether the item
+  /// has manual positions (new tags go last) or follows the global fallback.
   Future<void> setItemTags(int itemId, Set<int> tagIds) async {
     final GlobalTagDao dao = ref.read(globalTagDaoProvider);
     await dao.setItemTags(itemId, tagIds);
-    final Map<int, Set<int>> next = _copy();
+    final Map<int, List<int>> next = _copy();
     if (tagIds.isEmpty) {
       next.remove(itemId);
     } else {
-      next[itemId] = Set<int>.of(tagIds);
+      next[itemId] = await dao.getTagIdsByItem(itemId);
     }
-    state = AsyncData<Map<int, Set<int>>>(next);
+    state = AsyncData<Map<int, List<int>>>(next);
+  }
+
+  /// Persists a manual per-item reorder of the item's tags.
+  Future<void> reorderItemTags(int itemId, List<int> orderedTagIds) async {
+    final GlobalTagDao dao = ref.read(globalTagDaoProvider);
+    await dao.setItemTagPositions(itemId, orderedTagIds);
+    final Map<int, List<int>> next = _copy();
+    next[itemId] = List<int>.of(orderedTagIds);
+    state = AsyncData<Map<int, List<int>>>(next);
+  }
+
+  /// Reloads from the DB without an intermediate loading state — used after
+  /// a global tag reorder shifts the fallback order of unpositioned links.
+  Future<void> refreshFromDb() async {
+    final GlobalTagDao dao = ref.read(globalTagDaoProvider);
+    state = AsyncData<Map<int, List<int>>>(await dao.getAllItemTags());
   }
 
   /// In-memory cleanup after a tag was deleted (DB rows are already gone).
   void dropTagEverywhere(int tagId) {
-    final Map<int, Set<int>> next = <int, Set<int>>{};
-    for (final MapEntry<int, Set<int>> entry in _copy().entries) {
-      final Set<int> tags = Set<int>.of(entry.value)..remove(tagId);
+    final Map<int, List<int>> next = <int, List<int>>{};
+    for (final MapEntry<int, List<int>> entry in _copy().entries) {
+      final List<int> tags =
+          entry.value.where((int id) => id != tagId).toList();
       if (tags.isNotEmpty) next[entry.key] = tags;
     }
-    state = AsyncData<Map<int, Set<int>>>(next);
+    state = AsyncData<Map<int, List<int>>>(next);
   }
 
-  Map<int, Set<int>> _copy() {
-    final Map<int, Set<int>> current =
-        state.valueOrNull ?? <int, Set<int>>{};
-    return <int, Set<int>>{
-      for (final MapEntry<int, Set<int>> e in current.entries)
-        e.key: Set<int>.of(e.value),
+  Map<int, List<int>> _copy() {
+    final Map<int, List<int>> current =
+        state.valueOrNull ?? <int, List<int>>{};
+    return <int, List<int>>{
+      for (final MapEntry<int, List<int>> e in current.entries)
+        e.key: List<int>.of(e.value),
     };
   }
 }

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -175,8 +175,8 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
 
     final String searchQuery = ref.watch(collectionsSearchQueryProvider);
     final List<Tag> tags = _visibleTags(itemsAsync);
-    final Map<int, Set<int>> itemTags =
-        ref.watch(itemTagsProvider).valueOrNull ?? <int, Set<int>>{};
+    final Map<int, List<int>> itemTags =
+        ref.watch(itemTagsProvider).valueOrNull ?? <int, List<int>>{};
     final CollectionFilters activeFilters = CollectionFilters(
       mediaTypes: _filterTypes,
       platformIds: _filterPlatformIds,
@@ -307,8 +307,8 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
   /// Global tags actually used by this collection's items, in display order.
   List<Tag> _visibleTags(AsyncValue<List<CollectionItem>> itemsAsync) {
     final List<Tag> all = ref.watch(globalTagsProvider).valueOrNull ?? <Tag>[];
-    final Map<int, Set<int>> itemTags =
-        ref.watch(itemTagsProvider).valueOrNull ?? <int, Set<int>>{};
+    final Map<int, List<int>> itemTags =
+        ref.watch(itemTagsProvider).valueOrNull ?? <int, List<int>>{};
     final List<CollectionItem> items =
         itemsAsync.valueOrNull ?? <CollectionItem>[];
     final Set<int> used = <int>{
@@ -426,7 +426,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     AsyncValue<CollectionStats> statsAsync,
     String searchQuery,
     List<Tag> tags,
-    Map<int, Set<int>> itemTags,
+    Map<int, List<int>> itemTags,
   ) {
     final Set<int> validTagIds = <int>{
       for (final Tag tag in tags) tag.id,

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -42,7 +42,7 @@ class CollectionItemsView extends ConsumerWidget {
     this.onItemRemove,
     this.onItemFocusChanged,
     this.tags = const <Tag>[],
-    this.itemTags = const <int, Set<int>>{},
+    this.itemTags = const <int, List<int>>{},
     this.filterTagIds = const <int>{},
     this.groupByTags = false,
     this.header,
@@ -64,7 +64,7 @@ class CollectionItemsView extends ConsumerWidget {
   final List<Tag> tags;
 
   /// Item id → global tag ids (from `itemTagsProvider`).
-  final Map<int, Set<int>> itemTags;
+  final Map<int, List<int>> itemTags;
   final Set<int> filterTagIds;
   final bool groupByTags;
 
@@ -178,8 +178,9 @@ class CollectionItemsView extends ConsumerWidget {
     };
     final List<CollectionItem> untagged = <CollectionItem>[];
 
+    final Map<int, Tag> tagById = tags.byId;
     for (final CollectionItem item in items) {
-      final Tag? primary = tags.primaryFor(itemTags[item.id]);
+      final Tag? primary = tagById.primaryFor(itemTags[item.id]);
       if (primary != null) {
         grouped[primary.id]!.add(item);
       } else {
@@ -438,8 +439,8 @@ class CollectionItemsView extends ConsumerWidget {
 
   /// Opens the multi-select tag picker for the item and persists the result.
   void _editItemTags(BuildContext context, WidgetRef ref, int itemId) {
-    final Set<int> current =
-        ref.read(itemTagsProvider).valueOrNull?[itemId] ?? <int>{};
+    final Set<int> current = Set<int>.of(
+        ref.read(itemTagsProvider).valueOrNull?[itemId] ?? const <int>[]);
     TagPickerDialog.show(context, initialSelection: current)
         .then((Set<int>? selected) {
       if (selected == null || !context.mounted) return;

--- a/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
+++ b/lib/features/collections/widgets/collection_screen/collection_bulk_action_bar.dart
@@ -46,8 +46,8 @@ class CollectionBulkActionBar extends ConsumerWidget {
 
     final String anilistLang =
         ref.read(sharedPreferencesProvider).animeMangaTitleLanguage;
-    final Map<int, Set<int>> itemTags =
-        ref.watch(itemTagsProvider).valueOrNull ?? <int, Set<int>>{};
+    final Map<int, List<int>> itemTags =
+        ref.watch(itemTagsProvider).valueOrNull ?? <int, List<int>>{};
     final List<CollectionItem> visible = filters?.apply(
           all,
           tags,

--- a/lib/features/collections/widgets/collection_table/collection_table_view.dart
+++ b/lib/features/collections/widgets/collection_table/collection_table_view.dart
@@ -37,7 +37,7 @@ class CollectionTableView extends ConsumerStatefulWidget {
     this.heroHeader,
     this.onItemSecondaryTap,
     this.tags = const <Tag>[],
-    this.itemTags = const <int, Set<int>>{},
+    this.itemTags = const <int, List<int>>{},
     this.onRatingChanged,
     this.onStatusChanged,
     this.onTagsEdit,
@@ -61,7 +61,7 @@ class CollectionTableView extends ConsumerStatefulWidget {
   final List<Tag> tags;
 
   /// Item id → global tag ids (from `itemTagsProvider`).
-  final Map<int, Set<int>> itemTags;
+  final Map<int, List<int>> itemTags;
   final void Function(int itemId, double? rating)? onRatingChanged;
   final void Function(int itemId, ItemStatus status, MediaType mediaType)?
   onStatusChanged;

--- a/lib/features/collections/widgets/collection_table/table_rows.dart
+++ b/lib/features/collections/widgets/collection_table/table_rows.dart
@@ -15,8 +15,9 @@ List<TrinaRow<dynamic>> buildCollectionTableRows({
   required String anilistTitleLanguage,
   required S l,
   required List<Tag> tags,
-  required Map<int, Set<int>> itemTags,
+  required Map<int, List<int>> itemTags,
 }) {
+  final Map<int, Tag> tagById = tags.byId;
   return items.map((CollectionItem item) {
     return TrinaRow<dynamic>(
       data: item,
@@ -39,7 +40,7 @@ List<TrinaRow<dynamic>> buildCollectionTableRows({
         // All tag names joined so a "contains" filter matches any tag; sort
         // still keys off the leading (primary) tag.
         TableFields.tags: TrinaCell(
-          value: tags
+          value: tagById
               .orderedFor(itemTags[item.id])
               .map((Tag t) => t.name)
               .join(', '),

--- a/lib/features/collections/widgets/copy_as_text_dialog.dart
+++ b/lib/features/collections/widgets/copy_as_text_dialog.dart
@@ -110,14 +110,14 @@ class _CopyAsTextDialogState extends ConsumerState<_CopyAsTextDialog> {
   /// Item id → joined tag names for [items], resolved from the global tag
   /// providers in the tags' display order.
   Map<int, String> _tagsByItemId(List<CollectionItem> items) {
-    final Map<int, Set<int>> itemTags =
-        ref.read(itemTagsProvider).valueOrNull ?? const <int, Set<int>>{};
+    final Map<int, List<int>> itemTags =
+        ref.read(itemTagsProvider).valueOrNull ?? const <int, List<int>>{};
     if (itemTags.isEmpty) return const <int, String>{};
     final List<Tag> tags =
         ref.read(globalTagsProvider).valueOrNull ?? const <Tag>[];
     return <int, String>{
       for (final CollectionItem item in items)
-        if (itemTags[item.id] case final Set<int> ids when ids.isNotEmpty)
+        if (itemTags[item.id] case final List<int> ids when ids.isNotEmpty)
           item.id:
               tags.orderedFor(ids).map((Tag t) => t.name).join(', '),
     };

--- a/lib/features/collections/widgets/item_tags_section.dart
+++ b/lib/features/collections/widgets/item_tags_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/constants/platform_features.dart';
 import '../../../shared/models/tag.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -12,6 +13,10 @@ import 'tag_picker_dialog.dart';
 
 /// The item's tag chips; tapping any of them (or the empty placeholder)
 /// opens the multi-select picker over the global tag set.
+///
+/// When editable, chips can be dragged into a manual per-item order
+/// (immediate drag on desktop, long-press drag on mobile). Dropping on a
+/// chip moves the dragged one past it in the direction of travel.
 class ItemTagsSection extends ConsumerWidget {
   const ItemTagsSection({
     required this.itemId,
@@ -33,6 +38,7 @@ class ItemTagsSection extends ConsumerWidget {
 
     if (itemTags.isEmpty && !isEditable) return const SizedBox.shrink();
 
+    final bool canReorder = isEditable && itemTags.length > 1;
     final Widget content = Wrap(
       spacing: AppSpacing.xs,
       runSpacing: AppSpacing.xs,
@@ -43,13 +49,11 @@ class ItemTagsSection extends ConsumerWidget {
             icon: Icons.label_outlined,
           )
         else
-          for (final Tag tag in itemTags)
-            _buildChip(
-              label: tag.name,
-              accent: tag.color != null ? Color(tag.color!) : AppColors.brand,
-              textColor:
-                  tag.textColor != null ? Color(tag.textColor!) : null,
-            ),
+          for (int i = 0; i < itemTags.length; i++)
+            if (canReorder)
+              _buildDraggableChip(ref, itemTags, i)
+            else
+              _buildTagChip(itemTags[i]),
       ],
     );
 
@@ -64,11 +68,75 @@ class ItemTagsSection extends ConsumerWidget {
     );
   }
 
+  Widget _buildDraggableChip(WidgetRef ref, List<Tag> itemTags, int index) {
+    final Tag tag = itemTags[index];
+    final Widget chip = _buildTagChip(tag);
+    final Widget feedback = Material(
+      color: Colors.transparent,
+      child: _buildTagChip(tag),
+    );
+    final Widget childWhenDragging = Opacity(opacity: 0.35, child: chip);
+
+    final Widget target = DragTarget<_TagDragData>(
+      onWillAcceptWithDetails: (DragTargetDetails<_TagDragData> d) =>
+          d.data.itemId == itemId && d.data.tagId != tag.id,
+      onAcceptWithDetails: (DragTargetDetails<_TagDragData> d) =>
+          _reorder(ref, itemTags, d.data.tagId, index),
+      builder: (
+        BuildContext context,
+        List<_TagDragData?> candidates,
+        List<dynamic> rejected,
+      ) =>
+          candidates.isEmpty ? chip : _buildTagChip(tag, highlighted: true),
+    );
+
+    final _TagDragData data = _TagDragData(itemId: itemId, tagId: tag.id);
+    // Tap-drag conflicts with scrolling on mobile — require long-press there.
+    if (kIsMobile) {
+      return LongPressDraggable<_TagDragData>(
+        data: data,
+        feedback: feedback,
+        childWhenDragging: childWhenDragging,
+        child: target,
+      );
+    }
+    return Draggable<_TagDragData>(
+      data: data,
+      feedback: feedback,
+      childWhenDragging: childWhenDragging,
+      child: target,
+    );
+  }
+
+  Future<void> _reorder(
+    WidgetRef ref,
+    List<Tag> itemTags,
+    int draggedId,
+    int targetIndex,
+  ) async {
+    final List<int> ids = itemTags.map((Tag t) => t.id).toList();
+    final int oldIndex = ids.indexOf(draggedId);
+    if (oldIndex < 0 || oldIndex == targetIndex) return;
+    ids.removeAt(oldIndex);
+    ids.insert(targetIndex, draggedId);
+    await ref.read(itemTagsProvider.notifier).reorderItemTags(itemId, ids);
+  }
+
+  Widget _buildTagChip(Tag tag, {bool highlighted = false}) {
+    return _buildChip(
+      label: tag.name,
+      accent: tag.color != null ? Color(tag.color!) : AppColors.brand,
+      textColor: tag.textColor != null ? Color(tag.textColor!) : null,
+      highlighted: highlighted,
+    );
+  }
+
   Widget _buildChip({
     required String label,
     IconData? icon,
     Color? accent,
     Color? textColor,
+    bool highlighted = false,
   }) {
     final Color labelColor =
         textColor ?? accent ?? AppColors.textTertiary;
@@ -78,9 +146,12 @@ class ItemTagsSection extends ConsumerWidget {
         color: accent != null ? accent.withAlpha(30) : AppColors.surface,
         borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
         border: Border.all(
-          color: accent != null
-              ? accent.withAlpha(80)
-              : AppColors.surfaceBorder,
+          color: highlighted
+              ? AppColors.brand
+              : accent != null
+                  ? accent.withAlpha(80)
+                  : AppColors.surfaceBorder,
+          width: highlighted ? 1.5 : 1,
         ),
       ),
       child: Row(
@@ -107,11 +178,20 @@ class ItemTagsSection extends ConsumerWidget {
   }
 
   Future<void> _editTags(BuildContext context, WidgetRef ref) async {
-    final Set<int> current =
-        ref.read(itemTagsProvider).valueOrNull?[itemId] ?? <int>{};
+    final Set<int> current = Set<int>.of(
+        ref.read(itemTagsProvider).valueOrNull?[itemId] ?? const <int>[]);
     final Set<int>? selected =
         await TagPickerDialog.show(context, initialSelection: current);
     if (selected == null) return;
     await ref.read(itemTagsProvider.notifier).setItemTags(itemId, selected);
   }
+}
+
+/// Drag payload scoped to one item's tag chips, so a chip can't be dropped
+/// onto another item's section (or any other int-typed drag target).
+class _TagDragData {
+  const _TagDragData({required this.itemId, required this.tagId});
+
+  final int itemId;
+  final int tagId;
 }

--- a/lib/features/collections/widgets/tag_management_dialog.dart
+++ b/lib/features/collections/widgets/tag_management_dialog.dart
@@ -106,9 +106,9 @@ class _TagManagementDialogState extends ConsumerState<TagManagementDialog> {
     final S l = S.of(context);
     final AsyncValue<List<Tag>> tagsAsync = ref.watch(globalTagsProvider);
     final Map<int, int> usage = <int, int>{};
-    final Map<int, Set<int>> itemTags =
-        ref.watch(itemTagsProvider).valueOrNull ?? <int, Set<int>>{};
-    for (final Set<int> ids in itemTags.values) {
+    final Map<int, List<int>> itemTags =
+        ref.watch(itemTagsProvider).valueOrNull ?? <int, List<int>>{};
+    for (final List<int> ids in itemTags.values) {
       for (final int id in ids) {
         usage[id] = (usage[id] ?? 0) + 1;
       }

--- a/lib/features/collections/widgets/tag_picker_dialog.dart
+++ b/lib/features/collections/widgets/tag_picker_dialog.dart
@@ -8,7 +8,11 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../providers/global_tags_provider.dart';
 
-/// Multi-select picker over the global tag set with inline quick-create.
+/// Multi-select picker over the global tag set.
+///
+/// One text field drives both search (filters the list as you type) and
+/// quick-create: when the query matches no existing tag exactly, an explicit
+/// "Create «query»" row appears at the top of the list.
 ///
 /// Returns the chosen tag id set, or `null` when dismissed.
 class TagPickerDialog extends ConsumerStatefulWidget {
@@ -33,16 +37,18 @@ class TagPickerDialog extends ConsumerStatefulWidget {
 
 class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
   late final Set<int> _selected = Set<int>.of(widget.initialSelection);
-  final TextEditingController _createController = TextEditingController();
+  final TextEditingController _searchController = TextEditingController();
 
   @override
   void dispose() {
-    _createController.dispose();
+    _searchController.dispose();
     super.dispose();
   }
 
+  String get _query => _searchController.text.trim();
+
   Future<void> _createTag() async {
-    final String name = _createController.text.trim();
+    final String name = _query;
     if (name.isEmpty) return;
     final int id = await ref
         .read(globalTagsProvider.notifier)
@@ -50,8 +56,22 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
     if (!mounted) return;
     setState(() {
       _selected.add(id);
-      _createController.clear();
+      _searchController.clear();
     });
+  }
+
+  /// Enter selects the exact match when there is one, otherwise creates.
+  Future<void> _submitQuery(List<Tag> tags) async {
+    if (_query.isEmpty) return;
+    final Tag? exact = Tag.findByNameCaseInsensitive(tags, _query);
+    if (exact != null) {
+      setState(() {
+        _selected.add(exact.id);
+        _searchController.clear();
+      });
+      return;
+    }
+    await _createTag();
   }
 
   @override
@@ -59,6 +79,16 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
     final S l = S.of(context);
     final List<Tag> tags =
         ref.watch(globalTagsProvider).valueOrNull ?? <Tag>[];
+
+    final String query = _query;
+    final String lowerQuery = query.toLowerCase();
+    final List<Tag> visibleTags = query.isEmpty
+        ? tags
+        : tags
+            .where((Tag t) => t.name.toLowerCase().contains(lowerQuery))
+            .toList();
+    final bool offerCreate = query.isNotEmpty &&
+        Tag.findByNameCaseInsensitive(tags, query) == null;
 
     return AlertDialog(
       titlePadding: const EdgeInsets.fromLTRB(
@@ -80,29 +110,28 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: TextField(
-                      controller: _createController,
-                      decoration: InputDecoration(
-                        hintText: l.tagCreateHint,
-                        isDense: true,
-                      ),
-                      onSubmitted: (_) => _createTag(),
-                    ),
-                  ),
-                  const SizedBox(width: AppSpacing.xs),
-                  IconButton(
-                    icon: const Icon(Icons.add, size: 20),
-                    visualDensity: VisualDensity.compact,
-                    tooltip: l.tagCreate,
-                    onPressed: _createTag,
-                  ),
-                ],
+              TextField(
+                controller: _searchController,
+                autofocus: true,
+                decoration: InputDecoration(
+                  hintText: l.tagPickerSearchHint,
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  suffixIcon: query.isEmpty
+                      ? null
+                      : IconButton(
+                          icon: const Icon(Icons.clear, size: 18),
+                          visualDensity: VisualDensity.compact,
+                          onPressed: () =>
+                              setState(_searchController.clear),
+                        ),
+                  isDense: true,
+                ),
+                onChanged: (_) => setState(() {}),
+                onSubmitted: (_) => _submitQuery(tags),
               ),
               const SizedBox(height: AppSpacing.sm),
-              if (tags.isEmpty)
+              if (offerCreate) _buildCreateTile(l, query),
+              if (visibleTags.isEmpty && !offerCreate)
                 Padding(
                   padding: const EdgeInsets.all(AppSpacing.md),
                   child: Text(
@@ -112,7 +141,7 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
                   ),
                 )
               else
-                for (final Tag tag in tags)
+                for (final Tag tag in visibleTags)
                   CheckboxListTile(
                     dense: true,
                     visualDensity: VisualDensity.compact,
@@ -165,6 +194,33 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
           child: Text(l.apply),
         ),
       ],
+    );
+  }
+
+  Widget _buildCreateTile(S l, String query) {
+    return ListTile(
+      dense: true,
+      visualDensity: VisualDensity.compact,
+      contentPadding: EdgeInsets.zero,
+      onTap: _createTag,
+      leading: Container(
+        width: 24,
+        height: 24,
+        decoration: BoxDecoration(
+          color: AppColors.brand.withAlpha(30),
+          shape: BoxShape.circle,
+          border: Border.all(color: AppColors.brand.withAlpha(120)),
+        ),
+        child: const Icon(Icons.add, size: 16, color: AppColors.brand),
+      ),
+      title: Text(
+        l.tagCreateNamed(query),
+        style: AppTypography.bodySmall.copyWith(
+          color: AppColors.brand,
+          fontWeight: FontWeight.w500,
+        ),
+        overflow: TextOverflow.ellipsis,
+      ),
     );
   }
 }

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -59,8 +59,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     final Map<int, String> collectionNames =
         ref.watch(collectionNamesProvider);
     final Map<int, Tag> tagsMap = ref.watch(allTagsMapProvider);
-    final Map<int, Set<int>> itemTags =
-        ref.watch(itemTagsProvider).valueOrNull ?? <int, Set<int>>{};
+    final Map<int, List<int>> itemTags =
+        ref.watch(itemTagsProvider).valueOrNull ?? <int, List<int>>{};
     final ItemStatus? filterStatus = ref.watch(homeStatusFilterProvider);
     final bool favoriteOnly = ref.watch(homeFavoriteFilterProvider);
     final String searchQuery = ref.watch(homeSearchQueryProvider);
@@ -407,7 +407,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     Map<int, Tag> tagsMap,
     String lowerQuery,
   ) {
-    final Set<int>? ids = ref.read(itemTagsProvider).valueOrNull?[item.id];
+    final List<int>? ids = ref.read(itemTagsProvider).valueOrNull?[item.id];
     if (ids == null) return false;
     return ids.any((int id) =>
         tagsMap[id]?.name.toLowerCase().contains(lowerQuery) ?? false);
@@ -441,7 +441,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     List<CollectionItem> items,
     Map<int, String> collectionNames,
     Map<int, Tag> tagsMap,
-    Map<int, Set<int>> itemTags,
+    Map<int, List<int>> itemTags,
   ) {
     // getAll() returns display order, and the map preserves insertion order.
     final List<Tag> orderedTags = tagsMap.values.toList();
@@ -513,7 +513,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                 delegate: SliverChildBuilderDelegate(
                   (BuildContext context, int index) {
                     final CollectionItem item = groups[i].items[index];
-                    final Set<int>? tagIds = itemTags[item.id];
+                    final List<int>? tagIds = itemTags[item.id];
                     final Tag? tag = orderedTags.primaryFor(tagIds);
                     final int tagCount = tagIds?.length ?? 0;
                     final Set<int> selection =

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -781,6 +781,12 @@
   "tagsLabel": "Tags",
   "tagCreate": "New tag",
   "tagCreateHint": "Tag name",
+  "tagCreateNamed": "Create \"{name}\"",
+  "@tagCreateNamed": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
   "tagRename": "Rename tag",
   "tagDelete": "Delete tag",
   "tagDeleteConfirm": "Delete tag \"{name}\"? Items will be untagged.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3104,6 +3104,12 @@ abstract class S {
   /// **'Tag name'**
   String get tagCreateHint;
 
+  /// No description provided for @tagCreateNamed.
+  ///
+  /// In en, this message translates to:
+  /// **'Create \"{name}\"'**
+  String tagCreateNamed(String name);
+
   /// No description provided for @tagRename.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1729,6 +1729,11 @@ class SEn extends S {
   String get tagCreateHint => 'Tag name';
 
   @override
+  String tagCreateNamed(String name) {
+    return 'Create \"$name\"';
+  }
+
+  @override
   String get tagRename => 'Rename tag';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1768,6 +1768,11 @@ class SRu extends S {
   String get tagCreateHint => 'Название тега';
 
   @override
+  String tagCreateNamed(String name) {
+    return 'Создать «$name»';
+  }
+
+  @override
   String get tagRename => 'Переименовать тег';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1626,6 +1626,11 @@ class SZh extends S {
   String get tagCreateHint => '标签名称';
 
   @override
+  String tagCreateNamed(String name) {
+    return '创建“$name”';
+  }
+
+  @override
   String get tagRename => '重命名标签';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -686,6 +686,12 @@
   "tagsLabel": "Теги",
   "tagCreate": "Новый тег",
   "tagCreateHint": "Название тега",
+  "tagCreateNamed": "Создать «{name}»",
+  "@tagCreateNamed": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
   "tagRename": "Переименовать тег",
   "tagDelete": "Удалить тег",
   "tagDeleteConfirm": "Удалить тег «{name}»? Тайтлы останутся без тега.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -781,6 +781,12 @@
   "tagsLabel": "标签",
   "tagCreate": "新建标签",
   "tagCreateHint": "标签名称",
+  "tagCreateNamed": "创建“{name}”",
+  "@tagCreateNamed": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
   "tagRename": "重命名标签",
   "tagDelete": "删除标签",
   "tagDeleteConfirm": "删除标签「{name}」？项目将被取消标签。",

--- a/lib/shared/models/tag.dart
+++ b/lib/shared/models/tag.dart
@@ -112,23 +112,39 @@ class Tag {
   }
 }
 
-/// Shared "item's tags" projections over a display-ordered tag list, so every
-/// surface (grid, table, detail card) derives the same order and primary tag.
+/// Shared "item's tags" projections, so every surface (grid, table, detail
+/// card) derives the same order and primary tag.
+///
+/// [ids] come from `itemTagsProvider` already in the item's display order
+/// (manual positions, then global-order fallback — the DAO bakes that in),
+/// so both helpers follow the [ids] order, not this list's.
 extension TagListProjection on List<Tag> {
-  /// The subset of this list whose ids are in [ids], keeping display order.
-  List<Tag> orderedFor(Set<int>? ids) {
+  Map<int, Tag> get byId => <int, Tag>{for (final Tag t in this) t.id: t};
+
+  /// The tags of [ids] resolved against this list, keeping [ids] order.
+  List<Tag> orderedFor(List<int>? ids) => byId.orderedFor(ids);
+
+  /// The first tag of [ids] resolvable in this list, or `null` when untagged.
+  Tag? primaryFor(List<int>? ids) => byId.primaryFor(ids);
+}
+
+/// Same projections over a prebuilt id → tag map. Hoist
+/// [TagListProjection.byId] out of loops that project many items — the
+/// list-based helpers rebuild the map on every call.
+extension TagMapProjection on Map<int, Tag> {
+  List<Tag> orderedFor(List<int>? ids) {
     if (ids == null || ids.isEmpty) return const <Tag>[];
     return <Tag>[
-      for (final Tag tag in this)
-        if (ids.contains(tag.id)) tag,
+      for (final int id in ids)
+        if (this[id] case final Tag tag) tag,
     ];
   }
 
-  /// The first tag of [ids] in display order, or `null` when untagged.
-  Tag? primaryFor(Set<int>? ids) {
+  Tag? primaryFor(List<int>? ids) {
     if (ids == null || ids.isEmpty) return null;
-    for (final Tag tag in this) {
-      if (ids.contains(tag.id)) return tag;
+    for (final int id in ids) {
+      final Tag? tag = this[id];
+      if (tag != null) return tag;
     }
     return null;
   }

--- a/test/core/database/dao/global_tag_dao_test.dart
+++ b/test/core/database/dao/global_tag_dao_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:tonkatsu_box/core/database/dao/global_tag_dao.dart';
 import 'package:tonkatsu_box/core/database/migrations/migration_v54.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v56.dart';
 import 'package:tonkatsu_box/shared/models/tag.dart';
 
 void main() {
@@ -38,6 +39,7 @@ void main() {
             )
           ''');
           await MigrationV54().migrate(database);
+          await MigrationV56().migrate(database);
         },
       ),
     );
@@ -165,7 +167,7 @@ void main() {
         final Tag c = await dao.create('c');
         await dao.setItemTags(1, <int>{a.id, b.id});
         await dao.setItemTags(1, <int>{c.id});
-        expect(await dao.getTagIdsByItem(1), <int>{c.id});
+        expect(await dao.getTagIdsByItem(1), <int>[c.id]);
       });
 
       test('setItemTags with an empty set clears the item', () async {
@@ -181,11 +183,11 @@ void main() {
         await dao.setItemTags(1, <int>{a.id, b.id});
         await dao.setItemTags(2, <int>{b.id});
 
-        final Map<int, Set<int>> map =
+        final Map<int, List<int>> map =
             await dao.getTagIdsForItems(<int>[1, 2, 3]);
         expect(map, hasLength(2));
-        expect(map[1], <int>{a.id, b.id});
-        expect(map[2], <int>{b.id});
+        expect(map[1], <int>[a.id, b.id]);
+        expect(map[2], <int>[b.id]);
         expect(map.containsKey(3), isFalse);
       });
 
@@ -200,8 +202,8 @@ void main() {
 
         await dao.addTagToItems(<int>[1, 2], owned.id);
 
-        expect(await dao.getTagIdsByItem(1), <int>{a.id, owned.id});
-        expect(await dao.getTagIdsByItem(2), <int>{owned.id});
+        expect(await dao.getTagIdsByItem(1), <int>[a.id, owned.id]);
+        expect(await dao.getTagIdsByItem(2), <int>[owned.id]);
       });
 
       test('addTagToItems is idempotent for an already linked tag', () async {
@@ -209,7 +211,7 @@ void main() {
         await dao.addTagToItems(<int>[1], owned.id);
         await dao.addTagToItems(<int>[1], owned.id);
 
-        expect(await dao.getTagIdsByItem(1), <int>{owned.id});
+        expect(await dao.getTagIdsByItem(1), <int>[owned.id]);
       });
 
       test('addTagToItems with no items is a no-op', () async {
@@ -217,6 +219,88 @@ void main() {
         await dao.addTagToItems(<int>[], owned.id);
 
         expect(await dao.getTagIdsByItem(1), isEmpty);
+      });
+    });
+
+    group('per-item order', () {
+      test('without manual positions follows the global sort', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        final Tag c = await dao.create('c');
+        await dao.setItemTags(1, <int>{a.id, b.id, c.id});
+
+        await dao.setSortOrders(<int>[c.id, a.id, b.id]);
+
+        expect(await dao.getTagIdsByItem(1), <int>[c.id, a.id, b.id]);
+      });
+
+      test('setItemTagPositions overrides the global sort', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        final Tag c = await dao.create('c');
+        await dao.setItemTags(1, <int>{a.id, b.id, c.id});
+
+        await dao.setItemTagPositions(1, <int>[b.id, c.id, a.id]);
+
+        expect(await dao.getTagIdsByItem(1), <int>[b.id, c.id, a.id]);
+        final Map<int, List<int>> all = await dao.getAllItemTags();
+        expect(all[1], <int>[b.id, c.id, a.id]);
+      });
+
+      test('manual order survives a global reorder', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        await dao.setItemTags(1, <int>{a.id, b.id});
+        await dao.setItemTagPositions(1, <int>[b.id, a.id]);
+
+        await dao.setSortOrders(<int>[a.id, b.id]);
+
+        expect(await dao.getTagIdsByItem(1), <int>[b.id, a.id]);
+      });
+
+      test('new tags go after the positioned ones, in global order', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        final Tag c = await dao.create('c');
+        final Tag d = await dao.create('d');
+        await dao.setItemTags(1, <int>{a.id, b.id});
+        await dao.setItemTagPositions(1, <int>[b.id, a.id]);
+
+        await dao.setItemTags(1, <int>{a.id, b.id, c.id, d.id});
+
+        expect(
+          await dao.getTagIdsByItem(1),
+          <int>[b.id, a.id, c.id, d.id],
+        );
+      });
+
+      test('setItemTags keeps positions of surviving links', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        final Tag c = await dao.create('c');
+        await dao.setItemTags(1, <int>{a.id, b.id, c.id});
+        await dao.setItemTagPositions(1, <int>[c.id, b.id, a.id]);
+
+        await dao.setItemTags(1, <int>{a.id, c.id});
+
+        expect(await dao.getTagIdsByItem(1), <int>[c.id, a.id]);
+      });
+
+      test('copyItemTags carries links with their positions', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        await dao.setItemTags(1, <int>{a.id, b.id});
+        await dao.setItemTagPositions(1, <int>[b.id, a.id]);
+
+        final int copied = await dao.copyItemTags(1, 2);
+
+        expect(copied, 2);
+        expect(await dao.getTagIdsByItem(2), <int>[b.id, a.id]);
+      });
+
+      test('copyItemTags from an untagged item returns 0', () async {
+        expect(await dao.copyItemTags(1, 2), 0);
+        expect(await dao.getTagIdsByItem(2), isEmpty);
       });
     });
 

--- a/test/core/database/migrations/migration_v56_test.dart
+++ b/test/core/database/migrations/migration_v56_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v56.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  /// A pre-v56 database with the v54-shaped `item_tags` (no position).
+  Future<Database> openOldDb() async {
+    return factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 55,
+        onCreate: (Database db, int _) async {
+          await db.execute('''
+            CREATE TABLE item_tags (
+              item_id INTEGER NOT NULL,
+              tag_id INTEGER NOT NULL,
+              PRIMARY KEY (item_id, tag_id)
+            )
+          ''');
+        },
+      ),
+    );
+  }
+
+  Future<List<Map<String, Object?>>> columns(Database db) =>
+      db.rawQuery('PRAGMA table_info(item_tags)');
+
+  group('MigrationV56', () {
+    late Database db;
+
+    setUp(() async => db = await openOldDb());
+
+    tearDown(() async => db.close());
+
+    test('adds a nullable position column', () async {
+      await MigrationV56().migrate(db);
+
+      final Map<String, Object?> column = (await columns(db)).firstWhere(
+        (Map<String, Object?> c) => c['name'] == 'position',
+      );
+      expect(column['type'], 'INTEGER');
+      expect(column['notnull'], 0);
+      expect(column['dflt_value'], isNull);
+    });
+
+    test('existing links keep NULL (global-order fallback)', () async {
+      await db.insert('item_tags', <String, Object?>{
+        'item_id': 1,
+        'tag_id': 10,
+      });
+      await MigrationV56().migrate(db);
+
+      final List<Map<String, Object?>> rows = await db.query('item_tags');
+      expect(rows.single['position'], isNull);
+    });
+
+    test('re-run is a no-op', () async {
+      await MigrationV56().migrate(db);
+      await MigrationV56().migrate(db);
+
+      final Iterable<Object?> names =
+          (await columns(db)).map((Map<String, Object?> c) => c['name']);
+      expect(names.where((Object? n) => n == 'position'), hasLength(1));
+    });
+  });
+}

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -1420,7 +1420,7 @@ void main() {
         when(() => mockDatabase.globalTagDao).thenReturn(mockTagDao);
         when(() => mockTagDao.getAll()).thenAnswer((_) async => <Tag>[]);
         when(() => mockTagDao.getTagIdsForItems(any<List<int>>()))
-            .thenAnswer((_) async => <int, Set<int>>{});
+            .thenAnswer((_) async => <int, List<int>>{});
       });
 
       test('должен включить tv_seasons для tvShow элементов', () async {
@@ -1683,7 +1683,7 @@ void main() {
         when(() => mockDatabase.globalTagDao).thenReturn(mockTagDao);
         when(() => mockTagDao.getAll()).thenAnswer((_) async => <Tag>[]);
         when(() => mockTagDao.getTagIdsForItems(any<List<int>>()))
-            .thenAnswer((_) async => <int, Set<int>>{});
+            .thenAnswer((_) async => <int, List<int>>{});
       });
 
       test('должен включить tv_episodes для tvShow элементов', () async {
@@ -1849,7 +1849,7 @@ void main() {
         when(() => mockDatabase.globalTagDao).thenReturn(mockTagDao);
         when(() => mockTagDao.getAll()).thenAnswer((_) async => <Tag>[]);
         when(() => mockTagDao.getTagIdsForItems(any<List<int>>()))
-            .thenAnswer((_) async => <int, Set<int>>{});
+            .thenAnswer((_) async => <int, List<int>>{});
       });
 
       test('должен включить platforms для game элементов', () async {
@@ -2044,7 +2044,7 @@ void main() {
             .thenAnswer((_) async => <TierList>[]);
         when(() => mockTagDao.getAll()).thenAnswer((_) async => <Tag>[]);
         when(() => mockTagDao.getTagIdsForItems(any<List<int>>()))
-            .thenAnswer((_) async => <int, Set<int>>{});
+            .thenAnswer((_) async => <int, List<int>>{});
 
         sutMarks = ExportService(
           canvasRepository: mockCanvasRepo,

--- a/test/features/collections/helpers/collection_filters_test.dart
+++ b/test/features/collections/helpers/collection_filters_test.dart
@@ -33,7 +33,7 @@ void main() {
       createTestTag(id: 10, name: 'Favorites'),
       createTestTag(id: 20, name: 'Backlog'),
     ];
-    const Map<int, Set<int>> noLinks = <int, Set<int>>{};
+    const Map<int, List<int>> noLinks = <int, List<int>>{};
 
     test('no filters returns the list unchanged', () {
       final List<CollectionItem> items = <CollectionItem>[make(id: 1), make(id: 2)];
@@ -70,9 +70,9 @@ void main() {
         make(id: 2),
         make(id: 3),
       ];
-      final Map<int, Set<int>> links = <int, Set<int>>{
-        1: <int>{10},
-        2: <int>{20},
+      final Map<int, List<int>> links = <int, List<int>>{
+        1: <int>[10],
+        2: <int>[20],
       };
       final List<CollectionItem> r = const CollectionFilters(
         tagIds: <int>{10},
@@ -86,10 +86,10 @@ void main() {
         make(id: 2),
         make(id: 3),
       ];
-      final Map<int, Set<int>> links = <int, Set<int>>{
-        1: <int>{10},
-        2: <int>{20},
-        3: <int>{10, 20},
+      final Map<int, List<int>> links = <int, List<int>>{
+        1: <int>[10],
+        2: <int>[20],
+        3: <int>[10, 20],
       };
       final List<CollectionItem> r = const CollectionFilters(
         tagIds: <int>{10, 20},
@@ -102,8 +102,8 @@ void main() {
         make(id: 1),
         make(id: 2),
       ];
-      final Map<int, Set<int>> links = <int, Set<int>>{
-        1: <int>{10},
+      final Map<int, List<int>> links = <int, List<int>>{
+        1: <int>[10],
       };
       final List<CollectionItem> r = const CollectionFilters(
         tagIds: <int>{10, 20},
@@ -138,9 +138,9 @@ void main() {
         make(id: 1, name: 'A'),
         make(id: 2, name: 'B'),
       ];
-      final Map<int, Set<int>> links = <int, Set<int>>{
-        1: <int>{20, 10}, // Backlog + Favorites
-        2: <int>{20}, // Backlog
+      final Map<int, List<int>> links = <int, List<int>>{
+        1: <int>[20, 10], // Backlog + Favorites
+        2: <int>[20], // Backlog
       };
       final List<CollectionItem> r = const CollectionFilters(
         searchQuery: 'favor',

--- a/test/features/collections/providers/collections_provider_test.dart
+++ b/test/features/collections/providers/collections_provider_test.dart
@@ -520,10 +520,8 @@ void main() {
       mockTagDao = MockGlobalTagDao();
       when(() => mockTierListDao.getTierListById(any()))
           .thenAnswer((_) async => null);
-      when(() => mockTagDao.getTagIdsByItem(any()))
-          .thenAnswer((_) async => <int>{});
-      when(() => mockTagDao.setItemTags(any(), any()))
-          .thenAnswer((_) async {});
+      when(() => mockTagDao.copyItemTags(any(), any()))
+          .thenAnswer((_) async => 0);
     });
 
     ProviderContainer createMoveContainer({
@@ -661,10 +659,8 @@ void main() {
           )).thenAnswer((_) async {});
       when(() => mockTierListDao.getTierListById(any()))
           .thenAnswer((_) async => null);
-      when(() => mockTagDao.getTagIdsByItem(any()))
-          .thenAnswer((_) async => <int>{});
-      when(() => mockTagDao.setItemTags(any(), any()))
-          .thenAnswer((_) async {});
+      when(() => mockTagDao.copyItemTags(any(), any()))
+          .thenAnswer((_) async => 0);
     });
 
     ProviderContainer createRemapContainer({
@@ -705,13 +701,12 @@ void main() {
         mediaType: MediaType.game,
       );
 
-      verifyNever(() => mockTagDao.getTagIdsByItem(any()));
-      verifyNever(() => mockTagDao.setItemTags(any(), any()));
+      verifyNever(() => mockTagDao.copyItemTags(any(), any()));
     });
 
     test('cloneItem carries the source tag links onto the copy', () async {
-      when(() => mockTagDao.getTagIdsByItem(1))
-          .thenAnswer((_) async => <int>{7, 8});
+      when(() => mockTagDao.copyItemTags(1, 777))
+          .thenAnswer((_) async => 2);
 
       final ProviderContainer container = createRemapContainer(
         initialItems: <CollectionItem>[_makeItem()],
@@ -727,10 +722,10 @@ void main() {
       );
 
       expect(success, isTrue);
-      verify(() => mockTagDao.setItemTags(777, <int>{7, 8})).called(1);
+      verify(() => mockTagDao.copyItemTags(1, 777)).called(1);
     });
 
-    test('cloneItem skips the tag write when the source has no tags',
+    test('cloneItem still copies links when the source has no tags',
         () async {
       final ProviderContainer container = createRemapContainer(
         initialItems: <CollectionItem>[_makeItem()],
@@ -745,8 +740,7 @@ void main() {
         mediaType: MediaType.game,
       );
 
-      verify(() => mockTagDao.getTagIdsByItem(1)).called(1);
-      verifyNever(() => mockTagDao.setItemTags(any(), any()));
+      verify(() => mockTagDao.copyItemTags(1, 777)).called(1);
     });
 
     test('cloneItem returns false when repo reports duplicate', () async {
@@ -766,7 +760,7 @@ void main() {
       );
 
       expect(success, isFalse);
-      verifyNever(() => mockTagDao.getTagIdsByItem(any()));
+      verifyNever(() => mockTagDao.copyItemTags(any(), any()));
     });
   });
 

--- a/test/features/collections/providers/item_tags_provider_test.dart
+++ b/test/features/collections/providers/item_tags_provider_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/features/collections/providers/item_tags_provider.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockGlobalTagDao mockDao;
+  late ProviderContainer container;
+
+  setUpAll(registerAllFallbacks);
+
+  setUp(() {
+    mockDao = MockGlobalTagDao();
+    container = ProviderContainer(
+      overrides: <Override>[
+        globalTagDaoProvider.overrideWithValue(mockDao),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  Future<Map<int, List<int>>> load() async {
+    return container.read(itemTagsProvider.future);
+  }
+
+  group('ItemTagsNotifier', () {
+    test('build loads the whole junction from the dao', () async {
+      when(() => mockDao.getAllItemTags()).thenAnswer(
+        (_) async => <int, List<int>>{
+          1: <int>[10, 20],
+        },
+      );
+
+      expect(await load(), <int, List<int>>{
+        1: <int>[10, 20],
+      });
+    });
+
+    group('setItemTags', () {
+      setUp(() {
+        when(() => mockDao.getAllItemTags()).thenAnswer(
+          (_) async => <int, List<int>>{
+            1: <int>[10, 20],
+          },
+        );
+        when(() => mockDao.setItemTags(any(), any()))
+            .thenAnswer((_) async {});
+      });
+
+      test('re-reads the item order from the dao', () async {
+        await load();
+        when(() => mockDao.getTagIdsByItem(1))
+            .thenAnswer((_) async => <int>[20, 10, 30]);
+
+        await container
+            .read(itemTagsProvider.notifier)
+            .setItemTags(1, <int>{10, 20, 30});
+
+        verify(() => mockDao.setItemTags(1, <int>{10, 20, 30})).called(1);
+        expect(container.read(itemTagsProvider).valueOrNull?[1],
+            <int>[20, 10, 30]);
+      });
+
+      test('empty set removes the item entry without a dao read', () async {
+        await load();
+
+        await container
+            .read(itemTagsProvider.notifier)
+            .setItemTags(1, <int>{});
+
+        expect(
+          container.read(itemTagsProvider).valueOrNull,
+          isNot(contains(1)),
+        );
+        verifyNever(() => mockDao.getTagIdsByItem(any()));
+      });
+    });
+
+    test('reorderItemTags persists and reorders in memory', () async {
+      when(() => mockDao.getAllItemTags()).thenAnswer(
+        (_) async => <int, List<int>>{
+          1: <int>[10, 20, 30],
+        },
+      );
+      when(() => mockDao.setItemTagPositions(any(), any()))
+          .thenAnswer((_) async {});
+      await load();
+
+      await container
+          .read(itemTagsProvider.notifier)
+          .reorderItemTags(1, <int>[30, 10, 20]);
+
+      verify(() => mockDao.setItemTagPositions(1, <int>[30, 10, 20]))
+          .called(1);
+      expect(container.read(itemTagsProvider).valueOrNull?[1],
+          <int>[30, 10, 20]);
+    });
+
+    test('refreshFromDb replaces state without a loading gap', () async {
+      when(() => mockDao.getAllItemTags())
+          .thenAnswer((_) async => <int, List<int>>{});
+      await load();
+      when(() => mockDao.getAllItemTags()).thenAnswer(
+        (_) async => <int, List<int>>{
+          2: <int>[5],
+        },
+      );
+
+      await container.read(itemTagsProvider.notifier).refreshFromDb();
+
+      expect(container.read(itemTagsProvider).valueOrNull, <int, List<int>>{
+        2: <int>[5],
+      });
+    });
+
+    test('dropTagEverywhere removes the tag, keeping list order', () async {
+      when(() => mockDao.getAllItemTags()).thenAnswer(
+        (_) async => <int, List<int>>{
+          1: <int>[20, 10, 30],
+          2: <int>[10],
+        },
+      );
+      await load();
+
+      container.read(itemTagsProvider.notifier).dropTagEverywhere(10);
+
+      expect(container.read(itemTagsProvider).valueOrNull, <int, List<int>>{
+        1: <int>[20, 30],
+      });
+    });
+  });
+}

--- a/test/features/collections/widgets/dialogs/tag_picker_dialog_test.dart
+++ b/test/features/collections/widgets/dialogs/tag_picker_dialog_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/features/collections/widgets/tag_picker_dialog.dart';
+import 'package:tonkatsu_box/shared/models/tag.dart';
+
+import '../../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockGlobalTagDao mockDao;
+
+  setUpAll(registerAllFallbacks);
+
+  setUp(() {
+    mockDao = MockGlobalTagDao();
+    when(() => mockDao.getAll()).thenAnswer(
+      (_) async => <Tag>[
+        createTestTag(id: 1, name: 'Action'),
+        createTestTag(id: 2, name: 'Adventure', sortOrder: 1),
+      ],
+    );
+  });
+
+  Future<void> pump(
+    WidgetTester tester, {
+    Set<int> initialSelection = const <int>{},
+  }) async {
+    await tester.pumpApp(
+      TagPickerDialog(initialSelection: initialSelection),
+      overrides: <Override>[
+        globalTagDaoProvider.overrideWithValue(mockDao),
+      ],
+    );
+  }
+
+  Finder createTile() => find.widgetWithIcon(ListTile, Icons.add);
+
+  group('TagPickerDialog', () {
+    testWidgets('shows every tag when the search is empty', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester);
+
+      expect(find.byType(CheckboxListTile), findsNWidgets(2));
+      expect(createTile(), findsNothing);
+    });
+
+    testWidgets('typing filters the list case-insensitively', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester);
+
+      await tester.enterText(find.byType(TextField), 'venture');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CheckboxListTile), findsOneWidget);
+      expect(find.text('Adventure'), findsOneWidget);
+    });
+
+    testWidgets('a query with no exact match offers the create row', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester);
+
+      await tester.enterText(find.byType(TextField), 'Horror');
+      await tester.pumpAndSettle();
+
+      expect(createTile(), findsOneWidget);
+    });
+
+    testWidgets('an exact match (any case) hides the create row', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester);
+
+      await tester.enterText(find.byType(TextField), 'aCtIoN');
+      await tester.pumpAndSettle();
+
+      expect(createTile(), findsNothing);
+    });
+
+    testWidgets('tapping the create row creates and selects the tag', (
+      WidgetTester tester,
+    ) async {
+      when(
+        () => mockDao.create(
+          any(),
+          color: any(named: 'color'),
+          textColor: any(named: 'textColor'),
+        ),
+      ).thenAnswer(
+        (_) async => createTestTag(id: 9, name: 'Horror', sortOrder: 2),
+      );
+      await pump(tester);
+
+      await tester.enterText(find.byType(TextField), 'Horror');
+      await tester.pumpAndSettle();
+      await tester.tap(createTile());
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockDao.create(
+          'Horror',
+          color: any(named: 'color'),
+          textColor: any(named: 'textColor'),
+        ),
+      ).called(1);
+      // Search cleared, new tag listed and checked.
+      final CheckboxListTile horror = tester.widget(
+        find.ancestor(
+          of: find.text('Horror'),
+          matching: find.byType(CheckboxListTile),
+        ),
+      );
+      expect(horror.value, isTrue);
+      expect(find.byType(CheckboxListTile), findsNWidgets(3));
+    });
+
+    testWidgets('applying returns the selected ids', (
+      WidgetTester tester,
+    ) async {
+      Set<int>? result;
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => ElevatedButton(
+            onPressed: () async {
+              result = await TagPickerDialog.show(
+                context,
+                initialSelection: <int>{1},
+              );
+            },
+            child: const SizedBox.shrink(),
+          ),
+        ),
+        overrides: <Override>[
+          globalTagDaoProvider.overrideWithValue(mockDao),
+        ],
+      );
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Adventure'),
+          matching: find.byType(CheckboxListTile),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      expect(result, <int>{1, 2});
+    });
+  });
+}

--- a/test/features/collections/widgets/item_tags_section_test.dart
+++ b/test/features/collections/widgets/item_tags_section_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/features/collections/widgets/item_tags_section.dart';
+import 'package:tonkatsu_box/shared/models/tag.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockGlobalTagDao mockDao;
+
+  setUpAll(registerAllFallbacks);
+
+  setUp(() {
+    mockDao = MockGlobalTagDao();
+    when(() => mockDao.getAll()).thenAnswer(
+      (_) async => <Tag>[
+        createTestTag(id: 1, name: 'Alpha'),
+        createTestTag(id: 2, name: 'Beta', sortOrder: 1),
+        createTestTag(id: 3, name: 'Gamma', sortOrder: 2),
+      ],
+    );
+    when(() => mockDao.setItemTagPositions(any(), any()))
+        .thenAnswer((_) async {});
+  });
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required List<int> itemOrder,
+  }) async {
+    when(() => mockDao.getAllItemTags()).thenAnswer(
+      (_) async => <int, List<int>>{7: itemOrder},
+    );
+    await tester.pumpApp(
+      const ItemTagsSection(itemId: 7, isEditable: true),
+      overrides: <Override>[
+        globalTagDaoProvider.overrideWithValue(mockDao),
+      ],
+      wrapInScaffold: true,
+    );
+  }
+
+  group('ItemTagsSection', () {
+    testWidgets('renders chips in the per-item order', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester, itemOrder: <int>[3, 1, 2]);
+
+      final double gammaX = tester.getCenter(find.text('Gamma')).dx;
+      final double alphaX = tester.getCenter(find.text('Alpha')).dx;
+      final double betaX = tester.getCenter(find.text('Beta')).dx;
+      expect(gammaX, lessThan(alphaX));
+      expect(alphaX, lessThan(betaX));
+    });
+
+    testWidgets('dragging a chip onto another persists the new order', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester, itemOrder: <int>[1, 2, 3]);
+
+      await tester.drag(
+        find.text('Alpha'),
+        tester.getCenter(find.text('Gamma')) -
+            tester.getCenter(find.text('Alpha')),
+      );
+      await tester.pumpAndSettle();
+
+      verify(() => mockDao.setItemTagPositions(7, <int>[2, 3, 1]))
+          .called(1);
+      final double alphaX = tester.getCenter(find.text('Alpha')).dx;
+      final double betaX = tester.getCenter(find.text('Beta')).dx;
+      expect(betaX, lessThan(alphaX));
+    });
+
+    testWidgets('dragging backward inserts before the target chip', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester, itemOrder: <int>[1, 2, 3]);
+
+      await tester.drag(
+        find.text('Gamma'),
+        tester.getCenter(find.text('Alpha')) -
+            tester.getCenter(find.text('Gamma')),
+      );
+      await tester.pumpAndSettle();
+
+      verify(() => mockDao.setItemTagPositions(7, <int>[3, 1, 2]))
+          .called(1);
+    });
+
+    testWidgets('single tag renders without exceptions', (
+      WidgetTester tester,
+    ) async {
+      await pump(tester, itemOrder: <int>[2]);
+
+      expect(find.text('Beta'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/shared/models/tag_test.dart
+++ b/test/shared/models/tag_test.dart
@@ -103,23 +103,28 @@ void main() {
         Tag(id: 3, name: 'ccc', createdAt: 0),
       ];
 
-      test('orderedFor keeps display order regardless of set order', () {
+      test('orderedFor follows the ids order, not the list order', () {
         expect(
-          tags.orderedFor(<int>{3, 1}).map((Tag t) => t.id).toList(),
-          <int>[1, 3],
+          tags.orderedFor(<int>[3, 1]).map((Tag t) => t.id).toList(),
+          <int>[3, 1],
         );
       });
 
       test('orderedFor skips unknown ids and handles null/empty', () {
-        expect(tags.orderedFor(<int>{99}), isEmpty);
+        expect(tags.orderedFor(<int>[99]), isEmpty);
+        expect(
+          tags.orderedFor(<int>[99, 2]).map((Tag t) => t.id).toList(),
+          <int>[2],
+        );
         expect(tags.orderedFor(null), isEmpty);
-        expect(tags.orderedFor(<int>{}), isEmpty);
+        expect(tags.orderedFor(<int>[]), isEmpty);
       });
 
-      test('primaryFor returns the first tag in display order', () {
-        expect(tags.primaryFor(<int>{3, 2})?.id, 2);
+      test('primaryFor returns the first resolvable id', () {
+        expect(tags.primaryFor(<int>[3, 2])?.id, 3);
+        expect(tags.primaryFor(<int>[99, 2])?.id, 2);
         expect(tags.primaryFor(null), isNull);
-        expect(tags.primaryFor(<int>{99}), isNull);
+        expect(tags.primaryFor(<int>[99]), isNull);
       });
     });
 


### PR DESCRIPTION
Drag tag chips in the item detail card into a per-item order (desktop drag / Android long-press). item_tags gains a nullable position column (migration v56): NULL keeps the global-order fallback, new tags append after positioned ones. Order drives the primary tag on cards/table, survives export/import and item cloning. Tag picker's field now filters the list and offers an explicit "Create <name>" row when there is no exact match.