### PR TITLE
fix(tv): preserve watch progress and totals; richer episode tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,89 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Added
+
+- **Full export (.xcollx) with user data now carries watched-episode marks
+  and restores them on import**
+
+  Previously watch progress silently stayed behind: an exported collection
+  imported elsewhere arrived with statuses but zero episode checkmarks.
+  Episode likes/notes already travelled inside `_marks`. Older files
+  without the new section import as before; the format version stays 3.
+
+  * lib/core/services/export_service.dart
+    (ExportService._attachWatchedEpisodes): Nest the item's watch marks
+    under `_watched_episodes` (full export, user data only).
+  * lib/core/services/import_service.dart
+    (ImportService._importWatchedEpisodes): Restore the marks re-scoped
+    to the target collection; conflict-ignoring, so re-import merges.
+  * docs/RCOLL_FORMAT.md: Document the `_watched_episodes` item field.
+
+### Fixed
+
+- **Sparse cache rows no longer wipe episode/chapter/page totals**
+
+  Rows parsed from list endpoints (search, recommendations, similars)
+  carry no totals and used to erase the cached ones on upsert, degrading
+  progress badges from `38/38` to a bare `38`. Cache upserts for TV shows,
+  manga and books now keep the cached value when the incoming one is NULL;
+  adding a TV show from recommendations warms the cache like the search
+  flow does, and the episode tracker recovers missing totals from the
+  seasons cache for already-affected databases.
+
+- **Moving a TV show between collections takes its watch progress along**
+
+  Removing a show (or moving it to "uncategorized") keeps the marks, so
+  adding it back restores the progress.
+
+  * lib/core/database/dao/collection_dao.dart
+    (CollectionDao.updateItemCollectionId,
+    CollectionDao._transferWatchedEpisodes): Move watched_episodes rows
+    with the item; copy when a sibling animation/TV entry stays behind.
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier.moveItem),
+    lib/features/collections/helpers/bulk_operations.dart
+    (BulkOperations._invalidateAfterMutation): Refresh live episode
+    trackers after a move.
+
+- **Re-adding a just-removed show to the same collection works again**
+
+  * lib/features/collections/helpers/collection_actions.dart
+    (CollectionActions.removeItem): Invalidate the collected-ids cache on
+    removal.
+
+- **Episode progress badge shows "12/22" instead of a bare "12" and now
+  also appears on the All Items screen**
+
+  * lib/features/collections/providers/episode_tracker_provider.dart
+    (EpisodeTrackerState.totalEpisodes): Expose the resolved episode
+    totals to the badge.
+  * lib/features/collections/helpers/tracker_card_progress.dart
+    (trackerCardProgress): New shared badge helper used by
+    lib/features/collections/widgets/collection_items_view.dart and
+    lib/features/home/screens/all_items_screen.dart.
+  * lib/features/search/handlers/tv_show_handler.dart
+    (TvShowHandler._preloadSeasons), lib/core/api/tmdb/tmdb_tv_api.dart
+    (TmdbTvApi.getTvShowWithSeasons): Cache full show details on add with
+    a single /tv/{id} request.
+
+- **Fixed row overflows on narrow layouts**
+
+  * lib/features/collections/widgets/episode_tracker_section.dart
+    (EpisodeTrackerSection.build): The header title ellipsizes instead of
+    overflowing next to the watched counter.
+  * lib/shared/widgets/media_poster_card.dart (MediaPosterCard): The tag
+    badge shrinks on very narrow cards instead of overflowing.
+
 ### Changed
+
+- **Episode tracker got season posters, episode stills and overviews**
+
+  Season rows show the season poster with an all-watched badge and the air
+  year; episode rows show the episode still (dimmed with a check badge once
+  watched) and a two-line overview that expands on tap. The episode
+  checkbox is gone — tapping the row toggles watched, same as before.
+  Season posters and episode stills are cached on disk for offline use.
 
 - **Decouple the episode tracker and release calendar from TMDB**
 

--- a/docs/RCOLL_FORMAT.md
+++ b/docs/RCOLL_FORMAT.md
@@ -166,6 +166,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 | tag_names | array | no | Names of all assigned tags in the item's display order — manual per-item order when set, global tag order otherwise (full only, resolved into the global tag set on import) |
 | tag_name | string | no | First assigned tag name (full only). Legacy single-tag field kept for older app versions; readers prefer `tag_names` |
 | _marks | array | no | Per-unit likes/notes. Present only when `user_data` is `true`; re-anchored to the new item id on import (see Item Marks) |
+| _watched_episodes | array | no | Watched-episode marks of a TV/animation item (full + `user_data` only). Each entry: `{season, episode, watched_at}` with `watched_at` in Unix seconds or `null`. Re-scoped to the target collection on import; conflict-ignoring, so re-import merges. Absent in older files |
 
 **User data fields** (present only when top-level `user_data` is `true`):
 
@@ -309,6 +310,8 @@ When `media` is present during import, data is restored directly from the file v
 3. Creates collection and inserts items with metadata
 4. Restores collection-level canvas (viewport, items, connections)
 5. Restores per-item canvases (embedded in `_canvas` field of each item)
+   and watched-episode marks (embedded in `_watched_episodes`, when
+   `user_data` is present)
 6. Restores cover images and canvas images from base64 to local disk cache
 7. Restores tier lists — creates tier list, saves definitions, resolves entries via `itemIdMapping` (`media_type:external_id` → new item ID)
 8. Restores tracker data (RA progress) if present — upserts into `tracker_game_data`

--- a/lib/core/api/episode_source/tmdb_episode_source.dart
+++ b/lib/core/api/episode_source/tmdb_episode_source.dart
@@ -1,6 +1,3 @@
-// TMDB implementation of TvEpisodeSource.
-
-import '../../../shared/models/data_source.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
@@ -9,13 +6,9 @@ import 'tv_episode_source.dart';
 
 /// [TvEpisodeSource] backed by the TMDB API.
 class TmdbEpisodeSource implements TvEpisodeSource {
-  /// Creates a [TmdbEpisodeSource] over [api].
   const TmdbEpisodeSource(this._api);
 
   final TmdbApi _api;
-
-  @override
-  DataSource get source => DataSource.tmdb;
 
   @override
   Future<TvShow?> getShow(int showId) => _api.getTvShow(showId);

--- a/lib/core/api/episode_source/tv_episode_source.dart
+++ b/lib/core/api/episode_source/tv_episode_source.dart
@@ -1,5 +1,3 @@
-// Provider-agnostic source of TV show seasons and episodes.
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../shared/models/data_source.dart';
@@ -14,16 +12,10 @@ import 'tmdb_episode_source.dart';
 /// Implementations wrap one provider's API and return the shared
 /// [TvShow]/[TvSeason]/[TvEpisode] models with [source] stamped.
 abstract class TvEpisodeSource {
-  /// Provider this implementation serves.
-  DataSource get source;
-
-  /// Show details — used for total season/episode counts.
   Future<TvShow?> getShow(int showId);
 
-  /// The show's season list.
   Future<List<TvSeason>> getSeasons(int showId);
 
-  /// Episodes of one season.
   Future<List<TvEpisode>> getSeasonEpisodes(int showId, int seasonNumber);
 }
 

--- a/lib/core/api/tmdb/tmdb_tv_api.dart
+++ b/lib/core/api/tmdb/tmdb_tv_api.dart
@@ -109,7 +109,12 @@ class TmdbTvApi {
     }
   }
 
-  Future<TvShow?> getTvShow(int tmdbId) async {
+  Future<TvShow?> getTvShow(int tmdbId) async =>
+      (await getTvShowWithSeasons(tmdbId))?.$1;
+
+  /// One /tv/{id} fetch parsed as both the show and its seasons — callers
+  /// needing both must use this instead of hitting the endpoint twice.
+  Future<(TvShow, List<TvSeason>)?> getTvShowWithSeasons(int tmdbId) async {
     _client.ensureApiKey();
 
     try {
@@ -122,7 +127,18 @@ class TmdbTvApi {
         );
       }
 
-      return TvShow.fromJson(response.data as Map<String, dynamic>);
+      final Map<String, dynamic> data = response.data as Map<String, dynamic>;
+      final List<dynamic> seasons =
+          data['seasons'] as List<dynamic>? ?? <dynamic>[];
+      return (
+        TvShow.fromJson(data),
+        seasons
+            .map((dynamic item) => TvSeason.fromJson(
+                  item as Map<String, dynamic>,
+                  showId: tmdbId,
+                ))
+            .toList(),
+      );
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) {
         return null;

--- a/lib/core/api/tmdb_api.dart
+++ b/lib/core/api/tmdb_api.dart
@@ -163,6 +163,9 @@ class TmdbApi {
 
   Future<TvShow?> getTvShow(int tmdbId) => _tv.getTvShow(tmdbId);
 
+  Future<(TvShow, List<TvSeason>)?> getTvShowWithSeasons(int tmdbId) =>
+      _tv.getTvShowWithSeasons(tmdbId);
+
   Future<List<TvSeason>> getTvSeasons(int tmdbId) =>
       _tv.getTvSeasons(tmdbId);
 

--- a/lib/core/database/dao/book_dao.dart
+++ b/lib/core/database/dao/book_dao.dart
@@ -5,6 +5,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../../../shared/models/book.dart';
 import '../../../shared/models/data_source.dart';
 import '../query_chunk.dart';
+import '../sparse_upsert.dart';
 
 /// DAO for `books_cache`. Row identity is the pair `(id, source)`, so the same
 /// numeric `id` from OpenLibrary and Fantlab can coexist. `id` is stored as
@@ -15,13 +16,20 @@ class BookDao {
 
   final Future<Database> Function() _getDatabase;
 
+  // Fantlab/Google Books similars and search-list rows carry no page count;
+  // the column keeps the cached detail-endpoint value instead of being wiped.
+  static ({String sql, List<Object?> args}) _bookUpsert(Book book) =>
+      buildPreservingUpsert(
+        table: 'books_cache',
+        row: book.toDb(),
+        conflictKey: const <String>['id', 'source'],
+        preserveWhenNull: const <String>{'page_count'},
+      );
+
   Future<void> upsertBook(Book book) async {
     final Database db = await _getDatabase();
-    await db.insert(
-      'books_cache',
-      book.toDb(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
+    final ({String sql, List<Object?> args}) upsert = _bookUpsert(book);
+    await db.rawInsert(upsert.sql, upsert.args);
   }
 
   Future<void> upsertBooks(List<Book> books) async {
@@ -29,11 +37,8 @@ class BookDao {
     final Database db = await _getDatabase();
     final Batch batch = db.batch();
     for (final Book book in books) {
-      batch.insert(
-        'books_cache',
-        book.toDb(),
-        conflictAlgorithm: ConflictAlgorithm.replace,
-      );
+      final ({String sql, List<Object?> args}) upsert = _bookUpsert(book);
+      batch.rawInsert(upsert.sql, upsert.args);
     }
     await batch.commit(noResult: true);
   }

--- a/lib/core/database/dao/collection_dao.dart
+++ b/lib/core/database/dao/collection_dao.dart
@@ -541,12 +541,113 @@ class CollectionDao {
     });
   }
 
+  /// Watch marks are keyed by (collection, source, show), not by item id,
+  /// so they deliberately survive the removal: re-adding the show to the
+  /// same collection restores its progress.
   Future<void> removeItemFromCollection(int id) async {
     final Database db = await _getDatabase();
     await db.delete(
       'collection_items',
       where: 'id = ?',
       whereArgs: <Object?>[id],
+    );
+  }
+
+  /// The columns the watched-episodes helpers need, or null when the item
+  /// row is gone.
+  Future<Map<String, dynamic>?> _loadItemMeta(
+    DatabaseExecutor db,
+    int id,
+  ) async {
+    final List<Map<String, dynamic>> rows = await db.query(
+      'collection_items',
+      columns: <String>['collection_id', 'media_type', 'external_id', 'source'],
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+      limit: 1,
+    );
+    return rows.isEmpty ? null : rows.first;
+  }
+
+  /// Whether another tv/animation item for the same show remains in the
+  /// collection — it shares the watch marks, so they must not be
+  /// moved/deleted.
+  Future<bool> _hasTvSibling(
+    DatabaseExecutor db,
+    int collectionId,
+    int externalId,
+    String source,
+  ) async {
+    final List<Map<String, dynamic>> siblings = await db.query(
+      'collection_items',
+      columns: <String>['id'],
+      where: 'collection_id = ? AND external_id = ? '
+          "AND media_type IN ('tv_show', 'animation') "
+          "AND COALESCE(source, 'tmdb') = ?",
+      whereArgs: <Object?>[
+        collectionId,
+        externalId,
+        source,
+      ],
+      limit: 1,
+    );
+    return siblings.isNotEmpty;
+  }
+
+  Future<void> _deleteWatchedEpisodesUnlessShared(
+    DatabaseExecutor db,
+    int collectionId,
+    int externalId,
+    String source,
+  ) async {
+    if (await _hasTvSibling(db, collectionId, externalId, source)) return;
+    await db.delete(
+      'watched_episodes',
+      where: 'collection_id = ? AND source = ? AND show_id = ?',
+      whereArgs: <Object?>[
+        collectionId,
+        source,
+        externalId,
+      ],
+    );
+  }
+
+  /// Sibling items keep the source rows (copy instead of move); moves
+  /// to/from uncategorized leave the marks behind, like removal does.
+  Future<void> _transferWatchedEpisodes(
+    DatabaseExecutor db,
+    Map<String, dynamic> movedItem,
+    int? targetCollectionId,
+  ) async {
+    if (!MediaType.fromString(movedItem['media_type'] as String).isTvBacked) {
+      return;
+    }
+    final int? oldCollectionId = movedItem['collection_id'] as int?;
+    if (oldCollectionId == targetCollectionId) return;
+    if (oldCollectionId == null || targetCollectionId == null) return;
+    final int externalId = movedItem['external_id'] as int;
+    final String source = (movedItem['source'] as String?) ?? 'tmdb';
+
+    await db.rawInsert(
+      'INSERT OR REPLACE INTO watched_episodes '
+      '(collection_id, source, show_id, season_number, episode_number, '
+      'watched_at) '
+      'SELECT ?, source, show_id, season_number, episode_number, watched_at '
+      'FROM watched_episodes '
+      'WHERE collection_id = ? AND source = ? AND show_id = ?',
+      <Object?>[
+        targetCollectionId,
+        oldCollectionId,
+        source,
+        externalId,
+      ],
+    );
+
+    await _deleteWatchedEpisodesUnlessShared(
+      db,
+      oldCollectionId,
+      externalId,
+      source,
     );
   }
 
@@ -742,27 +843,34 @@ class CollectionDao {
   }
 
   /// Moves item to another collection (null = uncategorized) and appends to its
-  /// sort order. Returns false on UNIQUE conflict (already present in target).
+  /// sort order. Watch progress of tv-backed items moves along with the item.
+  /// Returns false on UNIQUE conflict (already present in target).
   Future<bool> updateItemCollectionId(int id, int? collectionId) async {
     final Database db = await _getDatabase();
     final int newSortOrder = await getNextSortOrder(collectionId);
-    try {
-      await db.update(
-        'collection_items',
-        <String, dynamic>{
-          'collection_id': collectionId,
-          'sort_order': newSortOrder,
-        },
-        where: 'id = ?',
-        whereArgs: <Object?>[id],
-      );
-      return true;
-    } on DatabaseException catch (e) {
-      if (e.isUniqueConstraintError()) {
-        return false;
+    return db.transaction((Transaction txn) async {
+      final Map<String, dynamic>? item = await _loadItemMeta(txn, id);
+      try {
+        await txn.update(
+          'collection_items',
+          <String, dynamic>{
+            'collection_id': collectionId,
+            'sort_order': newSortOrder,
+          },
+          where: 'id = ?',
+          whereArgs: <Object?>[id],
+        );
+      } on DatabaseException catch (e) {
+        if (e.isUniqueConstraintError()) {
+          return false;
+        }
+        rethrow;
       }
-      rethrow;
-    }
+      if (item != null) {
+        await _transferWatchedEpisodes(txn, item, collectionId);
+      }
+      return true;
+    });
   }
 
   /// Full-row copy resilient to new columns: overrides only id, collection_id,

--- a/lib/core/database/dao/manga_dao.dart
+++ b/lib/core/database/dao/manga_dao.dart
@@ -5,6 +5,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import '../../../shared/models/data_source.dart';
 import '../../../shared/models/manga.dart';
 import '../query_chunk.dart';
+import '../sparse_upsert.dart';
 
 /// DAO for `manga_cache`. Row identity is the pair `(id, source)`, so the same
 /// numeric `id` from AniList and MangaBaka can coexist.
@@ -13,13 +14,20 @@ class MangaDao {
 
   final Future<Database> Function() _getDatabase;
 
+  // MangaBaka list rows may lack chapter/volume totals; those columns keep
+  // the cached detail-endpoint value instead of being wiped by a sparse row.
+  static ({String sql, List<Object?> args}) _mangaUpsert(Manga manga) =>
+      buildPreservingUpsert(
+        table: 'manga_cache',
+        row: manga.toDb(),
+        conflictKey: const <String>['id', 'source'],
+        preserveWhenNull: const <String>{'chapters', 'volumes'},
+      );
+
   Future<void> upsertManga(Manga manga) async {
     final Database db = await _getDatabase();
-    await db.insert(
-      'manga_cache',
-      manga.toDb(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
+    final ({String sql, List<Object?> args}) upsert = _mangaUpsert(manga);
+    await db.rawInsert(upsert.sql, upsert.args);
   }
 
   Future<void> upsertMangas(List<Manga> mangas) async {
@@ -27,11 +35,8 @@ class MangaDao {
     final Database db = await _getDatabase();
     final Batch batch = db.batch();
     for (final Manga manga in mangas) {
-      batch.insert(
-        'manga_cache',
-        manga.toDb(),
-        conflictAlgorithm: ConflictAlgorithm.replace,
-      );
+      final ({String sql, List<Object?> args}) upsert = _mangaUpsert(manga);
+      batch.rawInsert(upsert.sql, upsert.args);
     }
     await batch.commit(noResult: true);
   }

--- a/lib/core/database/dao/tv_show_dao.dart
+++ b/lib/core/database/dao/tv_show_dao.dart
@@ -7,6 +7,7 @@ import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import '../query_chunk.dart';
+import '../sparse_upsert.dart';
 
 /// DAO for the `tv_shows_cache`, `tv_seasons_cache`, `tv_episodes_cache` and
 /// `watched_episodes` tables.
@@ -18,9 +19,6 @@ class TvShowDao {
 
   final Future<Database> Function() _getDatabase;
 
-  // ==================== TV Shows ====================
-
-  /// Returns the show by id within [source], or null if not cached.
   Future<TvShow?> getTvShowByTmdbId(
     int tmdbId, {
     DataSource source = DataSource.tmdb,
@@ -36,14 +34,26 @@ class TvShowDao {
     return TvShow.fromDb(rows.first);
   }
 
+  // Shows parsed from list endpoints (search, recommendations, imports)
+  // carry no totals/status; those columns keep the cached detail-endpoint
+  // value instead of being wiped by the sparse row.
+  static ({String sql, List<Object?> args}) _showUpsert(TvShow tvShow) =>
+      buildPreservingUpsert(
+        table: 'tv_shows_cache',
+        row: tvShow.toDb(),
+        conflictKey: const <String>['tmdb_id', 'source'],
+        preserveWhenNull: const <String>{
+          'total_seasons',
+          'total_episodes',
+          'status',
+        },
+      );
+
   /// Inserts or updates a show in the cache.
   Future<void> upsertTvShow(TvShow tvShow) async {
     final Database db = await _getDatabase();
-    await db.insert(
-      'tv_shows_cache',
-      tvShow.toDb(),
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
+    final ({String sql, List<Object?> args}) upsert = _showUpsert(tvShow);
+    await db.rawInsert(upsert.sql, upsert.args);
   }
 
   /// Saves a list of shows in a batch.
@@ -54,11 +64,8 @@ class TvShowDao {
     await db.transaction((Transaction txn) async {
       final Batch batch = txn.batch();
       for (final TvShow tvShow in tvShows) {
-        batch.insert(
-          'tv_shows_cache',
-          tvShow.toDb(),
-          conflictAlgorithm: ConflictAlgorithm.replace,
-        );
+        final ({String sql, List<Object?> args}) upsert = _showUpsert(tvShow);
+        batch.rawInsert(upsert.sql, upsert.args);
       }
       await batch.commit(noResult: true);
     });
@@ -85,8 +92,6 @@ class TvShowDao {
     final Database db = await _getDatabase();
     await db.delete('tv_shows_cache');
   }
-
-  // ==================== TV Seasons ====================
 
   /// Returns the show's seasons.
   Future<List<TvSeason>> getTvSeasonsByShowId(
@@ -126,8 +131,6 @@ class TvShowDao {
     final Database db = await _getDatabase();
     await db.delete('tv_seasons_cache');
   }
-
-  // ==================== TV Episodes ====================
 
   /// Returns all cached episodes of a show.
   Future<List<TvEpisode>> getEpisodesByShowId(
@@ -187,8 +190,6 @@ class TvShowDao {
       whereArgs: <Object?>[source.name, showId],
     );
   }
-
-  // ==================== Watched Episodes ====================
 
   /// Watched episodes of a show within a collection.
   ///

--- a/lib/core/database/migrations/migration_v57.dart
+++ b/lib/core/database/migrations/migration_v57.dart
@@ -2,17 +2,9 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'migration.dart';
 
-/// Adds an episode/show source discriminator. TV show identity becomes
-/// `(source, show id)`:
-/// - `tv_shows_cache` is rebuilt with a composite primary key
-///   `(tmdb_id, source)`;
-/// - `tv_seasons_cache`, `tv_episodes_cache` and `watched_episodes` gain a
-///   `source` column inside their UNIQUE keys;
-/// - `collection_items.source` is backfilled for tv shows and the tv-show
-///   unique indexes include it (like manga in v44).
-///
-/// SQLite can't alter constraints in place — the four tables are rebuilt and
-/// existing rows backfilled as `'tmdb'`.
+/// TV show identity becomes `(source, show id)`. SQLite can't alter
+/// constraints in place, so the four tv tables are rebuilt with a `source`
+/// discriminator in their keys and existing rows backfilled as `'tmdb'`.
 class MigrationV57 extends Migration {
   @override
   int get version => 57;

--- a/lib/core/database/sparse_upsert.dart
+++ b/lib/core/database/sparse_upsert.dart
@@ -1,0 +1,38 @@
+// Upsert SQL builder for media cache tables.
+
+/// Builds an `INSERT OR REPLACE` statement where [preserveWhenNull] columns
+/// keep the cached value when the incoming one is NULL.
+///
+/// Rows parsed from list endpoints (search, recommendations, similars) lack
+/// fields that only detail endpoints provide (episode totals, page counts);
+/// a plain REPLACE would wipe those cached values. Preserved columns are
+/// written as `COALESCE(?, (SELECT col ... WHERE key))` — the subquery reads
+/// the old row before REPLACE deletes it. This idiom works on any SQLite,
+/// unlike `ON CONFLICT DO UPDATE` (3.24+, missing on Android < 11).
+({String sql, List<Object?> args}) buildPreservingUpsert({
+  required String table,
+  required Map<String, Object?> row,
+  required List<String> conflictKey,
+  required Set<String> preserveWhenNull,
+}) {
+  final String keyFilter =
+      conflictKey.map((String k) => '$k = ?').join(' AND ');
+  final List<String> values = <String>[];
+  final List<Object?> args = <Object?>[];
+  for (final MapEntry<String, Object?> entry in row.entries) {
+    if (preserveWhenNull.contains(entry.key)) {
+      values.add(
+        'COALESCE(?, (SELECT ${entry.key} FROM $table WHERE $keyFilter))',
+      );
+      args
+        ..add(entry.value)
+        ..addAll(conflictKey.map((String k) => row[k]));
+    } else {
+      values.add('?');
+      args.add(entry.value);
+    }
+  }
+  final String sql = 'INSERT OR REPLACE INTO $table '
+      '(${row.keys.join(', ')}) VALUES (${values.join(', ')})';
+  return (sql: sql, args: args);
+}

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -160,9 +160,10 @@ class ExportService {
     // Collect hero image (if set)
     await _collectHeroImage(collection, images);
 
-    // Per-item marks (likes/notes) — user data only
+    // Per-item marks (likes/notes) and watch progress — user data only
     if (includeUserData) {
       await _attachItemMarks(items, exportItems);
+      await _attachWatchedEpisodes(collectionId, items, exportItems);
     }
 
     // Collect full media data for offline import (includes tv_seasons)
@@ -321,6 +322,37 @@ class ExportService {
       if (marks == null || marks.isEmpty) continue;
       exportItems[i]['_marks'] =
           marks.map((ItemMark m) => m.toExport()).toList();
+    }
+  }
+
+  /// Watch marks live in `watched_episodes`, not on the item — nest them
+  /// under `_watched_episodes` so progress survives export/import.
+  Future<void> _attachWatchedEpisodes(
+    int collectionId,
+    List<CollectionItem> items,
+    List<Map<String, dynamic>> exportItems,
+  ) async {
+    final DatabaseService? db = _database;
+    if (db == null) return;
+    for (int i = 0; i < items.length; i++) {
+      final CollectionItem item = items[i];
+      if (!item.mediaType.isTvBacked) continue;
+      // Resolve the source exactly like import will: parsed items carry no
+      // joined show, so their dataSource collapses to the raw column.
+      final DataSource source = item.source ?? DataSource.tmdb;
+      final Map<(int, int), DateTime?> watched = await db.tvShowDao
+          .getWatchedEpisodes(collectionId, source, item.externalId);
+      if (watched.isEmpty) continue;
+      exportItems[i]['_watched_episodes'] = <Map<String, dynamic>>[
+        for (final MapEntry<(int, int), DateTime?> e in watched.entries)
+          <String, dynamic>{
+            'season': e.key.$1,
+            'episode': e.key.$2,
+            'watched_at': e.value != null
+                ? e.value!.millisecondsSinceEpoch ~/ 1000
+                : null,
+          },
+      ];
     }
   }
 

--- a/lib/core/services/image_cache_service.dart
+++ b/lib/core/services/image_cache_service.dart
@@ -23,6 +23,10 @@ enum ImageType {
 
   tvShowPoster('tv_show_posters'),
 
+  tvSeasonPoster('tv_season_posters'),
+
+  tvEpisodeStill('tv_episode_stills'),
+
   canvasImage('canvas_images'),
 
   mangaCover('manga_covers'),

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -400,6 +400,7 @@ class ImportService {
 
           if (xcoll.includesUserData) {
             await _importItemMarks(itemData, itemId);
+            await _importWatchedEpisodes(itemData, collection.id, parsed);
           }
         } else if (collectionId != null) {
           // Item already exists — update from file.
@@ -433,6 +434,7 @@ class ImportService {
             // so re-importing onto an existing item merges, not duplicates.
             if (xcoll.includesUserData) {
               await _importItemMarks(itemData, existing.id);
+              await _importWatchedEpisodes(itemData, collection.id, parsed);
             }
           }
         }
@@ -1331,6 +1333,35 @@ class ImportService {
           ItemMark.fromExport(raw, itemId: collectionItemId),
     ];
     await _database.itemMarkDao.insertMarks(marks);
+  }
+
+  /// Restores watch marks nested under the item's `_watched_episodes` key,
+  /// re-scoped to the target collection. Older exports lack the key; rows
+  /// already marked stay untouched (insert is conflict-ignoring).
+  Future<void> _importWatchedEpisodes(
+    Map<String, dynamic> itemData,
+    int collectionId,
+    CollectionItem parsed,
+  ) async {
+    if (!parsed.mediaType.isTvBacked) return;
+    final List<dynamic>? raw =
+        itemData['_watched_episodes'] as List<dynamic>?;
+    if (raw == null || raw.isEmpty) return;
+    for (final dynamic entry in raw) {
+      if (entry is! Map<String, dynamic>) continue;
+      final Object? season = entry['season'];
+      final Object? episode = entry['episode'];
+      if (season is! int || episode is! int) continue;
+      final Object? watchedAtSec = entry['watched_at'];
+      await _database.tvShowDao.markEpisodeWatchedAt(
+        collectionId,
+        parsed.dataSource,
+        parsed.externalId,
+        season,
+        episode,
+        watchedAtSec is int ? watchedAtSec * 1000 : null,
+      );
+    }
   }
 
   /// [itemIdMapping]: 'media_type:external_id[:platform_id]' -> new collection_item_id.

--- a/lib/core/services/tv_show_cache_warmer.dart
+++ b/lib/core/services/tv_show_cache_warmer.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/models/data_source.dart';
+import '../../shared/models/tv_episode.dart';
+import '../../shared/models/tv_season.dart';
+import '../../shared/models/tv_show.dart';
+import '../api/tmdb_api.dart';
+import '../database/database_service.dart';
+
+/// Provider of [TvShowCacheWarmer].
+final Provider<TvShowCacheWarmer> tvShowCacheWarmerProvider =
+    Provider<TvShowCacheWarmer>((Ref ref) {
+  return TvShowCacheWarmer(
+    tmdb: ref.watch(tmdbApiProvider),
+    db: ref.watch(databaseServiceProvider),
+  );
+});
+
+/// Warms the TV cache after a show is added to a collection, so the detail
+/// screen and progress badges work without another network round-trip.
+///
+/// List endpoints (search, recommendations) return shows without
+/// season/episode totals; [warm] replaces the sparse cached row with full
+/// details and caches the show's seasons and their episodes.
+class TvShowCacheWarmer {
+  /// Creates the warmer over the TMDB API and the local cache.
+  TvShowCacheWarmer({
+    required TmdbApi tmdb,
+    required DatabaseService db,
+  })  : _tmdb = tmdb,
+        _db = db;
+
+  final TmdbApi _tmdb;
+  final DatabaseService _db;
+
+  /// Best-effort: on network/API failure the cache is left as is and data
+  /// loads on demand later.
+  Future<void> warm(int tmdbId) async {
+    try {
+      final (TvShow, List<TvSeason>)? full =
+          await _tmdb.getTvShowWithSeasons(tmdbId);
+      if (full != null) {
+        await _db.tvShowDao.upsertTvShow(full.$1);
+      }
+
+      List<TvSeason> seasons =
+          await _db.tvShowDao.getTvSeasonsByShowId(DataSource.tmdb, tmdbId);
+      if (seasons.isEmpty && full != null) {
+        seasons = full.$2;
+        if (seasons.isNotEmpty) {
+          await _db.tvShowDao.upsertTvSeasons(seasons);
+        }
+      }
+
+      for (final TvSeason season in seasons) {
+        final List<TvEpisode> cached = await _db.tvShowDao
+            .getEpisodesByShowAndSeason(
+                DataSource.tmdb, tmdbId, season.seasonNumber);
+        if (cached.isEmpty) {
+          final List<TvEpisode> episodes =
+              await _tmdb.getSeasonEpisodes(tmdbId, season.seasonNumber);
+          if (episodes.isNotEmpty) {
+            await _db.tvShowDao.upsertEpisodes(episodes);
+          }
+        }
+      }
+    } on Exception catch (_) {
+      // Cache stays sparse; episodes load on-demand later.
+    }
+  }
+}

--- a/lib/features/collections/helpers/bulk_operations.dart
+++ b/lib/features/collections/helpers/bulk_operations.dart
@@ -14,6 +14,7 @@ import '../../../shared/models/media_type.dart';
 import '../../home/providers/all_items_provider.dart';
 import '../../tier_lists/providers/tier_list_detail_provider.dart';
 import '../providers/collection_covers_provider.dart';
+import '../providers/episode_tracker_provider.dart';
 import '../providers/item_tags_provider.dart';
 import '../providers/collections_provider.dart';
 
@@ -193,8 +194,6 @@ class BulkOperations {
     return changedIds.length;
   }
 
-  // ---------------------------------------------------------------------------
-
   static void _invalidateAfterMutation(
     WidgetRef ref, {
     required Set<int?> affectedCollections,
@@ -209,6 +208,11 @@ class BulkOperations {
     }
     if (tagsChanged) {
       ref.invalidate(itemTagsProvider);
+    }
+    // Bulk moves transfer watched marks in the DB; live trackers keep the
+    // old in-memory state until invalidated.
+    if (affectedTypes.any((MediaType t) => t.isTvBacked)) {
+      ref.invalidate(episodeTrackerNotifierProvider);
     }
     for (final MediaType t in affectedTypes) {
       _invalidateCollectedIds(ref, t);

--- a/lib/features/collections/helpers/collection_actions.dart
+++ b/lib/features/collections/helpers/collection_actions.dart
@@ -241,7 +241,7 @@ class CollectionActions {
 
     await ref
         .read(collectionItemsNotifierProvider(collectionId).notifier)
-        .removeItem(item.id);
+        .removeItem(item.id, mediaType: item.mediaType);
 
     // Keep the canvas in sync: drop the removed item
     ref

--- a/lib/features/collections/helpers/tracker_card_progress.dart
+++ b/lib/features/collections/helpers/tracker_card_progress.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../shared/models/collection_item.dart';
+import '../../../shared/utils/item_card_progress.dart';
+import '../providers/episode_tracker_provider.dart';
+
+/// Card progress for shows whose marks live in the episode tracker rather
+/// than on the item ([itemCardProgress] returns null for them). Null for
+/// uncategorized items — episode tracking is collection-only.
+ItemCardProgress? trackerCardProgress(WidgetRef ref, CollectionItem item) {
+  final int? collectionId = item.collectionId;
+  if (collectionId == null) return null;
+  if (!item.mediaType.isTvBacked) return null;
+  final EpisodeTrackerState trackerState =
+      ref.watch(episodeTrackerNotifierProvider((
+    collectionId: collectionId,
+    showId: item.externalId,
+    source: item.dataSource,
+  )));
+  final int watched = trackerState.totalWatchedCount;
+  if (watched == 0) return null;
+  final int cachedTotal = item.tvShow?.totalEpisodes ?? 0;
+  final int total =
+      cachedTotal > 0 ? cachedTotal : trackerState.totalEpisodes ?? 0;
+  return ItemCardProgress(
+    label: total > 0 ? '$watched/$total' : '$watched',
+    fraction: total > 0 ? (watched / total).clamp(0.0, 1.0) : null,
+  );
+}

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -28,6 +28,7 @@ import '../../tier_lists/providers/tier_list_detail_provider.dart';
 import '../../settings/providers/profile_provider.dart';
 import '../../settings/providers/settings_provider.dart';
 import 'collection_covers_provider.dart';
+import 'episode_tracker_provider.dart';
 import 'item_tags_provider.dart';
 import 'sort_utils.dart';
 
@@ -712,6 +713,7 @@ class CollectionItemsNotifier
     ref.invalidate(collectionCoversProvider(_collectionId));
     ref.invalidate(uncategorizedItemCountProvider);
     _invalidateCollectedIds(mediaType);
+    _invalidateEpisodeTrackers(mediaType);
     ref.invalidate(allItemsNotifierProvider);
 
     for (final int tierListId in affectedTierListIds) {
@@ -738,6 +740,15 @@ class CollectionItemsNotifier
 
     for (final int tierListId in affectedTierListIds) {
       ref.invalidate(tierListDetailProvider(tierListId));
+    }
+  }
+
+  /// In-memory tracker state survives the DAO-side mark transfer on move,
+  /// so the show would keep showing zero progress in the target collection
+  /// until restart. Invalidating the family reloads every live tracker.
+  void _invalidateEpisodeTrackers(MediaType mediaType) {
+    if (mediaType.isTvBacked) {
+      ref.invalidate(episodeTrackerNotifierProvider);
     }
   }
 

--- a/lib/features/collections/providers/episode_tracker_provider.dart
+++ b/lib/features/collections/providers/episode_tracker_provider.dart
@@ -11,8 +11,8 @@ import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/data_source.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/item_status_logic.dart';
-import '../../../shared/models/media_type.dart';
 import '../../../shared/models/tv_episode.dart';
+import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import 'collections_provider.dart';
 
@@ -23,6 +23,7 @@ class EpisodeTrackerState {
     this.episodesBySeason = const <int, List<TvEpisode>>{},
     this.watchedEpisodes = const <(int, int), DateTime?>{},
     this.loadingSeasons = const <int, bool>{},
+    this.totalEpisodes,
     this.error,
   });
 
@@ -35,6 +36,10 @@ class EpisodeTrackerState {
   /// Per-season loading flags.
   final Map<int, bool> loadingSeasons;
 
+  /// Show's official episode count resolved by the tracker (specials
+  /// excluded). Fallback for cards whose cached [TvShow] has no totals.
+  final int? totalEpisodes;
+
   /// Load error, if any.
   final String? error;
 
@@ -43,12 +48,14 @@ class EpisodeTrackerState {
     Map<int, List<TvEpisode>>? episodesBySeason,
     Map<(int, int), DateTime?>? watchedEpisodes,
     Map<int, bool>? loadingSeasons,
+    int? totalEpisodes,
     String? error,
   }) {
     return EpisodeTrackerState(
       episodesBySeason: episodesBySeason ?? this.episodesBySeason,
       watchedEpisodes: watchedEpisodes ?? this.watchedEpisodes,
       loadingSeasons: loadingSeasons ?? this.loadingSeasons,
+      totalEpisodes: totalEpisodes ?? this.totalEpisodes,
       error: error,
     );
   }
@@ -144,10 +151,49 @@ class EpisodeTrackerNotifier
     // Episode tracking is not supported for uncategorized items
     if (_collectionId == null) return const EpisodeTrackerState();
 
+    // Only the cheap queries run eagerly: grid cards watch this provider
+    // per TV item and need just watched counts and totals. The full episode
+    // cache loads lazily via [ensureCachedEpisodesLoaded].
     Future<void>.microtask(_loadWatchedEpisodes);
-    Future<void>.microtask(_loadCachedEpisodes);
+    Future<void>.microtask(_resolveCachedTotals);
 
     return const EpisodeTrackerState();
+  }
+
+  bool _cachedEpisodesLoaded = false;
+
+  /// Loads the cached episode metadata once; the detail screen calls this —
+  /// cards don't need it.
+  Future<void> ensureCachedEpisodesLoaded() async {
+    if (_cachedEpisodesLoaded) return;
+    _cachedEpisodesLoaded = true;
+    await _loadCachedEpisodes();
+  }
+
+  /// Resolves the show's episode total from the local cache so progress
+  /// badges render "x/y" even when the cached show row has no totals
+  /// (rows written from list endpoints before the cache warmer existed).
+  /// Specials (season 0) are excluded, matching [totalWatchedCount].
+  Future<void> _resolveCachedTotals() async {
+    try {
+      final TvShow? show =
+          await _db.tvShowDao.getTvShowByTmdbId(_showId, source: _source);
+      int total = show?.totalEpisodes ?? 0;
+      if (total == 0) {
+        final List<TvSeason> seasons =
+            await _db.tvShowDao.getTvSeasonsByShowId(_source, _showId);
+        for (final TvSeason season in seasons) {
+          if (season.seasonNumber > 0) {
+            total += season.episodeCount ?? 0;
+          }
+        }
+      }
+      if (total > 0 && state.totalEpisodes == null) {
+        state = state.copyWith(totalEpisodes: total);
+      }
+    } on Exception catch (_) {
+      // Cache read failed — totals stay unknown, badges show bare counts.
+    }
   }
 
   Future<void> _loadWatchedEpisodes() async {
@@ -347,13 +393,11 @@ class EpisodeTrackerNotifier
         .valueOrNull;
     if (items == null) return;
 
-    // Find the show item (either tvShow or animation)
     CollectionItem? targetItem;
     for (final CollectionItem ci in items) {
       if (ci.externalId == _showId &&
-          (ci.source ?? DataSource.tmdb) == _source &&
-          (ci.mediaType == MediaType.tvShow ||
-           ci.mediaType == MediaType.animation)) {
+          ci.dataSource == _source &&
+          ci.mediaType.isTvBacked) {
         targetItem = ci;
         break;
       }
@@ -365,8 +409,8 @@ class EpisodeTrackerNotifier
     int totalSeasons = _cachedTotalSeasons ??
         targetItem.tvShow?.totalSeasons ?? 0;
 
-    // If totals are missing from the cache, fetch them from the source API
-    // (once per session, so we don't query on every toggle)
+    // Fetch missing totals from the source API once per session, so a
+    // toggle doesn't turn into a network call every time.
     if ((totalInShow == 0 || totalSeasons == 0) && !_hasFetchedTotals) {
       _hasFetchedTotals = true;
       try {
@@ -392,6 +436,12 @@ class EpisodeTrackerNotifier
         totalSeasons > 0 &&
         loadedRegularSeasons >= totalSeasons) {
       totalInShow = state.totalEpisodeCount;
+    }
+
+    // Publish resolved totals so progress badges can render "x/y" even when
+    // the cached show row (e.g. from search results) has no totals.
+    if (totalInShow > 0 && totalInShow != state.totalEpisodes) {
+      state = state.copyWith(totalEpisodes: totalInShow);
     }
 
     final ItemStatus? targetStatus = computeStatusFromProgress(

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/discord_rpc_service.dart';
 import '../../../core/services/image_cache_service.dart';
+import '../../../core/services/tv_show_cache_warmer.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
@@ -706,7 +708,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
             collectionId: widget.collectionId,
             itemId: item.id,
             externalId: item.externalId,
-            source: item.source ?? DataSource.tmdb,
+            source: item.dataSource,
             tvShow: config.tvShow,
             accentColor: config.accentColor,
           ),
@@ -957,6 +959,10 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
         mediaType: MediaType.tvShow,
         ownMapProvider: collectedTvShowIdsProvider,
         upsert: (DatabaseService db) => db.tvShowDao.upsertTvShow(tvShow),
+        // Recommendation rows carry no season/episode totals — warm the
+        // cache with full details like the search add flow does.
+        afterAdd: () =>
+            ref.read(tvShowCacheWarmerProvider).warm(tvShow.tmdbId),
       );
 
   Future<void> _addRecommendation({
@@ -965,6 +971,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
     required MediaType mediaType,
     required FutureProvider<Map<int, List<CollectedItemInfo>>> ownMapProvider,
     required Future<void> Function(DatabaseService db) upsert,
+    Future<void> Function()? afterAdd,
   }) async {
     final Map<int, List<CollectedItemInfo>> ownMap =
         await ref.read(ownMapProvider.future);
@@ -1002,6 +1009,10 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
     final bool success = await ref
         .read(collectionItemsNotifierProvider(collectionId).notifier)
         .addItem(mediaType: mediaType, externalId: tmdbId);
+
+    if (success && afterAdd != null) {
+      unawaited(afterAdd());
+    }
 
     if (!mounted) return;
 

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -7,7 +7,6 @@ import '../../../shared/constants/platform_features.dart';
 import '../../../shared/extensions/snackbar_extension.dart';
 import '../../../shared/models/collection_item.dart';
 import '../../../shared/models/collection_sort_mode.dart';
-import '../../../shared/models/data_source.dart';
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/tag.dart';
@@ -18,9 +17,9 @@ import '../../../shared/utils/item_card_progress.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../settings/providers/settings_provider.dart';
 import '../helpers/collection_actions.dart';
+import '../helpers/tracker_card_progress.dart';
 import '../providers/collection_selection_provider.dart';
 import '../providers/collections_provider.dart';
-import '../providers/episode_tracker_provider.dart';
 import '../providers/item_tags_provider.dart';
 import '../extensions/item_display_name.dart';
 import 'collection_table/collection_table_view.dart';
@@ -374,7 +373,7 @@ class CollectionItemsView extends ConsumerWidget {
     final bool selectionActive = selection.isNotEmpty;
     final bool isSelected = selection.contains(item.id);
     final ItemCardProgress? progress =
-        itemCardProgress(item) ?? _trackerProgress(ref, item);
+        itemCardProgress(item) ?? trackerCardProgress(ref, item);
 
     final Widget card = MediaPosterCard(
       key: ValueKey<int>(item.id),
@@ -437,30 +436,6 @@ class CollectionItemsView extends ConsumerWidget {
           .read(collectionSelectionProvider(collectionId).notifier)
           .toggle(item.id),
       child: card,
-    );
-  }
-
-  /// Card progress for TMDB shows, whose marks live in the episode tracker
-  /// rather than on the item (itemCardProgress returns null for them).
-  ItemCardProgress? _trackerProgress(WidgetRef ref, CollectionItem item) {
-    if (collectionId == null) return null;
-    if (item.mediaType != MediaType.tvShow &&
-        item.mediaType != MediaType.animation) {
-      return null;
-    }
-    final int watched = ref
-        .watch(episodeTrackerNotifierProvider((
-          collectionId: collectionId,
-          showId: item.externalId,
-          source: item.source ?? DataSource.tmdb,
-        )))
-        .totalWatchedCount;
-    if (watched == 0) return null;
-    final int total = item.tvShow?.totalEpisodes ?? 0;
-    return ItemCardProgress(
-      label: total > 0 ? '$watched/$total' : '$watched',
-      fraction:
-          total > 0 ? (watched / total).clamp(0.0, 1.0) : null,
     );
   }
 

--- a/lib/features/collections/widgets/episode_tracker_section.dart
+++ b/lib/features/collections/widgets/episode_tracker_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/episode_source/tv_episode_source.dart';
 import '../../../core/database/database_service.dart';
+import '../../../core/services/image_cache_service.dart';
 import '../../../shared/models/data_source.dart';
 import '../../../features/settings/providers/settings_provider.dart';
 import '../../../l10n/app_localizations.dart';
@@ -16,6 +17,7 @@ import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import '../../../shared/utils/date_format_preset.dart';
+import '../../../shared/widgets/cached_image.dart';
 import '../providers/episode_tracker_provider.dart';
 import '../providers/item_marks_provider.dart';
 import 'item_mark_controls.dart';
@@ -45,7 +47,6 @@ class EpisodeTrackerSection extends ConsumerWidget {
   /// Show id in the [source] provider's namespace.
   final int externalId;
 
-  /// Episode data source of the item.
   final DataSource source;
 
   /// Show data.
@@ -63,7 +64,10 @@ class EpisodeTrackerSection extends ConsumerWidget {
     final EpisodeTrackerState trackerState =
         ref.watch(episodeTrackerNotifierProvider(trackerArg));
 
-    final int totalEpisodes = tvShow?.totalEpisodes ?? 0;
+    // Sparse cached rows have no totals — fall back to the count the
+    // tracker resolved from the seasons cache.
+    final int totalEpisodes =
+        tvShow?.totalEpisodes ?? trackerState.totalEpisodes ?? 0;
     final int watchedCount = trackerState.totalWatchedCount;
 
     final S l = S.of(context);
@@ -74,13 +78,17 @@ class EpisodeTrackerSection extends ConsumerWidget {
           children: <Widget>[
             Icon(Icons.playlist_add_check, size: 20, color: accentColor),
             const SizedBox(width: AppSpacing.sm),
-            Text(
-              l.episodeProgress,
-              style: AppTypography.h3.copyWith(
-                fontWeight: FontWeight.w600,
+            Expanded(
+              child: Text(
+                l.episodeProgress,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.h3.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
-            const Spacer(),
+            const SizedBox(width: AppSpacing.sm),
             Text(
               totalEpisodes > 0
                   ? l.episodesWatchedOf(watchedCount, totalEpisodes)
@@ -130,7 +138,6 @@ class SeasonsListWidget extends ConsumerStatefulWidget {
   /// Show id in the [source] provider's namespace.
   final int showId;
 
-  /// Episode data source of the item.
   final DataSource source;
 
   /// Collection id (null for uncategorized).
@@ -155,6 +162,11 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
   @override
   void initState() {
     super.initState();
+    // Episode metadata is skipped on grid-card builds; the detail list is
+    // the consumer that needs it (marks titles, expanded seasons).
+    Future<void>.microtask(() => ref
+        .read(episodeTrackerNotifierProvider(_trackerArg).notifier)
+        .ensureCachedEpisodesLoaded());
     _loadSeasons();
   }
 
@@ -163,7 +175,6 @@ class _SeasonsListWidgetState extends ConsumerState<SeasonsListWidget> {
     List<TvSeason> seasons =
         await db.tvShowDao.getTvSeasonsByShowId(widget.source, widget.showId);
 
-    // Cache miss: fetch from the source API and cache the result
     if (seasons.isEmpty) {
       try {
         final TvEpisodeSource episodeSource =
@@ -597,9 +608,16 @@ class _SeasonExpansionTileState extends ConsumerState<SeasonExpansionTile> {
 
     final String seasonTitle =
         season.name ?? l.seasonName(seasonNum);
-    final String subtitle = episodeCount > 0
-        ? l.seasonEpisodesProgress(watchedCount, episodeCount)
-        : l.episodesWatched(watchedCount);
+    final String? airDate = season.airDate;
+    final int? airYear = airDate != null && airDate.length >= 4
+        ? int.tryParse(airDate.substring(0, 4))
+        : null;
+    final String subtitle = <String>[
+      episodeCount > 0
+          ? l.seasonEpisodesProgress(watchedCount, episodeCount)
+          : l.episodesWatched(watchedCount),
+      if (airYear != null) '$airYear',
+    ].join(' • ');
     final String? note = ref.watch(
       itemMarksProvider(itemId).select(
         (ItemMarksState s) => s.noteFor(kUnitSeason, seasonNum, 0),
@@ -609,10 +627,11 @@ class _SeasonExpansionTileState extends ConsumerState<SeasonExpansionTile> {
     return ExpansionTile(
       tilePadding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
       childrenPadding: const EdgeInsets.only(bottom: AppSpacing.sm),
-      leading: Icon(
-        allWatched ? Icons.check_circle : Icons.circle_outlined,
-        color: allWatched ? accentColor : AppColors.surfaceBorder,
-        size: 20,
+      leading: _SeasonLeading(
+        season: season,
+        source: trackerArg.source,
+        allWatched: allWatched,
+        accentColor: accentColor,
       ),
       title: Row(
         children: <Widget>[
@@ -809,59 +828,112 @@ class _EpisodeTileState extends ConsumerState<EpisodeTile> {
       ),
     );
 
-    final Widget tile = CheckboxListTile(
-      value: isWatched,
-      onChanged: (_) {
-        ref
-            .read(episodeTrackerNotifierProvider(widget.trackerArg).notifier)
-            .toggleEpisode(
-              episode.seasonNumber,
-              episode.episodeNumber,
-            );
-      },
-      title: Row(
-        children: <Widget>[
-          Expanded(
-            child: Text(
-              title,
-              style: AppTypography.bodySmall.copyWith(
-                decoration: isWatched ? TextDecoration.lineThrough : null,
-                color: isWatched
-                    ? AppColors.textSecondary
-                    : AppColors.textPrimary,
-              ),
-            ),
-          ),
-          ItemMarkControls(
-            itemId: widget.itemId,
-            unitType: kUnitEpisode,
-            parentNumber: episode.seasonNumber,
-            unitNumber: episode.episodeNumber,
-            onNotePressed: () =>
-                setState(() => _editingNote = !_editingNote),
-          ),
-        ],
-      ),
-      subtitle: (subtitleParts.isNotEmpty || (note != null && !_editingNote))
-          ? Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                if (subtitleParts.isNotEmpty)
-                  Text(
-                    subtitleParts.join(' \u2022 '),
-                    style: AppTypography.caption.copyWith(
-                      color: AppColors.textSecondary,
+    final String? overview = episode.overview;
+
+    void toggle() {
+      ref
+          .read(episodeTrackerNotifierProvider(widget.trackerArg).notifier)
+          .toggleEpisode(episode.seasonNumber, episode.episodeNumber);
+    }
+
+    final Widget tile = InkWell(
+      onTap: toggle,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (episode.stillUrl != null) ...<Widget>[
+              // Watched episodes get a dimmed still with a check badge,
+              // matching the struck-through title; the row tap toggles.
+              Stack(
+                children: <Widget>[
+                  Opacity(
+                    opacity: isWatched ? 0.55 : 1,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
+                      child: CachedImage(
+                        imageType: ImageType.tvEpisodeStill,
+                        imageId: '${widget.trackerArg.source.name}_'
+                            '${episode.tmdbShowId}_'
+                            's${episode.seasonNumber}e${episode.episodeNumber}',
+                        remoteUrl: episode.stillUrl!,
+                        width: 96,
+                        height: 54,
+                        fit: BoxFit.cover,
+                        memCacheWidth: 192,
+                        placeholder:
+                            const ColoredBox(color: AppColors.surfaceLight),
+                        errorWidget:
+                            const ColoredBox(color: AppColors.surfaceLight),
+                      ),
                     ),
                   ),
-                if (note != null && !_editingNote)
-                  MarkNoteText(note: note, accentColor: widget.accentColor),
-              ],
-            )
-          : null,
-      dense: true,
-      controlAffinity: ListTileControlAffinity.leading,
-      contentPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
-      visualDensity: VisualDensity.compact,
+                  if (isWatched)
+                    Positioned(
+                      right: 3,
+                      bottom: 3,
+                      child: _WatchedBadge(accentColor: widget.accentColor),
+                    ),
+                ],
+              ),
+            ],
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            title,
+                            style: AppTypography.bodySmall.copyWith(
+                              decoration: isWatched
+                                  ? TextDecoration.lineThrough
+                                  : null,
+                              color: isWatched
+                                  ? AppColors.textSecondary
+                                  : AppColors.textPrimary,
+                            ),
+                          ),
+                        ),
+                      ),
+                      ItemMarkControls(
+                        itemId: widget.itemId,
+                        unitType: kUnitEpisode,
+                        parentNumber: episode.seasonNumber,
+                        unitNumber: episode.episodeNumber,
+                        onNotePressed: () =>
+                            setState(() => _editingNote = !_editingNote),
+                      ),
+                    ],
+                  ),
+                  if (subtitleParts.isNotEmpty)
+                    Text(
+                      subtitleParts.join(' \u2022 '),
+                      style: AppTypography.caption.copyWith(
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  if (overview != null && overview.isNotEmpty) ...<Widget>[
+                    const SizedBox(height: 2),
+                    _ExpandableOverview(text: overview),
+                  ],
+                  if (note != null && !_editingNote)
+                    MarkNoteText(note: note, accentColor: widget.accentColor),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
 
     if (!_editingNote) return tile;
@@ -885,6 +957,114 @@ class _EpisodeTileState extends ConsumerState<EpisodeTile> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Season poster thumbnail with an "all watched" badge; falls back to the
+/// plain check indicator when the source has no poster for the season.
+class _SeasonLeading extends StatelessWidget {
+  const _SeasonLeading({
+    required this.season,
+    required this.source,
+    required this.allWatched,
+    required this.accentColor,
+  });
+
+  final TvSeason season;
+  final DataSource source;
+  final bool allWatched;
+  final Color accentColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final String? posterUrl = season.posterUrl;
+    if (posterUrl == null) {
+      return Icon(
+        allWatched ? Icons.check_circle : Icons.circle_outlined,
+        color: allWatched ? accentColor : AppColors.surfaceBorder,
+        size: 20,
+      );
+    }
+    return SizedBox(
+      width: 40,
+      height: 60,
+      child: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          ClipRRect(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
+            child: CachedImage(
+              imageType: ImageType.tvSeasonPoster,
+              imageId: '${source.name}_${season.tmdbShowId}_'
+                  's${season.seasonNumber}',
+              remoteUrl: posterUrl,
+              fit: BoxFit.cover,
+              memCacheWidth: 120,
+              placeholder: const ColoredBox(color: AppColors.surfaceLight),
+              errorWidget: const ColoredBox(color: AppColors.surfaceLight),
+            ),
+          ),
+          if (allWatched)
+            Positioned(
+              right: 2,
+              bottom: 2,
+              child: _WatchedBadge(accentColor: accentColor, size: 14),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Check-circle badge shown over a poster/still corner for watched items.
+class _WatchedBadge extends StatelessWidget {
+  const _WatchedBadge({required this.accentColor, this.size = 15});
+
+  final Color accentColor;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.background.withAlpha(200),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(Icons.check_circle, color: accentColor, size: size),
+    );
+  }
+}
+
+/// Episode overview clamped to two lines; tap toggles the full text.
+/// `canRequestFocus: false` keeps it out of D-pad traversal — the row's
+/// own InkWell stays the single gamepad stop per episode.
+class _ExpandableOverview extends StatefulWidget {
+  const _ExpandableOverview({required this.text});
+
+  final String text;
+
+  @override
+  State<_ExpandableOverview> createState() => _ExpandableOverviewState();
+}
+
+class _ExpandableOverviewState extends State<_ExpandableOverview> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => setState(() => _expanded = !_expanded),
+      canRequestFocus: false,
+      child: Text(
+        widget.text,
+        maxLines: _expanded ? null : 2,
+        overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
+        style: AppTypography.caption.copyWith(
+          color: AppColors.textTertiary,
+          height: 1.35,
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -23,6 +23,7 @@ import '../../../shared/widgets/filter_subfilter_bar.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../../shared/widgets/uncategorized_deprecation_banner.dart';
 import '../../collections/helpers/collection_actions.dart';
+import '../../collections/helpers/tracker_card_progress.dart';
 import '../../collections/providers/all_items_selection_provider.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../collections/extensions/item_display_name.dart';
@@ -515,7 +516,8 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                     final Set<int> selection =
                         ref.watch(allItemsSelectionProvider);
                     final bool isSelected = selection.contains(item.id);
-                    final ItemCardProgress? progress = itemCardProgress(item);
+                    final ItemCardProgress? progress =
+                        itemCardProgress(item) ?? trackerCardProgress(ref, item);
                     final MediaPosterCard card = MediaPosterCard(
                       key: ValueKey<int>(item.id),
                       variant: isLandscape ||

--- a/lib/features/search/handlers/tv_show_handler.dart
+++ b/lib/features/search/handlers/tv_show_handler.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../../core/services/image_cache_service.dart';
-import '../../../shared/models/data_source.dart';
+import '../../../core/services/tv_show_cache_warmer.dart';
 import '../../../shared/models/media_type.dart';
-import '../../../shared/models/tv_episode.dart';
-import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../services/search_collection_adder.dart';
@@ -83,7 +80,7 @@ class TvShowHandler implements MediaActionHandler {
       imageType: ImageType.tvShowPoster,
       imageId: tvShow.tmdbId.toString(),
       imageUrl: tvShow.posterUrl,
-      afterAdd: () => _preloadSeasons(tvShow.tmdbId),
+      afterAdd: () => _ref.read(tvShowCacheWarmerProvider).warm(tvShow.tmdbId),
     );
   }
 
@@ -122,32 +119,7 @@ class TvShowHandler implements MediaActionHandler {
       imageType: ImageType.tvShowPoster,
       imageId: tvShow.tmdbId.toString(),
       imageUrl: tvShow.posterUrl,
-      afterAdd: () => _preloadSeasons(tvShow.tmdbId),
+      afterAdd: () => _ref.read(tvShowCacheWarmerProvider).warm(tvShow.tmdbId),
     );
-  }
-
-  Future<void> _preloadSeasons(int tmdbId) async {
-    try {
-      final DatabaseService db = _ref.read(databaseServiceProvider);
-      final TmdbApi tmdb = _ref.read(tmdbApiProvider);
-
-      List<TvSeason> seasons =
-          await db.tvShowDao.getTvSeasonsByShowId(DataSource.tmdb, tmdbId);
-      if (seasons.isEmpty) {
-        seasons = await tmdb.getTvSeasons(tmdbId);
-        if (seasons.isNotEmpty) await db.tvShowDao.upsertTvSeasons(seasons);
-      }
-      for (final TvSeason season in seasons) {
-        final List<TvEpisode> cached = await db.tvShowDao
-            .getEpisodesByShowAndSeason(DataSource.tmdb, tmdbId, season.seasonNumber);
-        if (cached.isEmpty) {
-          final List<TvEpisode> episodes =
-              await tmdb.getSeasonEpisodes(tmdbId, season.seasonNumber);
-          if (episodes.isNotEmpty) await db.tvShowDao.upsertEpisodes(episodes);
-        }
-      }
-    } catch (_) {
-      // Network/API failure — episodes load on-demand later.
-    }
   }
 }

--- a/lib/shared/models/media_type.dart
+++ b/lib/shared/models/media_type.dart
@@ -38,6 +38,10 @@ enum MediaType {
 
   const MediaType(this.value);
 
+  /// Whether episode tracking applies (tv show or tv-based animation).
+  bool get isTvBacked =>
+      this == MediaType.tvShow || this == MediaType.animation;
+
   /// Fallback source for rows whose `source` column is NULL.
   DataSource get defaultSource => switch (this) {
         MediaType.game => DataSource.igdb,

--- a/lib/shared/models/tv_episode.dart
+++ b/lib/shared/models/tv_episode.dart
@@ -1,10 +1,7 @@
-// TV episode model shared by all episode sources.
-
 import 'data_source.dart';
 
 /// One episode of a TV show season.
 class TvEpisode {
-  /// Creates a [TvEpisode].
   const TvEpisode({
     required this.tmdbShowId,
     required this.seasonNumber,
@@ -17,7 +14,6 @@ class TvEpisode {
     this.source = DataSource.tmdb,
   });
 
-  /// Creates a [TvEpisode] from a TMDB API JSON response.
   factory TvEpisode.fromJson(
     Map<String, dynamic> json, {
     required int showId,
@@ -41,8 +37,7 @@ class TvEpisode {
     );
   }
 
-  /// Creates a [TvEpisode] from a database row. A missing or unknown
-  /// `source` reads as [DataSource.tmdb].
+  /// A missing or unknown `source` column reads as [DataSource.tmdb].
   factory TvEpisode.fromDb(Map<String, dynamic> row) {
     return TvEpisode(
       tmdbShowId: row['tmdb_show_id'] as int,
@@ -60,31 +55,21 @@ class TvEpisode {
   /// Show id in the [source] provider's namespace.
   final int tmdbShowId;
 
-  /// Season number.
   final int seasonNumber;
-
-  /// Episode number within the season.
   final int episodeNumber;
-
-  /// Episode title.
   final String name;
-
-  /// Episode overview.
   final String? overview;
 
-  /// Air date ("YYYY-MM-DD").
+  /// "YYYY-MM-DD".
   final String? airDate;
 
-  /// Still image URL.
   final String? stillUrl;
 
   /// Runtime in minutes.
   final int? runtime;
 
-  /// Provider this episode came from.
   final DataSource source;
 
-  /// Converts to a map for database storage.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'tmdb_show_id': tmdbShowId,
@@ -100,7 +85,6 @@ class TvEpisode {
     };
   }
 
-  /// Returns a copy with the given fields replaced.
   TvEpisode copyWith({
     int? tmdbShowId,
     int? seasonNumber,

--- a/lib/shared/models/tv_season.dart
+++ b/lib/shared/models/tv_season.dart
@@ -1,10 +1,7 @@
-// TV season model shared by all episode sources.
-
 import 'data_source.dart';
 
 /// One season of a TV show.
 class TvSeason {
-  /// Creates a [TvSeason].
   const TvSeason({
     required this.tmdbShowId,
     required this.seasonNumber,
@@ -15,7 +12,6 @@ class TvSeason {
     this.source = DataSource.tmdb,
   });
 
-  /// Creates a [TvSeason] from a TMDB API JSON response.
   factory TvSeason.fromJson(Map<String, dynamic> json, {required int showId}) {
     String? posterUrl;
     final String? posterPath = json['poster_path'] as String?;
@@ -33,8 +29,7 @@ class TvSeason {
     );
   }
 
-  /// Creates a [TvSeason] from a database row. A missing or unknown
-  /// `source` reads as [DataSource.tmdb].
+  /// A missing or unknown `source` column reads as [DataSource.tmdb].
   factory TvSeason.fromDb(Map<String, dynamic> row) {
     return TvSeason(
       tmdbShowId: row['tmdb_show_id'] as int,
@@ -50,25 +45,16 @@ class TvSeason {
   /// Show id in the [source] provider's namespace.
   final int tmdbShowId;
 
-  /// Season number.
   final int seasonNumber;
-
-  /// Season name.
   final String? name;
-
-  /// Number of episodes in the season.
   final int? episodeCount;
-
-  /// Season poster URL.
   final String? posterUrl;
 
-  /// Air date ("YYYY-MM-DD").
+  /// "YYYY-MM-DD".
   final String? airDate;
 
-  /// Provider this season came from.
   final DataSource source;
 
-  /// Converts to a map for database storage.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'tmdb_show_id': tmdbShowId,
@@ -81,7 +67,6 @@ class TvSeason {
     };
   }
 
-  /// Returns a copy with the given fields replaced.
   TvSeason copyWith({
     int? tmdbShowId,
     int? seasonNumber,

--- a/lib/shared/models/tv_show.dart
+++ b/lib/shared/models/tv_show.dart
@@ -1,12 +1,9 @@
-// TV show model shared by all show sources.
-
 import 'dart:convert';
 
 import 'data_source.dart';
 
 /// A TV show with catalog metadata.
 class TvShow {
-  /// Creates a [TvShow].
   const TvShow({
     required this.tmdbId,
     required this.title,
@@ -25,30 +22,26 @@ class TvShow {
     this.source = DataSource.tmdb,
   });
 
-  /// Создаёт [TvShow] из JSON ответа TMDB API.
   factory TvShow.fromJson(Map<String, dynamic> json) {
-    // Извлекаем URL постера
     String? posterUrl;
     final String? posterPath = json['poster_path'] as String?;
     if (posterPath != null) {
       posterUrl = 'https://image.tmdb.org/t/p/w342$posterPath';
     }
 
-    // Извлекаем URL бэкдропа
     String? backdropUrl;
     final String? backdropPath = json['backdrop_path'] as String?;
     if (backdropPath != null) {
       backdropUrl = 'https://image.tmdb.org/t/p/w780$backdropPath';
     }
 
-    // Извлекаем год из first_air_date (формат: "2008-01-20")
+    // first_air_date is "YYYY-MM-DD".
     int? firstAirYear;
     final String? firstAirDate = json['first_air_date'] as String?;
     if (firstAirDate != null && firstAirDate.length >= 4) {
       firstAirYear = int.tryParse(firstAirDate.substring(0, 4));
     }
 
-    // Извлекаем жанры
     List<String>? genres;
     if (json['genres'] != null) {
       final List<dynamic> genresList = json['genres'] as List<dynamic>;
@@ -60,7 +53,6 @@ class TvShow {
       genres = genreIds.map((dynamic id) => id.toString()).toList();
     }
 
-    // Конструируем URL страницы сериала на TMDB
     final int tmdbId = json['id'] as int;
 
     return TvShow(
@@ -82,8 +74,7 @@ class TvShow {
     );
   }
 
-  /// Creates a [TvShow] from a database row. A missing or unknown `source`
-  /// reads as [DataSource.tmdb].
+  /// A missing or unknown `source` column reads as [DataSource.tmdb].
   factory TvShow.fromDb(Map<String, dynamic> row) {
     List<String>? genres;
     if (row['genres'] != null && (row['genres'] as String).isNotEmpty) {
@@ -114,70 +105,56 @@ class TvShow {
   /// Show id in the [source] provider's namespace.
   final int tmdbId;
 
-  /// Название сериала (локализованное).
   final String title;
 
-  /// Оригинальное название сериала.
   final String? originalTitle;
 
-  /// URL постера сериала.
   final String? posterUrl;
 
-  /// URL бэкдропа сериала.
   final String? backdropUrl;
 
-  /// Описание сериала.
   final String? overview;
 
-  /// Список жанров.
   final List<String>? genres;
 
-  /// Год начала показа.
   final int? firstAirYear;
 
-  /// Общее количество сезонов.
   final int? totalSeasons;
 
-  /// Общее количество эпизодов.
   final int? totalEpisodes;
 
-  /// Рейтинг TMDB (0-10).
+  /// 0-10.
   final double? rating;
 
-  /// Статус сериала (Returning Series, Ended, Canceled).
+  /// TMDB value: "Returning Series", "Ended", "Canceled".
   final String? status;
 
-  /// URL страницы сериала на TMDB.
   final String? externalUrl;
 
-  /// Время кеширования (Unix timestamp).
+  /// Unix millis.
   final int? cachedAt;
 
-  /// Provider this show came from.
   final DataSource source;
 
-  /// URL маленького постера (w154) для thumbnail-ов.
+  /// w154 variant for thumbnails.
   String? get posterThumbUrl {
     if (posterUrl == null) return null;
     return posterUrl!.replaceFirst(RegExp(r'/w\d+'), '/w154');
   }
 
-  /// URL среднего бэкдропа (w300) для экранов деталей.
+  /// w300 variant for detail screens.
   String? get backdropSmallUrl {
     if (backdropUrl == null) return null;
     return backdropUrl!.replaceFirst('/w780', '/w300');
   }
 
-  /// Возвращает отформатированный рейтинг.
   String? get formattedRating {
     if (rating == null) return null;
     return rating!.toStringAsFixed(1);
   }
 
-  /// Возвращает жанры в виде строки через запятую.
   String? get genresString => genres?.join(', ');
 
-  /// Преобразует в Map для сохранения в базу данных.
   Map<String, dynamic> toDb() {
     return <String, dynamic>{
       'tmdb_id': tmdbId,
@@ -198,7 +175,6 @@ class TvShow {
     };
   }
 
-  /// Создаёт копию с изменёнными полями.
   TvShow copyWith({
     int? tmdbId,
     String? title,

--- a/lib/shared/widgets/media_poster_card.dart
+++ b/lib/shared/widgets/media_poster_card.dart
@@ -564,13 +564,22 @@ class _MediaPosterCardState extends State<MediaPosterCard>
                             const Spacer(),
                           if (widget.onTagTap != null ||
                               widget.tagName != null)
-                            _TagBadge(
-                              tagName: widget.tagName,
-                              tagColor: widget.tagColor,
-                              tagTextColor: widget.tagTextColor,
-                              moreCount: widget.tagMoreCount,
-                              compact: _isCompact,
-                              onTap: widget.onTagTap,
+                            // Align keeps the badge flush right inside its
+                            // flex share; bare Flexible would leave the
+                            // share's leftover trailing and pull the badge
+                            // toward the middle.
+                            Flexible(
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: _TagBadge(
+                                  tagName: widget.tagName,
+                                  tagColor: widget.tagColor,
+                                  tagTextColor: widget.tagTextColor,
+                                  moreCount: widget.tagMoreCount,
+                                  compact: _isCompact,
+                                  onTap: widget.onTagTap,
+                                ),
+                              ),
                             ),
                         ],
                       ),

--- a/test/core/api/episode_source/tmdb_episode_source_test.dart
+++ b/test/core/api/episode_source/tmdb_episode_source_test.dart
@@ -21,10 +21,6 @@ void main() {
   });
 
   group('TmdbEpisodeSource', () {
-    test('source is tmdb', () {
-      expect(source.source, DataSource.tmdb);
-    });
-
     test('getShow delegates to TmdbApi.getTvShow', () async {
       const TvShow show = TvShow(tmdbId: 100, title: 'Show');
       when(() => mockApi.getTvShow(100)).thenAnswer((_) async => show);
@@ -69,7 +65,6 @@ void main() {
       final TvEpisodeSource Function(DataSource) resolve =
           container.read(tvEpisodeSourceResolverProvider);
 
-      expect(resolve(DataSource.tmdb).source, DataSource.tmdb);
       for (final DataSource s in DataSource.values) {
         expect(resolve(s), isA<TvEpisodeSource>());
       }

--- a/test/core/api/tmdb_api_test.dart
+++ b/test/core/api/tmdb_api_test.dart
@@ -1034,6 +1034,80 @@ void main() {
       });
     });
 
+    group('getTvShowWithSeasons', () {
+      setUp(() {
+        sut.setApiKey(testApiKey);
+      });
+
+      test('should parse show and seasons from a single request', () async {
+        final Map<String, dynamic> tvShowJson = createTvShowJson();
+        tvShowJson['seasons'] = <Map<String, dynamic>>[
+          createSeasonJson(),
+          createSeasonJson(
+            seasonNumber: 2,
+            name: 'Сезон 2',
+            episodeCount: 13,
+            airDate: '2009-03-08',
+          ),
+        ];
+
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: tvShowJson,
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final (TvShow, List<TvSeason>)? result =
+            await sut.getTvShowWithSeasons(1396);
+
+        expect(result, isNotNull);
+        expect(result!.$1.tmdbId, equals(1396));
+        expect(result.$1.totalEpisodes, equals(62));
+        expect(result.$2, hasLength(2));
+        expect(result.$2[0].tmdbShowId, equals(1396));
+        expect(result.$2[1].seasonNumber, equals(2));
+        verify(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).called(1);
+      });
+
+      test('should return empty seasons when the payload has none', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenAnswer((_) async => Response<dynamic>(
+              data: createTvShowJson(),
+              statusCode: 200,
+              requestOptions: RequestOptions(),
+            ));
+
+        final (TvShow, List<TvSeason>)? result =
+            await sut.getTvShowWithSeasons(1396);
+
+        expect(result, isNotNull);
+        expect(result!.$2, isEmpty);
+      });
+
+      test('should return null при 404', () async {
+        when(() => mockDio.get<dynamic>(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+            )).thenThrow(DioException(
+          response: Response<dynamic>(
+            statusCode: 404,
+            requestOptions: RequestOptions(),
+          ),
+          requestOptions: RequestOptions(),
+        ));
+
+        expect(await sut.getTvShowWithSeasons(999999), isNull);
+      });
+    });
+
     group('getTvSeasons', () {
       setUp(() {
         sut.setApiKey(testApiKey);

--- a/test/core/database/dao/book_dao_test.dart
+++ b/test/core/database/dao/book_dao_test.dart
@@ -61,6 +61,28 @@ void main() {
             await dao.getBook('27448', source: DataSource.openLibrary);
         expect(loaded!.title, 'New');
       });
+
+      test('sparse row keeps the cached page count', () async {
+        // Similars/search-list rows carry no page count and must not wipe it.
+        await dao.upsertBook(
+          createTestBook(id: '27448', title: 'Full', pageCount: 350),
+        );
+        await dao.upsertBook(createTestBook(id: '27448', title: 'Similar'));
+
+        final Book? loaded =
+            await dao.getBook('27448', source: DataSource.openLibrary);
+        expect(loaded!.pageCount, 350);
+        expect(loaded.title, 'Similar');
+      });
+
+      test('full row updates the page count', () async {
+        await dao.upsertBook(createTestBook(id: '27448', pageCount: 350));
+        await dao.upsertBook(createTestBook(id: '27448', pageCount: 420));
+
+        final Book? loaded =
+            await dao.getBook('27448', source: DataSource.openLibrary);
+        expect(loaded!.pageCount, 420);
+      });
     });
 
     group('(id, source) primary key', () {

--- a/test/core/database/dao/collection_dao_test.dart
+++ b/test/core/database/dao/collection_dao_test.dart
@@ -1389,7 +1389,26 @@ void main() {
     });
 
     group('updateItemCollectionId', () {
+      void stubItemLookup() {
+        mockDb.stubTransaction(mockTxn);
+        when(
+          () => mockTxn.query(
+            'collection_items',
+            columns: <String>[
+              'collection_id',
+              'media_type',
+              'external_id',
+              'source',
+            ],
+            where: 'id = ?',
+            whereArgs: <Object?>[1],
+            limit: 1,
+          ),
+        ).thenAnswer((_) async => <Map<String, dynamic>>[]);
+      }
+
       test('moves item and returns true', () async {
+        stubItemLookup();
         when(
           () => mockDb.rawQuery(
             'SELECT MAX(sort_order) AS max_sort FROM collection_items '
@@ -1402,7 +1421,7 @@ void main() {
           ],
         );
         when(
-          () => mockDb.update(
+          () => mockTxn.update(
             'collection_items',
             any(),
             where: 'id = ?',
@@ -1416,6 +1435,7 @@ void main() {
       });
 
       test('returns false on unique constraint violation', () async {
+        stubItemLookup();
         when(
           () => mockDb.rawQuery(
             'SELECT MAX(sort_order) AS max_sort FROM collection_items '
@@ -1428,7 +1448,7 @@ void main() {
           ],
         );
         when(
-          () => mockDb.update(
+          () => mockTxn.update(
             'collection_items',
             any(),
             where: 'id = ?',

--- a/test/core/database/dao/collection_dao_watched_transfer_test.dart
+++ b/test/core/database/dao/collection_dao_watched_transfer_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/dao/anime_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/book_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/collection_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/custom_media_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/game_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/manga_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/movie_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/visual_novel_dao.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_registry.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late Database db;
+  late CollectionDao dao;
+
+  setUp(() async {
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: MigrationRegistry.all.last.version,
+        onCreate: (Database d, int _) async {
+          for (final Migration m in MigrationRegistry.all) {
+            await m.migrate(d);
+          }
+        },
+      ),
+    );
+    Future<Database> getDb() async => db;
+    dao = CollectionDao(
+      getDb,
+      gameDao: GameDao(getDb),
+      movieDao: MovieDao(getDb),
+      tvShowDao: TvShowDao(getDb),
+      visualNovelDao: VisualNovelDao(getDb),
+      animeDao: AnimeDao(getDb),
+      mangaDao: MangaDao(getDb),
+      bookDao: BookDao(getDb),
+      customMediaDao: CustomMediaDao(getDb),
+    );
+
+    for (final int id in <int>[1, 2]) {
+      await db.insert('collections', <String, Object?>{
+        'id': id,
+        'name': 'C$id',
+        'author': 'tester',
+        'created_at': 1700000000,
+      });
+    }
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<int> insertItem({
+    required int id,
+    required int collectionId,
+    required String mediaType,
+    required int externalId,
+    String? source,
+    int? platformId,
+  }) async {
+    return db.insert('collection_items', <String, Object?>{
+      'id': id,
+      'collection_id': collectionId,
+      'media_type': mediaType,
+      'external_id': externalId,
+      'source': source,
+      'platform_id': platformId,
+      'status': 'not_started',
+      'sort_order': id,
+      'added_at': 1700000000,
+    });
+  }
+
+  Future<void> insertWatched({
+    required int collectionId,
+    required int showId,
+    String source = 'tmdb',
+    int season = 1,
+    int episode = 1,
+  }) async {
+    await db.insert('watched_episodes', <String, Object?>{
+      'collection_id': collectionId,
+      'source': source,
+      'show_id': showId,
+      'season_number': season,
+      'episode_number': episode,
+      'watched_at': 1700000000,
+    });
+  }
+
+  Future<int> watchedCount(int collectionId, int showId) async {
+    final List<Map<String, Object?>> rows = await db.rawQuery(
+      'SELECT COUNT(*) AS cnt FROM watched_episodes '
+      'WHERE collection_id = ? AND show_id = ?',
+      <Object?>[collectionId, showId],
+    );
+    return rows.single['cnt']! as int;
+  }
+
+  group('CollectionDao.removeItemFromCollection — watched marks', () {
+    test('keeps watch marks so re-adding the show restores progress',
+        () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500, episode: 1);
+      await insertWatched(collectionId: 1, showId: 500, episode: 2);
+
+      await dao.removeItemFromCollection(10);
+
+      expect(await watchedCount(1, 500), 2);
+
+      await insertItem(
+          id: 12, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+
+      final TvShowDao tvDao = TvShowDao(() async => db);
+      final Map<(int, int), DateTime?> watched =
+          await tvDao.getWatchedEpisodes(1, DataSource.tmdb, 500);
+      expect(watched.keys, <(int, int)>{(1, 1), (1, 2)});
+    });
+  });
+
+  group('CollectionDao.updateItemCollectionId — watched transfer', () {
+    test('should move watch marks to the target collection', () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500, episode: 1);
+      await insertWatched(collectionId: 1, showId: 500, episode: 2);
+
+      final bool ok = await dao.updateItemCollectionId(10, 2);
+
+      expect(ok, isTrue);
+      expect(await watchedCount(1, 500), 0);
+      expect(await watchedCount(2, 500), 2);
+    });
+
+    test('should preserve watched_at on transfer', () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500);
+
+      await dao.updateItemCollectionId(10, 2);
+
+      final List<Map<String, Object?>> rows = await db.query(
+        'watched_episodes',
+        where: 'collection_id = 2',
+      );
+      expect(rows.single['watched_at'], 1700000000);
+    });
+
+    test(
+        'moving to uncategorized leaves marks in the source and restores '
+        'them on return', () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500, episode: 1);
+      await insertWatched(collectionId: 1, showId: 500, episode: 2);
+
+      await dao.updateItemCollectionId(10, null);
+
+      expect(await watchedCount(1, 500), 2);
+
+      await dao.updateItemCollectionId(10, 1);
+
+      final TvShowDao tvDao = TvShowDao(() async => db);
+      final Map<(int, int), DateTime?> watched =
+          await tvDao.getWatchedEpisodes(1, DataSource.tmdb, 500);
+      expect(watched.keys, <(int, int)>{(1, 1), (1, 2)});
+    });
+
+    test('should copy marks but keep the source rows while a sibling remains',
+        () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertItem(
+        id: 11,
+        collectionId: 1,
+        mediaType: 'animation',
+        externalId: 500,
+        platformId: 1,
+      );
+      await insertWatched(collectionId: 1, showId: 500);
+
+      await dao.updateItemCollectionId(10, 2);
+
+      expect(await watchedCount(1, 500), 1);
+      expect(await watchedCount(2, 500), 1);
+    });
+
+    test('should overwrite stale orphan marks in the target', () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500, episode: 1);
+      // An orphan of an earlier removal left in the target for the same
+      // episode.
+      await insertWatched(collectionId: 2, showId: 500, episode: 1);
+
+      final bool ok = await dao.updateItemCollectionId(10, 2);
+
+      expect(ok, isTrue);
+      expect(await watchedCount(2, 500), 1);
+    });
+
+    test('should not touch marks when moving a non-tv item', () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertItem(
+          id: 11, collectionId: 1, mediaType: 'movie', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500);
+
+      await dao.updateItemCollectionId(11, 2);
+
+      expect(await watchedCount(1, 500), 1);
+      expect(await watchedCount(2, 500), 0);
+    });
+
+    test('should keep marks in place when the move hits a UNIQUE conflict',
+        () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      await insertItem(
+          id: 11, collectionId: 2, mediaType: 'tv_show', externalId: 500);
+      await insertWatched(collectionId: 1, showId: 500);
+
+      final bool ok = await dao.updateItemCollectionId(10, 2);
+
+      expect(ok, isFalse);
+      expect(await watchedCount(1, 500), 1);
+      expect(await watchedCount(2, 500), 0);
+    });
+  });
+}

--- a/test/core/database/dao/manga_dao_test.dart
+++ b/test/core/database/dao/manga_dao_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:tonkatsu_box/core/database/dao/manga_dao.dart';
 import 'package:tonkatsu_box/shared/models/manga.dart';
 
@@ -17,28 +16,23 @@ void main() {
 
   group('MangaDao', () {
     group('upsertManga', () {
-      test('inserts manga with replace', () async {
+      test('upserts preserving chapters/volumes for sparse rows', () async {
         const Manga manga = Manga(
           id: 1,
           title: 'Test Manga',
         );
-        when(
-          () => mockDb.insert(
-            'manga_cache',
-            any(),
-            conflictAlgorithm: ConflictAlgorithm.replace,
-          ),
-        ).thenAnswer((_) async => 1);
+        when(() => mockDb.rawInsert(any(), any()))
+            .thenAnswer((_) async => 1);
 
         await dao.upsertManga(manga);
 
-        verify(
-          () => mockDb.insert(
-            'manga_cache',
-            any(),
-            conflictAlgorithm: ConflictAlgorithm.replace,
-          ),
-        ).called(1);
+        final VerificationResult captured =
+            verify(() => mockDb.rawInsert(captureAny(), any()));
+        captured.called(1);
+        final String sql = captured.captured.first as String;
+        expect(sql, startsWith('INSERT OR REPLACE INTO manga_cache'));
+        expect(sql, contains('COALESCE(?, (SELECT chapters'));
+        expect(sql, contains('COALESCE(?, (SELECT volumes'));
       });
     });
 
@@ -51,13 +45,7 @@ void main() {
       test('batch inserts multiple mangas', () async {
         final MockBatch mockBatch = MockBatch();
         when(() => mockDb.batch()).thenReturn(mockBatch);
-        when(
-          () => mockBatch.insert(
-            any(),
-            any(),
-            conflictAlgorithm: any(named: 'conflictAlgorithm'),
-          ),
-        ).thenReturn(null);
+        when(() => mockBatch.rawInsert(any(), any())).thenReturn(null);
         when(() => mockBatch.commit(noResult: true))
             .thenAnswer((_) async => <Object?>[]);
 
@@ -68,13 +56,7 @@ void main() {
 
         await dao.upsertMangas(mangas);
 
-        verify(
-          () => mockBatch.insert(
-            'manga_cache',
-            any(),
-            conflictAlgorithm: ConflictAlgorithm.replace,
-          ),
-        ).called(2);
+        verify(() => mockBatch.rawInsert(any(), any())).called(2);
         verify(() => mockBatch.commit(noResult: true)).called(1);
       });
     });

--- a/test/core/database/dao/tv_show_dao_test.dart
+++ b/test/core/database/dao/tv_show_dao_test.dart
@@ -32,6 +32,7 @@ void main() {
         conflictAlgorithm: any(named: 'conflictAlgorithm'),
       ),
     ).thenReturn(null);
+    when(() => mockBatch.rawInsert(any(), any())).thenReturn(null);
     when(() => mockBatch.commit(noResult: true))
         .thenAnswer((_) async => <Object?>[]);
   }
@@ -88,25 +89,23 @@ void main() {
     });
 
     group('upsertTvShow', () {
-      test('inserts with replace', () async {
+      test('upserts preserving totals and status for sparse rows', () async {
         const TvShow show = TvShow(tmdbId: 1, title: 'Test');
-        when(
-          () => mockDb.insert(
-            'tv_shows_cache',
-            any(),
-            conflictAlgorithm: ConflictAlgorithm.replace,
-          ),
-        ).thenAnswer((_) async => 1);
+        when(() => mockDb.rawInsert(any(), any()))
+            .thenAnswer((_) async => 1);
 
         await dao.upsertTvShow(show);
 
-        verify(
-          () => mockDb.insert(
-            'tv_shows_cache',
-            show.toDb(),
-            conflictAlgorithm: ConflictAlgorithm.replace,
-          ),
-        ).called(1);
+        final VerificationResult captured =
+            verify(() => mockDb.rawInsert(captureAny(), captureAny()));
+        captured.called(1);
+        final String sql = captured.captured.first as String;
+        expect(sql, startsWith('INSERT OR REPLACE INTO tv_shows_cache'));
+        expect(sql, contains('COALESCE(?, (SELECT total_seasons'));
+        expect(sql, contains('COALESCE(?, (SELECT total_episodes'));
+        expect(sql, contains('COALESCE(?, (SELECT status'));
+        final List<Object?> args = captured.captured[1] as List<Object?>;
+        expect(args, containsAllInOrder(<Object?>[1, 'Test']));
       });
     });
 
@@ -125,13 +124,7 @@ void main() {
           TvShow(tmdbId: 2, title: 'S2'),
         ]);
 
-        verify(
-          () => mockBatch.insert(
-            'tv_shows_cache',
-            any(),
-            conflictAlgorithm: ConflictAlgorithm.replace,
-          ),
-        ).called(2);
+        verify(() => mockBatch.rawInsert(any(), any())).called(2);
       });
     });
 

--- a/test/core/database/sparse_upsert_test.dart
+++ b/test/core/database/sparse_upsert_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/dao/manga_dao.dart';
+import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_registry.dart';
+import 'package:tonkatsu_box/core/database/sparse_upsert.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/manga.dart';
+import 'package:tonkatsu_box/shared/models/tv_show.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('buildPreservingUpsert', () {
+    test('coalesces only the preserved columns', () {
+      final ({String sql, List<Object?> args}) upsert = buildPreservingUpsert(
+        table: 't',
+        row: <String, Object?>{'id': 1, 'src': 's', 'a': 'x', 'b': null},
+        conflictKey: <String>['id', 'src'],
+        preserveWhenNull: <String>{'b'},
+      );
+
+      expect(
+        upsert.sql,
+        'INSERT OR REPLACE INTO t (id, src, a, b) VALUES (?, ?, ?, '
+        'COALESCE(?, (SELECT b FROM t WHERE id = ? AND src = ?)))',
+      );
+      // Preserved column appends the conflict-key values for its subquery.
+      expect(upsert.args, <Object?>[1, 's', 'x', null, 1, 's']);
+    });
+  });
+
+  group('sparse upserts against a real schema', () {
+    late Database db;
+
+    setUp(() async {
+      db = await databaseFactory.openDatabase(
+        inMemoryDatabasePath,
+        options: OpenDatabaseOptions(
+          version: MigrationRegistry.all.last.version,
+          onCreate: (Database d, int _) async {
+            for (final Migration m in MigrationRegistry.all) {
+              await m.migrate(d);
+            }
+          },
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    group('TvShowDao', () {
+      late TvShowDao dao;
+
+      setUp(() {
+        dao = TvShowDao(() async => db);
+      });
+
+      const TvShow fullShow = TvShow(
+        tmdbId: 45016,
+        title: 'The Bridge',
+        totalSeasons: 4,
+        totalEpisodes: 38,
+        status: 'Ended',
+        rating: 8.3,
+      );
+
+      // A row parsed from a list endpoint: no totals, no status.
+      const TvShow sparseShow = TvShow(
+        tmdbId: 45016,
+        title: 'The Bridge (updated)',
+        rating: 8.5,
+      );
+
+      test('sparse row keeps cached totals and status', () async {
+        await dao.upsertTvShow(fullShow);
+        await dao.upsertTvShow(sparseShow);
+
+        final TvShow? loaded = await dao.getTvShowByTmdbId(45016);
+        expect(loaded!.totalSeasons, 4);
+        expect(loaded.totalEpisodes, 38);
+        expect(loaded.status, 'Ended');
+        // Non-preserved fields still take the incoming values.
+        expect(loaded.title, 'The Bridge (updated)');
+        expect(loaded.rating, 8.5);
+      });
+
+      test('full row fills totals over a sparse one', () async {
+        await dao.upsertTvShow(sparseShow);
+        await dao.upsertTvShow(fullShow);
+
+        final TvShow? loaded = await dao.getTvShowByTmdbId(45016);
+        expect(loaded!.totalEpisodes, 38);
+        expect(loaded.title, 'The Bridge');
+      });
+
+      test('full row updates stale totals', () async {
+        await dao.upsertTvShow(fullShow);
+        await dao.upsertTvShow(
+          fullShow.copyWith(totalSeasons: 5, totalEpisodes: 46),
+        );
+
+        final TvShow? loaded = await dao.getTvShowByTmdbId(45016);
+        expect(loaded!.totalSeasons, 5);
+        expect(loaded.totalEpisodes, 46);
+      });
+
+      test('fresh sparse insert stays sparse', () async {
+        await dao.upsertTvShow(sparseShow);
+
+        final TvShow? loaded = await dao.getTvShowByTmdbId(45016);
+        expect(loaded!.totalEpisodes, isNull);
+      });
+
+      test('batch upsert preserves totals too', () async {
+        await dao.upsertTvShow(fullShow);
+        await dao.upsertTvShows(const <TvShow>[sparseShow]);
+
+        final TvShow? loaded = await dao.getTvShowByTmdbId(45016);
+        expect(loaded!.totalEpisodes, 38);
+      });
+    });
+
+    group('MangaDao', () {
+      late MangaDao dao;
+
+      setUp(() {
+        dao = MangaDao(() async => db);
+      });
+
+      test('sparse row keeps cached chapters and volumes', () async {
+        await dao.upsertManga(const Manga(
+          id: 7,
+          title: 'Berserk',
+          chapters: 380,
+          volumes: 42,
+        ));
+        await dao.upsertManga(const Manga(id: 7, title: 'Berserk (list)'));
+
+        final Manga? loaded = await dao.getManga(7);
+        expect(loaded!.chapters, 380);
+        expect(loaded.volumes, 42);
+        expect(loaded.title, 'Berserk (list)');
+      });
+
+      test('full row updates chapters over a sparse one', () async {
+        await dao.upsertManga(const Manga(id: 7, title: 'Berserk'));
+        await dao.upsertManga(const Manga(
+          id: 7,
+          title: 'Berserk',
+          chapters: 380,
+          volumes: 42,
+        ));
+
+        final Manga? loaded = await dao.getManga(7);
+        expect(loaded!.chapters, 380);
+        expect(loaded.volumes, 42);
+      });
+
+      test('rows from different sources stay independent', () async {
+        await dao.upsertManga(const Manga(
+          id: 7,
+          title: 'AniList row',
+          chapters: 380,
+        ));
+        await dao.upsertManga(const Manga(
+          id: 7,
+          source: DataSource.mangabaka,
+          title: 'MangaBaka row',
+        ));
+
+        final Manga? anilist = await dao.getManga(7);
+        final Manga? mangabaka =
+            await dao.getManga(7, source: DataSource.mangabaka);
+        expect(anilist!.chapters, 380);
+        expect(mangabaka!.chapters, isNull);
+      });
+    });
+  });
+}

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -2041,6 +2041,8 @@ void main() {
             .thenAnswer((_) async => <TvSeason>[]);
         when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
             .thenAnswer((_) async => <TvEpisode>[]);
+        when(() => mockTvShowDao.getWatchedEpisodes(any(), any(), any()))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockTierListDao.getTierListsByCollection(any()))
             .thenAnswer((_) async => <TierList>[]);
         when(() => mockTagDao.getAll()).thenAnswer((_) async => <Tag>[]);
@@ -2121,6 +2123,73 @@ void main() {
 
         expect(xcoll.items[0].containsKey('_marks'), isFalse);
         verifyNever(() => mockItemMarkDao.getMarksForItems(any()));
+      });
+
+      test('should attach _watched_episodes scoped to the export collection',
+          () async {
+        when(() => mockItemMarkDao.getMarksForItems(any()))
+            .thenAnswer((_) async => <ItemMark>[]);
+        when(() => mockTvShowDao.getWatchedEpisodes(1, DataSource.tmdb, 1399))
+            .thenAnswer(
+          (_) async => <(int, int), DateTime?>{
+            (1, 1): DateTime.fromMillisecondsSinceEpoch(1700000000000),
+            (1, 2): null,
+          },
+        );
+
+        final XcollFile xcoll = await sutMarks.createFullExport(
+          createTestCollection(),
+          twoTvItems(),
+          1,
+          includeUserData: true,
+        );
+
+        verify(() => mockTvShowDao.getWatchedEpisodes(1, DataSource.tmdb, 1399))
+            .called(1);
+        verify(() => mockTvShowDao.getWatchedEpisodes(1, DataSource.tmdb, 1400))
+            .called(1);
+
+        final List<dynamic> watched =
+            xcoll.items[0]['_watched_episodes'] as List<dynamic>;
+        expect(watched, hasLength(2));
+        final Map<String, dynamic> first = watched[0] as Map<String, dynamic>;
+        expect(first['season'], 1);
+        expect(first['episode'], 1);
+        expect(first['watched_at'], 1700000000);
+        final Map<String, dynamic> second = watched[1] as Map<String, dynamic>;
+        expect(second['episode'], 2);
+        expect(second['watched_at'], isNull);
+        // The show with no marks must not carry the key at all.
+        expect(xcoll.items[1].containsKey('_watched_episodes'), isFalse);
+      });
+
+      test('should not query watched episodes for non-tv items', () async {
+        when(() => mockItemMarkDao.getMarksForItems(any()))
+            .thenAnswer((_) async => <ItemMark>[]);
+
+        await sutMarks.createFullExport(
+          createTestCollection(),
+          <CollectionItem>[
+            createTestCollectionItem(id: 1, mediaType: MediaType.game),
+          ],
+          1,
+          includeUserData: true,
+        );
+
+        verifyNever(
+            () => mockTvShowDao.getWatchedEpisodes(any(), any(), any()));
+      });
+
+      test('should skip watched episodes when includeUserData is false',
+          () async {
+        await sutMarks.createFullExport(
+          createTestCollection(),
+          twoTvItems(),
+          1,
+        );
+
+        verifyNever(
+            () => mockTvShowDao.getWatchedEpisodes(any(), any(), any()));
       });
     });
   });

--- a/test/core/services/import_service_test.dart
+++ b/test/core/services/import_service_test.dart
@@ -14,6 +14,7 @@ import 'package:tonkatsu_box/shared/models/canvas_item.dart';
 import 'package:tonkatsu_box/shared/models/canvas_viewport.dart';
 import 'package:tonkatsu_box/shared/models/collection.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
 import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
@@ -2865,6 +2866,202 @@ void main() {
         ).captured.single as List<ItemMark>;
         expect(inserted, hasLength(2));
         expect(inserted.every((ItemMark m) => m.itemId == 77), isTrue);
+      });
+    });
+
+    group('import watched episodes (_watched_episodes)', () {
+      late ImportService sutV2;
+      late MockTvShowDao mockTvShowDao;
+
+      const List<Map<String, dynamic>> itemsWithWatched =
+          <Map<String, dynamic>>[
+        <String, dynamic>{
+          'media_type': 'tv_show',
+          'external_id': 1399,
+          '_watched_episodes': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'season': 1,
+              'episode': 1,
+              'watched_at': 1700000000,
+            },
+            <String, dynamic>{
+              'season': 1,
+              'episode': 2,
+              'watched_at': null,
+            },
+          ],
+        },
+      ];
+
+      setUp(() {
+        mockTvShowDao = MockTvShowDao();
+        when(() => mockDb.tvShowDao).thenReturn(mockTvShowDao);
+        when(() => mockTvShowDao.upsertTvShows(any()))
+            .thenAnswer((_) async {});
+        when(() => mockTvShowDao.markEpisodeWatchedAt(
+                any(), any(), any(), any(), any(), any()))
+            .thenAnswer((_) async {});
+
+        when(() => mockTmdb.getTvShow(1399)).thenAnswer(
+            (_) async => const TvShow(tmdbId: 1399, title: 'GoT'));
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+
+        sutV2 = ImportService(
+          repository: mockRepo,
+          igdbApi: mockApi,
+          tmdbApi: mockTmdb,
+          database: mockDb,
+          canvasRepository: mockCanvas,
+        );
+      });
+
+      XcollFile xcollWith({
+        required bool userData,
+        List<Map<String, dynamic>> items = itemsWithWatched,
+      }) =>
+          XcollFile(
+            version: 2,
+            format: ExportFormat.light,
+            name: 'Import',
+            author: 'Author',
+            created: testDate,
+            includesUserData: userData,
+            items: items,
+          );
+
+      test('should restore marks re-scoped to the target collection',
+          () async {
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verify(() => mockTvShowDao.markEpisodeWatchedAt(
+            5, DataSource.tmdb, 1399, 1, 1, 1700000000 * 1000)).called(1);
+        verify(() => mockTvShowDao.markEpisodeWatchedAt(
+            5, DataSource.tmdb, 1399, 1, 2, null)).called(1);
+      });
+
+      test('should skip watched marks when the file has no user data',
+          () async {
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: false),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verifyNever(() => mockTvShowDao.markEpisodeWatchedAt(
+            any(), any(), any(), any(), any(), any()));
+      });
+
+      test('should ignore _watched_episodes on a non-tv item', () async {
+        when(() => mockApi.getGamesByIds(any()))
+            .thenAnswer((_) async => const <Game>[Game(id: 100, name: 'G')]);
+        final MockGameDao gameDao = MockGameDao();
+        when(() => mockDb.gameDao).thenReturn(gameDao);
+        when(() => gameDao.upsertGame(any())).thenAnswer((_) async {});
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true, items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'game',
+              'external_id': 100,
+              '_watched_episodes': <Map<String, dynamic>>[
+                <String, dynamic>{'season': 1, 'episode': 1},
+              ],
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verifyNever(() => mockTvShowDao.markEpisodeWatchedAt(
+            any(), any(), any(), any(), any(), any()));
+      });
+
+      test('should tolerate files without the _watched_episodes key',
+          () async {
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true, items: const <Map<String, dynamic>>[
+            <String, dynamic>{'media_type': 'tv_show', 'external_id': 1399},
+          ]),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verifyNever(() => mockTvShowDao.markEpisodeWatchedAt(
+            any(), any(), any(), any(), any(), any()));
+      });
+
+      test('should restore marks onto an existing duplicate item', () async {
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => null);
+        when(() => mockRepo.findItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+            )).thenAnswer((_) async => createTestCollectionItem(
+              id: 77,
+              mediaType: MediaType.tvShow,
+              externalId: 1399,
+            ));
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verify(() => mockTvShowDao.markEpisodeWatchedAt(
+            5, DataSource.tmdb, 1399, 1, 1, 1700000000 * 1000)).called(1);
       });
     });
   });

--- a/test/core/services/tv_show_cache_warmer_test.dart
+++ b/test/core/services/tv_show_cache_warmer_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration.dart';
+import 'package:tonkatsu_box/core/database/migrations/migration_registry.dart';
+import 'package:tonkatsu_box/core/services/tv_show_cache_warmer.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+import 'package:tonkatsu_box/shared/models/tv_season.dart';
+import 'package:tonkatsu_box/shared/models/tv_show.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  const int showId = 45016;
+
+  const TvShow fullShow = TvShow(
+    tmdbId: showId,
+    title: 'The Bridge',
+    totalSeasons: 1,
+    totalEpisodes: 2,
+    status: 'Ended',
+  );
+
+  const List<TvSeason> apiSeasons = <TvSeason>[
+    TvSeason(tmdbShowId: showId, seasonNumber: 1, episodeCount: 2),
+  ];
+
+  const List<TvEpisode> apiEpisodes = <TvEpisode>[
+    TvEpisode(
+      tmdbShowId: showId,
+      seasonNumber: 1,
+      episodeNumber: 1,
+      name: 'Ep1',
+    ),
+    TvEpisode(
+      tmdbShowId: showId,
+      seasonNumber: 1,
+      episodeNumber: 2,
+      name: 'Ep2',
+    ),
+  ];
+
+  late Database db;
+  late TvShowDao dao;
+  late MockTmdbApi tmdb;
+  late MockDatabaseService dbService;
+  late TvShowCacheWarmer warmer;
+
+  setUp(() async {
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: MigrationRegistry.all.last.version,
+        onCreate: (Database d, int _) async {
+          for (final Migration m in MigrationRegistry.all) {
+            await m.migrate(d);
+          }
+        },
+      ),
+    );
+    dao = TvShowDao(() async => db);
+    tmdb = MockTmdbApi();
+    dbService = MockDatabaseService();
+    when(() => dbService.tvShowDao).thenReturn(dao);
+    warmer = TvShowCacheWarmer(tmdb: tmdb, db: dbService);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('TvShowCacheWarmer', () {
+    test('replaces a sparse show row and caches seasons with episodes',
+        () async {
+      // The row as written from a search/recommendation list: no totals.
+      await dao.upsertTvShow(const TvShow(tmdbId: showId, title: 'Sparse'));
+      when(() => tmdb.getTvShowWithSeasons(showId))
+          .thenAnswer((_) async => (fullShow, apiSeasons));
+      when(() => tmdb.getSeasonEpisodes(showId, 1))
+          .thenAnswer((_) async => apiEpisodes);
+
+      await warmer.warm(showId);
+
+      final TvShow? show = await dao.getTvShowByTmdbId(showId);
+      expect(show!.totalEpisodes, 2);
+      expect(show.status, 'Ended');
+      final List<TvSeason> seasons =
+          await dao.getTvSeasonsByShowId(DataSource.tmdb, showId);
+      expect(seasons, hasLength(1));
+      final List<TvEpisode> episodes =
+          await dao.getEpisodesByShowId(DataSource.tmdb, showId);
+      expect(episodes, hasLength(2));
+    });
+
+    test('skips episode fetch for seasons already cached', () async {
+      await dao.upsertTvSeasons(apiSeasons);
+      await dao.upsertEpisodes(apiEpisodes);
+      when(() => tmdb.getTvShowWithSeasons(showId))
+          .thenAnswer((_) async => (fullShow, apiSeasons));
+
+      await warmer.warm(showId);
+
+      verifyNever(() => tmdb.getSeasonEpisodes(any(), any()));
+    });
+
+    test('swallows API failures and leaves the cache untouched', () async {
+      await dao.upsertTvShow(const TvShow(tmdbId: showId, title: 'Sparse'));
+      when(() => tmdb.getTvShowWithSeasons(showId))
+          .thenThrow(Exception('network down'));
+
+      await warmer.warm(showId);
+
+      final TvShow? show = await dao.getTvShowByTmdbId(showId);
+      expect(show!.totalEpisodes, isNull);
+      expect(show.title, 'Sparse');
+    });
+  });
+}

--- a/test/core/services/xcoll_file_test.dart
+++ b/test/core/services/xcoll_file_test.dart
@@ -481,6 +481,44 @@ void main() {
 
         expect(restored.includesUserData, isTrue);
       });
+
+      test('round-trip _watched_episodes внутри item через JSON', () {
+        final XcollFile original = XcollFile(
+          version: 2,
+          format: ExportFormat.full,
+          name: 'Watched RT',
+          author: 'Author',
+          created: testDate,
+          includesUserData: true,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'tv_show',
+              'external_id': 1399,
+              '_watched_episodes': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'season': 1,
+                  'episode': 2,
+                  'watched_at': 1700000000,
+                },
+                <String, dynamic>{
+                  'season': 1,
+                  'episode': 3,
+                  'watched_at': null,
+                },
+              ],
+            },
+          ],
+        );
+
+        final XcollFile restored =
+            XcollFile.fromJsonString(original.toJsonString());
+
+        final List<dynamic> watched =
+            restored.items[0]['_watched_episodes'] as List<dynamic>;
+        expect(watched, hasLength(2));
+        expect((watched[0] as Map<String, dynamic>)['watched_at'], 1700000000);
+        expect((watched[1] as Map<String, dynamic>)['watched_at'], isNull);
+      });
     });
 
     test('fromJsonString/toJsonString round-trip', () {

--- a/test/features/collections/providers/collections_provider_test.dart
+++ b/test/features/collections/providers/collections_provider_test.dart
@@ -5,14 +5,28 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/data/repositories/collection_repository.dart';
 import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
+import 'package:tonkatsu_box/features/collections/providers/episode_tracker_provider.dart';
 import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 
 import '../../../helpers/test_helpers.dart';
 
 const int testCollectionId = 1;
+
+/// Counts family rebuilds so tests can assert tracker invalidation without
+/// wiring the real tracker's DB/API dependencies.
+class _ProbeEpisodeTrackerNotifier extends EpisodeTrackerNotifier {
+  static int buildCount = 0;
+
+  @override
+  EpisodeTrackerState build(EpisodeTrackerArg arg) {
+    buildCount++;
+    return const EpisodeTrackerState();
+  }
+}
 
 CollectionItem _makeItem({
   int id = 1,
@@ -539,11 +553,51 @@ void main() {
           sharedPreferencesProvider.overrideWithValue(sharedPrefs),
           tierListDaoProvider.overrideWithValue(mockTierListDao),
           globalTagDaoProvider.overrideWithValue(mockTagDao),
+          episodeTrackerNotifierProvider
+              .overrideWith(_ProbeEpisodeTrackerNotifier.new),
         ],
       );
       addTearDown(container.dispose);
       return container;
     }
+
+    Future<int> trackerBuildsAfterMove(MediaType mediaType) async {
+      _ProbeEpisodeTrackerNotifier.buildCount = 0;
+      when(() => mockTierListDao.getTierListIdsForItem(1))
+          .thenAnswer((_) async => <int>[]);
+      when(() => mockTierListDao.removeItemFromCollectionTierLists(
+          1, testCollectionId)).thenAnswer((_) async {});
+
+      final ProviderContainer container = createMoveContainer(
+        initialItems: <CollectionItem>[_makeItem(mediaType: mediaType)],
+      );
+      await waitForLoad(container, testCollectionId);
+
+      const EpisodeTrackerArg trackerArg = (
+        collectionId: testCollectionId,
+        showId: 500,
+        source: DataSource.tmdb,
+      );
+      container.read(episodeTrackerNotifierProvider(trackerArg));
+      expect(_ProbeEpisodeTrackerNotifier.buildCount, 1);
+
+      when(() => mockRepository.getItemsWithData(testCollectionId))
+          .thenAnswer((_) async => <CollectionItem>[]);
+      await container
+          .read(collectionItemsNotifierProvider(testCollectionId).notifier)
+          .moveItem(1, targetCollectionId: 99, mediaType: mediaType);
+
+      container.read(episodeTrackerNotifierProvider(trackerArg));
+      return _ProbeEpisodeTrackerNotifier.buildCount;
+    }
+
+    test('инвалидирует трекеры эпизодов при перемещении сериала', () async {
+      expect(await trackerBuildsAfterMove(MediaType.tvShow), 2);
+    });
+
+    test('не трогает трекеры эпизодов при перемещении игры', () async {
+      expect(await trackerBuildsAfterMove(MediaType.game), 1);
+    });
 
     test('удаляет entries из тир-листов исходной коллекции при перемещении',
         () async {

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -10,6 +10,7 @@ import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+import 'package:tonkatsu_box/shared/models/tv_season.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
 
 import '../../../helpers/test_helpers.dart';
@@ -161,6 +162,10 @@ void main() {
     // don't care about it are unaffected.
     when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
         .thenAnswer((_) async => <TvEpisode>[]);
+    when(() => mockTvShowDao.getTvShowByTmdbId(any(),
+        source: any(named: 'source'))).thenAnswer((_) async => null);
+    when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
+        .thenAnswer((_) async => <TvSeason>[]);
     mockTmdbApi = MockTmdbApi();
     when(() => mockTmdbApi.getTvShow(any()))
         .thenAnswer((_) async => null);
@@ -396,8 +401,9 @@ void main() {
             .called(1);
       });
 
-      test('should eagerly load cached episodes grouped by season on build',
-          () async {
+      test(
+          'should load cached episodes once via ensureCachedEpisodesLoaded, '
+          'not on build', () async {
         when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});
         when(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, testShowId)).thenAnswer(
@@ -409,9 +415,17 @@ void main() {
         );
 
         final ProviderContainer container = createContainer();
-        container.read(episodeTrackerNotifierProvider(testArg));
+        final EpisodeTrackerNotifier notifier = container
+            .read(episodeTrackerNotifierProvider(testArg).notifier);
 
         await Future<void>.delayed(Duration.zero);
+
+        // Grid cards watch this provider; building it must not pull the
+        // full episode cache.
+        verifyNever(() => mockTvShowDao.getEpisodesByShowId(any(), any()));
+
+        await notifier.ensureCachedEpisodesLoaded();
+        await notifier.ensureCachedEpisodesLoaded();
 
         final EpisodeTrackerState state =
             container.read(episodeTrackerNotifierProvider(testArg));
@@ -436,6 +450,86 @@ void main() {
 
         expect(state.error, contains('Failed to load watched episodes'));
         expect(state.error, contains('Database error'));
+      });
+
+      test('должен публиковать totals из кэшированной карточки шоу',
+          () async {
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.tmdb, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+        when(() => mockTvShowDao.getTvShowByTmdbId(testShowId,
+                source: any(named: 'source')))
+            .thenAnswer((_) async => const TvShow(
+                  tmdbId: testShowId,
+                  title: 'Show',
+                  totalEpisodes: 38,
+                ));
+
+        final ProviderContainer container = createContainer();
+        container.read(episodeTrackerNotifierProvider(testArg));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(episodeTrackerNotifierProvider(testArg))
+              .totalEpisodes,
+          38,
+        );
+      });
+
+      test(
+          'должен считать totals по кэшу сезонов без спецвыпусков, '
+          'когда карточка шоу без totals', () async {
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.tmdb, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+        when(() => mockTvShowDao.getTvSeasonsByShowId(
+                DataSource.tmdb, testShowId))
+            .thenAnswer((_) async => const <TvSeason>[
+                  TvSeason(
+                    tmdbShowId: testShowId,
+                    seasonNumber: 0,
+                    episodeCount: 5,
+                  ),
+                  TvSeason(
+                    tmdbShowId: testShowId,
+                    seasonNumber: 1,
+                    episodeCount: 10,
+                  ),
+                  TvSeason(
+                    tmdbShowId: testShowId,
+                    seasonNumber: 2,
+                    episodeCount: 8,
+                  ),
+                ]);
+
+        final ProviderContainer container = createContainer();
+        container.read(episodeTrackerNotifierProvider(testArg));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(episodeTrackerNotifierProvider(testArg))
+              .totalEpisodes,
+          18,
+        );
+      });
+
+      test('totals остаются null, когда в кэше ничего нет', () async {
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.tmdb, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+
+        final ProviderContainer container = createContainer();
+        container.read(episodeTrackerNotifierProvider(testArg));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(episodeTrackerNotifierProvider(testArg))
+              .totalEpisodes,
+          isNull,
+        );
       });
     });
 
@@ -1530,6 +1624,66 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await notifier.toggleEpisode(1, 1);
         await Future<void>.delayed(Duration.zero);
+      });
+
+      test('should publish totals from the cached show into state', () async {
+        final CollectionItem item = createTvItem(totalEpisodes: 22);
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.tmdb, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+        when(() => mockTvShowDao.markEpisodeWatched(
+                testCollectionId, DataSource.tmdb, testShowId, 1, 1))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container =
+            createTrackingContainer(<CollectionItem>[item]);
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+        await notifier.toggleEpisode(1, 1);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(episodeTrackerNotifierProvider(testArg)).totalEpisodes,
+          22,
+        );
+      });
+
+      test('should publish totals fetched from the API when the cache has none',
+          () async {
+        final CollectionItem item =
+            createTvItem(totalEpisodes: 0, totalSeasons: 0);
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.tmdb, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+        when(() => mockTvShowDao.markEpisodeWatched(
+                testCollectionId, DataSource.tmdb, testShowId, 1, 1))
+            .thenAnswer((_) async {});
+        when(() => mockTvShowDao.upsertTvShow(any())).thenAnswer((_) async {});
+        when(() => mockTmdbApi.getTvShow(testShowId)).thenAnswer(
+          (_) async => const TvShow(
+            tmdbId: testShowId,
+            title: 'Test Show',
+            totalEpisodes: 22,
+            totalSeasons: 2,
+          ),
+        );
+
+        final ProviderContainer container =
+            createTrackingContainer(<CollectionItem>[item]);
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(testArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+        await notifier.toggleEpisode(1, 1);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(episodeTrackerNotifierProvider(testArg)).totalEpisodes,
+          22,
+        );
+        verify(() => mockTvShowDao.upsertTvShow(any())).called(1);
       });
     });
   });

--- a/test/features/collections/screens/item_detail_screen_test.dart
+++ b/test/features/collections/screens/item_detail_screen_test.dart
@@ -51,6 +51,8 @@ void main() {
         .thenAnswer((_) async => <(int, int), DateTime?>{});
     when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
         .thenAnswer((_) async => <TvEpisode>[]);
+    when(() => mockTvShowDao.getTvShowByTmdbId(any(),
+        source: any(named: 'source'))).thenAnswer((_) async => null);
     final MockItemMarkDao mockItemMarkDao = MockItemMarkDao();
     when(() => mockDb.itemMarkDao).thenReturn(mockItemMarkDao);
     when(() => mockItemMarkDao.getMarksForItem(any()))

--- a/test/features/collections/widgets/episode_tracker_section_test.dart
+++ b/test/features/collections/widgets/episode_tracker_section_test.dart
@@ -4,11 +4,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/api/tmdb_api.dart';
 import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/core/services/image_cache_service.dart';
+import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
 import 'package:tonkatsu_box/features/collections/widgets/episode_tracker_section.dart';
 import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
+import 'package:tonkatsu_box/shared/models/tv_show.dart';
+import 'package:tonkatsu_box/shared/widgets/cached_image.dart';
 
 import '../../../helpers/test_helpers.dart';
 
@@ -36,6 +40,8 @@ void main() {
   late MockItemMarkDao mockItemMarkDao;
   late MockTmdbApi mockTmdbApi;
 
+  setUpAll(registerAllFallbacks);
+
   setUp(() {
     mockDb = MockDatabaseService();
     mockTvShowDao = MockTvShowDao();
@@ -48,6 +54,10 @@ void main() {
         .thenAnswer((_) async => <(int, int), DateTime?>{});
     when(() => mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, testShowId))
         .thenAnswer((_) async => <TvEpisode>[]);
+    when(() => mockTvShowDao.getTvShowByTmdbId(any(),
+        source: any(named: 'source'))).thenAnswer((_) async => null);
+    when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
+        .thenAnswer((_) async => <TvSeason>[]);
     when(() => mockItemMarkDao.getMarksForItem(testItemId))
         .thenAnswer((_) async => <ItemMark>[]);
   });
@@ -78,6 +88,191 @@ void main() {
     );
   }
 
+  group('EpisodeTrackerSection', () {
+    testWidgets('should render the header without overflow when narrow',
+        (WidgetTester tester) async {
+      when(() =>
+              mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, testShowId))
+          .thenAnswer((_) async => <TvSeason>[season1]);
+
+      await tester.pumpApp(
+        const SingleChildScrollView(
+          child: SizedBox(
+            width: 240,
+            child: EpisodeTrackerSection(
+              collectionId: testCollectionId,
+              itemId: testItemId,
+              externalId: testShowId,
+              source: DataSource.tmdb,
+              tvShow: TvShow(
+                tmdbId: testShowId,
+                title: 'Test Show',
+                totalEpisodes: 22,
+                totalSeasons: 2,
+              ),
+              accentColor: Colors.blue,
+            ),
+          ),
+        ),
+        overrides: <Override>[
+          databaseServiceProvider.overrideWithValue(mockDb),
+          tmdbApiProvider.overrideWithValue(mockTmdbApi),
+        ],
+        wrapInScaffold: true,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'рисует прогресс-бар из totals трекера, когда карточка шоу без них',
+        (WidgetTester tester) async {
+      when(() =>
+              mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, testShowId))
+          .thenAnswer((_) async => <TvSeason>[season1]);
+
+      await tester.pumpApp(
+        const SingleChildScrollView(
+          child: EpisodeTrackerSection(
+            collectionId: testCollectionId,
+            itemId: testItemId,
+            externalId: testShowId,
+            source: DataSource.tmdb,
+            tvShow: TvShow(tmdbId: testShowId, title: 'Sparse Show'),
+            accentColor: Colors.blue,
+          ),
+        ),
+        overrides: <Override>[
+          databaseServiceProvider.overrideWithValue(mockDb),
+          tmdbApiProvider.overrideWithValue(mockTmdbApi),
+        ],
+        wrapInScaffold: true,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+  });
+
+  group('EpisodeTile', () {
+    const TvEpisode episodeWithStill = TvEpisode(
+      tmdbShowId: testShowId,
+      seasonNumber: 1,
+      episodeNumber: 1,
+      name: 'Pilot',
+      overview: 'The one where it all starts.',
+      stillUrl: 'https://image.tmdb.org/t/p/w300/pilot.jpg',
+      airDate: '2023-01-01',
+      runtime: 45,
+    );
+
+    const TvEpisode episodeWithoutStill = TvEpisode(
+      tmdbShowId: testShowId,
+      seasonNumber: 1,
+      episodeNumber: 2,
+      name: 'Second',
+    );
+
+    Future<void> pumpTile(
+      WidgetTester tester,
+      TvEpisode episode, {
+      bool isWatched = false,
+    }) async {
+      final MockImageCacheService mockImageCache = MockImageCacheService();
+      when(() => mockImageCache.getImageUri(
+            type: any(named: 'type'),
+            imageId: any(named: 'imageId'),
+            remoteUrl: any(named: 'remoteUrl'),
+          )).thenAnswer((Invocation invocation) async => ImageResult(
+            uri: invocation.namedArguments[#remoteUrl] as String?,
+            isLocal: false,
+            isMissing: false,
+          ));
+
+      await tester.pumpApp(
+        SingleChildScrollView(
+          child: EpisodeTile(
+            episode: episode,
+            isWatched: isWatched,
+            trackerArg: (
+              collectionId: testCollectionId,
+              showId: testShowId,
+              source: DataSource.tmdb,
+            ),
+            itemId: testItemId,
+            accentColor: Colors.blue,
+          ),
+        ),
+        overrides: <Override>[
+          databaseServiceProvider.overrideWithValue(mockDb),
+          tmdbApiProvider.overrideWithValue(mockTmdbApi),
+          imageCacheServiceProvider.overrideWithValue(mockImageCache),
+          collectionItemsNotifierProvider.overrideWith(
+            MockCollectionItemsNotifier.new,
+          ),
+        ],
+        wrapInScaffold: true,
+      );
+      await tester.pump();
+    }
+
+    testWidgets('should show the still when the episode has one',
+        (WidgetTester tester) async {
+      await pumpTile(tester, episodeWithStill);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CachedImage), findsOneWidget);
+    });
+
+    testWidgets('should not build an image when the episode has no still',
+        (WidgetTester tester) async {
+      await pumpTile(tester, episodeWithoutStill);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CachedImage), findsNothing);
+    });
+
+    testWidgets('should render the overview text', (WidgetTester tester) async {
+      await pumpTile(tester, episodeWithStill);
+
+      expect(find.text(episodeWithStill.overview!), findsOneWidget);
+    });
+
+    testWidgets('should toggle the episode when the row is tapped',
+        (WidgetTester tester) async {
+      when(() => mockTvShowDao.markEpisodeWatched(
+            any(), any(), any(), any(), any()))
+          .thenAnswer((_) async {});
+
+      await pumpTile(tester, episodeWithoutStill);
+      await tester.tap(find.text('E2: Second'));
+      await tester.pump();
+
+      verify(() => mockTvShowDao.markEpisodeWatched(
+            testCollectionId,
+            DataSource.tmdb,
+            testShowId,
+            1,
+            2,
+          )).called(1);
+    });
+
+    testWidgets('should not toggle the episode when the overview is tapped',
+        (WidgetTester tester) async {
+      when(() => mockTvShowDao.markEpisodeWatched(
+            any(), any(), any(), any(), any()))
+          .thenAnswer((_) async {});
+
+      await pumpTile(tester, episodeWithStill);
+      await tester.tap(find.text(episodeWithStill.overview!));
+      await tester.pump();
+
+      verifyNever(() => mockTvShowDao.markEpisodeWatched(
+            any(), any(), any(), any(), any()));
+    });
+  });
+
   group('SeasonsListWidget', () {
     testWidgets('показывает Specials (season 0) в списке сезонов',
         (WidgetTester tester) async {
@@ -86,6 +281,62 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.byKey(const ValueKey<int>(0)), findsOneWidget);
       expect(find.byKey(const ValueKey<int>(1)), findsOneWidget);
+    });
+
+    testWidgets('should load the cached episode metadata once on mount',
+        (WidgetTester tester) async {
+      await pumpSeasonsList(tester, <TvSeason>[season1]);
+
+      verify(() =>
+              mockTvShowDao.getEpisodesByShowId(DataSource.tmdb, testShowId))
+          .called(1);
+    });
+
+    testWidgets('should show the season poster when the season has one',
+        (WidgetTester tester) async {
+      const TvSeason seasonWithPoster = TvSeason(
+        tmdbShowId: testShowId,
+        seasonNumber: 1,
+        name: 'Season 1',
+        episodeCount: 13,
+        posterUrl: 'https://image.tmdb.org/t/p/w342/s1.jpg',
+      );
+      final MockImageCacheService mockImageCache = MockImageCacheService();
+      when(() => mockImageCache.getImageUri(
+            type: any(named: 'type'),
+            imageId: any(named: 'imageId'),
+            remoteUrl: any(named: 'remoteUrl'),
+          )).thenAnswer((Invocation invocation) async => ImageResult(
+            uri: invocation.namedArguments[#remoteUrl] as String?,
+            isLocal: false,
+            isMissing: false,
+          ));
+
+      when(() =>
+              mockTvShowDao.getTvSeasonsByShowId(DataSource.tmdb, testShowId))
+          .thenAnswer((_) async => <TvSeason>[seasonWithPoster]);
+
+      await tester.pumpApp(
+        const SingleChildScrollView(
+          child: SeasonsListWidget(
+            showId: testShowId,
+            source: DataSource.tmdb,
+            collectionId: testCollectionId,
+            itemId: testItemId,
+            accentColor: Colors.blue,
+          ),
+        ),
+        overrides: <Override>[
+          databaseServiceProvider.overrideWithValue(mockDb),
+          tmdbApiProvider.overrideWithValue(mockTmdbApi),
+          imageCacheServiceProvider.overrideWithValue(mockImageCache),
+        ],
+        wrapInScaffold: true,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(CachedImage), findsOneWidget);
     });
 
     testWidgets('Specials идут после обычных сезонов',

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/data/repositories/collection_repository.dart';
+import 'package:tonkatsu_box/features/collections/providers/episode_tracker_provider.dart';
 import 'package:tonkatsu_box/features/home/screens/all_items_screen.dart';
 import 'package:tonkatsu_box/l10n/app_localizations.dart';
 import 'package:tonkatsu_box/features/settings/providers/profile_provider.dart';
@@ -18,12 +19,16 @@ import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/platform.dart' as model;
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+import 'package:tonkatsu_box/shared/models/tv_season.dart';
 import 'package:tonkatsu_box/shared/models/visual_novel.dart';
 import 'package:tonkatsu_box/shared/navigation/search_providers.dart';
 
 import '../../../helpers/test_helpers.dart';
 
 void main() {
+  setUpAll(registerAllFallbacks);
+
   late MockCollectionRepository mockRepo;
   late MockDatabaseService mockDb;
   late SharedPreferences prefs;
@@ -122,6 +127,17 @@ void main() {
 
     mockDb = MockDatabaseService();
     when(() => mockDb.database).thenAnswer((_) async => MockDatabase());
+    // TV cards spin up a real episode tracker for the progress badge.
+    final MockTvShowDao mockTvShowDao = MockTvShowDao();
+    when(() => mockDb.tvShowDao).thenReturn(mockTvShowDao);
+    when(() => mockTvShowDao.getWatchedEpisodes(any(), any(), any()))
+        .thenAnswer((_) async => <(int, int), DateTime?>{});
+    when(() => mockTvShowDao.getEpisodesByShowId(any(), any()))
+        .thenAnswer((_) async => <TvEpisode>[]);
+    when(() => mockTvShowDao.getTvShowByTmdbId(any(),
+        source: any(named: 'source'))).thenAnswer((_) async => null);
+    when(() => mockTvShowDao.getTvSeasonsByShowId(any(), any()))
+        .thenAnswer((_) async => <TvSeason>[]);
     final MockGameDao mockGameDao = MockGameDao();
     when(() => mockDb.gameDao).thenReturn(mockGameDao);
     when(() => mockGameDao.getPlatformById(19)).thenAnswer(
@@ -140,7 +156,10 @@ void main() {
     );
   });
 
-  Widget buildTestWidget({bool alwaysShowSubcategories = false}) {
+  Widget buildTestWidget({
+    bool alwaysShowSubcategories = false,
+    List<Override> extraOverrides = const <Override>[],
+  }) {
     return ProviderScope(
       overrides: <Override>[
         collectionRepositoryProvider.overrideWithValue(mockRepo),
@@ -157,6 +176,7 @@ void main() {
           color: '#FF0000',
           createdAt: DateTime(2025),
         )),
+        ...extraOverrides,
       ],
       child: const MaterialApp(
         localizationsDelegates: S.localizationsDelegates,
@@ -533,6 +553,62 @@ void main() {
       });
     });
   });
+
+  group('AllItemsScreen прогресс трекера эпизодов', () {
+    const EpisodeTrackerState trackedState = EpisodeTrackerState(
+      watchedEpisodes: <(int, int), DateTime?>{(1, 1): null, (1, 2): null},
+      totalEpisodes: 24,
+    );
+
+    CollectionItem makeTvItem({int? collectionId = 20}) {
+      return CollectionItem(
+        id: 3,
+        collectionId: collectionId,
+        mediaType: MediaType.tvShow,
+        externalId: 300,
+        sortOrder: 0,
+        status: ItemStatus.notStarted,
+        addedAt: DateTime(2025, 3, 1),
+      );
+    }
+
+    Future<void> pumpWithTvItem(
+      WidgetTester tester,
+      CollectionItem item,
+    ) async {
+      when(() =>
+              mockRepo.getAllItemsWithData(mediaType: any(named: 'mediaType')))
+          .thenAnswer((_) async => <CollectionItem>[item]);
+      await tester.pumpWidget(buildTestWidget(extraOverrides: <Override>[
+        episodeTrackerNotifierProvider
+            .overrideWith(() => _FakeEpisodeTrackerNotifier(trackedState)),
+      ]));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('показывает счётчик просмотренных серий для сериала',
+        (WidgetTester tester) async {
+      await pumpWithTvItem(tester, makeTvItem());
+
+      expect(find.text('2/24'), findsOneWidget);
+    });
+
+    testWidgets('не показывает счётчик для сериала без коллекции',
+        (WidgetTester tester) async {
+      await pumpWithTvItem(tester, makeTvItem(collectionId: null));
+
+      expect(find.text('2/24'), findsNothing);
+    });
+  });
+}
+
+class _FakeEpisodeTrackerNotifier extends EpisodeTrackerNotifier {
+  _FakeEpisodeTrackerNotifier(this._state);
+
+  final EpisodeTrackerState _state;
+
+  @override
+  EpisodeTrackerState build(EpisodeTrackerArg arg) => _state;
 }
 
 class _FakeSettingsNotifier extends SettingsNotifier {

--- a/test/shared/models/media_type_test.dart
+++ b/test/shared/models/media_type_test.dart
@@ -37,6 +37,17 @@ void main() {
       });
     });
 
+    group('isTvBacked', () {
+      test('true только для tvShow и animation', () {
+        for (final MediaType type in MediaType.values) {
+          expect(
+            type.isTvBacked,
+            type == MediaType.tvShow || type == MediaType.animation,
+          );
+        }
+      });
+    });
+
     group('value', () {
       test('game должен иметь значение "game"', () {
         expect(MediaType.game.value, 'game');

--- a/test/shared/widgets/media_poster_card_test.dart
+++ b/test/shared/widgets/media_poster_card_test.dart
@@ -472,5 +472,66 @@ void main() {
         expect(opened, isTrue);
       });
     });
+
+    group('narrow compact layout', () {
+      testWidgets(
+          'should not overflow with status, progress and tag at 60px width',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 60,
+              height: 250,
+              child: MediaPosterCard(
+                variant: CardVariant.compact,
+                title: 'Test Show',
+                imageUrl: '',
+                cacheImageType: ImageType.tvShowPoster,
+                cacheImageId: '1',
+                status: ItemStatus.inProgress,
+                progress: ItemCardProgress(label: '12/22', fraction: 0.5),
+                tagName: 'Very Long Tag Name',
+                tagColor: 0xFF4CAF50,
+              ),
+            ),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('should keep the tag badge anchored to the right edge',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(const MaterialApp(
+          localizationsDelegates: S.localizationsDelegates,
+          supportedLocales: S.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 150,
+              height: 250,
+              child: MediaPosterCard(
+                variant: CardVariant.grid,
+                title: 'Test Show',
+                imageUrl: '',
+                cacheImageType: ImageType.tvShowPoster,
+                cacheImageId: '1',
+                progress: ItemCardProgress(label: '12/22', fraction: 0.5),
+                tagName: 'Tag',
+                tagColor: 0xFF4CAF50,
+              ),
+            ),
+          ),
+        ));
+        await tester.pumpAndSettle();
+
+        final double cardRight =
+            tester.getTopRight(find.byType(MediaPosterCard)).dx;
+        final double badgeRight = tester.getTopRight(find.text('Tag')).dx;
+        expect(cardRight - badgeRight, lessThan(20));
+      });
+    });
   });
 }


### PR DESCRIPTION
- moving/re-adding a show keeps its watched episodes; full export (.xcollx) carries watched-episode marks and restores them on import
- sparse rows from list endpoints (search, recommendations, similars) no longer wipe cached totals: tv show episode/season counts, manga chapters/volumes, book page counts survive via preserving upserts
- adding a show from recommendations warms the cache (full details, seasons, episodes) like the search flow; the episode tracker resolves missing totals from the local seasons cache so progress badges show x/y again on already-affected databases
- episode tracker UI: season posters with all-watched badges, episode stills, expandable overviews; checkbox removed, row tap toggles
- grid cards no longer eager-load the full episode cache per TV item