### PR TITLE
feat(collections): date sorts, OR subfilters, compact card app bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,35 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * lib/l10n/app_en.arb, lib/l10n/app_ru.arb, lib/l10n/app_zh.arb
     (tagCreateNamed): New key.
 
+- **Sort by start date and completion date**
+
+  Two new sort modes in the collection sort menu, alongside the existing
+  ones: "Start Date" and "Completion Date" (the dates filled in on the
+  item card). Recent first by default, direction toggle flips to oldest
+  first; items without the date go last, ordered by name.
+
+  * lib/shared/models/collection_sort_mode.dart (CollectionSortMode.startDate,
+    CollectionSortMode.completionDate): New enum values + localized labels;
+    comments translated to English.
+  * lib/features/collections/providers/sort_utils.dart (applySortMode,
+    _compareNullableDatesDesc): New comparators, shared null-last helper.
+  * lib/l10n/app_en.arb, lib/l10n/app_ru.arb, lib/l10n/app_zh.arb
+    (sortStartDateDisplay, sortStartDateShort, sortCompletionDateDisplay,
+    sortCompletionDateShort): New keys.
+
 ### Changed
+
+- **Tighter item card action bar and subfilter row spacing**
+
+  Icons in the item detail top bar are slightly smaller (18px) with
+  compact tap boxes, so the six actions no longer read sparse. The gap
+  under the sub-filter chip row is halved.
+
+  * lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
+    (ItemDetailAppBar._action): iconSize 20 → 18, VisualDensity.compact,
+    padding 8 → 4; same for the overflow PopupMenuButton.
+  * lib/shared/widgets/filter_subfilter_bar.dart (_SubfilterBarState.build):
+    Bottom padding 8 → 4.
 
 - **TMDB content language list expanded from 3 to 45 locales**
 
@@ -457,6 +485,23 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     launchExternalUrl.
 
 ### Fixed
+
+- **Platform and format sub-filters now combine instead of hiding everything**
+
+  Selecting a game platform together with an anime/manga format (e.g. NES
+  + OVA) used to intersect the two groups and return an empty list. Active
+  sub-filter groups now unite, each scoped to its own kind of item: NES
+  games and OVA anime show side by side. Applies to both the collection
+  screen and All Items.
+
+  * lib/shared/utils/media_format.dart (MediaFormat.matchesSubfilters):
+    Replaces matchesFormatFilter — single OR predicate over platform +
+    format groups.
+  * lib/features/collections/helpers/collection_filters.dart
+    (CollectionFilters.apply), lib/features/home/screens/all_items_screen.dart
+    (_AllItemsScreenState): One combined subfilter pass instead of two
+    intersecting ones.
+
 
 - **Hardcover token now syncs between devices and counts in Settings**
 

--- a/lib/features/collections/helpers/collection_filters.dart
+++ b/lib/features/collections/helpers/collection_filters.dart
@@ -46,18 +46,13 @@ class CollectionFilters {
           .toList();
     }
 
-    if (platformIds.isNotEmpty) {
+    if (platformIds.isNotEmpty ||
+        mangaFormats.isNotEmpty ||
+        animeFormats.isNotEmpty) {
       result = result
-          .where((CollectionItem item) =>
-              item.effectivePlatformId != null &&
-              platformIds.contains(item.effectivePlatformId))
-          .toList();
-    }
-
-    if (mangaFormats.isNotEmpty || animeFormats.isNotEmpty) {
-      result = result
-          .where((CollectionItem item) => MediaFormat.matchesFormatFilter(
+          .where((CollectionItem item) => MediaFormat.matchesSubfilters(
                 item,
+                platformIds: platformIds,
                 mangaFormats: mangaFormats,
                 animeFormats: animeFormats,
               ))

--- a/lib/features/collections/providers/sort_utils.dart
+++ b/lib/features/collections/providers/sort_utils.dart
@@ -6,6 +6,19 @@ int _compareByDisplayName(CollectionItem a, CollectionItem b, String lang) =>
           b.displayName(lang).toLowerCase(),
         );
 
+/// Recent first; undated items sink last, kept stable by [tieBreaker].
+int _compareNullableDatesDesc(
+  DateTime? a,
+  DateTime? b,
+  int Function() tieBreaker,
+) {
+  if (a == null && b == null) return tieBreaker();
+  if (a == null) return 1;
+  if (b == null) return -1;
+  final int byDate = b.compareTo(a);
+  return byDate != 0 ? byDate : tieBreaker();
+}
+
 /// [CollectionSortMode.manual] returns the user-defined `sortOrder` as is;
 /// [isDescending] inverts every other mode but never manual.
 List<CollectionItem> applySortMode(
@@ -80,6 +93,22 @@ List<CollectionItem> applySortMode(
         final DateTime bAt = b.lastActivityAt ?? b.addedAt;
         return bAt.compareTo(aAt);
       });
+    case CollectionSortMode.startDate:
+      sorted.sort(
+        (CollectionItem a, CollectionItem b) => _compareNullableDatesDesc(
+          a.startedAt,
+          b.startedAt,
+          () => _compareByDisplayName(a, b, animeMangaTitleLanguage),
+        ),
+      );
+    case CollectionSortMode.completionDate:
+      sorted.sort(
+        (CollectionItem a, CollectionItem b) => _compareNullableDatesDesc(
+          a.completedAt,
+          b.completedAt,
+          () => _compareByDisplayName(a, b, animeMangaTitleLanguage),
+        ),
+      );
   }
   if (isDescending) {
     return sorted.reversed.toList();

--- a/lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
+++ b/lib/features/collections/widgets/item_detail/item_detail_app_bar.dart
@@ -5,6 +5,7 @@ import '../../../../shared/constants/platform_features.dart';
 import '../../../../shared/models/collection_item.dart';
 import '../../../../shared/models/media_type.dart';
 import '../../../../shared/theme/app_colors.dart';
+import '../../../../shared/theme/app_spacing.dart';
 import '../../../../shared/widgets/screen_app_bar.dart';
 
 enum ItemDetailMenuAction { refresh, rename, move, clone, copyLink, remove }
@@ -122,7 +123,8 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
           ),
         if (isEditable)
           PopupMenuButton<ItemDetailMenuAction>(
-            iconSize: kScreenAppBarIconSize,
+            iconSize: kScreenAppBarIconSize - 2,
+            padding: const EdgeInsets.all(AppSpacing.xs),
             icon: const Icon(Icons.more_vert, color: AppColors.textSecondary),
             onSelected: onMenuSelected,
             itemBuilder: (BuildContext context) =>
@@ -167,8 +169,8 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  /// An app-bar action whose icon matches the compact bar — the Material
-  /// default (24) reads oversized next to the 20px back button.
+  /// Smaller and tighter than Material defaults: with up to six actions the
+  /// default 48px tap boxes read sparse next to the 20px back button.
   Widget _action({
     required IconData iconData,
     required Color color,
@@ -179,7 +181,9 @@ class ItemDetailAppBar extends StatelessWidget implements PreferredSizeWidget {
       icon: Icon(iconData),
       color: color,
       tooltip: tooltip,
-      iconSize: kScreenAppBarIconSize,
+      iconSize: kScreenAppBarIconSize - 2,
+      visualDensity: VisualDensity.compact,
+      padding: const EdgeInsets.all(AppSpacing.xs),
       onPressed: onPressed,
     );
   }

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -140,13 +140,9 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
   ) {
     if (favoriteOnly && !item.isFavorite) return false;
     if (filterStatus != null && item.status != filterStatus) return false;
-    if (_selectedPlatformIds.isNotEmpty &&
-        (item.effectivePlatformId == null ||
-            !_selectedPlatformIds.contains(item.effectivePlatformId))) {
-      return false;
-    }
-    if (!MediaFormat.matchesFormatFilter(
+    if (!MediaFormat.matchesSubfilters(
       item,
+      platformIds: _selectedPlatformIds,
       mangaFormats: _selectedMangaFormats,
       animeFormats: _selectedAnimeFormats,
     )) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -77,6 +77,10 @@
   "sortLastActivityDisplay": "Last Activity",
   "sortLastActivityShort": "Activity",
   "sortLastActivityDesc": "Recent first",
+  "sortStartDateDisplay": "Start Date",
+  "sortStartDateShort": "Started",
+  "sortCompletionDateDisplay": "Completion Date",
+  "sortCompletionDateShort": "Finished",
 
   "sortDateOldest": "Oldest first",
   "sortStatusFinished": "Finished first",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -489,6 +489,30 @@ abstract class S {
   /// **'Recent first'**
   String get sortLastActivityDesc;
 
+  /// No description provided for @sortStartDateDisplay.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Date'**
+  String get sortStartDateDisplay;
+
+  /// No description provided for @sortStartDateShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Started'**
+  String get sortStartDateShort;
+
+  /// No description provided for @sortCompletionDateDisplay.
+  ///
+  /// In en, this message translates to:
+  /// **'Completion Date'**
+  String get sortCompletionDateDisplay;
+
+  /// No description provided for @sortCompletionDateShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Finished'**
+  String get sortCompletionDateShort;
+
   /// No description provided for @sortDateOldest.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -207,6 +207,18 @@ class SEn extends S {
   String get sortLastActivityDesc => 'Recent first';
 
   @override
+  String get sortStartDateDisplay => 'Start Date';
+
+  @override
+  String get sortStartDateShort => 'Started';
+
+  @override
+  String get sortCompletionDateDisplay => 'Completion Date';
+
+  @override
+  String get sortCompletionDateShort => 'Finished';
+
+  @override
   String get sortDateOldest => 'Oldest first';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -207,6 +207,18 @@ class SRu extends S {
   String get sortLastActivityDesc => 'Сначала недавние';
 
   @override
+  String get sortStartDateDisplay => 'Дата начала';
+
+  @override
+  String get sortStartDateShort => 'Начато';
+
+  @override
+  String get sortCompletionDateDisplay => 'Дата завершения';
+
+  @override
+  String get sortCompletionDateShort => 'Завершено';
+
+  @override
   String get sortDateOldest => 'Сначала старые';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -206,6 +206,18 @@ class SZh extends S {
   String get sortLastActivityDesc => '最近优先';
 
   @override
+  String get sortStartDateDisplay => '开始日期';
+
+  @override
+  String get sortStartDateShort => '开始';
+
+  @override
+  String get sortCompletionDateDisplay => '完成日期';
+
+  @override
+  String get sortCompletionDateShort => '完成';
+
+  @override
   String get sortDateOldest => '最早优先';
 
   @override

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -77,6 +77,10 @@
   "sortLastActivityDisplay": "Последняя активность",
   "sortLastActivityShort": "Активность",
   "sortLastActivityDesc": "Сначала недавние",
+  "sortStartDateDisplay": "Дата начала",
+  "sortStartDateShort": "Начато",
+  "sortCompletionDateDisplay": "Дата завершения",
+  "sortCompletionDateShort": "Завершено",
 
   "sortDateOldest": "Сначала старые",
   "sortStatusFinished": "Сначала завершённые",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -77,6 +77,10 @@
   "sortLastActivityDisplay": "最近活动",
   "sortLastActivityShort": "活动",
   "sortLastActivityDesc": "最近优先",
+  "sortStartDateDisplay": "开始日期",
+  "sortStartDateShort": "开始",
+  "sortCompletionDateDisplay": "完成日期",
+  "sortCompletionDateShort": "完成",
 
   "sortDateOldest": "最早优先",
   "sortStatusFinished": "已完成优先",

--- a/lib/shared/models/collection_sort_mode.dart
+++ b/lib/shared/models/collection_sort_mode.dart
@@ -1,32 +1,36 @@
-// Режим сортировки элементов коллекции.
-
 import '../../l10n/app_localizations.dart';
 
-/// Режим сортировки элементов в коллекции.
 enum CollectionSortMode {
-  /// Ручной порядок (drag-and-drop, sort_order ASC).
+  /// Manual order (drag-and-drop, sort_order ASC).
   manual('manual', 'Manual', 'Manual', 'Custom order'),
 
-  /// По дате добавления (added_at DESC, новые первыми).
+  /// By added date (added_at DESC, newest first).
   addedDate('added_date', 'Date Added', 'Date', 'Newest first'),
 
-  /// По статусу (активные первыми, завершённые последними).
+  /// By status (active first, finished last).
   status('status', 'Status', 'Status', 'Active first'),
 
-  /// По алфавиту (itemName ASC).
+  /// Alphabetical (itemName ASC).
   name('name', 'Name', 'A-Z', 'A to Z'),
 
-  /// По пользовательскому рейтингу (userRating DESC, высшие первыми).
+  /// By user rating (userRating DESC, highest first).
   rating('rating', 'My Rating', 'Rating', 'Highest first'),
 
   /// Favorites first (isFavorite DESC, then by name).
   favorite('favorite', 'Favorite', 'Favorite', 'Favorites first'),
 
-  /// По внешнему API-рейтингу (apiRating DESC, IGDB/TMDB).
+  /// By external API rating (apiRating DESC, IGDB/TMDB).
   externalRating('external_rating', 'External Rating', 'IGDB/TMDB', 'Highest first'),
 
-  /// По дате последней активности (lastActivityAt DESC, недавние первыми).
-  lastActivity('last_activity', 'Last Activity', 'Activity', 'Recent first');
+  /// By last activity (lastActivityAt DESC, recent first).
+  lastActivity('last_activity', 'Last Activity', 'Activity', 'Recent first'),
+
+  /// By start date (startedAt DESC, recent first, undated last).
+  startDate('start_date', 'Start Date', 'Started', 'Recent first'),
+
+  /// By completion date (completedAt DESC, recent first, undated last).
+  completionDate('completion_date', 'Completion Date', 'Finished',
+      'Recent first');
 
   const CollectionSortMode(
     this.value,
@@ -35,21 +39,17 @@ enum CollectionSortMode {
     this.description,
   );
 
-  /// Строковое значение для хранения в SharedPreferences.
+  /// Stored value for SharedPreferences.
   final String value;
 
-  /// Отображаемое название.
   final String displayLabel;
 
-  /// Короткий лейбл для компактного UI (2-6 символов).
+  /// Short label for compact UI (2-6 chars).
   final String shortLabel;
 
-  /// Краткое описание порядка сортировки.
   final String description;
 
-  /// Создаёт [CollectionSortMode] из строки.
-  ///
-  /// Возвращает [addedDate] для неизвестных значений.
+  /// Returns [addedDate] for unknown stored values.
   static CollectionSortMode fromString(String value) {
     for (final CollectionSortMode mode in CollectionSortMode.values) {
       if (mode.value == value) {
@@ -59,7 +59,6 @@ enum CollectionSortMode {
     return CollectionSortMode.addedDate;
   }
 
-  /// Локализованное отображаемое название.
   String localizedDisplayLabel(S l) {
     switch (this) {
       case CollectionSortMode.manual:
@@ -78,10 +77,13 @@ enum CollectionSortMode {
         return l.sortExternalRatingDisplay;
       case CollectionSortMode.lastActivity:
         return l.sortLastActivityDisplay;
+      case CollectionSortMode.startDate:
+        return l.sortStartDateDisplay;
+      case CollectionSortMode.completionDate:
+        return l.sortCompletionDateDisplay;
     }
   }
 
-  /// Локализованный короткий лейбл.
   String localizedShortLabel(S l) {
     switch (this) {
       case CollectionSortMode.manual:
@@ -100,6 +102,10 @@ enum CollectionSortMode {
         return l.sortExternalRatingShort;
       case CollectionSortMode.lastActivity:
         return l.sortLastActivityShort;
+      case CollectionSortMode.startDate:
+        return l.sortStartDateShort;
+      case CollectionSortMode.completionDate:
+        return l.sortCompletionDateShort;
     }
   }
 
@@ -125,10 +131,12 @@ enum CollectionSortMode {
         return l.sortRatingLowest;
       case CollectionSortMode.lastActivity:
         return l.sortDateOldest;
+      case CollectionSortMode.startDate:
+      case CollectionSortMode.completionDate:
+        return l.sortDateOldest;
     }
   }
 
-  /// Локализованное описание порядка сортировки.
   String localizedDescription(S l) {
     switch (this) {
       case CollectionSortMode.manual:
@@ -146,6 +154,9 @@ enum CollectionSortMode {
       case CollectionSortMode.externalRating:
         return l.sortRatingDesc;
       case CollectionSortMode.lastActivity:
+        return l.sortLastActivityDesc;
+      case CollectionSortMode.startDate:
+      case CollectionSortMode.completionDate:
         return l.sortLastActivityDesc;
     }
   }

--- a/lib/shared/utils/media_format.dart
+++ b/lib/shared/utils/media_format.dart
@@ -61,28 +61,24 @@ abstract final class MediaFormat {
     return result;
   }
 
-  /// Whether [item] survives the combined manga + anime format filter.
-  ///
-  /// With neither set active everything passes. Once any format is selected the
-  /// filter narrows globally like the games platform filter: only a manga whose
-  /// format is in [mangaFormats], or an anime whose format is in [animeFormats],
-  /// survives — every other item (games, other media types, unselected formats)
-  /// is hidden. Selecting formats in both sets keeps either (OR).
-  static bool matchesFormatFilter(
+  /// Active groups unite (OR), each scoped to its own kind of item — e.g.
+  /// NES + OVA keeps both NES games and OVA anime. No active groups = pass.
+  static bool matchesSubfilters(
     CollectionItem item, {
+    required Set<int> platformIds,
     required Set<String> mangaFormats,
     required Set<String> animeFormats,
   }) {
-    if (mangaFormats.isEmpty && animeFormats.isEmpty) return true;
-    switch (item.displayMediaType) {
-      case MediaType.manga:
-        final String? code = item.formatCode;
-        return code != null && mangaFormats.contains(code);
-      case MediaType.anime:
-        final String? code = item.formatCode;
-        return code != null && animeFormats.contains(code);
-      default:
-        return false;
+    if (platformIds.isEmpty && mangaFormats.isEmpty && animeFormats.isEmpty) {
+      return true;
     }
+    if (platformIds.contains(item.effectivePlatformId)) return true;
+    final String? code = item.formatCode;
+    if (code == null) return false;
+    return switch (item.displayMediaType) {
+      MediaType.manga => mangaFormats.contains(code),
+      MediaType.anime => animeFormats.contains(code),
+      _ => false,
+    };
   }
 }

--- a/lib/shared/widgets/filter_subfilter_bar.dart
+++ b/lib/shared/widgets/filter_subfilter_bar.dart
@@ -86,7 +86,7 @@ class _SubfilterBarState extends State<SubfilterBar> {
       // the horizontal inset lives inside it (below) instead.
       padding: const EdgeInsets.only(
         top: AppSpacing.xs,
-        bottom: AppSpacing.sm,
+        bottom: AppSpacing.xs,
       ),
       // Full-bleed band with no border or radius so the highlight reads as one
       // even row with no seams; the inner padding keeps the chips inset. Geometry

--- a/test/features/collections/helpers/collection_filters_test.dart
+++ b/test/features/collections/helpers/collection_filters_test.dart
@@ -214,6 +214,28 @@ void main() {
       expect(r.map((CollectionItem i) => i.id), <int>[1, 2]);
     });
 
+    test('platform and format subfilters keep either kind (OR)', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, platformId: 18),
+        make(id: 2, platformId: 6),
+        createTestCollectionItem(
+          id: 3,
+          mediaType: MediaType.anime,
+          anime: createTestAnime(format: 'OVA'),
+        ),
+        createTestCollectionItem(
+          id: 4,
+          mediaType: MediaType.anime,
+          anime: createTestAnime(format: 'TV'),
+        ),
+      ];
+      final List<CollectionItem> r = const CollectionFilters(
+        platformIds: <int>{18},
+        animeFormats: <String>{'OVA'},
+      ).apply(items, tags, noLinks);
+      expect(r.map((CollectionItem i) => i.id), <int>[1, 3]);
+    });
+
     test('combines filters with AND semantics', () {
       final List<CollectionItem> items = <CollectionItem>[
         make(id: 1, mediaType: MediaType.game, status: ItemStatus.completed),

--- a/test/features/collections/providers/sort_utils_test.dart
+++ b/test/features/collections/providers/sort_utils_test.dart
@@ -14,6 +14,8 @@ CollectionItem _makeItem({
   double? userRating,
   DateTime? addedAt,
   DateTime? lastActivityAt,
+  DateTime? startedAt,
+  DateTime? completedAt,
   double? apiRating,
   bool isFavorite = false,
 }) {
@@ -27,6 +29,8 @@ CollectionItem _makeItem({
     userRating: userRating,
     addedAt: addedAt ?? DateTime(2024, 1, id),
     lastActivityAt: lastActivityAt,
+    startedAt: startedAt,
+    completedAt: completedAt,
     isFavorite: isFavorite,
     game: Game(id: id * 100, name: name, rating: apiRating),
   );
@@ -592,6 +596,85 @@ void main() {
         );
 
         expect(result.first.id, 1);
+      });
+    });
+
+    group('CollectionSortMode.startDate', () {
+      test('по умолчанию недавно начатые первыми, без даты — последними', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Old', startedAt: DateTime(2024, 1, 1)),
+          _makeItem(id: 2, name: 'No date'),
+          _makeItem(id: 3, name: 'Recent', startedAt: DateTime(2024, 6, 1)),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.startDate,
+        );
+
+        expect(result.map((CollectionItem i) => i.id).toList(), <int>[3, 1, 2]);
+      });
+
+      test('без даты сортируются по имени между собой', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Zelda'),
+          _makeItem(id: 2, name: 'Ape Escape'),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.startDate,
+        );
+
+        expect(result.map((CollectionItem i) => i.id).toList(), <int>[2, 1]);
+      });
+
+      test('isDescending=true инвертирует порядок', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Old', startedAt: DateTime(2024, 1, 1)),
+          _makeItem(id: 2, name: 'Recent', startedAt: DateTime(2024, 6, 1)),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.startDate,
+          isDescending: true,
+        );
+
+        expect(result.first.id, 1);
+      });
+    });
+
+    group('CollectionSortMode.completionDate', () {
+      test('по умолчанию недавно завершённые первыми, без даты — последними',
+          () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'No date'),
+          _makeItem(id: 2, name: 'Recent', completedAt: DateTime(2024, 6, 1)),
+          _makeItem(id: 3, name: 'Old', completedAt: DateTime(2024, 1, 1)),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.completionDate,
+        );
+
+        expect(result.map((CollectionItem i) => i.id).toList(), <int>[2, 3, 1]);
+      });
+
+      test('одинаковые даты разрешаются по имени', () {
+        final DateTime same = DateTime(2024, 3, 1);
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 1, name: 'Zelda', completedAt: same),
+          _makeItem(id: 2, name: 'Ape Escape', completedAt: same),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.completionDate,
+        );
+
+        expect(result.map((CollectionItem i) => i.id).toList(), <int>[2, 1]);
       });
     });
 

--- a/test/shared/models/collection_sort_mode_test.dart
+++ b/test/shared/models/collection_sort_mode_test.dart
@@ -6,8 +6,8 @@ import 'package:tonkatsu_box/shared/models/collection_sort_mode.dart';
 void main() {
   group('CollectionSortMode', () {
     group('значения enum', () {
-      test('should contain 8 значений', () {
-        expect(CollectionSortMode.values.length, 8);
+      test('should contain 10 значений', () {
+        expect(CollectionSortMode.values.length, 10);
       });
 
       test('should contain все режимы сортировки', () {
@@ -217,6 +217,20 @@ void main() {
             CollectionSortMode.fromString('external_rating');
 
         expect(result, CollectionSortMode.externalRating);
+      });
+
+      test('should return startDate для "start_date"', () {
+        final CollectionSortMode result =
+            CollectionSortMode.fromString('start_date');
+
+        expect(result, CollectionSortMode.startDate);
+      });
+
+      test('should return completionDate для "completion_date"', () {
+        final CollectionSortMode result =
+            CollectionSortMode.fromString('completion_date');
+
+        expect(result, CollectionSortMode.completionDate);
       });
 
       test('should return addedDate для неизвестного значения', () {

--- a/test/shared/utils/media_format_test.dart
+++ b/test/shared/utils/media_format_test.dart
@@ -108,7 +108,7 @@ void main() {
       });
     });
 
-    group('matchesFormatFilter', () {
+    group('matchesSubfilters', () {
       test('passes everything when no format is selected', () {
         final CollectionItem item = createTestCollectionItem(
           mediaType: MediaType.manga,
@@ -116,8 +116,9 @@ void main() {
         );
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             item,
+            platformIds: const <int>{},
             mangaFormats: const <String>{},
             animeFormats: const <String>{},
           ),
@@ -129,8 +130,9 @@ void main() {
         final CollectionItem game = createTestCollectionItem();
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             game,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{},
           ),
@@ -145,8 +147,9 @@ void main() {
         );
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             item,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{},
           ),
@@ -161,8 +164,9 @@ void main() {
         );
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             item,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{},
           ),
@@ -177,8 +181,9 @@ void main() {
         );
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             item,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{},
           ),
@@ -197,20 +202,87 @@ void main() {
         );
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             manga,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{'TV'},
           ),
           isTrue,
         );
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             anime,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{'TV'},
           ),
           isTrue,
+        );
+      });
+
+      test('platform and format groups unite: NES game and OVA anime both '
+          'pass', () {
+        final CollectionItem nesGame =
+            createTestCollectionItem(platformId: 18);
+        final CollectionItem ovaAnime = createTestCollectionItem(
+          mediaType: MediaType.anime,
+          anime: createTestAnime(format: 'OVA'),
+        );
+
+        for (final CollectionItem item in <CollectionItem>[nesGame, ovaAnime]) {
+          expect(
+            MediaFormat.matchesSubfilters(
+              item,
+              platformIds: const <int>{18},
+              mangaFormats: const <String>{},
+              animeFormats: const <String>{'OVA'},
+            ),
+            isTrue,
+          );
+        }
+      });
+
+      test('a game on another platform fails even with formats active', () {
+        final CollectionItem game = createTestCollectionItem(platformId: 6);
+
+        expect(
+          MediaFormat.matchesSubfilters(
+            game,
+            platformIds: const <int>{18},
+            mangaFormats: const <String>{},
+            animeFormats: const <String>{'OVA'},
+          ),
+          isFalse,
+        );
+      });
+
+      test('platform-only selection keeps matching games and hides the rest',
+          () {
+        final CollectionItem nesGame =
+            createTestCollectionItem(platformId: 18);
+        final CollectionItem anime = createTestCollectionItem(
+          mediaType: MediaType.anime,
+          anime: createTestAnime(format: 'TV'),
+        );
+
+        expect(
+          MediaFormat.matchesSubfilters(
+            nesGame,
+            platformIds: const <int>{18},
+            mangaFormats: const <String>{},
+            animeFormats: const <String>{},
+          ),
+          isTrue,
+        );
+        expect(
+          MediaFormat.matchesSubfilters(
+            anime,
+            platformIds: const <int>{18},
+            mangaFormats: const <String>{},
+            animeFormats: const <String>{},
+          ),
+          isFalse,
         );
       });
 
@@ -221,8 +293,9 @@ void main() {
         );
 
         expect(
-          MediaFormat.matchesFormatFilter(
+          MediaFormat.matchesSubfilters(
             item,
+            platformIds: const <int>{},
             mangaFormats: const <String>{'MANGA'},
             animeFormats: const <String>{},
           ),


### PR DESCRIPTION
Sub-filters unite instead of intersecting: NES + OVA now shows both NES games and OVA anime (collection screen and All Items). Two new sort modes — Start Date and Completion Date (recent first, undated last). Item detail app bar icons are smaller with compact tap boxes; the gap under the subfilter chip row is halved.