### PR TITLE
feat(tv): decouple episode tracker and release calendar from TMDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Decouple the episode tracker and release calendar from TMDB**
+
+  Seasons, episodes and watch progress are now keyed by `(source, show id)`
+  instead of a bare TMDB id, so a future provider (e.g. TVmaze) can feed
+  the episode tracker without id collisions. Season/episode fetching goes
+  through a provider-agnostic `TvEpisodeSource` interface; TMDB is the
+  first and only implementation, and existing data is migrated as TMDB.
+  No user-visible behaviour changes yet.
+
+  * lib/core/api/episode_source/tv_episode_source.dart (TvEpisodeSource,
+    tvEpisodeSourceResolverProvider): New — season/episode source
+    interface and per-DataSource resolver (unknown sources fall back to
+    TMDB).
+  * lib/core/api/episode_source/tmdb_episode_source.dart
+    (TmdbEpisodeSource): New — TMDB implementation over TmdbApi.
+  * lib/core/database/migrations/migration_v57.dart (MigrationV57): New —
+    rebuilds tv_shows_cache with a (tmdb_id, source) primary key, adds
+    `source` to the UNIQUE keys of tv_seasons_cache, tv_episodes_cache
+    and watched_episodes, backfills existing rows as 'tmdb', re-scopes
+    the collection_items unique indexes so tv_show includes source
+    (idx_ci_coll_tv, idx_ci_uncat_tv), backfills
+    collection_items.source and mood_grid_cells.source for tv shows.
+  * lib/core/database/database_service.dart (DatabaseService._initDatabase),
+    lib/core/database/migrations/migration_registry.dart
+    (MigrationRegistry.all): Version 57.
+  * lib/shared/models/tv_show.dart (TvShow), tv_season.dart (TvSeason),
+    tv_episode.dart (TvEpisode): New `source` field (default tmdb) in
+    fromDb/toDb/copyWith/==/hashCode.
+  * lib/shared/models/data_source.dart (DataSource.fromNameOr): New —
+    parse with an explicit fallback.
+  * lib/shared/models/media_type.dart (MediaType.defaultSource): New —
+    fallback source for rows with a NULL source column.
+  * lib/core/database/dao/tv_show_dao.dart (TvShowDao.getTvShowByTmdbId,
+    TvShowDao.getTvSeasonsByShowId, TvShowDao.getEpisodesByShowId,
+    TvShowDao.getEpisodesByShowAndSeason, TvShowDao.clearEpisodesByShow,
+    TvShowDao.getWatchedEpisodes, TvShowDao.getWatchedEpisodesForShow,
+    TvShowDao.getAllWatchedEpisodes, TvShowDao.markEpisodeWatched,
+    TvShowDao.markEpisodeWatchedAt, TvShowDao.markEpisodeUnwatched,
+    TvShowDao.getWatchedEpisodeCount, TvShowDao.markSeasonWatched,
+    TvShowDao.unmarkSeasonWatched): All season/episode/watched queries
+    take a DataSource.
+  * lib/core/database/dao/collection_dao.dart
+    (CollectionDao.findCollectionItem, CollectionDao.findAllCollectionItems):
+    Optional source filter; (CollectionDao._loadJoinedData): tv shows
+    matched by (source, id); (CollectionDao.getCollectionCovers): tv
+    joins constrained by source to avoid cross-source row fan-out.
+  * lib/features/collections/providers/episode_tracker_provider.dart
+    (EpisodeTrackerArg, EpisodeTrackerNotifier): Family arg carries the
+    source; fetches go through the resolved TvEpisodeSource.
+  * lib/features/collections/widgets/episode_tracker_section.dart
+    (EpisodeTrackerSection, SeasonsListWidget): Source-aware season
+    loading.
+  * lib/features/releases/providers/releases_provider.dart
+    (ReleasesNotifier.refreshFromApi, ReleasesNotifier._eventsForShow,
+    isReleaseTrackedProvider): Tracked shows refresh via their own
+    source's TvEpisodeSource; the tracked-bell key includes the source.
+  * lib/features/collections/screens/item_detail_screen.dart
+    (_ItemDetailScreenState._toggleTracked): Subscribe/unsubscribe with
+    the item's data source.
+  * lib/features/search/handlers/tv_show_handler.dart (TvShowHandler):
+    Stamp the source on added items.
+  * lib/core/services/export_service.dart (ExportService.createFullExport):
+    TV shows deduped by source:id like manga.
+  * lib/core/services/backup_service.dart
+    (BackupService._restoreWatchedEpisodes): Watched rows restore into
+    their source namespace; legacy rows restore as TMDB.
+  * lib/core/import/sources/trakt/trakt_import_service.dart
+    (TraktImportService): Watched marks written as TMDB.
+  * lib/features/tier_lists/widgets/mood_grid_cell_media.dart
+    (resolveMoodGridCellMedia), lib/data/repositories/canvas_repository.dart
+    (CanvasRepository), lib/shared/models/collection_item.dart
+    (CollectionItem._resolvedMedia): Source-aware show lookups.
+
 ## [0.39.0] - 2026-07-18
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,9 +122,9 @@ Key entities:
 
 - **`collections`** + **`collection_items`** — user collections and their members. `collection_id` is nullable; `NULL` means uncategorized.
 - **`collection_items.media_type`** — discriminator: `game` / `movie` / `tvShow` / `anime` / `manga` / `visualNovel` / `book` / `custom`. `external_id` points at a row in the matching cache table.
-- **Media cache tables**: `games`, `movies_cache`, `tv_shows_cache` (+ `tv_seasons_cache`, `tv_episodes_cache`), `anime_cache`, `manga_cache`, `visual_novels_cache`, `books_cache`, `custom_items`. These are local mirrors of API responses keyed by external id (IGDB / TMDB / AniList / VNDB / OpenLibrary / Fantlab). `manga_cache` and `books_cache` use a composite key `(id, source)` since two providers can share a numeric id.
+- **Media cache tables**: `games`, `movies_cache`, `tv_shows_cache` (+ `tv_seasons_cache`, `tv_episodes_cache`), `anime_cache`, `manga_cache`, `visual_novels_cache`, `books_cache`, `custom_items`. These are local mirrors of API responses keyed by external id (IGDB / TMDB / AniList / VNDB / OpenLibrary / Fantlab). `manga_cache`, `books_cache` and `tv_shows_cache` (with its season/episode tables) use a composite key `(id, source)` since two providers can share a numeric id.
 - **`canvas_items` / `canvas_connections` / `canvas_viewport`** — the Board. Lives at both the collection level and the per-item level (`game_canvas_viewport`).
-- **`watched_episodes`** — episode-watch marks for TV shows.
+- **`watched_episodes`** — episode-watch marks for TV shows, keyed by `(collection_id, source, show_id, season, episode)`.
 - **`wishlist`** — quick free-text "look it up later" notes.
 - **`collection_tags`** — sub-categories inside a collection.
 - **`tier_lists` / `tier_definitions` / `tier_list_entries`** — Tier list.

--- a/lib/core/api/episode_source/tmdb_episode_source.dart
+++ b/lib/core/api/episode_source/tmdb_episode_source.dart
@@ -1,0 +1,29 @@
+// TMDB implementation of TvEpisodeSource.
+
+import '../../../shared/models/data_source.dart';
+import '../../../shared/models/tv_episode.dart';
+import '../../../shared/models/tv_season.dart';
+import '../../../shared/models/tv_show.dart';
+import '../tmdb_api.dart';
+import 'tv_episode_source.dart';
+
+/// [TvEpisodeSource] backed by the TMDB API.
+class TmdbEpisodeSource implements TvEpisodeSource {
+  /// Creates a [TmdbEpisodeSource] over [api].
+  const TmdbEpisodeSource(this._api);
+
+  final TmdbApi _api;
+
+  @override
+  DataSource get source => DataSource.tmdb;
+
+  @override
+  Future<TvShow?> getShow(int showId) => _api.getTvShow(showId);
+
+  @override
+  Future<List<TvSeason>> getSeasons(int showId) => _api.getTvSeasons(showId);
+
+  @override
+  Future<List<TvEpisode>> getSeasonEpisodes(int showId, int seasonNumber) =>
+      _api.getSeasonEpisodes(showId, seasonNumber);
+}

--- a/lib/core/api/episode_source/tv_episode_source.dart
+++ b/lib/core/api/episode_source/tv_episode_source.dart
@@ -1,0 +1,38 @@
+// Provider-agnostic source of TV show seasons and episodes.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../shared/models/data_source.dart';
+import '../../../shared/models/tv_episode.dart';
+import '../../../shared/models/tv_season.dart';
+import '../../../shared/models/tv_show.dart';
+import '../tmdb_api.dart';
+import 'tmdb_episode_source.dart';
+
+/// Season/episode data source for the episode tracker and release calendar.
+///
+/// Implementations wrap one provider's API and return the shared
+/// [TvShow]/[TvSeason]/[TvEpisode] models with [source] stamped.
+abstract class TvEpisodeSource {
+  /// Provider this implementation serves.
+  DataSource get source;
+
+  /// Show details — used for total season/episode counts.
+  Future<TvShow?> getShow(int showId);
+
+  /// The show's season list.
+  Future<List<TvSeason>> getSeasons(int showId);
+
+  /// Episodes of one season.
+  Future<List<TvEpisode>> getSeasonEpisodes(int showId, int seasonNumber);
+}
+
+/// Resolves the [TvEpisodeSource] for an item's [DataSource]. Unknown
+/// sources fall back to TMDB.
+final Provider<TvEpisodeSource Function(DataSource)>
+    tvEpisodeSourceResolverProvider =
+    Provider<TvEpisodeSource Function(DataSource)>((Ref ref) {
+  final TmdbEpisodeSource tmdb =
+      TmdbEpisodeSource(ref.watch(tmdbApiProvider));
+  return (DataSource source) => tmdb;
+});

--- a/lib/core/database/dao/collection_dao.dart
+++ b/lib/core/database/dao/collection_dao.dart
@@ -266,6 +266,7 @@ class CollectionDao {
     required MediaType mediaType,
     required int externalId,
     int? platformId,
+    DataSource? source,
   }) async {
     final Database db = await _getDatabase();
     final StringBuffer where = StringBuffer();
@@ -288,6 +289,13 @@ class CollectionDao {
       whereArgs.add(platformId);
     }
 
+    if (source != null) {
+      where.write(' AND COALESCE(source, ?) = ?');
+      whereArgs
+        ..add(mediaType.defaultSource.name)
+        ..add(source.name);
+    }
+
     final List<Map<String, dynamic>> rows = await db.query(
       'collection_items',
       where: where.toString(),
@@ -306,12 +314,14 @@ class CollectionDao {
     required MediaType mediaType,
     required int externalId,
     int? platformId,
+    DataSource? source,
   }) async {
     final CollectionItem? item = await findCollectionItem(
       collectionId: collectionId,
       mediaType: mediaType,
       externalId: externalId,
       platformId: platformId,
+      source: source,
     );
     if (item == null) return null;
     return (await _loadJoinedData(<CollectionItem>[item])).first;
@@ -320,12 +330,22 @@ class CollectionDao {
   Future<List<CollectionItem>> findAllCollectionItems({
     required MediaType mediaType,
     required int externalId,
+    DataSource? source,
   }) async {
     final Database db = await _getDatabase();
+    final StringBuffer where =
+        StringBuffer('media_type = ? AND external_id = ?');
+    final List<Object?> whereArgs = <Object?>[mediaType.value, externalId];
+    if (source != null) {
+      where.write(' AND COALESCE(source, ?) = ?');
+      whereArgs
+        ..add(mediaType.defaultSource.name)
+        ..add(source.name);
+    }
     final List<Map<String, dynamic>> rows = await db.query(
       'collection_items',
-      where: 'media_type = ? AND external_id = ?',
-      whereArgs: <Object?>[mediaType.value, externalId],
+      where: where.toString(),
+      whereArgs: whereArgs,
     );
     return rows.map(CollectionItem.fromDb).toList();
   }
@@ -1011,9 +1031,11 @@ class CollectionDao {
           ON ci.media_type = 'movie' AND ci.external_id = m.tmdb_id
         LEFT JOIN tv_shows_cache t
           ON ci.media_type = 'tv_show' AND ci.external_id = t.tmdb_id
+          AND t.source = COALESCE(ci.source, 'tmdb')
         LEFT JOIN tv_shows_cache t2
           ON ci.media_type = 'animation' AND ci.platform_id = 1
           AND ci.external_id = t2.tmdb_id
+          AND t2.source = COALESCE(ci.source, 'tmdb')
         LEFT JOIN movies_cache m2
           ON ci.media_type = 'animation' AND ci.platform_id != 1
           AND ci.external_id = m2.tmdb_id
@@ -1170,8 +1192,10 @@ class CollectionDao {
     final Map<int, Movie> moviesMap = <int, Movie>{
       for (final Movie m in resolvedMovies) m.tmdbId: m,
     };
-    final Map<int, TvShow> tvShowsMap = <int, TvShow>{
-      for (final TvShow t in resolvedTvShows) t.tmdbId: t,
+    // TV shows are keyed by `(source, id)` — ids from different providers
+    // can collide numerically.
+    final Map<String, TvShow> tvShowsMap = <String, TvShow>{
+      for (final TvShow t in resolvedTvShows) '${t.source.name}:${t.tmdbId}': t,
     };
     final Map<int, VisualNovel> vnMap = <int, VisualNovel>{
       for (final VisualNovel vn in visualNovels) vn.numericId: vn,
@@ -1206,10 +1230,16 @@ class CollectionDao {
         case MediaType.movie:
           return item.copyWith(movie: moviesMap[item.externalId]);
         case MediaType.tvShow:
-          return item.copyWith(tvShow: tvShowsMap[item.externalId]);
+          return item.copyWith(
+            tvShow: tvShowsMap[
+                '${(item.source ?? DataSource.tmdb).name}:${item.externalId}'],
+          );
         case MediaType.animation:
           if (item.platformId == AnimationSource.tvShow) {
-            return item.copyWith(tvShow: tvShowsMap[item.externalId]);
+            return item.copyWith(
+              tvShow: tvShowsMap[
+                  '${(item.source ?? DataSource.tmdb).name}:${item.externalId}'],
+            );
           }
           return item.copyWith(movie: moviesMap[item.externalId]);
         case MediaType.visualNovel:

--- a/lib/core/database/dao/tv_show_dao.dart
+++ b/lib/core/database/dao/tv_show_dao.dart
@@ -2,6 +2,7 @@
 
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
+import '../../../shared/models/data_source.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
@@ -9,6 +10,8 @@ import '../query_chunk.dart';
 
 /// DAO for the `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache` and
 /// `watched_episodes` tables.
+///
+/// Season, episode and watched rows are keyed by `(source, show id)`.
 class TvShowDao {
   /// Creates the DAO with a database accessor.
   const TvShowDao(this._getDatabase);
@@ -17,13 +20,16 @@ class TvShowDao {
 
   // ==================== TV Shows ====================
 
-  /// Returns the show by TMDB id, or null if not cached.
-  Future<TvShow?> getTvShowByTmdbId(int tmdbId) async {
+  /// Returns the show by id within [source], or null if not cached.
+  Future<TvShow?> getTvShowByTmdbId(
+    int tmdbId, {
+    DataSource source = DataSource.tmdb,
+  }) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
       'tv_shows_cache',
-      where: 'tmdb_id = ?',
-      whereArgs: <Object?>[tmdbId],
+      where: 'tmdb_id = ? AND source = ?',
+      whereArgs: <Object?>[tmdbId, source.name],
       limit: 1,
     );
     if (rows.isEmpty) return null;
@@ -58,7 +64,8 @@ class TvShowDao {
     });
   }
 
-  /// Returns several shows by a list of TMDB ids.
+  /// Returns matches across all sources for the given ids; callers
+  /// disambiguate by [TvShow.source] (two rows can share a numeric id).
   Future<List<TvShow>> getTvShowsByTmdbIds(List<int> tmdbIds) async {
     final Database db = await _getDatabase();
     return queryByIdsInChunks(tmdbIds, (List<int> chunk) async {
@@ -82,12 +89,15 @@ class TvShowDao {
   // ==================== TV Seasons ====================
 
   /// Returns the show's seasons.
-  Future<List<TvSeason>> getTvSeasonsByShowId(int tmdbShowId) async {
+  Future<List<TvSeason>> getTvSeasonsByShowId(
+    DataSource source,
+    int showId,
+  ) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
       'tv_seasons_cache',
-      where: 'tmdb_show_id = ?',
-      whereArgs: <Object?>[tmdbShowId],
+      where: 'source = ? AND tmdb_show_id = ?',
+      whereArgs: <Object?>[source.name, showId],
       orderBy: 'season_number ASC',
     );
     return rows.map(TvSeason.fromDb).toList();
@@ -120,12 +130,15 @@ class TvShowDao {
   // ==================== TV Episodes ====================
 
   /// Returns all cached episodes of a show.
-  Future<List<TvEpisode>> getEpisodesByShowId(int showId) async {
+  Future<List<TvEpisode>> getEpisodesByShowId(
+    DataSource source,
+    int showId,
+  ) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
       'tv_episodes_cache',
-      where: 'tmdb_show_id = ?',
-      whereArgs: <Object?>[showId],
+      where: 'source = ? AND tmdb_show_id = ?',
+      whereArgs: <Object?>[source.name, showId],
       orderBy: 'season_number ASC, episode_number ASC',
     );
     return rows.map(TvEpisode.fromDb).toList();
@@ -133,14 +146,15 @@ class TvShowDao {
 
   /// Returns cached episodes of a show's season.
   Future<List<TvEpisode>> getEpisodesByShowAndSeason(
+    DataSource source,
     int showId,
     int seasonNumber,
   ) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
       'tv_episodes_cache',
-      where: 'tmdb_show_id = ? AND season_number = ?',
-      whereArgs: <Object?>[showId, seasonNumber],
+      where: 'source = ? AND tmdb_show_id = ? AND season_number = ?',
+      whereArgs: <Object?>[source.name, showId, seasonNumber],
       orderBy: 'episode_number ASC',
     );
     return rows.map(TvEpisode.fromDb).toList();
@@ -165,12 +179,12 @@ class TvShowDao {
   }
 
   /// Clears a show's cached episodes.
-  Future<void> clearEpisodesByShow(int showId) async {
+  Future<void> clearEpisodesByShow(DataSource source, int showId) async {
     final Database db = await _getDatabase();
     await db.delete(
       'tv_episodes_cache',
-      where: 'tmdb_show_id = ?',
-      whereArgs: <Object?>[showId],
+      where: 'source = ? AND tmdb_show_id = ?',
+      whereArgs: <Object?>[source.name, showId],
     );
   }
 
@@ -181,14 +195,15 @@ class TvShowDao {
   /// Returns a set of (seasonNumber, episodeNumber) records.
   Future<Map<(int, int), DateTime?>> getWatchedEpisodes(
     int collectionId,
+    DataSource source,
     int showId,
   ) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
       'watched_episodes',
       columns: <String>['season_number', 'episode_number', 'watched_at'],
-      where: 'collection_id = ? AND show_id = ?',
-      whereArgs: <Object?>[collectionId, showId],
+      where: 'collection_id = ? AND source = ? AND show_id = ?',
+      whereArgs: <Object?>[collectionId, source.name, showId],
     );
     final Map<(int, int), DateTime?> result = <(int, int), DateTime?>{};
     for (final Map<String, dynamic> row in rows) {
@@ -207,13 +222,16 @@ class TvShowDao {
   /// counts as watched if it is marked in any collection. Release tracking
   /// treats a show as a single subscription regardless of how many collections
   /// hold it, so the per-collection split in `watched_episodes` is collapsed.
-  Future<Set<(int, int)>> getWatchedEpisodesForShow(int showId) async {
+  Future<Set<(int, int)>> getWatchedEpisodesForShow(
+    DataSource source,
+    int showId,
+  ) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> rows = await db.query(
       'watched_episodes',
       columns: <String>['season_number', 'episode_number'],
-      where: 'show_id = ?',
-      whereArgs: <Object?>[showId],
+      where: 'source = ? AND show_id = ?',
+      whereArgs: <Object?>[source.name, showId],
       distinct: true,
     );
     return <(int, int)>{
@@ -222,20 +240,21 @@ class TvShowDao {
     };
   }
 
-  /// All watched episodes deduped by show/season/episode (collection-agnostic),
-  /// for backup. Keeps the latest `watched_at`.
+  /// All watched episodes deduped by source/show/season/episode
+  /// (collection-agnostic), for backup. Keeps the latest `watched_at`.
   Future<List<Map<String, Object?>>> getAllWatchedEpisodes() async {
     final Database db = await _getDatabase();
     return db.rawQuery(
-      'SELECT show_id, season_number, episode_number, '
+      'SELECT source, show_id, season_number, episode_number, '
       'MAX(watched_at) AS watched_at FROM watched_episodes '
-      'GROUP BY show_id, season_number, episode_number',
+      'GROUP BY source, show_id, season_number, episode_number',
     );
   }
 
   /// Marks an episode watched with an explicit timestamp (restore path).
   Future<void> markEpisodeWatchedAt(
     int collectionId,
+    DataSource source,
     int showId,
     int seasonNumber,
     int episodeNumber,
@@ -246,6 +265,7 @@ class TvShowDao {
       'watched_episodes',
       <String, dynamic>{
         'collection_id': collectionId,
+        'source': source.name,
         'show_id': showId,
         'season_number': seasonNumber,
         'episode_number': episodeNumber,
@@ -258,6 +278,7 @@ class TvShowDao {
   /// Marks an episode as watched.
   Future<void> markEpisodeWatched(
     int collectionId,
+    DataSource source,
     int showId,
     int seasonNumber,
     int episodeNumber,
@@ -267,6 +288,7 @@ class TvShowDao {
       'watched_episodes',
       <String, dynamic>{
         'collection_id': collectionId,
+        'source': source.name,
         'show_id': showId,
         'season_number': seasonNumber,
         'episode_number': episodeNumber,
@@ -279,6 +301,7 @@ class TvShowDao {
   /// Clears the watched mark from an episode.
   Future<void> markEpisodeUnwatched(
     int collectionId,
+    DataSource source,
     int showId,
     int seasonNumber,
     int episodeNumber,
@@ -286,22 +309,29 @@ class TvShowDao {
     final Database db = await _getDatabase();
     await db.delete(
       'watched_episodes',
-      where: 'collection_id = ? AND show_id = ? '
+      where: 'collection_id = ? AND source = ? AND show_id = ? '
           'AND season_number = ? AND episode_number = ?',
-      whereArgs: <Object?>[collectionId, showId, seasonNumber, episodeNumber],
+      whereArgs: <Object?>[
+        collectionId,
+        source.name,
+        showId,
+        seasonNumber,
+        episodeNumber,
+      ],
     );
   }
 
   /// Returns the watched-episode count for a show within a collection.
   Future<int> getWatchedEpisodeCount(
     int collectionId,
+    DataSource source,
     int showId,
   ) async {
     final Database db = await _getDatabase();
     final List<Map<String, dynamic>> result = await db.rawQuery(
       'SELECT COUNT(*) as cnt FROM watched_episodes '
-      'WHERE collection_id = ? AND show_id = ?',
-      <Object?>[collectionId, showId],
+      'WHERE collection_id = ? AND source = ? AND show_id = ?',
+      <Object?>[collectionId, source.name, showId],
     );
     return result.first['cnt'] as int;
   }
@@ -309,6 +339,7 @@ class TvShowDao {
   /// Marks every episode of a season as watched.
   Future<void> markSeasonWatched(
     int collectionId,
+    DataSource source,
     int showId,
     int seasonNumber,
     List<int> episodeNumbers,
@@ -324,6 +355,7 @@ class TvShowDao {
           'watched_episodes',
           <String, dynamic>{
             'collection_id': collectionId,
+            'source': source.name,
             'show_id': showId,
             'season_number': seasonNumber,
             'episode_number': ep,
@@ -339,14 +371,16 @@ class TvShowDao {
   /// Clears the watched mark from every episode of a season.
   Future<void> unmarkSeasonWatched(
     int collectionId,
+    DataSource source,
     int showId,
     int seasonNumber,
   ) async {
     final Database db = await _getDatabase();
     await db.delete(
       'watched_episodes',
-      where: 'collection_id = ? AND show_id = ? AND season_number = ?',
-      whereArgs: <Object?>[collectionId, showId, seasonNumber],
+      where: 'collection_id = ? AND source = ? AND show_id = ? '
+          'AND season_number = ?',
+      whereArgs: <Object?>[collectionId, source.name, showId, seasonNumber],
     );
   }
 }

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -248,7 +248,7 @@ class DatabaseService {
     return databaseFactory.openDatabase(
       dbPath,
       options: OpenDatabaseOptions(
-        version: 56,
+        version: 57,
         onCreate: _onCreate,
         onUpgrade: _onUpgrade,
         onConfigure: (Database db) async {

--- a/lib/core/database/migrations/migration_registry.dart
+++ b/lib/core/database/migrations/migration_registry.dart
@@ -55,6 +55,7 @@ import 'migration_v53.dart';
 import 'migration_v54.dart';
 import 'migration_v55.dart';
 import 'migration_v56.dart';
+import 'migration_v57.dart';
 
 abstract final class MigrationRegistry {
   static final List<Migration> all = <Migration>[
@@ -114,6 +115,7 @@ abstract final class MigrationRegistry {
     MigrationV54(),
     MigrationV55(),
     MigrationV56(),
+    MigrationV57(),
   ];
 
   /// Schema version this build can open; newer databases must be rejected.

--- a/lib/core/database/migrations/migration_v57.dart
+++ b/lib/core/database/migrations/migration_v57.dart
@@ -1,0 +1,204 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// Adds an episode/show source discriminator. TV show identity becomes
+/// `(source, show id)`:
+/// - `tv_shows_cache` is rebuilt with a composite primary key
+///   `(tmdb_id, source)`;
+/// - `tv_seasons_cache`, `tv_episodes_cache` and `watched_episodes` gain a
+///   `source` column inside their UNIQUE keys;
+/// - `collection_items.source` is backfilled for tv shows and the tv-show
+///   unique indexes include it (like manga in v44).
+///
+/// SQLite can't alter constraints in place — the four tables are rebuilt and
+/// existing rows backfilled as `'tmdb'`.
+class MigrationV57 extends Migration {
+  @override
+  int get version => 57;
+
+  @override
+  String get description =>
+      'Show source: (tmdb_id, source) PK on tv_shows_cache, source column on '
+      'tv_seasons_cache/tv_episodes_cache/watched_episodes, '
+      'collection_items tv indexes';
+
+  @override
+  Future<void> migrate(Database db) async {
+    await _rebuildTvShowsCache(db);
+    await _rebuildTvSeasonsCache(db);
+    await _rebuildTvEpisodesCache(db);
+    await _rebuildWatchedEpisodes(db);
+    await _addCollectionItemsTvSource(db);
+    await _addMoodGridCellsTvSource(db);
+  }
+
+  Future<void> _rebuildTvShowsCache(Database db) async {
+    await db.execute('ALTER TABLE tv_shows_cache RENAME TO tv_shows_cache_old');
+    await db.execute('''
+      CREATE TABLE tv_shows_cache (
+        tmdb_id INTEGER NOT NULL,
+        source TEXT NOT NULL DEFAULT 'tmdb',
+        title TEXT NOT NULL,
+        original_title TEXT,
+        poster_url TEXT,
+        backdrop_url TEXT,
+        overview TEXT,
+        genres TEXT,
+        first_air_year INTEGER,
+        total_seasons INTEGER,
+        total_episodes INTEGER,
+        rating REAL,
+        status TEXT,
+        external_url TEXT,
+        cached_at INTEGER,
+        PRIMARY KEY (tmdb_id, source)
+      )
+    ''');
+    await db.execute('''
+      INSERT INTO tv_shows_cache (
+        tmdb_id, source, title, original_title, poster_url, backdrop_url,
+        overview, genres, first_air_year, total_seasons, total_episodes,
+        rating, status, external_url, cached_at
+      )
+      SELECT
+        tmdb_id, 'tmdb', title, original_title, poster_url, backdrop_url,
+        overview, genres, first_air_year, total_seasons, total_episodes,
+        rating, status, external_url, cached_at
+      FROM tv_shows_cache_old
+    ''');
+    await db.execute('DROP TABLE tv_shows_cache_old');
+  }
+
+  Future<void> _addCollectionItemsTvSource(Database db) async {
+    await db.execute(
+      "UPDATE collection_items SET source = 'tmdb' "
+      "WHERE media_type = 'tv_show' AND source IS NULL",
+    );
+
+    // Re-scope the generic non-game indexes off tv_show, add tv-specific
+    // unique indexes that include source.
+    await db.execute('DROP INDEX IF EXISTS idx_ci_coll_other');
+    await db.execute('DROP INDEX IF EXISTS idx_ci_uncat_other');
+    await db.execute('''
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_coll_other
+      ON collection_items(collection_id, media_type, external_id)
+      WHERE collection_id IS NOT NULL
+        AND media_type NOT IN ('game', 'manga', 'tv_show')
+    ''');
+    await db.execute('''
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_uncat_other
+      ON collection_items(media_type, external_id)
+      WHERE collection_id IS NULL
+        AND media_type NOT IN ('game', 'manga', 'tv_show')
+    ''');
+    await db.execute('''
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_coll_tv
+      ON collection_items(collection_id, media_type, external_id, COALESCE(source, 'tmdb'))
+      WHERE collection_id IS NOT NULL AND media_type = 'tv_show'
+    ''');
+    await db.execute('''
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_uncat_tv
+      ON collection_items(media_type, external_id, COALESCE(source, 'tmdb'))
+      WHERE collection_id IS NULL AND media_type = 'tv_show'
+    ''');
+  }
+
+  Future<void> _addMoodGridCellsTvSource(Database db) async {
+    await db.execute(
+      "UPDATE mood_grid_cells SET source = 'tmdb' "
+      "WHERE media_type = 'tv_show' AND source IS NULL",
+    );
+  }
+
+  Future<void> _rebuildTvSeasonsCache(Database db) async {
+    await db
+        .execute('ALTER TABLE tv_seasons_cache RENAME TO tv_seasons_cache_old');
+    await db.execute('''
+      CREATE TABLE tv_seasons_cache (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tmdb_show_id INTEGER NOT NULL,
+        season_number INTEGER NOT NULL,
+        name TEXT,
+        episode_count INTEGER,
+        poster_url TEXT,
+        air_date TEXT,
+        source TEXT NOT NULL DEFAULT 'tmdb',
+        UNIQUE(source, tmdb_show_id, season_number)
+      )
+    ''');
+    await db.execute('''
+      INSERT INTO tv_seasons_cache (
+        id, tmdb_show_id, season_number, name, episode_count, poster_url,
+        air_date, source
+      )
+      SELECT
+        id, tmdb_show_id, season_number, name, episode_count, poster_url,
+        air_date, 'tmdb'
+      FROM tv_seasons_cache_old
+    ''');
+    await db.execute('DROP TABLE tv_seasons_cache_old');
+  }
+
+  Future<void> _rebuildTvEpisodesCache(Database db) async {
+    await db.execute(
+        'ALTER TABLE tv_episodes_cache RENAME TO tv_episodes_cache_old');
+    await db.execute('''
+      CREATE TABLE tv_episodes_cache (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tmdb_show_id INTEGER NOT NULL,
+        season_number INTEGER NOT NULL,
+        episode_number INTEGER NOT NULL,
+        name TEXT,
+        overview TEXT,
+        air_date TEXT,
+        still_url TEXT,
+        runtime INTEGER,
+        cached_at INTEGER,
+        source TEXT NOT NULL DEFAULT 'tmdb',
+        UNIQUE(source, tmdb_show_id, season_number, episode_number)
+      )
+    ''');
+    await db.execute('''
+      INSERT INTO tv_episodes_cache (
+        id, tmdb_show_id, season_number, episode_number, name, overview,
+        air_date, still_url, runtime, cached_at, source
+      )
+      SELECT
+        id, tmdb_show_id, season_number, episode_number, name, overview,
+        air_date, still_url, runtime, cached_at, 'tmdb'
+      FROM tv_episodes_cache_old
+    ''');
+    await db.execute('DROP TABLE tv_episodes_cache_old');
+  }
+
+  Future<void> _rebuildWatchedEpisodes(Database db) async {
+    await db.execute(
+        'ALTER TABLE watched_episodes RENAME TO watched_episodes_old');
+    await db.execute('''
+      CREATE TABLE watched_episodes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        collection_id INTEGER NOT NULL,
+        show_id INTEGER NOT NULL,
+        season_number INTEGER NOT NULL,
+        episode_number INTEGER NOT NULL,
+        watched_at INTEGER,
+        source TEXT NOT NULL DEFAULT 'tmdb',
+        FOREIGN KEY (collection_id) REFERENCES collections(id)
+          ON DELETE CASCADE,
+        UNIQUE(collection_id, source, show_id, season_number, episode_number)
+      )
+    ''');
+    await db.execute('''
+      INSERT INTO watched_episodes (
+        id, collection_id, show_id, season_number, episode_number,
+        watched_at, source
+      )
+      SELECT
+        id, collection_id, show_id, season_number, episode_number,
+        watched_at, 'tmdb'
+      FROM watched_episodes_old
+    ''');
+    await db.execute('DROP TABLE watched_episodes_old');
+  }
+}

--- a/lib/core/import/sources/trakt/trakt_import_service.dart
+++ b/lib/core/import/sources/trakt/trakt_import_service.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 
 import '../../../../data/repositories/collection_repository.dart';
 import '../../../../data/repositories/wishlist_repository.dart';
+import '../../../../shared/models/data_source.dart';
 import '../../../../shared/models/collection.dart';
 import '../../../../shared/models/collection_item.dart';
 import '../../../../shared/models/item_status.dart';
@@ -514,6 +515,7 @@ class TraktImportService implements ImportSource {
             for (final _TraktEpisode episode in season.episodes) {
               await _database.tvShowDao.markEpisodeWatched(
                 collectionId,
+                DataSource.tmdb,
                 traktShow.tmdbId!,
                 season.number,
                 episode.number,

--- a/lib/core/services/backup_service.dart
+++ b/lib/core/services/backup_service.dart
@@ -13,6 +13,7 @@ import '../../data/repositories/collection_repository.dart';
 import '../../data/repositories/wishlist_repository.dart';
 import '../../shared/models/collection.dart';
 import '../../shared/models/collection_item.dart';
+import '../../shared/models/data_source.dart';
 import '../../shared/models/media_type.dart';
 import '../../shared/models/tag.dart';
 import '../../shared/models/calendar_entry.dart';
@@ -871,28 +872,32 @@ class BackupService {
 
   /// Restores watch progress. Backed up by show id (collection-agnostic), so
   /// each watched episode is re-applied to every restored collection holding
-  /// that TV show or anime.
+  /// that TV show or anime. Rows without a `source` restore as TMDB.
   Future<void> _restoreWatchedEpisodes(String jsonContent) async {
     final List<dynamic> list = jsonDecode(jsonContent) as List<dynamic>;
-    // Episodes of the same show repeat; memoize the lookup per show id.
-    final Map<int, List<CollectionItem>> itemsByShow =
-        <int, List<CollectionItem>>{};
+    // Episodes of the same show repeat; memoize the lookup per show key.
+    final Map<(DataSource, int), List<CollectionItem>> itemsByShow =
+        <(DataSource, int), List<CollectionItem>>{};
     for (final dynamic raw in list) {
       final Map<String, dynamic> m = raw as Map<String, dynamic>;
       final int showId = m['show_id'] as int;
+      final DataSource source =
+          DataSource.fromNameOr(m['source'] as String?, DataSource.tmdb);
       final int season = m['season_number'] as int;
       final int episode = m['episode_number'] as int;
       final int? watchedAt = m['watched_at'] as int?;
 
-      final List<CollectionItem> items = itemsByShow[showId] ??=
+      final List<CollectionItem> items = itemsByShow[(source, showId)] ??=
           <CollectionItem>[
         ...await _database.collectionDao.findAllCollectionItems(
           mediaType: MediaType.tvShow,
           externalId: showId,
+          source: source,
         ),
         ...await _database.collectionDao.findAllCollectionItems(
           mediaType: MediaType.animation,
           externalId: showId,
+          source: source,
         ),
       ];
       for (final CollectionItem item in items) {
@@ -900,6 +905,7 @@ class BackupService {
         if (collectionId == null) continue;
         await _database.tvShowDao.markEpisodeWatchedAt(
           collectionId,
+          source,
           showId,
           season,
           episode,

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -12,6 +12,7 @@ import '../../shared/models/canvas_item.dart';
 import '../../shared/models/canvas_viewport.dart';
 import '../../shared/models/collection.dart';
 import '../../shared/models/collection_item.dart';
+import '../../shared/models/data_source.dart';
 import '../../shared/models/item_mark.dart';
 import '../../shared/models/media_type.dart';
 import '../../shared/models/tracker_game_data.dart';
@@ -413,8 +414,10 @@ class ExportService {
     final Map<int, Map<String, dynamic>> games = <int, Map<String, dynamic>>{};
     final Map<int, Map<String, dynamic>> movies =
         <int, Map<String, dynamic>>{};
-    final Map<int, Map<String, dynamic>> tvShows =
-        <int, Map<String, dynamic>>{};
+    // Keyed by `source:externalId` — show ids from different providers can
+    // share a numeric id, like manga.
+    final Map<String, Map<String, dynamic>> tvShows =
+        <String, Map<String, dynamic>>{};
     final Map<int, Map<String, dynamic>> vns = <int, Map<String, dynamic>>{};
     // Keyed by `source:externalId` — AniList and MangaBaka can share a numeric
     // id, so an int key would drop one of them from the export.
@@ -428,7 +431,7 @@ class ExportService {
         <int, Map<String, dynamic>>{};
     final Map<int, Map<String, dynamic>> customItems =
         <int, Map<String, dynamic>>{};
-    final Set<int> tvShowIds = <int>{};
+    final Set<(DataSource, int)> tvShowKeys = <(DataSource, int)>{};
     final Set<int> platformIds = <int>{};
 
     for (final CollectionItem item in items) {
@@ -449,20 +452,24 @@ class ExportService {
             movies[item.externalId] = data;
           }
         case MediaType.tvShow:
-          if (item.tvShow != null && !tvShows.containsKey(item.externalId)) {
+          final String tvKey =
+              '${(item.source ?? DataSource.tmdb).name}:${item.externalId}';
+          if (item.tvShow != null && !tvShows.containsKey(tvKey)) {
             final Map<String, dynamic> data = item.tvShow!.toDb();
             data.remove('cached_at');
-            tvShows[item.externalId] = data;
+            tvShows[tvKey] = data;
           }
-          tvShowIds.add(item.externalId);
+          tvShowKeys.add((item.source ?? DataSource.tmdb, item.externalId));
         case MediaType.animation:
           if (item.platformId == AnimationSource.tvShow) {
-            if (item.tvShow != null && !tvShows.containsKey(item.externalId)) {
+            final String animKey =
+                '${(item.source ?? DataSource.tmdb).name}:${item.externalId}';
+            if (item.tvShow != null && !tvShows.containsKey(animKey)) {
               final Map<String, dynamic> data = item.tvShow!.toDb();
               data.remove('cached_at');
-              tvShows[item.externalId] = data;
+              tvShows[animKey] = data;
             }
-            tvShowIds.add(item.externalId);
+            tvShowKeys.add((item.source ?? DataSource.tmdb, item.externalId));
           } else {
             if (item.movie != null && !movies.containsKey(item.externalId)) {
               final Map<String, dynamic> data = item.movie!.toDb();
@@ -508,11 +515,11 @@ class ExportService {
     // Seasons and episodes from the DB cache, fetched in parallel per showId.
     final List<Map<String, dynamic>> allSeasons = <Map<String, dynamic>>[];
     final List<Map<String, dynamic>> allEpisodes = <Map<String, dynamic>>[];
-    if (_database != null && tvShowIds.isNotEmpty) {
-      for (final int showId in tvShowIds) {
+    if (_database != null && tvShowKeys.isNotEmpty) {
+      for (final (DataSource source, int showId) in tvShowKeys) {
         final List<Object> results = await Future.wait(<Future<Object>>[
-          _database.tvShowDao.getTvSeasonsByShowId(showId),
-          _database.tvShowDao.getEpisodesByShowId(showId),
+          _database.tvShowDao.getTvSeasonsByShowId(source, showId),
+          _database.tvShowDao.getEpisodesByShowId(source, showId),
         ]);
         final List<TvSeason> seasons = results[0] as List<TvSeason>;
         final List<TvEpisode> episodes = results[1] as List<TvEpisode>;

--- a/lib/data/repositories/canvas_repository.dart
+++ b/lib/data/repositories/canvas_repository.dart
@@ -270,9 +270,16 @@ class CanvasRepository {
     final Map<int, Movie> moviesMap = <int, Movie>{
       for (final Movie m in results[1] as List<Movie>) m.tmdbId: m,
     };
-    final Map<int, TvShow> tvShowsMap = <int, TvShow>{
-      for (final TvShow t in results[2] as List<TvShow>) t.tmdbId: t,
-    };
+    // Like manga, canvas items carry no show source, so a numeric id can
+    // match rows from several providers. TMDB wins to keep behaviour
+    // deterministic.
+    final Map<int, TvShow> tvShowsMap = <int, TvShow>{};
+    for (final TvShow t in results[2] as List<TvShow>) {
+      final TvShow? existing = tvShowsMap[t.tmdbId];
+      if (existing == null || t.source == DataSource.tmdb) {
+        tvShowsMap[t.tmdbId] = t;
+      }
+    }
     final Map<int, VisualNovel> vnMap = <int, VisualNovel>{
       for (final VisualNovel vn in results[3] as List<VisualNovel>)
         vn.numericId: vn,

--- a/lib/features/collections/providers/episode_tracker_provider.dart
+++ b/lib/features/collections/providers/episode_tracker_provider.dart
@@ -5,9 +5,10 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
-import '../../../core/api/tmdb_api.dart';
+import '../../../core/api/episode_source/tv_episode_source.dart';
 import '../../../core/database/database_service.dart';
 import '../../../shared/models/collection_item.dart';
+import '../../../shared/models/data_source.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/item_status_logic.dart';
 import '../../../shared/models/media_type.dart';
@@ -95,40 +96,50 @@ class EpisodeTrackerState {
   }
 }
 
+/// Family argument of the episode tracker. `source` selects the
+/// season/episode provider ([TvEpisodeSource]) and namespaces DB rows.
+typedef EpisodeTrackerArg = ({
+  int? collectionId,
+  int showId,
+  DataSource source,
+});
+
 /// Episode tracking provider.
 ///
 /// When collectionId == null (uncategorized), tracking is disabled.
 final NotifierProviderFamily<EpisodeTrackerNotifier, EpisodeTrackerState,
-        ({int? collectionId, int showId})>
+        EpisodeTrackerArg>
     episodeTrackerNotifierProvider = NotifierProvider.family<
         EpisodeTrackerNotifier,
         EpisodeTrackerState,
-        ({int? collectionId, int showId})>(
+        EpisodeTrackerArg>(
   EpisodeTrackerNotifier.new,
 );
 
 /// Notifier that manages watched episodes.
-class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
-    ({int? collectionId, int showId})> {
+class EpisodeTrackerNotifier
+    extends FamilyNotifier<EpisodeTrackerState, EpisodeTrackerArg> {
   static final Logger _log = Logger('EpisodeTrackerNotifier');
 
   late DatabaseService _db;
-  late TmdbApi _tmdbApi;
+  late TvEpisodeSource _episodeSource;
   late int? _collectionId;
   late int _showId;
+  late DataSource _source;
 
-  // Show totals fetched from the TMDB API, cached so we don't re-query on
+  // Show totals fetched from the source API, cached so we don't re-query on
   // every toggleEpisode/toggleSeason.
   int? _cachedTotalEpisodes;
   int? _cachedTotalSeasons;
   bool _hasFetchedTotals = false;
 
   @override
-  EpisodeTrackerState build(({int? collectionId, int showId}) arg) {
+  EpisodeTrackerState build(EpisodeTrackerArg arg) {
     _collectionId = arg.collectionId;
     _showId = arg.showId;
+    _source = arg.source;
     _db = ref.watch(databaseServiceProvider);
-    _tmdbApi = ref.watch(tmdbApiProvider);
+    _episodeSource = ref.watch(tvEpisodeSourceResolverProvider)(arg.source);
 
     // Episode tracking is not supported for uncategorized items
     if (_collectionId == null) return const EpisodeTrackerState();
@@ -144,7 +155,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
     if (collId == null) return;
     try {
       final Map<(int, int), DateTime?> watched =
-          await _db.tvShowDao.getWatchedEpisodes(collId, _showId);
+          await _db.tvShowDao.getWatchedEpisodes(collId, _source, _showId);
       state = state.copyWith(watchedEpisodes: watched);
     } on Exception catch (e) {
       state = state.copyWith(error: 'Failed to load watched episodes: $e');
@@ -157,7 +168,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
   Future<void> _loadCachedEpisodes() async {
     try {
       final List<TvEpisode> episodes =
-          await _db.tvShowDao.getEpisodesByShowId(_showId);
+          await _db.tvShowDao.getEpisodesByShowId(_source, _showId);
       if (episodes.isEmpty) return;
       final Map<int, List<TvEpisode>> bySeason = <int, List<TvEpisode>>{};
       for (final TvEpisode ep in episodes) {
@@ -190,11 +201,12 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
 
     try {
       List<TvEpisode> episodes =
-          await _db.tvShowDao.getEpisodesByShowAndSeason(_showId, seasonNumber);
+          await _db.tvShowDao
+              .getEpisodesByShowAndSeason(_source, _showId, seasonNumber);
 
       if (episodes.isEmpty) {
         episodes =
-            await _tmdbApi.getSeasonEpisodes(_showId, seasonNumber);
+            await _episodeSource.getSeasonEpisodes(_showId, seasonNumber);
         if (episodes.isNotEmpty) {
           await _db.tvShowDao.upsertEpisodes(episodes);
         }
@@ -236,7 +248,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
 
     try {
       final List<TvEpisode> episodes =
-          await _tmdbApi.getSeasonEpisodes(_showId, seasonNumber);
+          await _episodeSource.getSeasonEpisodes(_showId, seasonNumber);
       if (episodes.isNotEmpty) {
         await _db.tvShowDao.upsertEpisodes(episodes);
       }
@@ -271,14 +283,14 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
 
     if (isWatched) {
       await _db.tvShowDao.markEpisodeUnwatched(
-          collId, _showId, season, episode);
+          collId, _source, _showId, season, episode);
       final Map<(int, int), DateTime?> updated =
           Map<(int, int), DateTime?>.of(state.watchedEpisodes)
             ..remove((season, episode));
       state = state.copyWith(watchedEpisodes: updated);
     } else {
       await _db.tvShowDao.markEpisodeWatched(
-          collId, _showId, season, episode);
+          collId, _source, _showId, season, episode);
       final Map<(int, int), DateTime?> updated =
           Map<(int, int), DateTime?>.of(state.watchedEpisodes)
             ..[(season, episode)] = DateTime.now();
@@ -299,7 +311,8 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
     final bool allWatched = watchedCount == episodes.length;
 
     if (allWatched) {
-      await _db.tvShowDao.unmarkSeasonWatched(collId, _showId, season);
+      await _db.tvShowDao.unmarkSeasonWatched(
+          collId, _source, _showId, season);
       final Map<(int, int), DateTime?> updated =
           Map<(int, int), DateTime?>.of(state.watchedEpisodes);
       for (final TvEpisode ep in episodes) {
@@ -310,7 +323,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
       final List<int> episodeNumbers =
           episodes.map((TvEpisode ep) => ep.episodeNumber).toList();
       await _db.tvShowDao.markSeasonWatched(
-          collId, _showId, season, episodeNumbers);
+          collId, _source, _showId, season, episodeNumbers);
       final DateTime now = DateTime.now();
       final Map<(int, int), DateTime?> updated =
           Map<(int, int), DateTime?>.of(state.watchedEpisodes);
@@ -338,6 +351,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
     CollectionItem? targetItem;
     for (final CollectionItem ci in items) {
       if (ci.externalId == _showId &&
+          (ci.source ?? DataSource.tmdb) == _source &&
           (ci.mediaType == MediaType.tvShow ||
            ci.mediaType == MediaType.animation)) {
         targetItem = ci;
@@ -351,12 +365,12 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
     int totalSeasons = _cachedTotalSeasons ??
         targetItem.tvShow?.totalSeasons ?? 0;
 
-    // If totals are missing from the cache, fetch them from the TMDB API
+    // If totals are missing from the cache, fetch them from the source API
     // (once per session, so we don't query on every toggle)
     if ((totalInShow == 0 || totalSeasons == 0) && !_hasFetchedTotals) {
       _hasFetchedTotals = true;
       try {
-        final TvShow? freshShow = await _tmdbApi.getTvShow(_showId);
+        final TvShow? freshShow = await _episodeSource.getShow(_showId);
         if (freshShow != null) {
           await _db.tvShowDao.upsertTvShow(freshShow);
           totalInShow = freshShow.totalEpisodes ?? 0;
@@ -365,7 +379,7 @@ class EpisodeTrackerNotifier extends FamilyNotifier<EpisodeTrackerState,
           _cachedTotalSeasons = totalSeasons;
         }
       } on Exception catch (e) {
-        _log.warning('TMDB API unavailable, using cached episode data', e);
+        _log.warning('Source API unavailable, using cached episode data', e);
       }
     }
 

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -205,15 +205,20 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
 
   Future<void> _toggleTracked(CollectionItem item) async {
     final TrackedReleaseDao dao = ref.read(trackedReleaseDaoProvider);
+    final DataSource source = item.dataSource;
     final bool tracked =
-        await dao.isTracked(item.externalId, DataSource.tmdb, item.mediaType);
+        await dao.isTracked(item.externalId, source, item.mediaType);
     if (tracked) {
-      await dao.unsubscribe(item.externalId, DataSource.tmdb, item.mediaType);
+      await dao.unsubscribe(item.externalId, source, item.mediaType);
     } else {
-      await dao.subscribe(item.externalId, DataSource.tmdb, item.mediaType);
+      await dao.subscribe(item.externalId, source, item.mediaType);
     }
     ref.invalidate(isReleaseTrackedProvider(
-      (externalId: item.externalId, mediaType: item.mediaType),
+      (
+        externalId: item.externalId,
+        source: source,
+        mediaType: item.mediaType,
+      ),
     ));
     ref.invalidate(releasesProvider);
   }
@@ -599,6 +604,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
               ? ref
                       .watch(isReleaseTrackedProvider((
                         externalId: item.externalId,
+                        source: item.dataSource,
                         mediaType: item.mediaType,
                       )))
                       .valueOrNull ??
@@ -700,6 +706,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
             collectionId: widget.collectionId,
             itemId: item.id,
             externalId: item.externalId,
+            source: item.source ?? DataSource.tmdb,
             tvShow: config.tvShow,
             accentColor: config.accentColor,
           ),

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -7,6 +7,7 @@ import '../../../shared/constants/platform_features.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/collection_sort_mode.dart';
+import '../../../shared/models/data_source.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/tag.dart';
@@ -448,8 +449,11 @@ class CollectionItemsView extends ConsumerWidget {
       return null;
     }
     final int watched = ref
-        .watch(episodeTrackerNotifierProvider(
-            (collectionId: collectionId, showId: item.externalId)))
+        .watch(episodeTrackerNotifierProvider((
+          collectionId: collectionId,
+          showId: item.externalId,
+          source: item.source ?? DataSource.tmdb,
+        )))
         .totalWatchedCount;
     if (watched == 0) return null;
     final int total = item.tvShow?.totalEpisodes ?? 0;

--- a/lib/features/collections/widgets/episode_tracker_section.dart
+++ b/lib/features/collections/widgets/episode_tracker_section.dart
@@ -3,8 +3,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/api/tmdb_api.dart';
+import '../../../core/api/episode_source/tv_episode_source.dart';
 import '../../../core/database/database_service.dart';
+import '../../../shared/models/data_source.dart';
 import '../../../features/settings/providers/settings_provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/app_colors.dart';
@@ -29,6 +30,7 @@ class EpisodeTrackerSection extends ConsumerWidget {
     required this.collectionId,
     required this.itemId,
     required this.externalId,
+    required this.source,
     required this.tvShow,
     required this.accentColor,
     super.key,
@@ -40,8 +42,11 @@ class EpisodeTrackerSection extends ConsumerWidget {
   /// Owning `collection_items.id` — anchor for per-episode marks.
   final int itemId;
 
-  /// TMDB show id.
+  /// Show id in the [source] provider's namespace.
   final int externalId;
+
+  /// Episode data source of the item.
+  final DataSource source;
 
   /// Show data.
   final TvShow? tvShow;
@@ -52,9 +57,8 @@ class EpisodeTrackerSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final int tmdbShowId = externalId;
-    final ({int? collectionId, int showId}) trackerArg =
-        (collectionId: collectionId, showId: tmdbShowId);
+    final EpisodeTrackerArg trackerArg =
+        (collectionId: collectionId, showId: externalId, source: source);
 
     final EpisodeTrackerState trackerState =
         ref.watch(episodeTrackerNotifierProvider(trackerArg));
@@ -100,7 +104,8 @@ class EpisodeTrackerSection extends ConsumerWidget {
         ],
         const SizedBox(height: 12),
         SeasonsListWidget(
-          tmdbShowId: tmdbShowId,
+          showId: externalId,
+          source: source,
           collectionId: collectionId,
           itemId: itemId,
           accentColor: accentColor,
@@ -114,15 +119,19 @@ class EpisodeTrackerSection extends ConsumerWidget {
 class SeasonsListWidget extends ConsumerStatefulWidget {
   /// Creates a [SeasonsListWidget].
   const SeasonsListWidget({
-    required this.tmdbShowId,
+    required this.showId,
+    required this.source,
     required this.collectionId,
     required this.itemId,
     required this.accentColor,
     super.key,
   });
 
-  /// TMDB show id.
-  final int tmdbShowId;
+  /// Show id in the [source] provider's namespace.
+  final int showId;
+
+  /// Episode data source of the item.
+  final DataSource source;
 
   /// Collection id (null for uncategorized).
   final int? collectionId;
@@ -152,18 +161,19 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
   Future<void> _loadSeasons() async {
     final DatabaseService db = ref.read(databaseServiceProvider);
     List<TvSeason> seasons =
-        await db.tvShowDao.getTvSeasonsByShowId(widget.tmdbShowId);
+        await db.tvShowDao.getTvSeasonsByShowId(widget.source, widget.showId);
 
-    // Cache miss: fetch from the TMDB API and cache the result
+    // Cache miss: fetch from the source API and cache the result
     if (seasons.isEmpty) {
       try {
-        final TmdbApi tmdbApi = ref.read(tmdbApiProvider);
-        seasons = await tmdbApi.getTvSeasons(widget.tmdbShowId);
+        final TvEpisodeSource episodeSource =
+            ref.read(tvEpisodeSourceResolverProvider)(widget.source);
+        seasons = await episodeSource.getSeasons(widget.showId);
         if (seasons.isNotEmpty) {
           await db.tvShowDao.upsertTvSeasons(seasons);
         }
       } on Exception catch (_) {
-        // TMDB API unavailable — show empty season list, not critical.
+        // Source API unavailable — show empty season list, not critical.
         // User can retry via pull-to-refresh.
       }
     }
@@ -185,10 +195,11 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
 
     try {
       final DatabaseService db = ref.read(databaseServiceProvider);
-      final TmdbApi tmdbApi = ref.read(tmdbApiProvider);
+      final TvEpisodeSource episodeSource =
+          ref.read(tvEpisodeSourceResolverProvider)(widget.source);
 
       final List<TvSeason> seasons =
-          await tmdbApi.getTvSeasons(widget.tmdbShowId);
+          await episodeSource.getSeasons(widget.showId);
       if (seasons.isNotEmpty) {
         await db.tvShowDao.upsertTvSeasons(seasons);
       }
@@ -218,9 +229,10 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
     }
   }
 
-  ({int? collectionId, int showId}) get _trackerArg => (
+  EpisodeTrackerArg get _trackerArg => (
         collectionId: widget.collectionId,
-        showId: widget.tmdbShowId,
+        showId: widget.showId,
+        source: widget.source,
       );
 
   @override
@@ -551,7 +563,7 @@ class SeasonExpansionTile extends ConsumerStatefulWidget {
   final EpisodeTrackerState trackerState;
 
   /// Argument for the tracker provider.
-  final ({int? collectionId, int showId}) trackerArg;
+  final EpisodeTrackerArg trackerArg;
 
   /// Owning `collection_items.id` — anchor for per-episode/season marks.
   final int itemId;
@@ -571,7 +583,7 @@ class _SeasonExpansionTileState extends ConsumerState<SeasonExpansionTile> {
   Widget build(BuildContext context) {
     final TvSeason season = widget.season;
     final EpisodeTrackerState trackerState = widget.trackerState;
-    final ({int? collectionId, int showId}) trackerArg = widget.trackerArg;
+    final EpisodeTrackerArg trackerArg = widget.trackerArg;
     final int itemId = widget.itemId;
     final Color accentColor = widget.accentColor;
     final S l = S.of(context);
@@ -747,7 +759,7 @@ class EpisodeTile extends ConsumerStatefulWidget {
   final DateTime? watchedAt;
 
   /// Argument for the tracker provider.
-  final ({int? collectionId, int showId}) trackerArg;
+  final EpisodeTrackerArg trackerArg;
 
   /// Owning `collection_items.id` — anchor for per-episode marks.
   final int itemId;

--- a/lib/features/releases/providers/releases_provider.dart
+++ b/lib/features/releases/providers/releases_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/api/tmdb_api.dart';
+import '../../../core/api/episode_source/tv_episode_source.dart';
 import '../../../core/database/database_service.dart';
 import '../../../shared/models/calendar_entry.dart';
 import '../../../shared/models/calendar_recurrence.dart';
@@ -13,14 +13,15 @@ import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import '../models/release_event.dart';
 
-/// Whether a TMDB title is currently tracked, for the detail-screen bell.
-final AutoDisposeFutureProviderFamily<bool, ({int externalId, MediaType mediaType})>
-    isReleaseTrackedProvider =
-    FutureProvider.autoDispose.family<bool, ({int externalId, MediaType mediaType})>(
-  (Ref ref, ({int externalId, MediaType mediaType}) key) {
+/// Whether a title is currently tracked, for the detail-screen bell.
+final AutoDisposeFutureProviderFamily<bool,
+        ({int externalId, DataSource source, MediaType mediaType})>
+    isReleaseTrackedProvider = FutureProvider.autoDispose.family<bool,
+        ({int externalId, DataSource source, MediaType mediaType})>(
+  (Ref ref, ({int externalId, DataSource source, MediaType mediaType}) key) {
     return ref
         .watch(trackedReleaseDaoProvider)
-        .isTracked(key.externalId, DataSource.tmdb, key.mediaType);
+        .isTracked(key.externalId, key.source, key.mediaType);
   },
 );
 
@@ -63,20 +64,20 @@ class ReleasesNotifier extends AsyncNotifier<ReleasesCalendarData> {
     MediaType.animation,
   };
 
-  /// Re-fetches seasons and episodes for every tracked show from TMDB and
-  /// updates the cache, then rebuilds. Used by pull-to-refresh / the refresh
-  /// button — the only way to pick up newly announced episodes.
+  /// Re-fetches seasons and episodes for every tracked show from its source
+  /// API and updates the cache, then rebuilds. Used by pull-to-refresh / the
+  /// refresh button — the only way to pick up newly announced episodes.
   Future<void> refreshFromApi() async {
     final DatabaseService db = ref.read(databaseServiceProvider);
-    final TmdbApi api = ref.read(tmdbApiProvider);
+    final TvEpisodeSource Function(DataSource) resolve =
+        ref.read(tvEpisodeSourceResolverProvider);
     final List<TrackedRelease> tracked = await db.trackedReleaseDao.getAll();
 
     for (final TrackedRelease t in tracked) {
-      if (t.source != DataSource.tmdb || !_supported.contains(t.mediaType)) {
-        continue;
-      }
+      if (!_supported.contains(t.mediaType)) continue;
       try {
-        final List<TvSeason> seasons = await api.getTvSeasons(t.externalId);
+        final TvEpisodeSource api = resolve(t.source);
+        final List<TvSeason> seasons = await api.getSeasons(t.externalId);
         if (seasons.isNotEmpty) await db.tvShowDao.upsertTvSeasons(seasons);
         for (final TvSeason s in seasons) {
           final List<TvEpisode> episodes =
@@ -101,19 +102,18 @@ class ReleasesNotifier extends AsyncNotifier<ReleasesCalendarData> {
     await db.calendarEntryDao.deletePastOnce(today);
 
     final List<TrackedRelease> tracked = await db.trackedReleaseDao.getAll();
-    final List<TrackedRelease> tmdb = tracked
-        .where((TrackedRelease t) =>
-            t.source == DataSource.tmdb && _supported.contains(t.mediaType))
+    final List<TrackedRelease> shows = tracked
+        .where((TrackedRelease t) => _supported.contains(t.mediaType))
         .toList();
     final List<CalendarEntry> manual = await db.calendarEntryDao.getAll();
 
     final List<List<ReleaseEvent>> perShow = await Future.wait(<Future<List<ReleaseEvent>>>[
-      ...tmdb.map((TrackedRelease t) => _eventsForShow(db, t, today)),
+      ...shows.map((TrackedRelease t) => _eventsForShow(db, t, today)),
       ...manual.map((CalendarEntry e) => _eventsForEntry(db, e, today)),
     ]);
 
     return ReleasesCalendarData(
-      trackedCount: tmdb.length + manual.length,
+      trackedCount: shows.length + manual.length,
       events: perShow.expand((List<ReleaseEvent> e) => e).toList(),
     );
   }
@@ -129,6 +129,7 @@ class ReleasesNotifier extends AsyncNotifier<ReleasesCalendarData> {
       collectionId: null,
       mediaType: entry.mediaType,
       externalId: entry.externalId,
+      source: entry.source,
     );
     if (item == null) return <ReleaseEvent>[];
 
@@ -188,14 +189,16 @@ class ReleasesNotifier extends AsyncNotifier<ReleasesCalendarData> {
     DateTime today,
   ) async {
     // The reads are independent — start them together.
-    final Future<TvShow?> showF = db.tvShowDao.getTvShowByTmdbId(t.externalId);
+    final Future<TvShow?> showF =
+        db.tvShowDao.getTvShowByTmdbId(t.externalId, source: t.source);
     final Future<CollectionItem?> itemF = db.collectionDao.findCollectionItem(
       collectionId: null,
       mediaType: t.mediaType,
       externalId: t.externalId,
+      source: t.source,
     );
     final Future<List<TvEpisode>> episodesF =
-        db.tvShowDao.getEpisodesByShowId(t.externalId);
+        db.tvShowDao.getEpisodesByShowId(t.source, t.externalId);
 
     final CollectionItem? item = await itemF;
     final TvShow? show = await showF;

--- a/lib/features/search/handlers/tv_show_handler.dart
+++ b/lib/features/search/handlers/tv_show_handler.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../../core/services/image_cache_service.dart';
+import '../../../shared/models/data_source.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
@@ -76,6 +77,7 @@ class TvShowHandler implements MediaActionHandler {
       platformId: mediaType == MediaType.animation
           ? AnimationSource.tvShow
           : null,
+      source: tvShow.source,
       title: tvShow.title,
       upsert: () => _ref.read(tvShowDaoProvider).upsertTvShow(tvShow),
       imageType: ImageType.tvShowPoster,
@@ -114,6 +116,7 @@ class TvShowHandler implements MediaActionHandler {
       platformId: mediaType == MediaType.animation
           ? AnimationSource.tvShow
           : null,
+      source: tvShow.source,
       title: tvShow.title,
       upsert: () => _ref.read(tvShowDaoProvider).upsertTvShow(tvShow),
       imageType: ImageType.tvShowPoster,
@@ -128,14 +131,15 @@ class TvShowHandler implements MediaActionHandler {
       final DatabaseService db = _ref.read(databaseServiceProvider);
       final TmdbApi tmdb = _ref.read(tmdbApiProvider);
 
-      List<TvSeason> seasons = await db.tvShowDao.getTvSeasonsByShowId(tmdbId);
+      List<TvSeason> seasons =
+          await db.tvShowDao.getTvSeasonsByShowId(DataSource.tmdb, tmdbId);
       if (seasons.isEmpty) {
         seasons = await tmdb.getTvSeasons(tmdbId);
         if (seasons.isNotEmpty) await db.tvShowDao.upsertTvSeasons(seasons);
       }
       for (final TvSeason season in seasons) {
-        final List<TvEpisode> cached =
-            await db.tvShowDao.getEpisodesByShowAndSeason(tmdbId, season.seasonNumber);
+        final List<TvEpisode> cached = await db.tvShowDao
+            .getEpisodesByShowAndSeason(DataSource.tmdb, tmdbId, season.seasonNumber);
         if (cached.isEmpty) {
           final List<TvEpisode> episodes =
               await tmdb.getSeasonEpisodes(tmdbId, season.seasonNumber);

--- a/lib/features/tier_lists/widgets/mood_grid_cell_media.dart
+++ b/lib/features/tier_lists/widgets/mood_grid_cell_media.dart
@@ -89,7 +89,10 @@ Future<MoodGridCellMedia> resolveMoodGridCellMedia(
         rating: movie?.rating,
       );
     case MediaType.tvShow:
-      final TvShow? tvShow = await db.tvShowDao.getTvShowByTmdbId(externalId);
+      final TvShow? tvShow = await db.tvShowDao.getTvShowByTmdbId(
+        externalId,
+        source: source ?? DataSource.tmdb,
+      );
       return MoodGridCellMedia(
         title: tvShow?.title,
         coverUrl: tvShow?.posterUrl,
@@ -102,7 +105,10 @@ Future<MoodGridCellMedia> resolveMoodGridCellMedia(
     case MediaType.animation:
       final bool isTvBased = platformId == AnimationSource.tvShow;
       if (isTvBased) {
-        final TvShow? tvShow = await db.tvShowDao.getTvShowByTmdbId(externalId);
+        final TvShow? tvShow = await db.tvShowDao.getTvShowByTmdbId(
+          externalId,
+          source: source ?? DataSource.tmdb,
+        );
         return MoodGridCellMedia(
           title: tvShow?.title,
           coverUrl: tvShow?.posterUrl,

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -332,7 +332,7 @@ class CollectionItem with Exportable {
           genresString: tvShow?.genresString,
           genres: tvShow?.genres,
           mediaStatus: tvShow?.status,
-          source: DataSource.tmdb,
+          source: tvShow?.source ?? source ?? DataSource.tmdb,
           imageType: ImageType.tvShowPoster,
           placeholderIcon: Icons.tv_outlined,
         );
@@ -353,7 +353,7 @@ class CollectionItem with Exportable {
             genresString: tvShow?.genresString,
             genres: tvShow?.genres,
             mediaStatus: tvShow?.status,
-            source: DataSource.tmdb,
+            source: tvShow?.source ?? source ?? DataSource.tmdb,
             imageType: ImageType.tvShowPoster,
             placeholderIcon: Icons.animation,
           );

--- a/lib/shared/models/data_source.dart
+++ b/lib/shared/models/data_source.dart
@@ -66,11 +66,16 @@ enum DataSource {
   /// Parses a [DataSource] from its stored name (the `source` column in DB /
   /// export). Returns [DataSource.anilist] for null and unknown values — the
   /// safe manga default, since the manga cache was AniList-only before v44.
-  static DataSource fromName(String? name) {
-    if (name == null) return DataSource.anilist;
+  static DataSource fromName(String? name) =>
+      fromNameOr(name, DataSource.anilist);
+
+  /// Parses a stored name with an explicit [fallback] for null and unknown
+  /// values.
+  static DataSource fromNameOr(String? name, DataSource fallback) {
+    if (name == null) return fallback;
     for (final DataSource s in DataSource.values) {
       if (s.name == name) return s;
     }
-    return DataSource.anilist;
+    return fallback;
   }
 }

--- a/lib/shared/models/media_type.dart
+++ b/lib/shared/models/media_type.dart
@@ -1,4 +1,5 @@
 import '../../l10n/app_localizations.dart';
+import 'data_source.dart';
 
 /// Media content type of a collection item.
 enum MediaType {
@@ -36,6 +37,19 @@ enum MediaType {
   custom('custom');
 
   const MediaType(this.value);
+
+  /// Fallback source for rows whose `source` column is NULL.
+  DataSource get defaultSource => switch (this) {
+        MediaType.game => DataSource.igdb,
+        MediaType.movie => DataSource.tmdb,
+        MediaType.tvShow => DataSource.tmdb,
+        MediaType.animation => DataSource.tmdb,
+        MediaType.visualNovel => DataSource.vndb,
+        MediaType.manga => DataSource.anilist,
+        MediaType.anime => DataSource.anilist,
+        MediaType.book => DataSource.openLibrary,
+        MediaType.custom => DataSource.local,
+      };
 
   /// String value stored in the database.
   final String value;

--- a/lib/shared/models/tv_episode.dart
+++ b/lib/shared/models/tv_episode.dart
@@ -1,10 +1,10 @@
-// Модель эпизода сериала из TMDB.
+// TV episode model shared by all episode sources.
 
-/// Модель эпизода сериала из TMDB API.
-///
-/// Представляет один эпизод конкретного сезона сериала.
+import 'data_source.dart';
+
+/// One episode of a TV show season.
 class TvEpisode {
-  /// Создаёт экземпляр [TvEpisode].
+  /// Creates a [TvEpisode].
   const TvEpisode({
     required this.tmdbShowId,
     required this.seasonNumber,
@@ -14,9 +14,10 @@ class TvEpisode {
     this.airDate,
     this.stillUrl,
     this.runtime,
+    this.source = DataSource.tmdb,
   });
 
-  /// Создаёт [TvEpisode] из JSON ответа TMDB API.
+  /// Creates a [TvEpisode] from a TMDB API JSON response.
   factory TvEpisode.fromJson(
     Map<String, dynamic> json, {
     required int showId,
@@ -40,7 +41,8 @@ class TvEpisode {
     );
   }
 
-  /// Создаёт [TvEpisode] из записи базы данных.
+  /// Creates a [TvEpisode] from a database row. A missing or unknown
+  /// `source` reads as [DataSource.tmdb].
   factory TvEpisode.fromDb(Map<String, dynamic> row) {
     return TvEpisode(
       tmdbShowId: row['tmdb_show_id'] as int,
@@ -51,34 +53,38 @@ class TvEpisode {
       airDate: row['air_date'] as String?,
       stillUrl: row['still_url'] as String?,
       runtime: row['runtime'] as int?,
+      source: DataSource.fromNameOr(row['source'] as String?, DataSource.tmdb),
     );
   }
 
-  /// ID сериала в TMDB.
+  /// Show id in the [source] provider's namespace.
   final int tmdbShowId;
 
-  /// Номер сезона.
+  /// Season number.
   final int seasonNumber;
 
-  /// Номер эпизода.
+  /// Episode number within the season.
   final int episodeNumber;
 
-  /// Название эпизода.
+  /// Episode title.
   final String name;
 
-  /// Описание эпизода.
+  /// Episode overview.
   final String? overview;
 
-  /// Дата выхода (формат: "YYYY-MM-DD").
+  /// Air date ("YYYY-MM-DD").
   final String? airDate;
 
-  /// URL кадра из эпизода (still image).
+  /// Still image URL.
   final String? stillUrl;
 
-  /// Длительность эпизода в минутах.
+  /// Runtime in minutes.
   final int? runtime;
 
-  /// Преобразует в Map для сохранения в базу данных.
+  /// Provider this episode came from.
+  final DataSource source;
+
+  /// Converts to a map for database storage.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'tmdb_show_id': tmdbShowId,
@@ -89,11 +95,12 @@ class TvEpisode {
       'air_date': airDate,
       'still_url': stillUrl,
       'runtime': runtime,
+      'source': source.name,
       'cached_at': DateTime.now().millisecondsSinceEpoch,
     };
   }
 
-  /// Создаёт копию с изменёнными полями.
+  /// Returns a copy with the given fields replaced.
   TvEpisode copyWith({
     int? tmdbShowId,
     int? seasonNumber,
@@ -103,6 +110,7 @@ class TvEpisode {
     String? airDate,
     String? stillUrl,
     int? runtime,
+    DataSource? source,
   }) {
     return TvEpisode(
       tmdbShowId: tmdbShowId ?? this.tmdbShowId,
@@ -113,6 +121,7 @@ class TvEpisode {
       airDate: airDate ?? this.airDate,
       stillUrl: stillUrl ?? this.stillUrl,
       runtime: runtime ?? this.runtime,
+      source: source ?? this.source,
     );
   }
 
@@ -120,6 +129,7 @@ class TvEpisode {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     return other is TvEpisode &&
+        other.source == source &&
         other.tmdbShowId == tmdbShowId &&
         other.seasonNumber == seasonNumber &&
         other.episodeNumber == episodeNumber;
@@ -127,7 +137,7 @@ class TvEpisode {
 
   @override
   int get hashCode =>
-      Object.hash(tmdbShowId, seasonNumber, episodeNumber);
+      Object.hash(source, tmdbShowId, seasonNumber, episodeNumber);
 
   @override
   String toString() =>

--- a/lib/shared/models/tv_season.dart
+++ b/lib/shared/models/tv_season.dart
@@ -1,10 +1,10 @@
-// Модель сезона сериала из TMDB.
+// TV season model shared by all episode sources.
 
-/// Модель сезона сериала из TMDB API.
-///
-/// Представляет сезон сериала с метаданными.
+import 'data_source.dart';
+
+/// One season of a TV show.
 class TvSeason {
-  /// Создаёт экземпляр [TvSeason].
+  /// Creates a [TvSeason].
   const TvSeason({
     required this.tmdbShowId,
     required this.seasonNumber,
@@ -12,9 +12,10 @@ class TvSeason {
     this.episodeCount,
     this.posterUrl,
     this.airDate,
+    this.source = DataSource.tmdb,
   });
 
-  /// Создаёт [TvSeason] из JSON ответа TMDB API.
+  /// Creates a [TvSeason] from a TMDB API JSON response.
   factory TvSeason.fromJson(Map<String, dynamic> json, {required int showId}) {
     String? posterUrl;
     final String? posterPath = json['poster_path'] as String?;
@@ -32,7 +33,8 @@ class TvSeason {
     );
   }
 
-  /// Создаёт [TvSeason] из записи базы данных.
+  /// Creates a [TvSeason] from a database row. A missing or unknown
+  /// `source` reads as [DataSource.tmdb].
   factory TvSeason.fromDb(Map<String, dynamic> row) {
     return TvSeason(
       tmdbShowId: row['tmdb_show_id'] as int,
@@ -41,28 +43,32 @@ class TvSeason {
       episodeCount: row['episode_count'] as int?,
       posterUrl: row['poster_url'] as String?,
       airDate: row['air_date'] as String?,
+      source: DataSource.fromNameOr(row['source'] as String?, DataSource.tmdb),
     );
   }
 
-  /// ID сериала в TMDB.
+  /// Show id in the [source] provider's namespace.
   final int tmdbShowId;
 
-  /// Номер сезона.
+  /// Season number.
   final int seasonNumber;
 
-  /// Название сезона.
+  /// Season name.
   final String? name;
 
-  /// Количество эпизодов в сезоне.
+  /// Number of episodes in the season.
   final int? episodeCount;
 
-  /// URL постера сезона.
+  /// Season poster URL.
   final String? posterUrl;
 
-  /// Дата выхода сезона (формат: "YYYY-MM-DD").
+  /// Air date ("YYYY-MM-DD").
   final String? airDate;
 
-  /// Преобразует в Map для сохранения в базу данных.
+  /// Provider this season came from.
+  final DataSource source;
+
+  /// Converts to a map for database storage.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'tmdb_show_id': tmdbShowId,
@@ -71,10 +77,11 @@ class TvSeason {
       'episode_count': episodeCount,
       'poster_url': posterUrl,
       'air_date': airDate,
+      'source': source.name,
     };
   }
 
-  /// Создаёт копию с изменёнными полями.
+  /// Returns a copy with the given fields replaced.
   TvSeason copyWith({
     int? tmdbShowId,
     int? seasonNumber,
@@ -82,6 +89,7 @@ class TvSeason {
     int? episodeCount,
     String? posterUrl,
     String? airDate,
+    DataSource? source,
   }) {
     return TvSeason(
       tmdbShowId: tmdbShowId ?? this.tmdbShowId,
@@ -90,6 +98,7 @@ class TvSeason {
       episodeCount: episodeCount ?? this.episodeCount,
       posterUrl: posterUrl ?? this.posterUrl,
       airDate: airDate ?? this.airDate,
+      source: source ?? this.source,
     );
   }
 
@@ -97,12 +106,13 @@ class TvSeason {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     return other is TvSeason &&
+        other.source == source &&
         other.tmdbShowId == tmdbShowId &&
         other.seasonNumber == seasonNumber;
   }
 
   @override
-  int get hashCode => Object.hash(tmdbShowId, seasonNumber);
+  int get hashCode => Object.hash(source, tmdbShowId, seasonNumber);
 
   @override
   String toString() =>

--- a/lib/shared/models/tv_show.dart
+++ b/lib/shared/models/tv_show.dart
@@ -1,12 +1,12 @@
-// Модель сериала из TMDB.
+// TV show model shared by all show sources.
 
 import 'dart:convert';
 
-/// Модель сериала из TMDB API.
-///
-/// Представляет сериал с метаданными из TheMovieDB.
+import 'data_source.dart';
+
+/// A TV show with catalog metadata.
 class TvShow {
-  /// Создаёт экземпляр [TvShow].
+  /// Creates a [TvShow].
   const TvShow({
     required this.tmdbId,
     required this.title,
@@ -22,6 +22,7 @@ class TvShow {
     this.status,
     this.externalUrl,
     this.cachedAt,
+    this.source = DataSource.tmdb,
   });
 
   /// Создаёт [TvShow] из JSON ответа TMDB API.
@@ -81,7 +82,8 @@ class TvShow {
     );
   }
 
-  /// Создаёт [TvShow] из записи базы данных.
+  /// Creates a [TvShow] from a database row. A missing or unknown `source`
+  /// reads as [DataSource.tmdb].
   factory TvShow.fromDb(Map<String, dynamic> row) {
     List<String>? genres;
     if (row['genres'] != null && (row['genres'] as String).isNotEmpty) {
@@ -105,10 +107,11 @@ class TvShow {
       status: row['status'] as String?,
       externalUrl: row['external_url'] as String?,
       cachedAt: row['cached_at'] as int?,
+      source: DataSource.fromNameOr(row['source'] as String?, DataSource.tmdb),
     );
   }
 
-  /// Уникальный идентификатор сериала в TMDB.
+  /// Show id in the [source] provider's namespace.
   final int tmdbId;
 
   /// Название сериала (локализованное).
@@ -150,6 +153,9 @@ class TvShow {
   /// Время кеширования (Unix timestamp).
   final int? cachedAt;
 
+  /// Provider this show came from.
+  final DataSource source;
+
   /// URL маленького постера (w154) для thumbnail-ов.
   String? get posterThumbUrl {
     if (posterUrl == null) return null;
@@ -188,6 +194,7 @@ class TvShow {
       'status': status,
       'external_url': externalUrl,
       'cached_at': cachedAt,
+      'source': source.name,
     };
   }
 
@@ -207,6 +214,7 @@ class TvShow {
     String? status,
     String? externalUrl,
     int? cachedAt,
+    DataSource? source,
   }) {
     return TvShow(
       tmdbId: tmdbId ?? this.tmdbId,
@@ -223,17 +231,20 @@ class TvShow {
       status: status ?? this.status,
       externalUrl: externalUrl ?? this.externalUrl,
       cachedAt: cachedAt ?? this.cachedAt,
+      source: source ?? this.source,
     );
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is TvShow && other.tmdbId == tmdbId;
+    return other is TvShow &&
+        other.source == source &&
+        other.tmdbId == tmdbId;
   }
 
   @override
-  int get hashCode => tmdbId.hashCode;
+  int get hashCode => Object.hash(source, tmdbId);
 
   @override
   String toString() => 'TvShow(tmdbId: $tmdbId, title: $title)';

--- a/test/core/api/episode_source/tmdb_episode_source_test.dart
+++ b/test/core/api/episode_source/tmdb_episode_source_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/episode_source/tmdb_episode_source.dart';
+import 'package:tonkatsu_box/core/api/episode_source/tv_episode_source.dart';
+import 'package:tonkatsu_box/core/api/tmdb_api.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+import 'package:tonkatsu_box/shared/models/tv_season.dart';
+import 'package:tonkatsu_box/shared/models/tv_show.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockTmdbApi mockApi;
+  late TmdbEpisodeSource source;
+
+  setUp(() {
+    mockApi = MockTmdbApi();
+    source = TmdbEpisodeSource(mockApi);
+  });
+
+  group('TmdbEpisodeSource', () {
+    test('source is tmdb', () {
+      expect(source.source, DataSource.tmdb);
+    });
+
+    test('getShow delegates to TmdbApi.getTvShow', () async {
+      const TvShow show = TvShow(tmdbId: 100, title: 'Show');
+      when(() => mockApi.getTvShow(100)).thenAnswer((_) async => show);
+
+      expect(await source.getShow(100), show);
+    });
+
+    test('getSeasons delegates to TmdbApi.getTvSeasons', () async {
+      const List<TvSeason> seasons = <TvSeason>[
+        TvSeason(tmdbShowId: 100, seasonNumber: 1),
+      ];
+      when(() => mockApi.getTvSeasons(100)).thenAnswer((_) async => seasons);
+
+      expect(await source.getSeasons(100), seasons);
+    });
+
+    test('getSeasonEpisodes delegates to TmdbApi.getSeasonEpisodes', () async {
+      const List<TvEpisode> episodes = <TvEpisode>[
+        TvEpisode(
+          tmdbShowId: 100,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+        ),
+      ];
+      when(() => mockApi.getSeasonEpisodes(100, 1))
+          .thenAnswer((_) async => episodes);
+
+      expect(await source.getSeasonEpisodes(100, 1), episodes);
+    });
+  });
+
+  group('tvEpisodeSourceResolverProvider', () {
+    test('resolves every source to an implementation', () {
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          tmdbApiProvider.overrideWithValue(mockApi),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final TvEpisodeSource Function(DataSource) resolve =
+          container.read(tvEpisodeSourceResolverProvider);
+
+      expect(resolve(DataSource.tmdb).source, DataSource.tmdb);
+      for (final DataSource s in DataSource.values) {
+        expect(resolve(s), isA<TvEpisodeSource>());
+      }
+    });
+  });
+}

--- a/test/core/database/dao/collection_dao_covers_test.dart
+++ b/test/core/database/dao/collection_dao_covers_test.dart
@@ -164,4 +164,76 @@ void main() {
       );
     });
   });
+
+  group('CollectionDao.getCollectionCovers — tv show source', () {
+    Future<void> insertTvShow({
+      required int tmdbId,
+      required String source,
+      required String posterUrl,
+    }) async {
+      await db.insert('tv_shows_cache', <String, Object?>{
+        'tmdb_id': tmdbId,
+        'source': source,
+        'title': 'Show $source',
+        'poster_url': posterUrl,
+        'cached_at': 1700000000,
+      });
+    }
+
+    test('should not duplicate a cover when two sources share a show id',
+        () async {
+      await insertTvShow(
+        tmdbId: 700,
+        source: 'tmdb',
+        posterUrl: 'https://x.test/tmdb.jpg',
+      );
+      await insertTvShow(
+        tmdbId: 700,
+        source: 'anilist',
+        posterUrl: 'https://x.test/anilist.jpg',
+      );
+      await db.insert('collection_items', <String, Object?>{
+        'id': 10,
+        'collection_id': 1,
+        'media_type': 'tv_show',
+        'external_id': 700,
+        'source': 'tmdb',
+        'status': 'not_started',
+        'sort_order': 0,
+        'added_at': 1700000000,
+      });
+
+      final List<CoverInfo> covers = await dao.getCollectionCovers(1);
+
+      expect(covers, hasLength(1));
+      expect(covers.first.thumbnailUrl, 'https://x.test/tmdb.jpg');
+    });
+
+    test('should match a NULL item source to the tmdb row', () async {
+      await insertTvShow(
+        tmdbId: 701,
+        source: 'anilist',
+        posterUrl: 'https://x.test/anilist.jpg',
+      );
+      await insertTvShow(
+        tmdbId: 701,
+        source: 'tmdb',
+        posterUrl: 'https://x.test/tmdb.jpg',
+      );
+      await db.insert('collection_items', <String, Object?>{
+        'id': 11,
+        'collection_id': 1,
+        'media_type': 'tv_show',
+        'external_id': 701,
+        'status': 'not_started',
+        'sort_order': 0,
+        'added_at': 1700000000,
+      });
+
+      final List<CoverInfo> covers = await dao.getCollectionCovers(1);
+
+      expect(covers, hasLength(1));
+      expect(covers.first.thumbnailUrl, 'https://x.test/tmdb.jpg');
+    });
+  });
 }

--- a/test/core/database/dao/tv_show_dao_test.dart
+++ b/test/core/database/dao/tv_show_dao_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
@@ -43,8 +44,8 @@ void main() {
         when(
           () => mockDb.query(
             'tv_shows_cache',
-            where: 'tmdb_id = ?',
-            whereArgs: <Object?>[999],
+            where: 'tmdb_id = ? AND source = ?',
+            whereArgs: <Object?>[999, 'tmdb'],
             limit: 1,
           ),
         ).thenAnswer((_) async => <Map<String, dynamic>>[]);
@@ -72,8 +73,8 @@ void main() {
         when(
           () => mockDb.query(
             'tv_shows_cache',
-            where: 'tmdb_id = ?',
-            whereArgs: <Object?>[200],
+            where: 'tmdb_id = ? AND source = ?',
+            whereArgs: <Object?>[200, 'tmdb'],
             limit: 1,
           ),
         ).thenAnswer((_) async => <Map<String, dynamic>>[row]);
@@ -173,8 +174,8 @@ void main() {
         when(
           () => mockDb.query(
             'tv_seasons_cache',
-            where: 'tmdb_show_id = ?',
-            whereArgs: <Object?>[200],
+            where: 'source = ? AND tmdb_show_id = ?',
+            whereArgs: <Object?>['tmdb', 200],
             orderBy: 'season_number ASC',
           ),
         ).thenAnswer(
@@ -182,6 +183,7 @@ void main() {
             <String, dynamic>{
               'tmdb_show_id': 200,
               'season_number': 1,
+              'source': 'tmdb',
               'name': 'Season 1',
               'episode_count': 10,
               'poster_url': null,
@@ -190,7 +192,8 @@ void main() {
           ],
         );
 
-        final List<TvSeason> result = await dao.getTvSeasonsByShowId(200);
+        final List<TvSeason> result =
+            await dao.getTvSeasonsByShowId(DataSource.tmdb, 200);
 
         expect(result.length, 1);
         expect(result.first.seasonNumber, 1);
@@ -240,8 +243,8 @@ void main() {
         when(
           () => mockDb.query(
             'tv_episodes_cache',
-            where: 'tmdb_show_id = ?',
-            whereArgs: <Object?>[200],
+            where: 'source = ? AND tmdb_show_id = ?',
+            whereArgs: <Object?>['tmdb', 200],
             orderBy: 'season_number ASC, episode_number ASC',
           ),
         ).thenAnswer(
@@ -259,7 +262,8 @@ void main() {
           ],
         );
 
-        final List<TvEpisode> result = await dao.getEpisodesByShowId(200);
+        final List<TvEpisode> result =
+            await dao.getEpisodesByShowId(DataSource.tmdb, 200);
 
         expect(result.length, 1);
         expect(result.first.name, 'Pilot');
@@ -271,14 +275,14 @@ void main() {
         when(
           () => mockDb.query(
             'tv_episodes_cache',
-            where: 'tmdb_show_id = ? AND season_number = ?',
-            whereArgs: <Object?>[200, 2],
+            where: 'source = ? AND tmdb_show_id = ? AND season_number = ?',
+            whereArgs: <Object?>['tmdb', 200, 2],
             orderBy: 'episode_number ASC',
           ),
         ).thenAnswer((_) async => <Map<String, dynamic>>[]);
 
         final List<TvEpisode> result =
-            await dao.getEpisodesByShowAndSeason(200, 2);
+            await dao.getEpisodesByShowAndSeason(DataSource.tmdb, 200, 2);
 
         expect(result, isEmpty);
       });
@@ -318,18 +322,18 @@ void main() {
         when(
           () => mockDb.delete(
             'tv_episodes_cache',
-            where: 'tmdb_show_id = ?',
-            whereArgs: <Object?>[200],
+            where: 'source = ? AND tmdb_show_id = ?',
+            whereArgs: <Object?>['tmdb', 200],
           ),
         ).thenAnswer((_) async => 10);
 
-        await dao.clearEpisodesByShow(200);
+        await dao.clearEpisodesByShow(DataSource.tmdb, 200);
 
         verify(
           () => mockDb.delete(
             'tv_episodes_cache',
-            where: 'tmdb_show_id = ?',
-            whereArgs: <Object?>[200],
+            where: 'source = ? AND tmdb_show_id = ?',
+            whereArgs: <Object?>['tmdb', 200],
           ),
         ).called(1);
       });
@@ -343,8 +347,8 @@ void main() {
           () => mockDb.query(
             'watched_episodes',
             columns: <String>['season_number', 'episode_number', 'watched_at'],
-            where: 'collection_id = ? AND show_id = ?',
-            whereArgs: <Object?>[1, 200],
+            where: 'collection_id = ? AND source = ? AND show_id = ?',
+            whereArgs: <Object?>[1, 'tmdb', 200],
           ),
         ).thenAnswer(
           (_) async => <Map<String, dynamic>>[
@@ -362,7 +366,7 @@ void main() {
         );
 
         final Map<(int, int), DateTime?> result =
-            await dao.getWatchedEpisodes(1, 200);
+            await dao.getWatchedEpisodes(1, DataSource.tmdb, 200);
 
         expect(result.length, 2);
         expect(result[(1, 1)], isNotNull);
@@ -376,8 +380,8 @@ void main() {
           () => mockDb.query(
             'watched_episodes',
             columns: <String>['season_number', 'episode_number'],
-            where: 'show_id = ?',
-            whereArgs: <Object?>[200],
+            where: 'source = ? AND show_id = ?',
+            whereArgs: <Object?>['tmdb', 200],
             distinct: true,
           ),
         ).thenAnswer(
@@ -388,7 +392,7 @@ void main() {
         );
 
         final Set<(int, int)> result =
-            await dao.getWatchedEpisodesForShow(200);
+            await dao.getWatchedEpisodesForShow(DataSource.tmdb, 200);
 
         expect(result, <(int, int)>{(1, 1), (2, 3)});
       });
@@ -399,6 +403,7 @@ void main() {
         when(() => mockDb.rawQuery(any())).thenAnswer(
           (_) async => <Map<String, Object?>>[
             <String, Object?>{
+              'source': 'tmdb',
               'show_id': 200,
               'season_number': 1,
               'episode_number': 1,
@@ -422,7 +427,8 @@ void main() {
               conflictAlgorithm: ConflictAlgorithm.ignore,
             )).thenAnswer((_) async => 1);
 
-        await dao.markEpisodeWatchedAt(1, 200, 2, 3, 1705320000000);
+        await dao.markEpisodeWatchedAt(
+            1, DataSource.tmdb, 200, 2, 3, 1705320000000);
 
         final VerificationResult captured = verify(
           () => mockDb.insert(
@@ -450,7 +456,7 @@ void main() {
           ),
         ).thenAnswer((_) async => 1);
 
-        await dao.markEpisodeWatched(1, 200, 1, 3);
+        await dao.markEpisodeWatched(1, DataSource.tmdb, 200, 1, 3);
 
         final VerificationResult captured = verify(
           () => mockDb.insert(
@@ -464,6 +470,7 @@ void main() {
         final Map<String, dynamic> data =
             captured.captured.first as Map<String, dynamic>;
         expect(data['collection_id'], 1);
+        expect(data['source'], 'tmdb');
         expect(data['show_id'], 200);
         expect(data['season_number'], 1);
         expect(data['episode_number'], 3);
@@ -476,20 +483,20 @@ void main() {
         when(
           () => mockDb.delete(
             'watched_episodes',
-            where: 'collection_id = ? AND show_id = ? '
+            where: 'collection_id = ? AND source = ? AND show_id = ? '
                 'AND season_number = ? AND episode_number = ?',
-            whereArgs: <Object?>[1, 200, 1, 3],
+            whereArgs: <Object?>[1, 'tmdb', 200, 1, 3],
           ),
         ).thenAnswer((_) async => 1);
 
-        await dao.markEpisodeUnwatched(1, 200, 1, 3);
+        await dao.markEpisodeUnwatched(1, DataSource.tmdb, 200, 1, 3);
 
         verify(
           () => mockDb.delete(
             'watched_episodes',
-            where: 'collection_id = ? AND show_id = ? '
+            where: 'collection_id = ? AND source = ? AND show_id = ? '
                 'AND season_number = ? AND episode_number = ?',
-            whereArgs: <Object?>[1, 200, 1, 3],
+            whereArgs: <Object?>[1, 'tmdb', 200, 1, 3],
           ),
         ).called(1);
       });
@@ -500,8 +507,8 @@ void main() {
         when(
           () => mockDb.rawQuery(
             'SELECT COUNT(*) as cnt FROM watched_episodes '
-            'WHERE collection_id = ? AND show_id = ?',
-            <Object?>[1, 200],
+            'WHERE collection_id = ? AND source = ? AND show_id = ?',
+            <Object?>[1, 'tmdb', 200],
           ),
         ).thenAnswer(
           (_) async => <Map<String, dynamic>>[
@@ -509,13 +516,16 @@ void main() {
           ],
         );
 
-        expect(await dao.getWatchedEpisodeCount(1, 200), 15);
+        expect(
+          await dao.getWatchedEpisodeCount(1, DataSource.tmdb, 200),
+          15,
+        );
       });
     });
 
     group('markSeasonWatched', () {
       test('skips when episode list is empty', () async {
-        await dao.markSeasonWatched(1, 200, 1, <int>[]);
+        await dao.markSeasonWatched(1, DataSource.tmdb, 200, 1, <int>[]);
 
         verifyNever(() => mockTxn.batch());
       });
@@ -523,7 +533,8 @@ void main() {
       test('batch inserts episodes for season', () async {
         stubTransaction();
 
-        await dao.markSeasonWatched(1, 200, 1, <int>[1, 2, 3]);
+        await dao.markSeasonWatched(
+            1, DataSource.tmdb, 200, 1, <int>[1, 2, 3]);
 
         verify(
           () => mockBatch.insert(
@@ -540,18 +551,20 @@ void main() {
         when(
           () => mockDb.delete(
             'watched_episodes',
-            where: 'collection_id = ? AND show_id = ? AND season_number = ?',
-            whereArgs: <Object?>[1, 200, 2],
+            where: 'collection_id = ? AND source = ? AND show_id = ? '
+                'AND season_number = ?',
+            whereArgs: <Object?>[1, 'tmdb', 200, 2],
           ),
         ).thenAnswer((_) async => 5);
 
-        await dao.unmarkSeasonWatched(1, 200, 2);
+        await dao.unmarkSeasonWatched(1, DataSource.tmdb, 200, 2);
 
         verify(
           () => mockDb.delete(
             'watched_episodes',
-            where: 'collection_id = ? AND show_id = ? AND season_number = ?',
-            whereArgs: <Object?>[1, 200, 2],
+            where: 'collection_id = ? AND source = ? AND show_id = ? '
+                'AND season_number = ?',
+            whereArgs: <Object?>[1, 'tmdb', 200, 2],
           ),
         ).called(1);
       });

--- a/test/core/database/migrations/migration_v57_test.dart
+++ b/test/core/database/migrations/migration_v57_test.dart
@@ -1,0 +1,338 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_v57.dart';
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  // Tables as they were before this migration: UNIQUE keys without `source`.
+  Future<Database> openOldDb() async {
+    return factory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: 56,
+        onCreate: (Database db, int _) async {
+          await db.execute('''
+            CREATE TABLE collections (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL
+            )
+          ''');
+          await db.execute('''
+            CREATE TABLE tv_shows_cache (
+              tmdb_id INTEGER PRIMARY KEY,
+              title TEXT NOT NULL,
+              original_title TEXT,
+              poster_url TEXT,
+              backdrop_url TEXT,
+              overview TEXT,
+              genres TEXT,
+              first_air_year INTEGER,
+              total_seasons INTEGER,
+              total_episodes INTEGER,
+              rating REAL,
+              status TEXT,
+              external_url TEXT,
+              cached_at INTEGER
+            )
+          ''');
+          await db.execute('''
+            CREATE TABLE collection_items (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              collection_id INTEGER,
+              media_type TEXT NOT NULL,
+              external_id INTEGER NOT NULL,
+              source TEXT
+            )
+          ''');
+          await db.execute('''
+            CREATE UNIQUE INDEX idx_ci_coll_other
+            ON collection_items(collection_id, media_type, external_id)
+            WHERE collection_id IS NOT NULL
+              AND media_type NOT IN ('game', 'manga')
+          ''');
+          await db.execute('''
+            CREATE UNIQUE INDEX idx_ci_uncat_other
+            ON collection_items(media_type, external_id)
+            WHERE collection_id IS NULL
+              AND media_type NOT IN ('game', 'manga')
+          ''');
+          await db.execute('''
+            CREATE TABLE mood_grid_cells (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              media_type TEXT,
+              external_id INTEGER,
+              source TEXT
+            )
+          ''');
+          await db.execute('''
+            CREATE TABLE tv_seasons_cache (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              tmdb_show_id INTEGER NOT NULL,
+              season_number INTEGER NOT NULL,
+              name TEXT,
+              episode_count INTEGER,
+              poster_url TEXT,
+              air_date TEXT,
+              UNIQUE(tmdb_show_id, season_number)
+            )
+          ''');
+          await db.execute('''
+            CREATE TABLE tv_episodes_cache (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              tmdb_show_id INTEGER NOT NULL,
+              season_number INTEGER NOT NULL,
+              episode_number INTEGER NOT NULL,
+              name TEXT,
+              overview TEXT,
+              air_date TEXT,
+              still_url TEXT,
+              runtime INTEGER,
+              cached_at INTEGER,
+              UNIQUE(tmdb_show_id, season_number, episode_number)
+            )
+          ''');
+          await db.execute('''
+            CREATE TABLE watched_episodes (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              collection_id INTEGER NOT NULL,
+              show_id INTEGER NOT NULL,
+              season_number INTEGER NOT NULL,
+              episode_number INTEGER NOT NULL,
+              watched_at INTEGER,
+              FOREIGN KEY (collection_id) REFERENCES collections(id)
+                ON DELETE CASCADE,
+              UNIQUE(collection_id, show_id, season_number, episode_number)
+            )
+          ''');
+        },
+      ),
+    );
+  }
+
+  group('MigrationV57', () {
+    late Database db;
+
+    setUp(() async {
+      db = await openOldDb();
+      await db.insert('collections', <String, Object?>{'id': 1, 'name': 'TV'});
+      await db.insert('tv_shows_cache', <String, Object?>{
+        'tmdb_id': 100,
+        'title': 'Show 100',
+        'total_seasons': 2,
+      });
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'tv_show',
+        'external_id': 100,
+      });
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'movie',
+        'external_id': 42,
+      });
+      await db.insert('mood_grid_cells', <String, Object?>{
+        'media_type': 'tv_show',
+        'external_id': 100,
+      });
+      await db.insert('tv_seasons_cache', <String, Object?>{
+        'tmdb_show_id': 100,
+        'season_number': 1,
+        'name': 'Season 1',
+        'episode_count': 10,
+      });
+      await db.insert('tv_episodes_cache', <String, Object?>{
+        'tmdb_show_id': 100,
+        'season_number': 1,
+        'episode_number': 3,
+        'name': 'Pilot x3',
+        'cached_at': 1000,
+      });
+      await db.insert('watched_episodes', <String, Object?>{
+        'collection_id': 1,
+        'show_id': 100,
+        'season_number': 1,
+        'episode_number': 3,
+        'watched_at': 2000,
+      });
+      await MigrationV57().migrate(db);
+    });
+
+    tearDown(() async => db.close());
+
+    test('existing rows backfilled as source=tmdb', () async {
+      for (final String table in <String>[
+        'tv_seasons_cache',
+        'tv_episodes_cache',
+        'watched_episodes',
+      ]) {
+        final List<Map<String, Object?>> rows = await db.query(table);
+        expect(rows, hasLength(1), reason: table);
+        expect(rows.first['source'], 'tmdb', reason: table);
+      }
+    });
+
+    test('row data survives the rebuild', () async {
+      final Map<String, Object?> season =
+          (await db.query('tv_seasons_cache')).first;
+      expect(season['name'], 'Season 1');
+      expect(season['episode_count'], 10);
+
+      final Map<String, Object?> episode =
+          (await db.query('tv_episodes_cache')).first;
+      expect(episode['name'], 'Pilot x3');
+      expect(episode['cached_at'], 1000);
+
+      final Map<String, Object?> watched =
+          (await db.query('watched_episodes')).first;
+      expect(watched['collection_id'], 1);
+      expect(watched['watched_at'], 2000);
+    });
+
+    test('same show id from another source coexists in every table', () async {
+      await db.insert('tv_seasons_cache', <String, Object?>{
+        'tmdb_show_id': 100,
+        'season_number': 1,
+        'source': 'tvmaze',
+      });
+      await db.insert('tv_episodes_cache', <String, Object?>{
+        'tmdb_show_id': 100,
+        'season_number': 1,
+        'episode_number': 3,
+        'source': 'tvmaze',
+      });
+      await db.insert('watched_episodes', <String, Object?>{
+        'collection_id': 1,
+        'show_id': 100,
+        'season_number': 1,
+        'episode_number': 3,
+        'source': 'tvmaze',
+      });
+
+      for (final String table in <String>[
+        'tv_seasons_cache',
+        'tv_episodes_cache',
+        'watched_episodes',
+      ]) {
+        final List<Map<String, Object?>> rows = await db.query(table);
+        expect(rows, hasLength(2), reason: table);
+      }
+    });
+
+    test('UNIQUE still rejects a duplicate within one source', () async {
+      await expectLater(
+        db.insert('tv_episodes_cache', <String, Object?>{
+          'tmdb_show_id': 100,
+          'season_number': 1,
+          'episode_number': 3,
+          'source': 'tmdb',
+        }),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('source defaults to tmdb for inserts without the column', () async {
+      await db.insert('tv_episodes_cache', <String, Object?>{
+        'tmdb_show_id': 200,
+        'season_number': 1,
+        'episode_number': 1,
+      });
+      final List<Map<String, Object?>> rows = await db.query(
+        'tv_episodes_cache',
+        where: 'tmdb_show_id = ?',
+        whereArgs: <Object?>[200],
+      );
+      expect(rows.first['source'], 'tmdb');
+    });
+
+    test('watched_episodes keeps the ON DELETE CASCADE to collections',
+        () async {
+      await db.execute('PRAGMA foreign_keys = ON');
+      await db
+          .delete('collections', where: 'id = ?', whereArgs: <Object?>[1]);
+      final List<Map<String, Object?>> rows =
+          await db.query('watched_episodes');
+      expect(rows, isEmpty);
+    });
+
+    test('tv_shows_cache keeps existing rows as source=tmdb', () async {
+      final List<Map<String, Object?>> rows = await db.query(
+        'tv_shows_cache',
+        where: 'tmdb_id = ?',
+        whereArgs: <Object?>[100],
+      );
+      expect(rows, hasLength(1));
+      expect(rows.first['source'], 'tmdb');
+      expect(rows.first['title'], 'Show 100');
+      expect(rows.first['total_seasons'], 2);
+    });
+
+    test('tv_shows_cache allows same id from two sources (composite PK)',
+        () async {
+      await db.insert('tv_shows_cache', <String, Object?>{
+        'tmdb_id': 100,
+        'source': 'tvmaze',
+        'title': 'Show 100 (other)',
+      });
+      final List<Map<String, Object?>> rows = await db.query(
+        'tv_shows_cache',
+        where: 'tmdb_id = ?',
+        whereArgs: <Object?>[100],
+      );
+      expect(rows, hasLength(2));
+    });
+
+    test('collection_items.source backfilled for tv_show only', () async {
+      final List<Map<String, Object?>> tv = await db.query(
+        'collection_items',
+        where: 'media_type = ?',
+        whereArgs: <Object?>['tv_show'],
+      );
+      expect(tv.first['source'], 'tmdb');
+      final List<Map<String, Object?>> movie = await db.query(
+        'collection_items',
+        where: 'media_type = ?',
+        whereArgs: <Object?>['movie'],
+      );
+      expect(movie.first['source'], isNull);
+    });
+
+    test('collection_items tv unique index includes source', () async {
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'tv_show',
+        'external_id': 100,
+        'source': 'tvmaze',
+      });
+      final List<Map<String, Object?>> rows = await db.query(
+        'collection_items',
+        where: 'media_type = ? AND external_id = ?',
+        whereArgs: <Object?>['tv_show', 100],
+      );
+      expect(rows, hasLength(2));
+    });
+
+    test('collection_items tv duplicate within one source is rejected',
+        () async {
+      await expectLater(
+        db.insert('collection_items', <String, Object?>{
+          'collection_id': 1,
+          'media_type': 'tv_show',
+          'external_id': 100,
+          'source': 'tmdb',
+        }),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('mood_grid_cells.source backfilled for tv_show', () async {
+      final List<Map<String, Object?>> cells = await db.query(
+        'mood_grid_cells',
+        where: 'media_type = ?',
+        whereArgs: <Object?>['tv_show'],
+      );
+      expect(cells.first['source'], 'tmdb');
+    });
+  });
+}

--- a/test/core/import/sources/trakt/trakt_import_service_test.dart
+++ b/test/core/import/sources/trakt/trakt_import_service_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/api/tmdb_api.dart';
 import 'package:tonkatsu_box/core/services/import_service.dart';
 import 'package:tonkatsu_box/core/import/sources/trakt/trakt_import_service.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
@@ -472,7 +473,7 @@ void main() {
 
         when(() => mockMovieDao.upsertMovie(any())).thenAnswer((_) async {});
         when(() => mockTvShowDao.upsertTvShow(any())).thenAnswer((_) async {});
-        when(() => mockTvShowDao.markEpisodeWatched(any(), any(), any(), any()))
+        when(() => mockTvShowDao.markEpisodeWatched(any(), any(), any(), any(), any()))
             .thenAnswer((_) async {});
 
         when(() => mockWishlist.getAll(
@@ -1030,7 +1031,7 @@ void main() {
         await sut.import(TraktImportOptions(zipPath: zipPath));
 
         verify(() =>
-                mockTvShowDao.markEpisodeWatched(any(), 200, any(), any()))
+                mockTvShowDao.markEpisodeWatched(any(), any(), 200, any(), any()))
             .called(4);
       });
 
@@ -1532,7 +1533,7 @@ void main() {
         await sut.import(TraktImportOptions(zipPath: zipPath));
 
         verifyNever(
-            () => mockTvShowDao.markEpisodeWatched(any(), any(), any(), any()));
+            () => mockTvShowDao.markEpisodeWatched(any(), any(), any(), any(), any()));
       });
 
       test('should skip rating без TMDB ID', () async {
@@ -1792,7 +1793,7 @@ void main() {
         );
 
         expect(result.success, isTrue);
-        verify(() => mockTvShowDao.markEpisodeWatched(1, 200, 1, 1)).called(1);
+        verify(() => mockTvShowDao.markEpisodeWatched(1, DataSource.tmdb, 200, 1, 1)).called(1);
       });
 
       test('должен считать completedAt для show status == completed',

--- a/test/core/services/backup_service_test.dart
+++ b/test/core/services/backup_service_test.dart
@@ -300,6 +300,7 @@ void main() {
       when(() => collDao.findAllCollectionItems(
             mediaType: MediaType.tvShow,
             externalId: 200,
+            source: DataSource.tmdb,
           )).thenAnswer((_) async => <CollectionItem>[
             createTestCollectionItem(
               id: 1,
@@ -311,8 +312,10 @@ void main() {
       when(() => collDao.findAllCollectionItems(
             mediaType: MediaType.animation,
             externalId: 200,
+            source: DataSource.tmdb,
           )).thenAnswer((_) async => <CollectionItem>[]);
       when(() => tvDao.markEpisodeWatchedAt(
+            any(),
             any(),
             any(),
             any(),
@@ -329,7 +332,8 @@ void main() {
 
       await makeService().restoreFromBackup(zipPath: path);
 
-      verify(() => tvDao.markEpisodeWatchedAt(7, 200, 1, 4, 1705320000000))
+      verify(() => tvDao.markEpisodeWatchedAt(
+              7, DataSource.tmdb, 200, 1, 4, 1705320000000))
           .called(1);
     });
 
@@ -342,6 +346,7 @@ void main() {
       when(() => collDao.findAllCollectionItems(
             mediaType: MediaType.tvShow,
             externalId: 200,
+            source: DataSource.tmdb,
           )).thenAnswer((_) async => <CollectionItem>[
             createTestCollectionItem(
               id: 1,
@@ -353,8 +358,10 @@ void main() {
       when(() => collDao.findAllCollectionItems(
             mediaType: MediaType.animation,
             externalId: 200,
+            source: DataSource.tmdb,
           )).thenAnswer((_) async => <CollectionItem>[]);
       when(() => tvDao.markEpisodeWatchedAt(
+            any(),
             any(),
             any(),
             any(),
@@ -376,8 +383,10 @@ void main() {
       verify(() => collDao.findAllCollectionItems(
             mediaType: MediaType.tvShow,
             externalId: 200,
+            source: DataSource.tmdb,
           )).called(1);
-      verify(() => tvDao.markEpisodeWatchedAt(any(), any(), any(), any(), any()))
+      verify(() => tvDao.markEpisodeWatchedAt(
+              any(), any(), any(), any(), any(), any()))
           .called(2);
     });
   });

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/services/export_service.dart';
 import 'package:tonkatsu_box/core/services/image_cache_service.dart';
 import 'package:tonkatsu_box/core/services/xcoll_file.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/canvas_connection.dart';
 import 'package:tonkatsu_box/shared/models/canvas_item.dart';
 import 'package:tonkatsu_box/shared/models/canvas_viewport.dart';
@@ -1412,7 +1413,7 @@ void main() {
             .thenAnswer((_) async => <CanvasItem>[]);
         when(() => mockImageCache.readImageBytes(any(), any()))
             .thenAnswer((_) async => null);
-        when(() => mockTvShowDao.getEpisodesByShowId(any()))
+        when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockDatabase.tierListDao).thenReturn(mockTierListDao);
         when(() => mockTierListDao.getTierListsByCollection(any()))
@@ -1440,7 +1441,7 @@ void main() {
           ),
         ];
 
-        when(() => mockTvShowDao.getTvSeasonsByShowId(1399))
+        when(() => mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, 1399))
             .thenAnswer((_) async => testSeasons);
 
         final ExportService sutMedia = ExportService(
@@ -1478,7 +1479,7 @@ void main() {
       });
 
       test('не должен включить tv_seasons когда сезонов нет', () async {
-        when(() => mockTvShowDao.getTvSeasonsByShowId(any()))
+        when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
             .thenAnswer((_) async => <TvSeason>[]);
 
         final ExportService sutMedia = ExportService(
@@ -1516,7 +1517,7 @@ void main() {
           ),
         ];
 
-        when(() => mockTvShowDao.getTvSeasonsByShowId(999))
+        when(() => mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, 999))
             .thenAnswer((_) async => testSeasons);
 
         final ExportService sutMedia = ExportService(
@@ -1574,7 +1575,7 @@ void main() {
             await sutMedia.createFullExport(collection, items, 1);
 
         expect(xcoll.media.containsKey('tv_seasons'), isFalse);
-        verifyNever(() => mockTvShowDao.getTvSeasonsByShowId(any()));
+        verifyNever(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()));
       });
 
       test('без database should skip tv_seasons', () async {
@@ -1607,7 +1608,7 @@ void main() {
           TvSeason(tmdbShowId: 1399, seasonNumber: 1, name: 'S1'),
         ];
 
-        when(() => mockTvShowDao.getTvSeasonsByShowId(1399))
+        when(() => mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, 1399))
             .thenAnswer((_) async => testSeasons);
 
         final ExportService sutMedia = ExportService(
@@ -1639,7 +1640,7 @@ void main() {
         final XcollFile xcoll =
             await sutMedia.createFullExport(collection, items, 1);
 
-        verify(() => mockTvShowDao.getTvSeasonsByShowId(1399)).called(1);
+        verify(() => mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, 1399)).called(1);
         final List<dynamic> seasons =
             xcoll.media['tv_seasons'] as List<dynamic>;
         expect(seasons.length, equals(1));
@@ -1673,9 +1674,9 @@ void main() {
             .thenAnswer((_) async => <CanvasItem>[]);
         when(() => mockImageCache.readImageBytes(any(), any()))
             .thenAnswer((_) async => null);
-        when(() => mockTvShowDao.getTvSeasonsByShowId(any()))
+        when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
             .thenAnswer((_) async => <TvSeason>[]);
-        when(() => mockTvShowDao.getEpisodesByShowId(any()))
+        when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockDatabase.tierListDao).thenReturn(mockTierListDao);
         when(() => mockTierListDao.getTierListsByCollection(any()))
@@ -1706,7 +1707,7 @@ void main() {
           ),
         ];
 
-        when(() => mockTvShowDao.getEpisodesByShowId(1399))
+        when(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, 1399))
             .thenAnswer((_) async => testEpisodes);
 
         final ExportService sut = ExportService(
@@ -1779,7 +1780,7 @@ void main() {
           ),
         ];
 
-        when(() => mockTvShowDao.getEpisodesByShowId(1399))
+        when(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, 1399))
             .thenAnswer((_) async => testEpisodes);
 
         final ExportService sut = ExportService(
@@ -1811,7 +1812,7 @@ void main() {
         final XcollFile xcoll =
             await sut.createFullExport(collection, items, 1);
 
-        verify(() => mockTvShowDao.getEpisodesByShowId(1399)).called(1);
+        verify(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, 1399)).called(1);
         expect(xcoll.media.containsKey('tv_episodes'), isTrue);
       });
     });
@@ -2036,9 +2037,9 @@ void main() {
             .thenAnswer((_) async => <CanvasItem>[]);
         when(() => mockImageCache.readImageBytes(any(), any()))
             .thenAnswer((_) async => null);
-        when(() => mockTvShowDao.getTvSeasonsByShowId(any()))
+        when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
             .thenAnswer((_) async => <TvSeason>[]);
-        when(() => mockTvShowDao.getEpisodesByShowId(any()))
+        when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTierListDao.getTierListsByCollection(any()))
             .thenAnswer((_) async => <TierList>[]);

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
 import 'package:tonkatsu_box/features/collections/providers/episode_tracker_provider.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
@@ -73,9 +74,10 @@ class TrackingCollectionItemsNotifier extends CollectionItemsNotifier {
 const int testCollectionId = 1;
 const int testShowId = 100;
 
-const ({int collectionId, int showId}) testArg = (
+const ({int collectionId, int showId, DataSource source}) testArg = (
   collectionId: testCollectionId,
   showId: testShowId,
+  source: DataSource.tmdb,
 );
 
 const TvEpisode testEpisode1 = TvEpisode(
@@ -149,13 +151,15 @@ void main() {
   late MockTvShowDao mockTvShowDao;
   late MockTmdbApi mockTmdbApi;
 
+  setUpAll(registerAllFallbacks);
+
   setUp(() {
     mockDb = MockDatabaseService();
     mockTvShowDao = MockTvShowDao();
     when(() => mockDb.tvShowDao).thenReturn(mockTvShowDao);
     // Eager cache load on build; default to no cached episodes so tests that
     // don't care about it are unaffected.
-    when(() => mockTvShowDao.getEpisodesByShowId(any()))
+    when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
         .thenAnswer((_) async => <TvEpisode>[]);
     mockTmdbApi = MockTmdbApi();
     when(() => mockTmdbApi.getTvShow(any()))
@@ -357,7 +361,7 @@ void main() {
   group('EpisodeTrackerNotifier', () {
     group('build', () {
       test('должен инициализироваться с пустым состоянием', () {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
 
         final ProviderContainer container = createContainer();
@@ -376,7 +380,7 @@ void main() {
           (1, 2): null,
           (2, 1): null,
         };
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
 
         final ProviderContainer container = createContainer();
@@ -388,15 +392,15 @@ void main() {
             container.read(episodeTrackerNotifierProvider(testArg));
 
         expect(state.watchedEpisodes, watchedEpisodes);
-        verify(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        verify(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .called(1);
       });
 
       test('should eagerly load cached episodes grouped by season on build',
           () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowId(testShowId)).thenAnswer(
+        when(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, testShowId)).thenAnswer(
           (_) async => <TvEpisode>[
             testEpisode1,
             testEpisode2,
@@ -414,12 +418,12 @@ void main() {
 
         expect(state.episodesBySeason[1], hasLength(2));
         expect(state.episodesBySeason[2], hasLength(1));
-        verify(() => mockTvShowDao.getEpisodesByShowId(testShowId)).called(1);
+        verify(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, testShowId)).called(1);
       });
 
       test('should handle ошибку загрузки просмотренных эпизодов',
           () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenThrow(Exception('Database error'));
 
         final ProviderContainer container = createContainer();
@@ -437,14 +441,15 @@ void main() {
 
     group('loadSeason', () {
       test('должен загружать эпизоды из кеша БД', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> cachedEpisodes = <TvEpisode>[
           testEpisode1,
           testEpisode2,
           testEpisode3,
         ];
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => cachedEpisodes);
 
         final ProviderContainer container = createContainer();
@@ -461,15 +466,17 @@ void main() {
         expect(state.episodesBySeason[1], cachedEpisodes);
         expect(state.loadingSeasons[1], false);
         expect(state.error, isNull);
-        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .called(1);
         verifyNever(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1));
       });
 
       test('должен загружать эпизоды из API если кеш пуст', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         final List<TvEpisode> apiEpisodes = <TvEpisode>[
           testEpisode1,
@@ -495,16 +502,18 @@ void main() {
         expect(state.episodesBySeason[1], apiEpisodes);
         expect(state.loadingSeasons[1], false);
         expect(state.error, isNull);
-        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .called(1);
         verify(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1)).called(1);
         verify(() => mockTvShowDao.upsertEpisodes(apiEpisodes)).called(1);
       });
 
       test('должен кешировать результаты API в БД', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         final List<TvEpisode> apiEpisodes = <TvEpisode>[
           testEpisode1,
@@ -527,9 +536,10 @@ void main() {
       });
 
       test('не должен кешировать пустой список из API', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
@@ -550,9 +560,10 @@ void main() {
       });
 
       test('should handle ошибку загрузки из API', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenThrow(Exception('API error'));
@@ -575,10 +586,11 @@ void main() {
       });
 
       test('не должен загружать уже загруженный сезон', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> cachedEpisodes = <TvEpisode>[testEpisode1];
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => cachedEpisodes);
 
         final ProviderContainer container = createContainer();
@@ -590,14 +602,16 @@ void main() {
         await notifier.loadSeason(1);
         await notifier.loadSeason(1);
 
-        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .called(1);
       });
 
       test('не должен загружать сезон, который уже загружается', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async {
           // Simulate slow load to exercise the in-flight guard.
           await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -615,14 +629,16 @@ void main() {
 
         await Future.wait(<Future<void>>[load1, load2]);
 
-        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        verify(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .called(1);
       });
 
       test('should set loading flag во время загрузки', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async {
           await Future<void>.delayed(const Duration(milliseconds: 50));
           return <TvEpisode>[testEpisode1];
@@ -650,10 +666,10 @@ void main() {
 
     group('toggleEpisode', () {
       test('должен отмечать эпизод как просмотренный', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container = createContainer();
@@ -669,16 +685,16 @@ void main() {
 
         expect(state.isEpisodeWatched(1, 1), true);
         verify(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .called(1);
       });
 
       test('должен снимать отметку просмотра с эпизода', () async {
         final Map<(int, int), DateTime?> watchedEpisodes = <(int, int), DateTime?>{(1, 1): null};
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
         when(
-          () => mockTvShowDao.markEpisodeUnwatched(testCollectionId, testShowId, 1, 1),
+          () => mockTvShowDao.markEpisodeUnwatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1),
         ).thenAnswer((_) async {});
 
         final ProviderContainer container = createContainer();
@@ -694,18 +710,18 @@ void main() {
 
         expect(state.isEpisodeWatched(1, 1), false);
         verify(
-          () => mockTvShowDao.markEpisodeUnwatched(testCollectionId, testShowId, 1, 1),
+          () => mockTvShowDao.markEpisodeUnwatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1),
         ).called(1);
       });
 
       test('should update состояние после отметки просмотра', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 2))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 2))
             .thenAnswer((_) async {});
 
         final ProviderContainer container = createContainer();
@@ -728,10 +744,11 @@ void main() {
 
     group('refreshSeason', () {
       test('должен принудительно загружать эпизоды из API', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> cachedEpisodes = <TvEpisode>[testEpisode1];
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => cachedEpisodes);
         final List<TvEpisode> apiEpisodes = <TvEpisode>[
           testEpisode1,
@@ -763,7 +780,7 @@ void main() {
 
       test('should update эпизоды даже если сезон ещё не загружен',
           () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         final List<TvEpisode> apiEpisodes = <TvEpisode>[testEpisode1];
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
@@ -786,7 +803,7 @@ void main() {
       });
 
       test('should handle ошибку API при обновлении', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenThrow(Exception('API unavailable'));
@@ -806,7 +823,7 @@ void main() {
       });
 
       test('не должен кешировать пустой результат API', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
@@ -825,15 +842,17 @@ void main() {
 
     group('toggleSeason', () {
       test('должен отмечать все эпизоды сезона как просмотренные', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer(
           (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
         );
         when(
           () => mockTvShowDao.markSeasonWatched(
             testCollectionId,
+            DataSource.tmdb,
             testShowId,
             1,
             <int>[1, 2, 3],
@@ -859,6 +878,7 @@ void main() {
         verify(
           () => mockTvShowDao.markSeasonWatched(
             testCollectionId,
+            DataSource.tmdb,
             testShowId,
             1,
             <int>[1, 2, 3],
@@ -873,13 +893,14 @@ void main() {
           (1, 2): null,
           (1, 3): null,
         };
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer(
           (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
         );
-        when(() => mockTvShowDao.unmarkSeasonWatched(testCollectionId, testShowId, 1))
+        when(() => mockTvShowDao.unmarkSeasonWatched(testCollectionId, DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container = createContainer();
@@ -898,22 +919,24 @@ void main() {
         expect(state.isEpisodeWatched(1, 2), false);
         expect(state.isEpisodeWatched(1, 3), false);
         expect(state.watchedCountForSeason(1), 0);
-        verify(() => mockTvShowDao.unmarkSeasonWatched(testCollectionId, testShowId, 1))
+        verify(() => mockTvShowDao.unmarkSeasonWatched(testCollectionId, DataSource.tmdb, testShowId, 1))
             .called(1);
       });
 
       test('должен отмечать частично просмотренный сезон как полностью просмотренный',
           () async {
         final Map<(int, int), DateTime?> watchedEpisodes = <(int, int), DateTime?>{(1, 1): null};
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => watchedEpisodes);
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer(
           (_) async => <TvEpisode>[testEpisode1, testEpisode2, testEpisode3],
         );
         when(
           () => mockTvShowDao.markSeasonWatched(
             testCollectionId,
+            DataSource.tmdb,
             testShowId,
             1,
             <int>[1, 2, 3],
@@ -936,6 +959,7 @@ void main() {
         verify(
           () => mockTvShowDao.markSeasonWatched(
             testCollectionId,
+            DataSource.tmdb,
             testShowId,
             1,
             <int>[1, 2, 3],
@@ -944,7 +968,7 @@ void main() {
       });
 
       test('не должен делать ничего если сезон не загружен', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
 
         final ProviderContainer container = createContainer();
@@ -956,15 +980,16 @@ void main() {
         await notifier.toggleSeason(1);
 
         verifyNever(
-          () => mockTvShowDao.markSeasonWatched(any(), any(), any(), any()),
+          () => mockTvShowDao.markSeasonWatched(any(), any(), any(), any(), any()),
         );
-        verifyNever(() => mockTvShowDao.unmarkSeasonWatched(any(), any(), any()));
+        verifyNever(() => mockTvShowDao.unmarkSeasonWatched(any(), any(), any(), any()));
       });
 
       test('не должен делать ничего если сезон пустой', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
         when(() => mockTmdbApi.getSeasonEpisodes(testShowId, 1))
             .thenAnswer((_) async => <TvEpisode>[]);
@@ -979,9 +1004,9 @@ void main() {
         await notifier.toggleSeason(1);
 
         verifyNever(
-          () => mockTvShowDao.markSeasonWatched(any(), any(), any(), any()),
+          () => mockTvShowDao.markSeasonWatched(any(), any(), any(), any(), any()),
         );
-        verifyNever(() => mockTvShowDao.unmarkSeasonWatched(any(), any(), any()));
+        verifyNever(() => mockTvShowDao.unmarkSeasonWatched(any(), any(), any(), any()));
       });
     });
 
@@ -1033,10 +1058,10 @@ void main() {
       test('должен перевести в inProgress при первом отмеченном эпизоде',
           () async {
         final CollectionItem item = createTvItem();
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1057,10 +1082,10 @@ void main() {
       test('должен перевести в inProgress при статусе planned', () async {
         final CollectionItem item =
             createTvItem(status: ItemStatus.planned);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1080,12 +1105,12 @@ void main() {
           () async {
         final CollectionItem item =
             createTvItem(totalEpisodes: 2, status: ItemStatus.notStarted);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{
                   (1, 1): DateTime(2024),
                 });
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 2))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 2))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1105,10 +1130,10 @@ void main() {
           () async {
         final CollectionItem item =
             createTvItem(totalEpisodes: 0, status: ItemStatus.notStarted);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1132,13 +1157,15 @@ void main() {
           totalSeasons: 1,
           status: ItemStatus.notStarted,
         );
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async =>
                 <TvEpisode>[testEpisode1, testEpisode2, testEpisode3]);
         when(() => mockTvShowDao.markSeasonWatched(
               testCollectionId,
+              DataSource.tmdb,
               testShowId,
               1,
               <int>[1, 2, 3],
@@ -1172,12 +1199,12 @@ void main() {
           () async {
         final CollectionItem item =
             createTvItem(totalEpisodes: 2, status: ItemStatus.notStarted);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{
                   (0, 1): DateTime(2024),
                 });
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1197,10 +1224,10 @@ void main() {
       test('отметка только спецвыпуска не должна включать inProgress',
           () async {
         final CollectionItem item = createTvItem();
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 0, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 0, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1222,15 +1249,18 @@ void main() {
           totalSeasons: 2,
           status: ItemStatus.notStarted,
         );
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 0))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 0))
             .thenAnswer((_) async => <TvEpisode>[testEpisodeSpecial]);
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async =>
                 <TvEpisode>[testEpisode1, testEpisode2, testEpisode3]);
         when(() => mockTvShowDao.markSeasonWatched(
               testCollectionId,
+              DataSource.tmdb,
               testShowId,
               1,
               <int>[1, 2, 3],
@@ -1258,12 +1288,12 @@ void main() {
           () async {
         final CollectionItem item =
             createTvItem(status: ItemStatus.inProgress);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{
                   (1, 1): DateTime(2024),
                 });
         when(() => mockTvShowDao.markEpisodeUnwatched(
-                testCollectionId, testShowId, 1, 1))
+                testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1283,14 +1313,14 @@ void main() {
           () async {
         final CollectionItem item =
             createTvItem(totalEpisodes: 3, status: ItemStatus.completed);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{
                   (1, 1): DateTime(2024),
                   (1, 2): DateTime(2024),
                   (1, 3): DateTime(2024),
                 });
         when(() => mockTvShowDao.markEpisodeUnwatched(
-                testCollectionId, testShowId, 1, 3))
+                testCollectionId, DataSource.tmdb, testShowId, 1, 3))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1310,10 +1340,10 @@ void main() {
         final CollectionItem item = createTvItem(
           mediaType: MediaType.animation,
         );
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1332,12 +1362,12 @@ void main() {
       test('не должен менять статус dropped при отметке эпизода', () async {
         final CollectionItem item =
             createTvItem(status: ItemStatus.dropped);
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{
                   (1, 1): DateTime(2024),
                 });
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 2))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 2))
             .thenAnswer((_) async {});
 
         final ProviderContainer container =
@@ -1353,12 +1383,14 @@ void main() {
       });
 
       test('не должен менять статус если collectionId == null', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(any(), testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(any(), any(), testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
 
-        const ({int? collectionId, int showId}) uncatArg = (
+        const ({int? collectionId, int showId, DataSource source}) uncatArg =
+            (
           collectionId: null,
           showId: testShowId,
+          source: DataSource.tmdb,
         );
         final ProviderContainer container =
             createTrackingContainer(<CollectionItem>[]);
@@ -1375,24 +1407,28 @@ void main() {
         final CollectionItem item =
             createTvItem(totalEpisodes: 5, status: ItemStatus.notStarted);
 
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
 
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async =>
                 <TvEpisode>[testEpisode1, testEpisode2, testEpisode3]);
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 2))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 2))
             .thenAnswer(
                 (_) async => <TvEpisode>[testEpisode2s1, testEpisode2s2]);
 
         when(() => mockTvShowDao.markSeasonWatched(
               testCollectionId,
+              DataSource.tmdb,
               testShowId,
               1,
               <int>[1, 2, 3],
             )).thenAnswer((_) async {});
         when(() => mockTvShowDao.markSeasonWatched(
               testCollectionId,
+              DataSource.tmdb,
               testShowId,
               2,
               <int>[1, 2],
@@ -1439,13 +1475,15 @@ void main() {
         final CollectionItem item =
             createTvItem(totalEpisodes: 3, status: ItemStatus.notStarted);
 
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
-        when(() => mockTvShowDao.getEpisodesByShowAndSeason(testShowId, 1))
+        when(() => mockTvShowDao.getEpisodesByShowAndSeason(
+                DataSource.tmdb, testShowId, 1))
             .thenAnswer((_) async =>
                 <TvEpisode>[testEpisode1, testEpisode2, testEpisode3]);
         when(() => mockTvShowDao.markSeasonWatched(
               testCollectionId,
+              DataSource.tmdb,
               testShowId,
               1,
               <int>[1, 2, 3],
@@ -1479,10 +1517,10 @@ void main() {
       });
 
       test('не должен менять статус если items == null', () async {
-        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+        when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() =>
-                mockTvShowDao.markEpisodeWatched(testCollectionId, testShowId, 1, 1))
+                mockTvShowDao.markEpisodeWatched(testCollectionId, DataSource.tmdb, testShowId, 1, 1))
             .thenAnswer((_) async {});
 
         final ProviderContainer container = createContainer();

--- a/test/features/collections/screens/item_detail_screen_test.dart
+++ b/test/features/collections/screens/item_detail_screen_test.dart
@@ -45,11 +45,11 @@ void main() {
 
     final MockTvShowDao mockTvShowDao = MockTvShowDao();
     when(() => mockDb.tvShowDao).thenReturn(mockTvShowDao);
-    when(() => mockTvShowDao.getTvSeasonsByShowId(any()))
+    when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
         .thenAnswer((_) async => <TvSeason>[]);
-    when(() => mockTvShowDao.getWatchedEpisodes(any(), any()))
+    when(() => mockTvShowDao.getWatchedEpisodes(any(), any(), any()))
         .thenAnswer((_) async => <(int, int), DateTime?>{});
-    when(() => mockTvShowDao.getEpisodesByShowId(any()))
+    when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
         .thenAnswer((_) async => <TvEpisode>[]);
     final MockItemMarkDao mockItemMarkDao = MockItemMarkDao();
     when(() => mockDb.itemMarkDao).thenReturn(mockItemMarkDao);

--- a/test/features/collections/widgets/collection_items_view_test.dart
+++ b/test/features/collections/widgets/collection_items_view_test.dart
@@ -470,7 +470,7 @@ class _FakeEpisodeTrackerNotifier extends EpisodeTrackerNotifier {
   final Map<(int, int), DateTime?> _watched;
 
   @override
-  EpisodeTrackerState build(({int? collectionId, int showId}) arg) =>
+  EpisodeTrackerState build(EpisodeTrackerArg arg) =>
       EpisodeTrackerState(watchedEpisodes: _watched);
 }
 

--- a/test/features/collections/widgets/episode_tracker_section_test.dart
+++ b/test/features/collections/widgets/episode_tracker_section_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/api/tmdb_api.dart';
 import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/features/collections/widgets/episode_tracker_section.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
@@ -42,9 +43,10 @@ void main() {
     mockTmdbApi = MockTmdbApi();
     when(() => mockDb.tvShowDao).thenReturn(mockTvShowDao);
     when(() => mockDb.itemMarkDao).thenReturn(mockItemMarkDao);
-    when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, testShowId))
+    when(() => mockTvShowDao.getWatchedEpisodes(
+            testCollectionId, DataSource.tmdb, testShowId))
         .thenAnswer((_) async => <(int, int), DateTime?>{});
-    when(() => mockTvShowDao.getEpisodesByShowId(testShowId))
+    when(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, testShowId))
         .thenAnswer((_) async => <TvEpisode>[]);
     when(() => mockItemMarkDao.getMarksForItem(testItemId))
         .thenAnswer((_) async => <ItemMark>[]);
@@ -54,13 +56,15 @@ void main() {
     WidgetTester tester,
     List<TvSeason> seasons,
   ) async {
-    when(() => mockTvShowDao.getTvSeasonsByShowId(testShowId))
+    when(() =>
+            mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, testShowId))
         .thenAnswer((_) async => seasons);
 
     await tester.pumpApp(
       const SingleChildScrollView(
         child: SeasonsListWidget(
-          tmdbShowId: testShowId,
+          showId: testShowId,
+          source: DataSource.tmdb,
           collectionId: testCollectionId,
           itemId: testItemId,
           accentColor: Colors.blue,

--- a/test/features/releases/providers/releases_provider_test.dart
+++ b/test/features/releases/providers/releases_provider_test.dart
@@ -104,14 +104,17 @@ void main() {
           collectionId: any(named: 'collectionId'),
           mediaType: any(named: 'mediaType'),
           externalId: any(named: 'externalId'),
+          source: any(named: 'source'),
         )).thenAnswer((_) async => createTestCollectionItem());
     when(() => collDao.findCollectionItemWithData(
           collectionId: any(named: 'collectionId'),
           mediaType: any(named: 'mediaType'),
           externalId: any(named: 'externalId'),
+          source: any(named: 'source'),
         )).thenAnswer((_) async => createTestCollectionItem());
-    when(() => tvDao.getTvShowByTmdbId(any())).thenAnswer((_) async => null);
-    when(() => tvDao.getEpisodesByShowId(any()))
+    when(() => tvDao.getTvShowByTmdbId(any(), source: any(named: 'source')))
+        .thenAnswer((_) async => null);
+    when(() => tvDao.getEpisodesByShowId(any(), any()))
         .thenAnswer((_) async => <TvEpisode>[]);
   });
 
@@ -137,13 +140,13 @@ void main() {
       expect(data.events, isEmpty);
     });
 
-    test('should keep only TMDB TV and anime subscriptions', () async {
+    test('should keep only TV and anime subscriptions', () async {
       when(() => trackedDao.getAll()).thenAnswer((_) async => <TrackedRelease>[
             tracked(1, DataSource.tmdb, MediaType.tvShow),
             tracked(2, DataSource.anilist, MediaType.manga),
             tracked(3, DataSource.tmdb, MediaType.movie),
           ]);
-      when(() => tvDao.getEpisodesByShowId(1))
+      when(() => tvDao.getEpisodesByShowId(DataSource.tmdb, 1))
           .thenAnswer((_) async => <TvEpisode>[episode(1, 1, 1, future)]);
 
       final ReleasesCalendarData data =
@@ -156,7 +159,7 @@ void main() {
     test('should list upcoming episodes only and drop past ones', () async {
       when(() => trackedDao.getAll()).thenAnswer((_) async =>
           <TrackedRelease>[tracked(1, DataSource.tmdb, MediaType.tvShow)]);
-      when(() => tvDao.getEpisodesByShowId(1)).thenAnswer(
+      when(() => tvDao.getEpisodesByShowId(DataSource.tmdb, 1)).thenAnswer(
         (_) async => <TvEpisode>[
           episode(1, 1, 1, past),
           episode(1, 1, 2, future),
@@ -175,12 +178,13 @@ void main() {
     test('should drop a show no longer in any collection', () async {
       when(() => trackedDao.getAll()).thenAnswer((_) async =>
           <TrackedRelease>[tracked(1, DataSource.tmdb, MediaType.tvShow)]);
-      when(() => tvDao.getEpisodesByShowId(1))
+      when(() => tvDao.getEpisodesByShowId(DataSource.tmdb, 1))
           .thenAnswer((_) async => <TvEpisode>[episode(1, 1, 1, future)]);
       when(() => collDao.findCollectionItem(
             collectionId: any(named: 'collectionId'),
             mediaType: any(named: 'mediaType'),
             externalId: any(named: 'externalId'),
+            source: any(named: 'source'),
           )).thenAnswer((_) async => null);
 
       final ReleasesCalendarData data =
@@ -282,6 +286,7 @@ void main() {
             collectionId: any(named: 'collectionId'),
             mediaType: any(named: 'mediaType'),
             externalId: any(named: 'externalId'),
+            source: any(named: 'source'),
           )).thenAnswer((_) async => null);
 
       final ReleasesCalendarData data =
@@ -294,7 +299,7 @@ void main() {
     test('should skip episodes without a parseable air date', () async {
       when(() => trackedDao.getAll()).thenAnswer((_) async =>
           <TrackedRelease>[tracked(1, DataSource.tmdb, MediaType.tvShow)]);
-      when(() => tvDao.getEpisodesByShowId(1)).thenAnswer(
+      when(() => tvDao.getEpisodesByShowId(DataSource.tmdb, 1)).thenAnswer(
         (_) async => <TvEpisode>[
           episode(1, 1, 1, null),
           episode(1, 1, 2, future),

--- a/test/features/search/handlers/tmdb_handlers_test.dart
+++ b/test/features/search/handlers/tmdb_handlers_test.dart
@@ -41,6 +41,7 @@ void main() {
           mediaType: any(named: 'mediaType'),
           externalId: any(named: 'externalId'),
           platformId: any(named: 'platformId'),
+          source: any(named: 'source'),
           title: any(named: 'title'),
           upsert: any(named: 'upsert'),
           imageType: any(named: 'imageType'),

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:tonkatsu_box/shared/models/anime.dart';
 import 'package:tonkatsu_box/shared/models/canvas_viewport.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
 import 'package:tonkatsu_box/shared/models/manga.dart';
 import 'package:tonkatsu_box/shared/models/item_mark.dart';
@@ -26,6 +27,7 @@ import 'mocks.dart';
 
 void registerAllFallbacks() {
   registerFallbackValue(MediaType.game);
+  registerFallbackValue(DataSource.tmdb);
   registerFallbackValue(ItemStatus.notStarted);
   registerFallbackValue(CollectionType.own);
   registerFallbackValue(ImageType.gameCover);

--- a/test/shared/models/tv_episode_test.dart
+++ b/test/shared/models/tv_episode_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
 
 void main() {
@@ -773,6 +774,87 @@ void main() {
       );
 
       expect(episode.toString(), 'TvEpisode(showId: 99999, S15E23: Finale)');
+    });
+
+    group('source', () {
+      test('defaults to tmdb', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+        );
+
+        expect(episode.source, DataSource.tmdb);
+        expect(episode.toDb()['source'], 'tmdb');
+      });
+
+      test('fromDb reads a missing source as tmdb', () {
+        final TvEpisode episode = TvEpisode.fromDb(<String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+          'episode_number': 1,
+          'name': 'Pilot',
+        });
+
+        expect(episode.source, DataSource.tmdb);
+      });
+
+      test('fromDb reads an unknown source as tmdb', () {
+        final TvEpisode episode = TvEpisode.fromDb(<String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+          'episode_number': 1,
+          'name': 'Pilot',
+          'source': 'not-a-source',
+        });
+
+        expect(episode.source, DataSource.tmdb);
+      });
+
+      test('source survives a toDb/fromDb round-trip', () {
+        const TvEpisode original = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+          source: DataSource.anilist,
+        );
+
+        expect(TvEpisode.fromDb(original.toDb()).source, DataSource.anilist);
+      });
+
+      test('episodes differing only by source are not equal', () {
+        const TvEpisode tmdb = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+        );
+        const TvEpisode other = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+          source: DataSource.anilist,
+        );
+
+        expect(tmdb, isNot(equals(other)));
+      });
+
+      test('copyWith replaces source', () {
+        const TvEpisode episode = TvEpisode(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          name: 'Pilot',
+        );
+
+        expect(
+          episode.copyWith(source: DataSource.anilist).source,
+          DataSource.anilist,
+        );
+      });
     });
   });
 }

--- a/test/shared/models/tv_season_test.dart
+++ b/test/shared/models/tv_season_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
 
 void main() {
@@ -390,6 +391,54 @@ void main() {
       );
 
       expect(season.toString(), 'TvSeason(showId: 1396, season: 0)');
+    });
+
+    group('source', () {
+      test('defaults to tmdb', () {
+        const TvSeason season = TvSeason(tmdbShowId: 1396, seasonNumber: 1);
+
+        expect(season.source, DataSource.tmdb);
+        expect(season.toDb()['source'], 'tmdb');
+      });
+
+      test('fromDb reads a missing source as tmdb', () {
+        final TvSeason season = TvSeason.fromDb(<String, dynamic>{
+          'tmdb_show_id': 1396,
+          'season_number': 1,
+        });
+
+        expect(season.source, DataSource.tmdb);
+      });
+
+      test('source survives a toDb/fromDb round-trip', () {
+        const TvSeason original = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          source: DataSource.anilist,
+        );
+
+        expect(TvSeason.fromDb(original.toDb()).source, DataSource.anilist);
+      });
+
+      test('seasons differing only by source are not equal', () {
+        const TvSeason tmdb = TvSeason(tmdbShowId: 1396, seasonNumber: 1);
+        const TvSeason other = TvSeason(
+          tmdbShowId: 1396,
+          seasonNumber: 1,
+          source: DataSource.anilist,
+        );
+
+        expect(tmdb, isNot(equals(other)));
+      });
+
+      test('copyWith replaces source', () {
+        const TvSeason season = TvSeason(tmdbShowId: 1396, seasonNumber: 1);
+
+        expect(
+          season.copyWith(source: DataSource.anilist).source,
+          DataSource.anilist,
+        );
+      });
     });
   });
 }

--- a/test/shared/models/tv_show_test.dart
+++ b/test/shared/models/tv_show_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
 
 void main() {
@@ -692,6 +693,54 @@ void main() {
 
       expect(show.toString(),
           'TvShow(tmdbId: 100, title: Игра Престолов)');
+    });
+
+    group('source', () {
+      test('defaults to tmdb', () {
+        const TvShow show = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+
+        expect(show.source, DataSource.tmdb);
+        expect(show.toDb()['source'], 'tmdb');
+      });
+
+      test('fromDb reads a missing source as tmdb', () {
+        final TvShow show = TvShow.fromDb(<String, dynamic>{
+          'tmdb_id': 1396,
+          'title': 'Breaking Bad',
+        });
+
+        expect(show.source, DataSource.tmdb);
+      });
+
+      test('source survives a toDb/fromDb round-trip', () {
+        const TvShow original = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+          source: DataSource.anilist,
+        );
+
+        expect(TvShow.fromDb(original.toDb()).source, DataSource.anilist);
+      });
+
+      test('shows differing only by source are not equal', () {
+        const TvShow tmdb = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+        const TvShow other = TvShow(
+          tmdbId: 1396,
+          title: 'Breaking Bad',
+          source: DataSource.anilist,
+        );
+
+        expect(tmdb, isNot(equals(other)));
+      });
+
+      test('copyWith replaces source', () {
+        const TvShow show = TvShow(tmdbId: 1396, title: 'Breaking Bad');
+
+        expect(
+          show.copyWith(source: DataSource.anilist).source,
+          DataSource.anilist,
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Seasons, episodes and watch progress are keyed by (source, show id): migration v57 rebuilds tv_shows_cache with a composite PK and adds source to the UNIQUE keys of tv_seasons_cache, tv_episodes_cache and watched_episodes, backfilling existing rows as tmdb. Season/episode fetching goes through the provider-agnostic TvEpisodeSource interface with TMDB as the first implementation.