### PR TITLE
refactor(models,ui): make shared models pure Dart, move UI mapping to extensions

### DIFF
--- a/.claude/skills/finish/SKILL.md
+++ b/.claude/skills/finish/SKILL.md
@@ -103,6 +103,18 @@ Allowed exceptions (do NOT flag these):
 - Generated l10n (`app_localizations*.dart`) and `.arb` — localisation resources.
 - A short badge `label` that legitimately differs from a full display name — e.g. `DataSource.steamGridDb.label` is `'SGDB'` but the credits screen shows `'SteamGridDB'`; these are different concepts, do not force one into the other. Same for a per-tab `SearchSource.id` (`'movies'`, `'manga'`) which is a media/tab identifier, not the provider name.
 
+**R2c — model purity (mandatory)**
+
+`lib/shared/models/**` stays pure Dart: no `package:flutter`, no `dart:ui`, no l10n imports — direct or transitive through other model files. Models hold data only (ARGB colors as `int`, hex colors as `String`, stored enum values); presentation (`Color`, `IconData`, localized labels) lives in `extension <Model>Ui` files under `lib/shared/constants/*_ui.dart`, hex⇄Color codecs in `lib/shared/utils/color_hex.dart`. Rationale: the model layer is slated for extraction into a pure-Dart core package shared with the selfhost server (`dev/backlog/selfhost-web/`), and `dart:ui` does not exist in a plain Dart VM.
+
+How to check (must return nothing):
+
+```bash
+grep -rln "package:flutter\|dart:ui\|l10n/" lib/shared/models/
+```
+
+Fix: move the offending getter/method into the model's `*_ui.dart` extension (create it if missing), store the raw value in the model, and add the extension import at call sites. Never "fix" by re-adding a Flutter type to a model.
+
 **R3 — localisation**
 - Every UI string uses `S.of(context).key` or `final S l = S.of(context);`.
 - ARB: every key exists in **every** `lib/l10n/app_*.arb` locale file (glob them — the set grows over time: en, ru, zh, …); placeholder names match across all of them; Russian plurals use ICU `=0` / `=1` / `few` / `other`. Languages without plural forms (e.g. Chinese) may render an ICU-plural key as a single flat string (`{count} 项`) as long as they keep the same placeholders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Changed
+
+- **Make all models pure Dart: move UI mapping out of the model layer**
+
+  No user-visible change. Colors, icons and localized labels that lived
+  inside model classes moved to extension files so the model layer no
+  longer depends on Flutter — groundwork for sharing models with the
+  planned selfhost server.
+
+  * lib/shared/constants/item_status_ui.dart (ItemStatusUi),
+    data_source_ui.dart (DataSourceUi), collection_item_ui.dart
+    (CollectionItemUi), canvas_item_ui.dart (CanvasItemUi), profile_ui.dart
+    (ProfileUi), platform_ui.dart (PlatformUi), tier_definition_ui.dart
+    (TierDefinitionUi): New presentation extensions holding the moved
+    getters (color, materialIcon, localizedLabel, genericLabel,
+    placeholderIcon, mediaPlaceholderIcon, familyColor, displayColor).
+  * lib/shared/utils/color_hex.dart (ColorHex.fromHex, ColorHex.toHex): New
+    hex-string color codec, replacing Profile.hexToColor / colorToHex and a
+    private duplicate in edit_connection_dialog.dart.
+  * lib/shared/models/item_status.dart (ItemStatus), data_source.dart
+    (DataSource.colorValue), profile.dart (Profile), collection_item.dart
+    (CollectionItem), canvas_item.dart (CanvasItem), platform.dart
+    (Platform), tier_definition.dart (TierDefinition.colorValue): Flutter
+    and dart:ui imports removed; DataSource and TierDefinition store the
+    color as an ARGB int.
+  * lib/shared/constants/media_type_theme.dart
+    (MediaTypeTheme.placeholderIconFor): New shared outlined-icon mapping;
+    collection_item_ui.dart, canvas_item_ui.dart and
+    lib/features/releases/screens/releases_screen.dart
+    (_ReleasesScreenState._placeholderIcon) delegate to it instead of
+    keeping three hand-maintained copies.
+  * lib/features/tier_lists/providers/tier_list_detail_provider.dart
+    (TierListDetailNotifier.updateTierDefinition,
+    TierListDetailNotifier.addTier): Convert the picked Color to an ARGB
+    int at the UI boundary.
+  * lib/features/settings/widgets/edit_profile_dialog.dart,
+    create_profile_dialog.dart, lib/features/settings/screens/
+    profiles_screen.dart, lib/features/splash/screens/
+    profile_picker_screen.dart: Switch to ColorHex and Profile.displayColor.
+  * Consumer widgets across lib/features/ and lib/shared/widgets/: one-line
+    imports of the new extension files.
+
 ### Added
 
 - **TVmaze as a TV series source**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -106,7 +106,7 @@ Current features: `collections` (main module — collection screens, ItemDetail,
 
 ### `shared/`
 
-- **`models/`** — immutable models with `fromJson` / `fromDb` constructors and `toDb` / `copyWith` methods. List them with `ls lib/shared/models/`.
+- **`models/`** — immutable models with `fromJson` / `fromDb` constructors and `toDb` / `copyWith` methods. List them with `ls lib/shared/models/`. Pure Dart only: no `package:flutter` / `dart:ui` / l10n imports — presentation (colors, icons, localized labels) lives in `shared/constants/*_ui.dart` extensions.
 - **`widgets/`** — shared widgets: `ScreenAppBar`, `CachedImage`, `MediaPosterCard`, `SourceBadge`, `StarRatingBar`, etc.
 - **`theme/`** — `AppColors`, `AppTypography`, `AppSpacing`, `AppTheme` (Material 3 dark).
 - **`navigation/`** — `NavigationShell` (Rail on desktop, BottomBar on mobile).

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -70,6 +70,7 @@ import '../widgets/reviews_section.dart';
 import '../widgets/status_chip_row.dart';
 import '../../settings/providers/settings_provider.dart';
 import '../../../shared/keyboard/keyboard_shortcuts.dart';
+import '../../../shared/constants/collection_item_ui.dart';
 
 /// Unified detail screen for any collection item, dispatched off
 /// [CollectionItem.mediaType].

--- a/lib/features/collections/widgets/bulk_action_bar.dart
+++ b/lib/features/collections/widgets/bulk_action_bar.dart
@@ -1,6 +1,3 @@
-// Works both inside a collection and on All Items: operates on a
-// `List<CollectionItem>` via [BulkOperations], so collectionId is optional.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -18,6 +15,7 @@ import '../../../shared/widgets/confirm_dialog.dart';
 import '../helpers/bulk_operations.dart';
 import '../providers/collections_provider.dart';
 import 'bulk_export/bulk_poster_export_dialog.dart';
+import '../../../shared/constants/item_status_ui.dart';
 
 /// Selection toolbar that works both inside a single collection and on All
 /// Items. When [collectionId] is set the bar excludes that collection from

--- a/lib/features/collections/widgets/bulk_export/bulk_poster_mosaic_view.dart
+++ b/lib/features/collections/widgets/bulk_export/bulk_poster_mosaic_view.dart
@@ -9,6 +9,7 @@ import '../../../../shared/theme/app_colors.dart';
 import '../../../../shared/theme/app_spacing.dart';
 import '../../../../shared/theme/app_typography.dart';
 import '../../../../shared/widgets/cached_image.dart';
+import '../../../../shared/constants/collection_item_ui.dart';
 
 /// Off-screen widget rendered into a PNG via [RepaintBoundary].
 ///

--- a/lib/features/collections/widgets/canvas_view.dart
+++ b/lib/features/collections/widgets/canvas_view.dart
@@ -18,6 +18,7 @@ import 'canvas_image_item.dart';
 import 'canvas_item_actions.dart';
 import 'canvas_link_item.dart';
 import 'canvas_text_item.dart';
+import '../../../shared/constants/canvas_item_ui.dart';
 
 class CanvasView extends ConsumerStatefulWidget {
   const CanvasView({

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -27,6 +27,7 @@ import 'context_menu_item.dart';
 import 'tag_picker_dialog.dart';
 import 'selectable_poster_card.dart';
 import 'status_chip_row.dart';
+import '../../../shared/constants/platform_ui.dart';
 
 /// Grid or table view for collection items, picked from [isTableMode];
 /// otherwise the grid is shown. In table mode a manual sort enables

--- a/lib/features/collections/widgets/collection_table/cells/status_cell.dart
+++ b/lib/features/collections/widgets/collection_table/cells/status_cell.dart
@@ -6,6 +6,7 @@ import '../../../../../shared/models/media_type.dart';
 import '../../../../../shared/theme/app_colors.dart';
 import '../../../../../shared/theme/app_spacing.dart';
 import '../../../../../shared/theme/app_typography.dart';
+import '../../../../../shared/constants/item_status_ui.dart';
 
 class StatusCell extends StatelessWidget {
   const StatusCell({

--- a/lib/features/collections/widgets/collection_table/cells/thumbnail_cell.dart
+++ b/lib/features/collections/widgets/collection_table/cells/thumbnail_cell.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../../../shared/models/collection_item.dart';
 import '../../../../../shared/theme/app_colors.dart';
 import '../../../../../shared/widgets/cached_image.dart';
+import '../../../../../shared/constants/collection_item_ui.dart';
 
 class ThumbnailCell extends StatelessWidget {
   const ThumbnailCell({

--- a/lib/features/collections/widgets/collection_table/collection_table_view.dart
+++ b/lib/features/collections/widgets/collection_table/collection_table_view.dart
@@ -21,6 +21,7 @@ import 'table_layout_store.dart';
 import 'table_rows.dart';
 import 'table_style.dart';
 import 'table_toolbar.dart';
+import '../../../../shared/constants/item_status_ui.dart';
 
 /// Grid-backed table view of a collection (trina_grid): drag-to-reorder and
 /// resize columns, per-column sort and filters, inline editing through the

--- a/lib/features/collections/widgets/collection_table/table_rows.dart
+++ b/lib/features/collections/widgets/collection_table/table_rows.dart
@@ -6,6 +6,7 @@ import '../../../../shared/models/media_type.dart';
 import '../../../../shared/models/tag.dart';
 import '../../../../shared/utils/item_card_progress.dart';
 import 'table_fields.dart';
+import '../../../../shared/constants/item_status_ui.dart';
 
 /// Builds grid rows for the collection table. Cell values are the plain
 /// sortable/filterable representations; widgets come from column renderers.

--- a/lib/features/collections/widgets/dialogs/edit_connection_dialog.dart
+++ b/lib/features/collections/widgets/dialogs/edit_connection_dialog.dart
@@ -5,8 +5,7 @@ import '../../../../shared/models/canvas_connection.dart';
 import '../../../../shared/theme/app_spacing.dart';
 import '../../../../shared/widgets/color_picker_dialog.dart';
 import '../../../../shared/widgets/segmented_pill.dart';
-
-// Dialog for editing a canvas connection's properties.
+import '../../../../shared/utils/color_hex.dart';
 
 /// Dialog for editing a connection's label, color and style.
 ///
@@ -68,15 +67,7 @@ class _EditConnectionDialogState extends State<EditConnectionDialog> {
     _selectedStyle = widget.initialStyle ?? ConnectionStyle.solid;
   }
 
-  Color get _selectedColorValue {
-    final String cleaned = _selectedColor.replaceFirst('#', '');
-    return Color(int.parse('FF$cleaned', radix: 16));
-  }
-
-  String _colorToHex(Color color) {
-    final int rgb = color.toARGB32() & 0xFFFFFF;
-    return '#${rgb.toRadixString(16).toUpperCase().padLeft(6, '0')}';
-  }
+  Color get _selectedColorValue => ColorHex.fromHex(_selectedColor);
 
   @override
   void dispose() {
@@ -130,7 +121,7 @@ class _EditConnectionDialogState extends State<EditConnectionDialog> {
                   currentColor: _selectedColorValue,
                 );
                 if (picked == null) return;
-                setState(() => _selectedColor = _colorToHex(picked));
+                setState(() => _selectedColor = ColorHex.toHex(picked));
               },
               borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
               child: Row(

--- a/lib/features/collections/widgets/item_detail/item_detail_media_config.dart
+++ b/lib/features/collections/widgets/item_detail/item_detail_media_config.dart
@@ -13,6 +13,7 @@ import '../../../../shared/models/tv_show.dart';
 import '../../../../shared/theme/app_colors.dart';
 import '../../../../shared/widgets/media_detail_view.dart';
 import '../../../../shared/widgets/source_badge.dart';
+import '../../../../shared/constants/collection_item_ui.dart';
 
 class ItemDetailMediaConfig {
   const ItemDetailMediaConfig({

--- a/lib/features/collections/widgets/status_chip_row.dart
+++ b/lib/features/collections/widgets/status_chip_row.dart
@@ -7,6 +7,7 @@ import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_durations.dart';
 import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/constants/item_status_ui.dart';
 
 const String _kStatusMenuPrefix = 'status:';
 

--- a/lib/features/collections/widgets/status_ribbon.dart
+++ b/lib/features/collections/widgets/status_ribbon.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/models/item_status.dart';
 import '../../../shared/models/media_type.dart';
+import '../../../shared/constants/item_status_ui.dart';
 
 /// Hidden for [ItemStatus.notStarted]. Must be placed in a [Stack] inside
 /// a widget with `clipBehavior: Clip.antiAlias` (e.g. [Card]).

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -34,6 +34,7 @@ import '../../collections/widgets/context_menu_item.dart';
 import '../../collections/widgets/status_chip_row.dart';
 import '../providers/all_items_provider.dart';
 import '../../collections/providers/item_tags_provider.dart';
+import '../../../shared/constants/platform_ui.dart';
 
 /// Grid of all items across all collections (Home tab). The platforms
 /// filter row appears only while Games is selected.

--- a/lib/features/releases/screens/releases_screen.dart
+++ b/lib/features/releases/screens/releases_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/constants/media_type_theme.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -795,18 +796,8 @@ class _ReleasesScreenState extends ConsumerState<ReleasesScreen> {
     );
   }
 
-  IconData _placeholderIcon(MediaType? type) => switch (type) {
-        MediaType.game => Icons.videogame_asset,
-        MediaType.movie => Icons.movie_outlined,
-        MediaType.tvShow => Icons.tv_outlined,
-        MediaType.animation => Icons.animation,
-        MediaType.visualNovel => Icons.menu_book,
-        MediaType.manga => Icons.auto_stories,
-        MediaType.anime => Icons.play_circle_outline,
-        MediaType.book => Icons.menu_book,
-        MediaType.custom => Icons.dashboard_customize,
-        null => Icons.event,
-      };
+  IconData _placeholderIcon(MediaType? type) =>
+      type != null ? MediaTypeTheme.placeholderIconFor(type) : Icons.event;
 
   Color _colorFor(ReleaseEvent e) {
     if (e.isUpcoming) return AppColors.statusPlanned;

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -24,6 +24,7 @@ import '../widgets/collection_chips_row.dart';
 import '../widgets/discover_customize_sheet.dart';
 import '../widgets/discover_feed.dart';
 import '../widgets/filter_bar.dart';
+import '../../../shared/constants/platform_ui.dart';
 
 /// Search and browse screen — two modes: Browse (filter bar + Discover/Grid)
 /// and Search (query field + results).

--- a/lib/features/settings/content/credits_content.dart
+++ b/lib/features/settings/content/credits_content.dart
@@ -1,5 +1,3 @@
-// API-provider attribution and license screen content (no Scaffold/AppBar).
-
 import 'package:flutter/material.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/constants/media_type_theme.dart';
@@ -12,6 +10,7 @@ import '../../../shared/theme/app_typography.dart';
 import '../../../shared/utils/url_launch.dart';
 import '../../../shared/widgets/source_logo.dart';
 import '../widgets/settings_group.dart';
+import '../../../shared/constants/data_source_ui.dart';
 
 /// One attribution entry.
 typedef _Provider = ({

--- a/lib/features/settings/screens/profiles_screen.dart
+++ b/lib/features/settings/screens/profiles_screen.dart
@@ -17,6 +17,7 @@ import '../../../shared/widgets/sub_screen_title_bar.dart';
 import '../providers/profile_provider.dart';
 import '../widgets/create_profile_dialog.dart';
 import '../widgets/edit_profile_dialog.dart';
+import '../../../shared/constants/profile_ui.dart';
 
 class ProfilesScreen extends ConsumerStatefulWidget {
   const ProfilesScreen({super.key});
@@ -166,13 +167,13 @@ class _ProfilesScreenState extends ConsumerState<ProfilesScreen> {
           return Card(
             margin: const EdgeInsets.only(bottom: AppSpacing.sm),
             color: isCurrent
-                ? profile.colorValue.withAlpha(15)
+                ? profile.displayColor.withAlpha(15)
                 : AppColors.surface,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
               side: BorderSide(
                 color: isCurrent
-                    ? profile.colorValue.withAlpha(60)
+                    ? profile.displayColor.withAlpha(60)
                     : AppColors.surfaceBorder,
               ),
             ),
@@ -181,7 +182,7 @@ class _ProfilesScreenState extends ConsumerState<ProfilesScreen> {
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: profile.colorValue,
+                  color: profile.displayColor,
                   shape: BoxShape.circle,
                 ),
                 child: Center(
@@ -203,7 +204,7 @@ class _ProfilesScreenState extends ConsumerState<ProfilesScreen> {
                     Icon(
                       Icons.check_circle,
                       size: 16,
-                      color: profile.colorValue,
+                      color: profile.displayColor,
                     ),
                   ],
                 ],

--- a/lib/features/settings/widgets/create_profile_dialog.dart
+++ b/lib/features/settings/widgets/create_profile_dialog.dart
@@ -8,6 +8,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/color_picker_dialog.dart';
+import '../../../shared/utils/color_hex.dart';
 
 /// Диалог создания нового профиля.
 ///
@@ -75,14 +76,14 @@ class _CreateProfileDialogState extends State<CreateProfileDialog> {
             Text(l.colorPickerTitle, style: AppTypography.body),
             const SizedBox(height: AppSpacing.sm),
             _ProfileColorPickerButton(
-              color: Profile.hexToColor(_selectedColor),
+              color: ColorHex.fromHex(_selectedColor),
               onTap: () async {
                 final Color? picked = await ColorPickerDialog.show(
                   context: context,
-                  currentColor: Profile.hexToColor(_selectedColor),
+                  currentColor: ColorHex.fromHex(_selectedColor),
                 );
                 if (picked == null) return;
-                setState(() => _selectedColor = Profile.colorToHex(picked));
+                setState(() => _selectedColor = ColorHex.toHex(picked));
               },
             ),
           ],

--- a/lib/features/settings/widgets/edit_profile_dialog.dart
+++ b/lib/features/settings/widgets/edit_profile_dialog.dart
@@ -7,6 +7,7 @@ import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/color_picker_dialog.dart';
 import '../../../shared/widgets/confirm_dialog.dart';
+import '../../../shared/utils/color_hex.dart';
 
 sealed class EditProfileResult {
   const EditProfileResult();
@@ -120,10 +121,10 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
               onTap: () async {
                 final Color? picked = await ColorPickerDialog.show(
                   context: context,
-                  currentColor: Profile.hexToColor(_selectedColor),
+                  currentColor: ColorHex.fromHex(_selectedColor),
                 );
                 if (picked == null) return;
-                setState(() => _selectedColor = Profile.colorToHex(picked));
+                setState(() => _selectedColor = ColorHex.toHex(picked));
               },
               borderRadius: BorderRadius.circular(AppSpacing.radiusXl),
               child: Padding(
@@ -135,7 +136,7 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
                       width: 36,
                       height: 36,
                       decoration: BoxDecoration(
-                        color: Profile.hexToColor(_selectedColor),
+                        color: ColorHex.fromHex(_selectedColor),
                         shape: BoxShape.circle,
                         border: Border.all(color: Colors.white.withAlpha(40)),
                       ),

--- a/lib/features/splash/screens/profile_picker_screen.dart
+++ b/lib/features/splash/screens/profile_picker_screen.dart
@@ -1,5 +1,3 @@
-// Экран выбора профиля при запуске.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -14,6 +12,7 @@ import '../../../shared/theme/app_typography.dart';
 import '../../settings/providers/profile_provider.dart';
 import '../../settings/providers/settings_provider.dart';
 import '../../settings/widgets/create_profile_dialog.dart';
+import '../../../shared/constants/profile_ui.dart';
 
 /// Ключ SharedPreferences для пропуска выбора профиля.
 const String kSkipProfilePickerKey = 'skip_profile_picker';
@@ -172,12 +171,12 @@ class _ProfileCard extends StatelessWidget {
         ),
         decoration: BoxDecoration(
           color: isCurrent
-              ? profile.colorValue.withAlpha(20)
+              ? profile.displayColor.withAlpha(20)
               : AppColors.surface,
           borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
           border: Border.all(
             color: isCurrent
-                ? profile.colorValue.withAlpha(80)
+                ? profile.displayColor.withAlpha(80)
                 : AppColors.surfaceBorder,
           ),
         ),
@@ -188,7 +187,7 @@ class _ProfileCard extends StatelessWidget {
               width: 48,
               height: 48,
               decoration: BoxDecoration(
-                color: profile.colorValue,
+                color: profile.displayColor,
                 shape: BoxShape.circle,
               ),
               child: Center(

--- a/lib/features/tier_lists/providers/tier_list_detail_provider.dart
+++ b/lib/features/tier_lists/providers/tier_list_detail_provider.dart
@@ -346,7 +346,7 @@ class TierListDetailNotifier
     final List<TierDefinition> updated = state.definitions.map(
       (TierDefinition def) {
         if (def.tierKey == tierKey) {
-          return def.copyWith(label: label, color: color);
+          return def.copyWith(label: label, colorValue: color?.toARGB32());
         }
         return def;
       },
@@ -362,7 +362,7 @@ class TierListDetailNotifier
     )..add(TierDefinition(
         tierKey: tierKey,
         label: label,
-        color: color,
+        colorValue: color.toARGB32(),
         sortOrder: state.definitions.length,
       ));
 

--- a/lib/features/tier_lists/widgets/tier_item_card.dart
+++ b/lib/features/tier_lists/widgets/tier_item_card.dart
@@ -6,6 +6,7 @@ import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/widgets/cached_image.dart';
+import '../../../shared/constants/platform_ui.dart';
 
 const double kTierItemWidth = 90;
 const double kTierItemImageHeight = 120;

--- a/lib/features/tier_lists/widgets/tier_list_export_view.dart
+++ b/lib/features/tier_lists/widgets/tier_list_export_view.dart
@@ -9,6 +9,7 @@ import '../../../shared/theme/app_assets.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../providers/tier_list_detail_provider.dart';
 import 'tier_item_card.dart';
+import '../../../shared/constants/tier_definition_ui.dart';
 
 const double _kExportItemWidth = 80;
 const double _kExportItemHeight = 110;

--- a/lib/features/tier_lists/widgets/tier_list_view.dart
+++ b/lib/features/tier_lists/widgets/tier_list_view.dart
@@ -13,6 +13,7 @@ import '../../../shared/theme/app_typography.dart';
 import '../providers/tier_list_detail_provider.dart';
 import 'tier_item_card.dart';
 import 'tier_row.dart';
+import '../../../shared/constants/tier_definition_ui.dart';
 
 /// Tiers stacked over the Unranked pool, with a vertical drag handle between
 /// them so the user can resize the two regions.

--- a/lib/features/tier_lists/widgets/tier_row.dart
+++ b/lib/features/tier_lists/widgets/tier_row.dart
@@ -8,6 +8,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import 'tier_item_card.dart';
+import '../../../shared/constants/tier_definition_ui.dart';
 
 const double _kCompactBreakpoint = 500;
 

--- a/lib/features/welcome/widgets/welcome_step_sources.dart
+++ b/lib/features/welcome/widgets/welcome_step_sources.dart
@@ -17,6 +17,7 @@ import 'welcome_card.dart';
 import 'welcome_chip.dart';
 import 'welcome_hero.dart';
 import 'welcome_reveal.dart';
+import '../../../shared/constants/data_source_ui.dart';
 
 /// Sources — every search provider with its logo and media types, plus inline
 /// API-key fields for IGDB and TMDB.

--- a/lib/shared/constants/canvas_item_ui.dart
+++ b/lib/shared/constants/canvas_item_ui.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+import '../models/canvas_item.dart';
+import '../models/media_type.dart';
+import 'media_type_theme.dart';
+
+/// Presentation extras for [CanvasItem].
+extension CanvasItemUi on CanvasItem {
+  /// Falls back to a note icon for non-media canvas items (text / image / link).
+  IconData get mediaPlaceholderIcon {
+    final MediaType? media = asMediaType;
+    return media != null
+        ? MediaTypeTheme.placeholderIconFor(media)
+        : Icons.note;
+  }
+}

--- a/lib/shared/constants/collection_item_ui.dart
+++ b/lib/shared/constants/collection_item_ui.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+import '../models/collection_item.dart';
+import 'media_type_theme.dart';
+
+/// Presentation extras for [CollectionItem].
+extension CollectionItemUi on CollectionItem {
+  /// Custom items masquerading as another type get that type's icon.
+  IconData get placeholderIcon =>
+      MediaTypeTheme.placeholderIconFor(displayMediaType);
+}

--- a/lib/shared/constants/data_source_ui.dart
+++ b/lib/shared/constants/data_source_ui.dart
@@ -1,0 +1,9 @@
+import 'dart:ui';
+
+import '../models/data_source.dart';
+
+/// Presentation extras for [DataSource].
+extension DataSourceUi on DataSource {
+  /// Brand color of the source.
+  Color get color => Color(colorValue);
+}

--- a/lib/shared/constants/item_status_ui.dart
+++ b/lib/shared/constants/item_status_ui.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../models/item_status.dart';
+import '../models/media_type.dart';
+import '../theme/app_colors.dart';
+
+/// Presentation extras for [ItemStatus].
+extension ItemStatusUi on ItemStatus {
+  Color get color {
+    switch (this) {
+      case ItemStatus.notStarted:
+        return AppColors.textSecondary;
+      case ItemStatus.inProgress:
+        return AppColors.statusInProgress;
+      case ItemStatus.completed:
+        return AppColors.statusCompleted;
+      case ItemStatus.dropped:
+        return AppColors.statusDropped;
+      case ItemStatus.planned:
+        return AppColors.statusPlanned;
+      case ItemStatus.replaying:
+        return AppColors.statusReplaying;
+    }
+  }
+
+  IconData get materialIcon {
+    switch (this) {
+      case ItemStatus.notStarted:
+        return Icons.radio_button_unchecked;
+      case ItemStatus.inProgress:
+        return Icons.play_arrow_rounded;
+      case ItemStatus.completed:
+        return Icons.check_circle;
+      case ItemStatus.dropped:
+        return Icons.pause_circle_filled;
+      case ItemStatus.planned:
+        return Icons.bookmark;
+      case ItemStatus.replaying:
+        return Icons.replay_circle_filled;
+    }
+  }
+
+  /// Localised label adapted to [mediaType] (Playing / Watching / Reading).
+  String localizedLabel(S l, MediaType mediaType) {
+    switch (this) {
+      case ItemStatus.notStarted:
+        return l.statusNotStarted;
+      case ItemStatus.inProgress:
+        return mediaType == MediaType.game ? l.statusPlaying : l.statusWatching;
+      case ItemStatus.completed:
+        return l.statusCompleted;
+      case ItemStatus.dropped:
+        return l.statusDropped;
+      case ItemStatus.planned:
+        return l.statusPlanned;
+      case ItemStatus.replaying:
+        switch (mediaType) {
+          case MediaType.game:
+          case MediaType.visualNovel:
+            return l.statusReplaying;
+          case MediaType.manga:
+          case MediaType.book:
+            return l.statusRereading;
+          case MediaType.movie:
+          case MediaType.tvShow:
+          case MediaType.animation:
+          case MediaType.anime:
+          case MediaType.custom:
+            return l.statusRewatching;
+        }
+    }
+  }
+
+  /// Localised label not tied to a media type, for contexts where the type
+  /// is unknown (table headers, filters).
+  String genericLabel(S l) {
+    switch (this) {
+      case ItemStatus.notStarted:
+        return l.statusNotStarted;
+      case ItemStatus.inProgress:
+        return l.statusInProgress;
+      case ItemStatus.completed:
+        return l.statusCompleted;
+      case ItemStatus.dropped:
+        return l.statusDropped;
+      case ItemStatus.planned:
+        return l.statusPlanned;
+      case ItemStatus.replaying:
+        return l.statusReplay;
+    }
+  }
+}

--- a/lib/shared/constants/media_type_theme.dart
+++ b/lib/shared/constants/media_type_theme.dart
@@ -1,43 +1,29 @@
-// Цветовые темы и иконки для типов медиа.
 
 import 'package:flutter/material.dart';
 
 import '../models/media_type.dart';
 import '../theme/app_colors.dart';
 
-/// Цвета и иконки для визуального разделения типов медиа.
-///
-/// 🎮 Игры — индиго, 🎬 Фильмы — оранжевый, 📺 Сериалы — лаймовый,
-/// 🎞️ Анимация — пурпурный.
+/// Colors and icons that visually distinguish media types.
 abstract final class MediaTypeTheme {
-  /// Цвет для игр.
   static const Color gameColor = AppColors.gameAccent;
 
-  /// Цвет для фильмов.
   static const Color movieColor = AppColors.movieAccent;
 
-  /// Цвет для сериалов.
   static const Color tvShowColor = AppColors.tvShowAccent;
 
-  /// Цвет для анимации.
   static const Color animationColor = AppColors.animationAccent;
 
-  /// Цвет для визуальных новелл.
   static const Color visualNovelColor = AppColors.visualNovelAccent;
 
-  /// Цвет для манги.
   static const Color mangaColor = AppColors.mangaAccent;
 
-  /// Цвет для аниме.
   static const Color animeColor = AppColors.animeAccent;
 
-  /// Цвет для книг.
   static const Color bookColor = AppColors.bookAccent;
 
-  /// Цвет для кастомных элементов.
   static const Color customColor = AppColors.customAccent;
 
-  /// Возвращает иконку для типа медиа.
   static IconData iconFor(MediaType type) => switch (type) {
         MediaType.game => Icons.videogame_asset,
         MediaType.movie => Icons.movie,
@@ -50,7 +36,19 @@ abstract final class MediaTypeTheme {
         MediaType.custom => Icons.dashboard_customize,
       };
 
-  /// Возвращает цвет для типа медиа.
+  /// Placeholder icon for missing covers — outlined variants of [iconFor].
+  static IconData placeholderIconFor(MediaType type) => switch (type) {
+        MediaType.game => Icons.videogame_asset,
+        MediaType.movie => Icons.movie_outlined,
+        MediaType.tvShow => Icons.tv_outlined,
+        MediaType.animation => Icons.animation,
+        MediaType.visualNovel => Icons.menu_book,
+        MediaType.manga => Icons.auto_stories,
+        MediaType.anime => Icons.play_circle_outline,
+        MediaType.book => Icons.menu_book,
+        MediaType.custom => Icons.dashboard_customize,
+      };
+
   static Color colorFor(MediaType type) => switch (type) {
         MediaType.game => gameColor,
         MediaType.movie => movieColor,

--- a/lib/shared/constants/platform_ui.dart
+++ b/lib/shared/constants/platform_ui.dart
@@ -1,0 +1,38 @@
+import 'dart:ui';
+
+import '../models/platform.dart';
+
+/// Presentation extras for [Platform].
+extension PlatformUi on Platform {
+  /// Color keyed off the IGDB platform ID family (Sony, Nintendo, Microsoft,
+  /// Sega, PC, Atari), falling back to purple for everything else.
+  Color get familyColor {
+    // Sony: PS1(7), PS2(8), PS3(9), PS4(48), PS5(167), PSP(38), Vita(46)
+    if (const <int>{7, 8, 9, 48, 167, 38, 46, 165}.contains(id)) {
+      return const Color(0xFF0070D1); // PlayStation blue
+    }
+    // Nintendo: NES(18), SNES(19), N64(4), GC(21), Wii(5), WiiU(41),
+    // Switch(130), GB(33), GBA(24), DS(20), 3DS(37)
+    if (const <int>{18, 19, 4, 21, 5, 41, 130, 33, 24, 20, 37, 137, 159}
+        .contains(id)) {
+      return const Color(0xFFE60012); // Nintendo red
+    }
+    // Microsoft: Xbox(11), X360(12), XOne(49), XSX(169)
+    if (const <int>{11, 12, 49, 169}.contains(id)) {
+      return const Color(0xFF107C10); // Xbox green
+    }
+    // Sega: Genesis/MD(29), Saturn(32), DC(23), SMS(64), GG(35)
+    if (const <int>{29, 32, 23, 64, 35, 78, 30, 84}.contains(id)) {
+      return const Color(0xFF17569B); // Sega blue
+    }
+    // PC(6), Mac(14), Linux(3)
+    if (const <int>{6, 14, 3, 162, 163}.contains(id)) {
+      return const Color(0xFF6B7280); // PC gray
+    }
+    // Atari: 2600(59), 7800(60), Jaguar(62), Lynx(61), ST(63)
+    if (const <int>{59, 60, 62, 61, 63}.contains(id)) {
+      return const Color(0xFFB45309); // Atari amber
+    }
+    return const Color(0xFF7C3AED); // default purple
+  }
+}

--- a/lib/shared/constants/profile_ui.dart
+++ b/lib/shared/constants/profile_ui.dart
@@ -1,0 +1,10 @@
+import 'dart:ui';
+
+import '../models/profile.dart';
+import '../utils/color_hex.dart';
+
+/// Presentation extras for [Profile].
+extension ProfileUi on Profile {
+  /// Profile color parsed from the stored hex string.
+  Color get displayColor => ColorHex.fromHex(color);
+}

--- a/lib/shared/constants/tier_definition_ui.dart
+++ b/lib/shared/constants/tier_definition_ui.dart
@@ -1,0 +1,9 @@
+import 'dart:ui';
+
+import '../models/tier_definition.dart';
+
+/// Presentation extras for [TierDefinition].
+extension TierDefinitionUi on TierDefinition {
+  /// Tier label color.
+  Color get color => Color(colorValue);
+}

--- a/lib/shared/models/canvas_item.dart
+++ b/lib/shared/models/canvas_item.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
-
 import 'image_type.dart';
 import 'anime.dart';
 import 'book.dart';
@@ -290,31 +288,6 @@ class CanvasItem with Exportable {
         ),
       CanvasItemType.custom => (customMedia?.id ?? 0).toString(),
       _ => '0',
-    };
-  }
-
-  IconData get mediaPlaceholderIcon {
-    return switch (itemType) {
-      CanvasItemType.game => Icons.videogame_asset,
-      CanvasItemType.movie => Icons.movie_outlined,
-      CanvasItemType.tvShow => Icons.tv_outlined,
-      CanvasItemType.animation => Icons.animation,
-      CanvasItemType.visualNovel => Icons.menu_book,
-      CanvasItemType.manga => Icons.auto_stories,
-      CanvasItemType.anime => Icons.play_circle_outline,
-      CanvasItemType.book => Icons.menu_book,
-      CanvasItemType.custom => switch (customMedia?.displayType) {
-        MediaType.game => Icons.videogame_asset,
-        MediaType.movie => Icons.movie_outlined,
-        MediaType.tvShow => Icons.tv_outlined,
-        MediaType.animation => Icons.animation,
-        MediaType.visualNovel => Icons.menu_book,
-        MediaType.manga => Icons.auto_stories,
-        MediaType.anime => Icons.play_circle_outline,
-        MediaType.book => Icons.menu_book,
-        _ => Icons.dashboard_customize,
-      },
-      _ => Icons.note,
     };
   }
 

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 
 import 'image_type.dart';
 import 'book.dart';
@@ -276,7 +275,6 @@ class CollectionItem with Exportable {
     String? mediaStatus,
     DataSource source,
     ImageType imageType,
-    IconData placeholderIcon,
   }) get _resolvedMedia {
     switch (mediaType) {
       case MediaType.game:
@@ -296,7 +294,6 @@ class CollectionItem with Exportable {
           mediaStatus: null,
           source: DataSource.igdb,
           imageType: ImageType.gameCover,
-          placeholderIcon: Icons.videogame_asset,
         );
       case MediaType.movie:
         return (
@@ -315,7 +312,6 @@ class CollectionItem with Exportable {
           mediaStatus: null,
           source: DataSource.tmdb,
           imageType: ImageType.moviePoster,
-          placeholderIcon: Icons.movie_outlined,
         );
       case MediaType.tvShow:
         return (
@@ -334,7 +330,6 @@ class CollectionItem with Exportable {
           mediaStatus: tvShow?.status,
           source: tvShow?.source ?? source ?? DataSource.tmdb,
           imageType: ImageType.tvShowPoster,
-          placeholderIcon: Icons.tv_outlined,
         );
       case MediaType.animation:
         final bool isTvBased = platformId == AnimationSource.tvShow;
@@ -355,7 +350,6 @@ class CollectionItem with Exportable {
             mediaStatus: tvShow?.status,
             source: tvShow?.source ?? source ?? DataSource.tmdb,
             imageType: ImageType.tvShowPoster,
-            placeholderIcon: Icons.animation,
           );
         }
         return (
@@ -374,7 +368,6 @@ class CollectionItem with Exportable {
           mediaStatus: null,
           source: DataSource.tmdb,
           imageType: ImageType.moviePoster,
-          placeholderIcon: Icons.animation,
         );
       case MediaType.visualNovel:
         return (
@@ -393,7 +386,6 @@ class CollectionItem with Exportable {
           mediaStatus: null,
           source: DataSource.vndb,
           imageType: ImageType.vnCover,
-          placeholderIcon: Icons.menu_book,
         );
       case MediaType.manga:
         return (
@@ -412,7 +404,6 @@ class CollectionItem with Exportable {
           mediaStatus: manga?.statusLabel,
           source: manga?.source ?? DataSource.anilist,
           imageType: ImageType.mangaCover,
-          placeholderIcon: Icons.auto_stories,
         );
       case MediaType.book:
         return (
@@ -431,7 +422,6 @@ class CollectionItem with Exportable {
           mediaStatus: null,
           source: book?.source ?? DataSource.openLibrary,
           imageType: ImageType.bookCover,
-          placeholderIcon: Icons.menu_book,
         );
       case MediaType.anime:
         return (
@@ -450,11 +440,8 @@ class CollectionItem with Exportable {
           mediaStatus: anime?.statusLabel,
           source: anime?.source ?? source ?? DataSource.anilist,
           imageType: ImageType.animeCover,
-          placeholderIcon: Icons.play_circle_outline,
         );
       case MediaType.custom:
-        final MediaType displayType =
-            customMedia?.displayType ?? MediaType.custom;
         return (
           name: customMedia?.title,
           coverUrl: customMedia?.coverUrl,
@@ -471,9 +458,6 @@ class CollectionItem with Exportable {
           mediaStatus: null,
           source: DataSource.local,
           imageType: ImageType.customCover,
-          placeholderIcon: displayType == MediaType.custom
-              ? Icons.dashboard_customize
-              : _placeholderIconFor(displayType),
         );
     }
   }
@@ -591,18 +575,6 @@ class CollectionItem with Exportable {
 
   String get platformName => platform?.displayName ?? 'Unknown Platform';
 
-  static IconData _placeholderIconFor(MediaType type) => switch (type) {
-        MediaType.game => Icons.videogame_asset,
-        MediaType.movie => Icons.movie_outlined,
-        MediaType.tvShow => Icons.tv_outlined,
-        MediaType.animation => Icons.animation,
-        MediaType.visualNovel => Icons.menu_book,
-        MediaType.manga => Icons.auto_stories,
-        MediaType.anime => Icons.play_circle_outline,
-        MediaType.book => Icons.menu_book,
-        MediaType.custom => Icons.dashboard_customize,
-      };
-
   bool get hasAuthorComment =>
       authorComment != null && authorComment!.isNotEmpty;
 
@@ -635,7 +607,6 @@ class CollectionItem with Exportable {
   String? get mediaStatus => _resolvedMedia.mediaStatus;
   DataSource get dataSource => _resolvedMedia.source;
   ImageType get imageType => _resolvedMedia.imageType;
-  IconData get placeholderIcon => _resolvedMedia.placeholderIcon;
 
   /// Source-aware image-cache id (anime / manga are namespaced by provider).
   /// Use this everywhere a cover is read from / written to the image cache.

--- a/lib/shared/models/data_source.dart
+++ b/lib/shared/models/data_source.dart
@@ -1,71 +1,65 @@
-import 'package:flutter/material.dart';
-
 import '../theme/app_assets.dart';
 
 /// External data provider.
 enum DataSource {
   /// IGDB — game database.
-  igdb('IGDB', Color(0xFF9147FF), AppAssets.iconIgdbColor),
+  igdb('IGDB', 0xFF9147FF, AppAssets.iconIgdbColor),
 
   /// TMDB — movie and TV database.
-  tmdb('TMDB', Color(0xFF01D277), AppAssets.iconTmdbColor),
+  tmdb('TMDB', 0xFF01D277, AppAssets.iconTmdbColor),
 
   /// TVmaze — keyless TV series database with season / episode data.
-  tvmaze('TVmaze', Color(0xFF3C5C8C), AppAssets.iconTvMazeColor),
+  tvmaze('TVmaze', 0xFF3C5C8C, AppAssets.iconTvMazeColor),
 
   /// SteamGridDB — Steam artwork.
-  steamGridDb('SGDB', Color(0xFF3A9BDC), AppAssets.iconSteamGridDbColor),
+  steamGridDb('SGDB', 0xFF3A9BDC, AppAssets.iconSteamGridDbColor),
 
   /// VGMaps — video game maps.
-  vgMaps('VGMaps', Color(0xFFE57C23), null),
+  vgMaps('VGMaps', 0xFFE57C23, null),
 
   /// VNDB — visual novel database.
-  vndb('VNDB', Color(0xFF2A5FC1), AppAssets.iconVndbColor),
+  vndb('VNDB', 0xFF2A5FC1, AppAssets.iconVndbColor),
 
   /// AniList — anime and manga database.
-  anilist('AniList', Color(0xFF3DB4F2), AppAssets.iconAnilistColor),
+  anilist('AniList', 0xFF3DB4F2, AppAssets.iconAnilistColor),
 
   /// MangaBaka — open catalog of manga / manhwa / manhua / light novels.
-  mangabaka('MangaBaka', Color(0xFFE5484D), AppAssets.iconMangaBakaColor),
+  mangabaka('MangaBaka', 0xFFE5484D, AppAssets.iconMangaBakaColor),
 
   /// MangaDex — large manga catalog with localized titles and chapter counts.
-  mangadex('MangaDex', Color(0xFFFF6740), AppAssets.iconMangaDexColor),
+  mangadex('MangaDex', 0xFFFF6740, AppAssets.iconMangaDexColor),
 
   /// Kitsu — independent anime and manga catalog.
-  kitsu('Kitsu', Color(0xFFF75239), AppAssets.iconKitsuColor),
+  kitsu('Kitsu', 0xFFF75239, AppAssets.iconKitsuColor),
 
   /// OpenLibrary — global open book catalog (~40M works, CC0/ODbL).
-  openLibrary('OpenLibrary', Color(0xFF9B6A4F), AppAssets.iconOpenLibraryColor),
+  openLibrary('OpenLibrary', 0xFF9B6A4F, AppAssets.iconOpenLibraryColor),
 
   /// Fantlab — community book catalog with detailed metadata.
-  fantlab('Fantlab', Color(0xFFC5302E), AppAssets.iconFantlabColor),
+  fantlab('Fantlab', 0xFFC5302E, AppAssets.iconFantlabColor),
 
   /// ComicVine — comics / graphic novels catalog (volumes + issues). Feeds the
   /// `book` media type with `BookKind.comic` records.
-  comicVine('ComicVine', Color(0xFFF26522), AppAssets.iconComicVineColor),
+  comicVine('ComicVine', 0xFFF26522, AppAssets.iconComicVineColor),
 
   /// Google Books — global book catalog (millions of editions, public search).
   /// Feeds the `book` media type with `BookKind.book` records.
-  googleBooks(
-    'Google Books',
-    Color(0xFF4285F4),
-    AppAssets.iconGoogleBooksColor,
-  ),
+  googleBooks('Google Books', 0xFF4285F4, AppAssets.iconGoogleBooksColor),
 
   /// Hardcover — community book catalog (books, series, moods, ratings).
   /// Feeds the `book` media type; graphic novels map to `BookKind.comic`.
-  hardcover('Hardcover', Color(0xFF6366F1), AppAssets.iconHardcoverColor),
+  hardcover('Hardcover', 0xFF6366F1, AppAssets.iconHardcoverColor),
 
   /// Local source (custom items).
-  local('Custom', Color(0xFF26A69A), null);
+  local('Custom', 0xFF26A69A, null);
 
-  const DataSource(this.label, this.color, this.iconAsset);
+  const DataSource(this.label, this.colorValue, this.iconAsset);
 
   /// Short display label.
   final String label;
 
-  /// Brand color of the source.
-  final Color color;
+  /// Brand color of the source as an ARGB int.
+  final int colorValue;
 
   /// Path to the color PNG logo (null when there is no brand asset).
   final String? iconAsset;

--- a/lib/shared/models/item_status.dart
+++ b/lib/shared/models/item_status.dart
@@ -1,9 +1,3 @@
-import 'package:flutter/material.dart';
-
-import '../../l10n/app_localizations.dart';
-import '../theme/app_colors.dart';
-import 'media_type.dart';
-
 /// Universal collection-item status with media-type-aware labels.
 enum ItemStatus {
   notStarted('not_started'),
@@ -47,71 +41,6 @@ enum ItemStatus {
     return null;
   }
 
-  Color get color {
-    switch (this) {
-      case ItemStatus.notStarted:
-        return AppColors.textSecondary;
-      case ItemStatus.inProgress:
-        return AppColors.statusInProgress;
-      case ItemStatus.completed:
-        return AppColors.statusCompleted;
-      case ItemStatus.dropped:
-        return AppColors.statusDropped;
-      case ItemStatus.planned:
-        return AppColors.statusPlanned;
-      case ItemStatus.replaying:
-        return AppColors.statusReplaying;
-    }
-  }
-
-  IconData get materialIcon {
-    switch (this) {
-      case ItemStatus.notStarted:
-        return Icons.radio_button_unchecked;
-      case ItemStatus.inProgress:
-        return Icons.play_arrow_rounded;
-      case ItemStatus.completed:
-        return Icons.check_circle;
-      case ItemStatus.dropped:
-        return Icons.pause_circle_filled;
-      case ItemStatus.planned:
-        return Icons.bookmark;
-      case ItemStatus.replaying:
-        return Icons.replay_circle_filled;
-    }
-  }
-
-  /// Localised label adapted to [mediaType] (Playing / Watching / Reading).
-  String localizedLabel(S l, MediaType mediaType) {
-    switch (this) {
-      case ItemStatus.notStarted:
-        return l.statusNotStarted;
-      case ItemStatus.inProgress:
-        return mediaType == MediaType.game ? l.statusPlaying : l.statusWatching;
-      case ItemStatus.completed:
-        return l.statusCompleted;
-      case ItemStatus.dropped:
-        return l.statusDropped;
-      case ItemStatus.planned:
-        return l.statusPlanned;
-      case ItemStatus.replaying:
-        switch (mediaType) {
-          case MediaType.game:
-          case MediaType.visualNovel:
-            return l.statusReplaying;
-          case MediaType.manga:
-          case MediaType.book:
-            return l.statusRereading;
-          case MediaType.movie:
-          case MediaType.tvShow:
-          case MediaType.animation:
-          case MediaType.anime:
-          case MediaType.custom:
-            return l.statusRewatching;
-        }
-    }
-  }
-
   /// English display name (locale-independent).
   ///
   /// For non-localised contexts such as text export and MAL export.
@@ -129,25 +58,6 @@ enum ItemStatus {
         return 'Planned';
       case ItemStatus.replaying:
         return 'Replay';
-    }
-  }
-
-  /// Localised label not tied to a media type, for contexts where the type
-  /// is unknown (table headers, filters).
-  String genericLabel(S l) {
-    switch (this) {
-      case ItemStatus.notStarted:
-        return l.statusNotStarted;
-      case ItemStatus.inProgress:
-        return l.statusInProgress;
-      case ItemStatus.completed:
-        return l.statusCompleted;
-      case ItemStatus.dropped:
-        return l.statusDropped;
-      case ItemStatus.planned:
-        return l.statusPlanned;
-      case ItemStatus.replaying:
-        return l.statusReplay;
     }
   }
 

--- a/lib/shared/models/platform.dart
+++ b/lib/shared/models/platform.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 class Platform {
   const Platform({
     required this.id,
@@ -30,38 +28,6 @@ class Platform {
   final String? abbreviation;
 
   String get displayName => abbreviation ?? name;
-
-  /// Color keyed off the IGDB platform ID family (Sony, Nintendo, Microsoft,
-  /// Sega, PC, Atari), falling back to purple for everything else.
-  Color get familyColor {
-    // Sony: PS1(7), PS2(8), PS3(9), PS4(48), PS5(167), PSP(38), Vita(46)
-    if (const <int>{7, 8, 9, 48, 167, 38, 46, 165}.contains(id)) {
-      return const Color(0xFF0070D1); // PlayStation blue
-    }
-    // Nintendo: NES(18), SNES(19), N64(4), GC(21), Wii(5), WiiU(41),
-    // Switch(130), GB(33), GBA(24), DS(20), 3DS(37)
-    if (const <int>{18, 19, 4, 21, 5, 41, 130, 33, 24, 20, 37, 137, 159}
-        .contains(id)) {
-      return const Color(0xFFE60012); // Nintendo red
-    }
-    // Microsoft: Xbox(11), X360(12), XOne(49), XSX(169)
-    if (const <int>{11, 12, 49, 169}.contains(id)) {
-      return const Color(0xFF107C10); // Xbox green
-    }
-    // Sega: Genesis/MD(29), Saturn(32), DC(23), SMS(64), GG(35)
-    if (const <int>{29, 32, 23, 64, 35, 78, 30, 84}.contains(id)) {
-      return const Color(0xFF17569B); // Sega blue
-    }
-    // PC(6), Mac(14), Linux(3)
-    if (const <int>{6, 14, 3, 162, 163}.contains(id)) {
-      return const Color(0xFF6B7280); // PC gray
-    }
-    // Atari: 2600(59), 7800(60), Jaguar(62), Lynx(61), ST(63)
-    if (const <int>{59, 60, 62, 61, 63}.contains(id)) {
-      return const Color(0xFFB45309); // Atari amber
-    }
-    return const Color(0xFF7C3AED); // default purple
-  }
 
   @override
   bool operator ==(Object other) {

--- a/lib/shared/models/profile.dart
+++ b/lib/shared/models/profile.dart
@@ -1,12 +1,7 @@
-// Модель пользовательского профиля.
-
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
-
-/// Пользовательский профиль с изолированной БД и настройками.
+/// User profile with an isolated database and settings.
 class Profile {
-  /// Создаёт [Profile].
   const Profile({
     required this.id,
     required this.name,
@@ -14,7 +9,6 @@ class Profile {
     required this.createdAt,
   });
 
-  /// Создаёт [Profile] из JSON.
   factory Profile.fromJson(Map<String, dynamic> json) {
     return Profile(
       id: json['id'] as String,
@@ -24,37 +18,18 @@ class Profile {
     );
   }
 
-  /// Уникальный идентификатор (slug или UUID).
+  /// Unique identifier (slug or UUID); doubles as the profile folder name.
   final String id;
 
-  /// Отображаемое имя.
   final String name;
 
-  /// Hex цвет профиля (e.g. '#EF7B44').
+  /// Profile color as a hex string (e.g. '#EF7B44').
   final String color;
 
-  /// Дата создания.
   final DateTime createdAt;
 
-  /// Цвет как [Color].
-  Color get colorValue => hexToColor(color);
-
-  /// Конвертирует hex строку (e.g. '#EF7B44') в [Color].
-  static Color hexToColor(String hex) {
-    final String cleaned = hex.replaceFirst('#', '');
-    return Color(int.parse('FF$cleaned', radix: 16));
-  }
-
-  /// Конвертирует [Color] в hex строку в формате '#RRGGBB'.
-  static String colorToHex(Color color) {
-    final int rgb = color.toARGB32() & 0xFFFFFF;
-    return '#${rgb.toRadixString(16).toUpperCase().padLeft(6, '0')}';
-  }
-
-  /// Имя папки профиля.
   String get folderName => id;
 
-  /// Сериализация в JSON.
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'id': id,
@@ -64,7 +39,6 @@ class Profile {
     };
   }
 
-  /// Создаёт копию с изменёнными полями.
   Profile copyWith({
     String? name,
     String? color,
@@ -78,16 +52,14 @@ class Profile {
   }
 }
 
-/// Данные всех профилей (profiles.json).
+/// Contents of profiles.json: the profile list and the active profile id.
 class ProfilesData {
-  /// Создаёт [ProfilesData].
   const ProfilesData({
     required this.version,
     required this.currentProfileId,
     required this.profiles,
   });
 
-  /// Создаёт [ProfilesData] из JSON.
   factory ProfilesData.fromJson(Map<String, dynamic> json) {
     final List<dynamic> profilesList = json['profiles'] as List<dynamic>;
     return ProfilesData(
@@ -100,14 +72,13 @@ class ProfilesData {
     );
   }
 
-  /// Создаёт [ProfilesData] из JSON строки.
   factory ProfilesData.fromJsonString(String jsonString) {
     return ProfilesData.fromJson(
       jsonDecode(jsonString) as Map<String, dynamic>,
     );
   }
 
-  /// Дефолтные данные для первого запуска.
+  /// Initial data for the first launch.
   factory ProfilesData.defaultData({String authorName = 'Default'}) {
     return ProfilesData(
       version: 1,
@@ -123,24 +94,19 @@ class ProfilesData {
     );
   }
 
-  /// Версия формата.
+  /// Format version.
   final int version;
 
-  /// ID текущего активного профиля.
   final String currentProfileId;
 
-  /// Список всех профилей.
   final List<Profile> profiles;
 
-  /// Текущий активный профиль.
-  ///
-  /// Если [currentProfileId] не найден — возвращает первый профиль.
+  /// Falls back to the first profile when [currentProfileId] is not found.
   Profile get currentProfile => profiles.firstWhere(
         (Profile p) => p.id == currentProfileId,
         orElse: () => profiles.first,
       );
 
-  /// Сериализация в JSON.
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
       'version': version,
@@ -150,12 +116,10 @@ class ProfilesData {
     };
   }
 
-  /// Сериализация в JSON строку.
   String toJsonString() {
     return const JsonEncoder.withIndent('  ').convert(toJson());
   }
 
-  /// Создаёт копию с изменёнными полями.
   ProfilesData copyWith({
     String? currentProfileId,
     List<Profile>? profiles,
@@ -168,30 +132,25 @@ class ProfilesData {
   }
 }
 
-/// Статистика профиля.
+/// Per-profile collection statistics.
 class ProfileStats {
-  /// Создаёт [ProfileStats].
   const ProfileStats({
     required this.collectionsCount,
     required this.itemsCount,
   });
 
-  /// Пустая статистика.
   static const ProfileStats empty = ProfileStats(
     collectionsCount: 0,
     itemsCount: 0,
   );
 
-  /// Количество коллекций.
   final int collectionsCount;
 
-  /// Количество элементов.
   final int itemsCount;
 }
 
-/// Предустановленные цвета для профилей.
+/// Preset profile colors.
 abstract final class ProfileColors {
-  /// Список доступных цветов.
   static const List<String> values = <String>[
     '#EF7B44', // Brand orange
     '#F44336', // Red

--- a/lib/shared/models/tier_definition.dart
+++ b/lib/shared/models/tier_definition.dart
@@ -1,111 +1,100 @@
-// Определение тира — метка, цвет и порядок в тир-листе.
-
-import 'dart:ui';
-
-/// Определение тира (S, A, B, C или кастомный).
-///
-/// Описывает один уровень в тир-листе: ключ, метку, цвет и порядок.
+/// One tier level in a tier list: key, label, color and order.
+/// The color is stored as an ARGB int; the Color getter lives in
+/// shared/constants/tier_definition_ui.dart.
 class TierDefinition {
-  /// Создаёт [TierDefinition].
   const TierDefinition({
     required this.tierKey,
     required this.label,
-    required this.color,
+    required this.colorValue,
     required this.sortOrder,
   });
 
-  /// Создаёт [TierDefinition] из записи базы данных.
   factory TierDefinition.fromDb(Map<String, dynamic> row) {
     return TierDefinition(
       tierKey: row['tier_key'] as String,
       label: row['label'] as String,
-      color: Color(row['color'] as int),
+      colorValue: row['color'] as int,
       sortOrder: row['sort_order'] as int,
     );
   }
 
-  /// Создаёт [TierDefinition] из экспортированных данных.
   factory TierDefinition.fromExport(Map<String, dynamic> json) {
     return TierDefinition(
       tierKey: json['tier_key'] as String,
       label: json['label'] as String,
-      color: Color(json['color'] as int),
+      colorValue: json['color'] as int,
       sortOrder: json['sort_order'] as int,
     );
   }
 
-  /// Уникальный ключ тира (например, 'S', 'A', 'custom_1').
+  /// Unique tier key (e.g. 'S', 'A', 'custom_1').
   final String tierKey;
 
-  /// Отображаемая метка.
   final String label;
 
-  /// Цвет метки тира.
-  final Color color;
+  /// Tier label color as an ARGB int.
+  final int colorValue;
 
-  /// Порядок сортировки (0 = верхний тир).
+  /// Sort order (0 = top tier).
   final int sortOrder;
 
-  /// Преобразует в Map для сохранения в базу данных.
   Map<String, dynamic> toDb(int tierListId) {
     return <String, dynamic>{
       'tier_list_id': tierListId,
       'tier_key': tierKey,
       'label': label,
-      'color': color.toARGB32(),
+      'color': colorValue,
       'sort_order': sortOrder,
     };
   }
 
-  /// Преобразует в Map для экспорта.
   Map<String, dynamic> toExport() {
     return <String, dynamic>{
       'tier_key': tierKey,
       'label': label,
-      'color': color.toARGB32(),
+      'color': colorValue,
       'sort_order': sortOrder,
     };
   }
 
-  /// Создаёт копию с изменёнными полями.
   TierDefinition copyWith({
     String? tierKey,
     String? label,
-    Color? color,
+    int? colorValue,
     int? sortOrder,
   }) {
     return TierDefinition(
       tierKey: tierKey ?? this.tierKey,
       label: label ?? this.label,
-      color: color ?? this.color,
+      colorValue: colorValue ?? this.colorValue,
       sortOrder: sortOrder ?? this.sortOrder,
     );
   }
 
-  /// Набор тиров по умолчанию: S / A / B / C.
+  /// Default tier set: S / A / B / C.
   static const List<TierDefinition> defaults = <TierDefinition>[
     TierDefinition(
       tierKey: 'S',
       label: 'S',
-      color: Color(0xFFFF4444),
+      colorValue: 0xFFFF4444,
       sortOrder: 0,
     ),
     TierDefinition(
       tierKey: 'A',
       label: 'A',
-      color: Color(0xFFFF8C00),
+      colorValue: 0xFFFF8C00,
       sortOrder: 1,
     ),
     TierDefinition(
       tierKey: 'B',
       label: 'B',
-      color: Color(0xFFFFD700),
+      colorValue: 0xFFFFD700,
       sortOrder: 2,
     ),
     TierDefinition(
       tierKey: 'C',
       label: 'C',
-      color: Color(0xFF44BB44),
+      colorValue: 0xFF44BB44,
       sortOrder: 3,
     ),
   ];

--- a/lib/shared/utils/color_hex.dart
+++ b/lib/shared/utils/color_hex.dart
@@ -1,0 +1,16 @@
+import 'dart:ui';
+
+/// Converts between hex strings (e.g. '#EF7B44') and [Color].
+abstract final class ColorHex {
+  /// Parses a hex string (with or without leading '#') into an opaque [Color].
+  static Color fromHex(String hex) {
+    final String cleaned = hex.replaceFirst('#', '');
+    return Color(int.parse('FF$cleaned', radix: 16));
+  }
+
+  /// Formats a [Color] as '#RRGGBB' (alpha is dropped).
+  static String toHex(Color color) {
+    final int rgb = color.toARGB32() & 0xFFFFFF;
+    return '#${rgb.toRadixString(16).toUpperCase().padLeft(6, '0')}';
+  }
+}

--- a/lib/shared/widgets/card_link_picker.dart
+++ b/lib/shared/widgets/card_link_picker.dart
@@ -12,6 +12,7 @@ import '../theme/app_spacing.dart';
 import '../theme/app_typography.dart';
 import 'cached_image.dart';
 import 'source_badge.dart';
+import '../constants/collection_item_ui.dart';
 
 /// Opens the card picker and returns the chosen item, or `null` if dismissed.
 Future<CollectionItem?> showCardLinkPicker(

--- a/lib/shared/widgets/chevron_filter_bar.dart
+++ b/lib/shared/widgets/chevron_filter_bar.dart
@@ -1,6 +1,3 @@
-// Reusable chevron segments for the filter bars on AllItemsScreen and
-// CollectionScreen (media type / status filtering).
-
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart' show SemanticsRole;
 
@@ -10,6 +7,7 @@ import '../models/item_status.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_spacing.dart';
 import '../theme/app_typography.dart';
+import '../constants/item_status_ui.dart';
 
 /// Filter-bar segment: a V-notch on the left (except the first) and a
 /// V-point on the right (except the last). [compact] shows a tooltip'd icon

--- a/lib/shared/widgets/media_poster_card.dart
+++ b/lib/shared/widgets/media_poster_card.dart
@@ -12,6 +12,7 @@ import '../theme/app_spacing.dart';
 import '../theme/app_typography.dart';
 import 'cached_image.dart';
 import 'dual_rating_badge.dart';
+import '../constants/item_status_ui.dart';
 
 enum CardVariant {
   /// Full-size grid (collection + search).

--- a/lib/shared/widgets/source_badge.dart
+++ b/lib/shared/widgets/source_badge.dart
@@ -1,8 +1,7 @@
-// Бейдж источника данных (IGDB, TMDB, SteamGridDB, VGMaps).
-
 import 'package:flutter/material.dart';
 
 import '../models/data_source.dart';
+import '../constants/data_source_ui.dart';
 
 export '../models/data_source.dart';
 

--- a/lib/shared/widgets/source_logo.dart
+++ b/lib/shared/widgets/source_logo.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/data_source.dart';
+import '../constants/data_source_ui.dart';
 
 /// A [DataSource]'s brand logo, with a colored monogram fallback when the
 /// source has no logo asset. Set [showGlow] for a soft brand-colored halo.

--- a/test/features/tier_lists/providers/tier_list_detail_provider_test.dart
+++ b/test/features/tier_lists/providers/tier_list_detail_provider_test.dart
@@ -11,6 +11,7 @@ import 'package:tonkatsu_box/shared/models/tier_list.dart';
 import 'package:tonkatsu_box/shared/models/tier_list_entry.dart';
 
 import '../../../helpers/test_helpers.dart';
+import 'package:tonkatsu_box/shared/constants/tier_definition_ui.dart';
 
 void main() {
   setUpAll(() {

--- a/test/helpers/builders.dart
+++ b/test/helpers/builders.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:tonkatsu_box/data/repositories/collection_repository.dart';
 import 'package:tonkatsu_box/shared/models/book.dart';
@@ -473,7 +472,7 @@ TierDefinition createTestTierDefinition({
   return TierDefinition(
     tierKey: tierKey,
     label: label,
-    color: Color(colorValue),
+    colorValue: colorValue,
     sortOrder: sortOrder,
   );
 }

--- a/test/shared/models/canvas_item_test.dart
+++ b/test/shared/models/canvas_item_test.dart
@@ -8,6 +8,7 @@ import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/visual_novel.dart';
 
 import '../../helpers/test_helpers.dart';
+import 'package:tonkatsu_box/shared/constants/canvas_item_ui.dart';
 
 void main() {
   group('CanvasItemType', () {

--- a/test/shared/models/item_status_test.dart
+++ b/test/shared/models/item_status_test.dart
@@ -1,9 +1,7 @@
-// Asserts enum invariants: statuses have unique colors and icons.
-// Concrete color/icon values are not checked (design decisions).
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
+import 'package:tonkatsu_box/shared/constants/item_status_ui.dart';
 
 void main() {
   group('ItemStatus', () {

--- a/test/shared/models/profile_test.dart
+++ b/test/shared/models/profile_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/shared/models/profile.dart';
 
 import '../../helpers/test_helpers.dart';
+import 'package:tonkatsu_box/shared/constants/profile_ui.dart';
+import 'package:tonkatsu_box/shared/utils/color_hex.dart';
 
 void main() {
   group('Profile', () {
@@ -62,25 +64,25 @@ void main() {
       });
     });
 
-    group('colorValue', () {
+    group('displayColor', () {
       test('should convert hex with hash to Color', () {
         final Profile profile = createTestProfile(color: '#EF7B44');
-        expect(profile.colorValue, const Color(0xFFEF7B44));
+        expect(profile.displayColor, const Color(0xFFEF7B44));
       });
 
       test('should handle lowercase hex', () {
         final Profile profile = createTestProfile(color: '#abcdef');
-        expect(profile.colorValue, const Color(0xFFABCDEF));
+        expect(profile.displayColor, const Color(0xFFABCDEF));
       });
     });
 
     group('hexToColor', () {
       test('should convert hex with hash prefix', () {
-        expect(Profile.hexToColor('#FF0000'), const Color(0xFFFF0000));
+        expect(ColorHex.fromHex('#FF0000'), const Color(0xFFFF0000));
       });
 
       test('should convert hex without hash prefix', () {
-        expect(Profile.hexToColor('00FF00'), const Color(0xFF00FF00));
+        expect(ColorHex.fromHex('00FF00'), const Color(0xFF00FF00));
       });
     });
 

--- a/test/shared/models/tier_definition_test.dart
+++ b/test/shared/models/tier_definition_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/shared/models/tier_definition.dart';
 
 import '../../helpers/test_helpers.dart';
+import 'package:tonkatsu_box/shared/constants/tier_definition_ui.dart';
 
 void main() {
   group('TierDefinition', () {
@@ -94,7 +95,7 @@ void main() {
       test('должен копировать с изменённым color', () {
         final TierDefinition original = createTestTierDefinition();
         final TierDefinition copy =
-            original.copyWith(color: const Color(0xFF00FF00));
+            original.copyWith(colorValue: 0xFF00FF00);
         expect(copy.color, const Color(0xFF00FF00));
       });
     });


### PR DESCRIPTION
Colors, icons and localized labels move out of the 7 models that imported Flutter or dart:ui (item_status, data_source, profile, collection_item, canvas_item, platform, tier_definition) into extension files under shared/constants/*_ui.dart; DataSource and TierDefinition store colors as ARGB ints, hex codec extracted to shared/utils/color_hex.dart. Duplicate MediaType->icon switches collapse into MediaTypeTheme.placeholderIconFor. Groundwork for sharing the model layer with the selfhost server; the finish skill gains a mandatory model-purity check (R2c).