### PR TITLE
feat(l10n): add French (fr) localization

### DIFF
--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,0 +1,2429 @@
+{
+  "@@locale": "fr",
+
+  "appName": "Tonkatsu Box",
+
+  "navMain": "Accueil",
+  "navCollections": "Collections",
+  "navWishlist": "Liste de souhaits",
+  "navSettings": "Paramètres",
+  "navReleases": "Sorties",
+
+  "releasesEmpty": "Aucune série suivie",
+  "releasesEmptyHint": "Cliquez sur la cloche sur une série ou un anime pour suivre les nouvelles sorties.",
+  "releasesTrackShow": "Suivre les sorties",
+  "releasesUntrackShow": "Arrêter de suivre",
+  "releasesViewDay": "Jour",
+  "releasesViewWeek": "Semaine",
+  "releasesViewMonth": "Mois",
+  "releasesTabCalendar": "Calendrier",
+  "releasesTabAll": "Toutes les sorties",
+  "releasesToday": "Aujourd'hui",
+  "refresh": "Rafraîchir",
+  "releasesNoEpisodes": "Pas d'épisodes",
+  "releasesEpisode": "Saison {season} · Épisode {episode}",
+  "@releasesEpisode": {
+    "placeholders": {
+      "season": {"type": "int"},
+      "episode": {"type": "int"}
+    }
+  },
+  "calendarAdd": "Ajouter au calendrier",
+  "calendarRemove": "Retirer du calendrier",
+  "date": "Date",
+  "calendarRepeat": "Répéter",
+  "recurrenceOnce": "Une fois",
+  "recurrenceWeekly": "Hebdomadaire",
+  "recurrenceMonthly": "Mensuel",
+
+  "statusNotStarted": "Pas commencé",
+  "statusPlaying": "Commencé",
+  "statusWatching": "Commencé",
+  "statusInProgress": "En cours",
+  "statusCompleted": "Terminé",
+  "statusDropped": "Abandonné",
+  "statusPlanned": "Planifié",
+  "statusReplay": "Recommencé",
+  "rewatchCountEdit": "Nombre de re-vues",
+  "rewatchCountHint": "Vide = non suivi",
+  "statusReplaying": "Rejouer",
+  "statusRewatching": "Revisionnage",
+  "statusRereading": "Relecture",
+  "all": "Tout",
+
+  "mediaTypeGame": "Jeu",
+  "mediaTypeMovie": "Film",
+  "mediaTypeTvShow": "Série",
+  "mediaTypeAnimation": "Animation",
+  "mediaTypeVisualNovel": "Visual Novel",
+  "mediaTypeManga": "Manga",
+  "mediaTypeAnime": "Anime",
+  "mediaTypeBook": "Livre",
+  "mediaTypeCustom": "Personnalisé",
+
+  "sortManualDisplay": "Manuel",
+  "sortManualDesc": "Ordre personnalisé",
+  "sortDateDisplay": "Date d'ajout",
+  "sortDateDesc": "Date d'ajout (↓)",
+  "status": "Statut",
+  "sortStatusDesc": "Actif (↓)",
+  "name": "Nom",
+  "sortNameShort": "A à Z",
+  "rating": "Note",
+  "sortRatingDesc": "Note (↓)",
+  "sortFavoriteDesc": "Favoris (↓)",
+  "sortExternalRatingDisplay": "Note des sources",
+  "sortExternalRatingShort": "IGDB/TMDB",
+  "sortLastActivityDisplay": "Dernière activité",
+  "sortLastActivityShort": "Activité",
+  "sortLastActivityDesc": "Activité (↓)",
+  "sortStartDateDisplay": "Date de début",
+  "sortStartDateShort": "Commencé",
+  "sortCompletionDateDisplay": "Date de fin",
+  "sortCompletionDateShort": "Terminé",
+
+  "sortDateOldest": "Date d'ajout (↑)",
+  "sortStatusFinished": "Terminé(s) (↓)",
+  "sortRatingLowest": "Note (↑)",
+  "sortFavoriteLast": "Favoris (↑)",
+
+  "searchSortRelevanceShort": "Pert.",
+  "searchSortRatingShort": "Note",
+  "searchSortRatingDisplay": "Note",
+
+  "cancel": "Annuler",
+  "confirm": "OK",
+  "restore": "Restaurer",
+  "create": "Créer",
+  "save": "Sauvegarder",
+  "add": "Ajouter",
+  "delete": "Supprimer",
+  "rename": "Renommer",
+  "retry": "Réessayer",
+  "edit": "Modifier",
+  "done": "Fait",
+  "clear": "Effacer",
+  "reset": "Réinitialiser",
+  "search": "Rechercher",
+  "open": "Ouvrir",
+  "remove": "Retirer",
+  "moveToTop": "Placer en haut",
+  "moveToBottom": "Placer en bas",
+  "favorite": "Favori",
+  "addToFavorites": "Ajouter aux favoris",
+  "removeFromFavorites": "Retirer des favoris",
+  "bulkSelected": "{count, plural, =1{1 sélectionné} other{{count} sélectionnés}}",
+  "@bulkSelected": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkClearSelection": "Effacer la sélection",
+  "selectAll": "Tout sélectionner",
+  "bulkMove": "Ajouter la sélection à la collection",
+  "bulkCopy": "Copier la sélection et placer dans la collection",
+  "bulkChangeStatus": "Changer statut",
+  "bulkRemoveConfirm": "Retirer {count, plural, =1{1 titre} other{{count} titres}} de cette collection ?",
+  "@bulkRemoveConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkResult": "Fait: {done} • Doublon(s): {skipped}",
+  "@bulkResult": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "skipped": {"type": "int"}
+    }
+  },
+  "bulkRemoved": "Retiré(s): {count}",
+  "@bulkRemoved": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkStatusUpdated": "Statut modifié pour {count, plural, =1{1 titre} other{{count} titres}}",
+  "@bulkStatusUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkExportPngTitle": "Exporter en PNG",
+  "columnsCount": "Colonnes",
+  "bulkExportPngItemsCount": "{count, plural, =1{1 image} other{{count} images}}",
+  "@bulkExportPngItemsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkExportPngItemsCountPreview": "{total, plural, =1{1 image} other{{total} images}} ({preview} dans l'aperçu)",
+  "@bulkExportPngItemsCountPreview": {
+    "placeholders": {
+      "total": {"type": "int"},
+      "preview": {"type": "int"}
+    }
+  },
+  "bulkExportPngPreparing": "Préparation des couvertures: {done} / {total}",
+  "@bulkExportPngPreparing": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "bulkExportPngSave": "Enregistrer en PNG",
+  "imageSaved": "Image sauvegardée",
+  "bulkExportPngFailed": "Impossible de sauvegarder l'image",
+  "back": "Retour",
+  "next": "Suivant",
+  "skip": "Passer",
+  "update": "Mettre à jour",
+  "test": "Test",
+  "close": "Fermer",
+  "keep": "Garder",
+  "change": "Changer",
+
+  "settingsProfile": "Auteur de la collection",
+  "settingsProfileSubtitle": "Nom d'auteur pour vos collections",
+  "settingsAuthorName": "Nom d'auteur",
+  "settingsCredentialsSubtitle": "Clés API pour IGDB, SteamGridDB et TMDB",
+  "settingsCacheSubtitle": "Mode hors-ligne et stockage des couvertures",
+  "settingsDatabaseSubtitle": "Exporter, importer, réinitialiser",
+  "settingsTraktImportSubtitle": "Historique, notes, liste de visionnage",
+  "settingsKinoriumImport": "Importer depuis Kinorium",
+  "settingsKinoriumImportSubtitle": "Films et séries via un fichier CSV",
+  "settingsDebug": "Débug",
+  "settingsDebugSubtitle": "Outils développeurs",
+  "settingsDebugSubtitleNoKey": "Ajoutez une clé API SteamGridDB pour accéder aux outils.",
+  "settingsLaboratory": "Laboratoire",
+  "settingsLaboratoryCardDesigns": "Designs des bannières",
+  "settingsLaboratoryCardDesignsSubtitle": "Mises en pages expérimentales des affiches",
+  "settingsHelp": "Aide",
+  "settingsWelcomeGuide": "Première utilisation",
+  "settingsWelcomeGuideSubtitle": "Première utilisation de Tonkatsu Box",
+  "settingsAbout": "À propos",
+  "settingsVersion": "Version",
+  "settingsCreditsLicenses": "Crédits & Licences",
+  "settingsChangelog": "Nouveautés",
+  "settingsChangelogEmpty": "Aucune note de version disponible",
+  "settingsCreditsLicensesSubtitle": "TMDB, IGDB, SteamGridDB, licences open-source",
+  "settingsError": "Erreur",
+  "settingsAppLanguage": "Langue de l'application",
+  "settingsConnections": "Connexions",
+  "settingsApiKeys": "Clés API",
+  "settingsApiKeysValue": "{active}/{total}",
+  "@settingsApiKeysValue": {
+    "placeholders": {
+      "active": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "settingsAppearance": "Apparence",
+  "settingsAppearanceSubtitle": "Langue, affichage et contenu",
+  "settingsAppLanguageSubtitle": "Langue de l'interface",
+  "settingsContentLanguageSubtitle": "TMDB seulement pour l'instant (films et séries)",
+  "settingsDataSources": "Sources",
+  "settingsDataSourcesSubtitle": "IGDB, TMDB, SteamGridDB",
+  "settingsApiKeysSubtitle": "Configurez la connexion aux bases de données",
+  "settingsStorage": "Stockage",
+  "settingsStorageSubtitle": "Cache (images) et base de données",
+  "settingsBackup": "Sauvegarde",
+  "settingsBackupSubtitle": "Sauvegarde complète et restauration",
+  "settingsBackupAll": "Sauvegarder toutes les données",
+  "settingsBackupAllSubtitle": "Toutes les collections, liste de souhaits et paramètres",
+  "settingsRestoreBackup": "Restaurer depuis une sauvegarde",
+  "settingsRestoreBackupSubtitle": "Importer une sauvegarde",
+  "backupSuccess": "Sauvegarde effectuée: {collections} collections, {items} titres",
+  "@backupSuccess": {
+    "placeholders": {
+      "collections": {"type": "int"},
+      "items": {"type": "int"}
+    }
+  },
+  "restoreConfirmTitle": "Restaurer la sauvegarde ?",
+  "restoreConfirmBody": "{collections} collections, {items} titres, {wishlist} souhaits",
+  "@restoreConfirmBody": {
+    "placeholders": {
+      "collections": {"type": "int"},
+      "items": {"type": "int"},
+      "wishlist": {"type": "int"}
+    }
+  },
+  "restoreConfirmHint": "Les collections existantes ne seront pas affectées",
+  "restoreSettings": "Restaurer les paramètres",
+  "restoreWishlist": "Restaurer la liste de souhaits",
+  "restoreSuccess": "Restauration effectuée : {collections} collections, {items} titres",
+  "@restoreSuccess": {
+    "placeholders": {
+      "collections": {"type": "int"},
+      "items": {"type": "int"}
+    }
+  },
+  "restoreInvalidArchive": "Erreur : mauvaise sauvegarde",
+  "restoreProgressTitle": "Restauration de la sauvegarde",
+  "restoreProgressWarning": "Ne fermez pas l'application. Cela peut prendre plusieurs minutes.",
+  "restoreStageReading": "Lecture de la sauvegarde...",
+  "restoreStageCollections": "Restauration des collections... ({current}/{total})",
+  "@restoreStageCollections": {
+    "placeholders": {
+      "current": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "restoreStageWishlist": "Restauration de la liste de souhaits...",
+  "restoreStageSettings": "Restauration des paramètres...",
+  "restoreStageFinalizing": "Bientôt terminé...",
+  "settingsImport": "Importer",
+  "settingsImportSubtitle": "Importer des collections depuis des services externes",
+  "settingsContentLanguage": "Langue du contenu",
+  "settingsData": "Données",
+  "settingsCacheValue": "{size}",
+  "@settingsCacheValue": {
+    "placeholders": {
+      "size": {"type": "String"}
+    }
+  },
+
+  "credentialsTitle": "Identifiants",
+  "credentialsWelcome": "Bienvenue sur Tonkatsu Box !",
+  "credentialsWelcomeHint": "Pour commencer, vous devez inscrire vos identifiants API pour IGDB. Retrouvez vos Client ID et Client Secret sur la Console de développeur Twitch.",
+  "credentialsCopyTwitchUrl": "Copier l'URL de la Console Twitch",
+  "credentialsUrlCopied": "URL copiée : {url}",
+  "@credentialsUrlCopied": {
+    "placeholders": {
+      "url": {"type": "String"}
+    }
+  },
+  "credentialsIgdbSection": "Identifiants pour l'API IGDB",
+  "credentialsClientId": "Client ID",
+  "credentialsClientIdHint": "Entrez votre Twitch Client ID",
+  "credentialsClientSecret": "Client Secret",
+  "credentialsClientSecretHint": "Entrez votre Twitch Client Secret",
+  "credentialsConnectionStatus": "Statut de connexion",
+  "credentialsPlatformsSynced": "Plateformes synchronisées",
+  "credentialsPlatformsAvailable": "Plateformes disponibles",
+  "credentialsLastSync": "Dernière synchronisation",
+  "credentialsVerifyConnection": "Vérifier connexion",
+  "credentialsRefreshPlatforms": "Rafraîchir les plateformes",
+  "credentialsSteamGridDbSection": "API SteamGridDB",
+  "credentialsApiKey": "Clé API",
+  "credentialsUsingBuiltInKey": "Utiliser la clé intégrée",
+  "credentialsEnterSteamGridDbKey": "Entrez votre clé API SteamGridDB",
+  "credentialsTmdbSection": "API TMDB (Films et TV)",
+  "credentialsEnterTmdbKey": "Entrez votre clé API TMDB (v3)",
+  "credentialsComicVineSection": "API ComicVine (Comics)",
+  "credentialsEnterComicVineKey": "Entrez votre clé API ComicVine",
+  "credentialsGoogleBooksSection": "API Google Books (Livres)",
+  "credentialsEnterGoogleBooksKey": "Entrez votre clé API Google Books (optionnel)",
+  "credentialsHardcoverSection": "API Hardcover (Livres)",
+  "credentialsEnterHardcoverKey": "Entrez votre token API Hardcover",
+  "credentialsOwnKeyHint": "Pour de moins grandes restrictions d'utilisation, nous recommandons l'utilisation de vos propres clés API.",
+  "credentialsConnected": "Connecté",
+  "credentialsConnectionError": "Erreur de connexion",
+  "credentialsChecking": "Vérification...",
+  "credentialsNotConnected": "Pas connecté",
+  "credentialsEnterBoth": "Veuillez entrer votre Client ID et Client Secret",
+  "credentialsConnectedSynced": "Connexion établie, plateformes synchronisées !",
+  "credentialsConnectedSyncFailed": "Connecté, mais la synchronisation a échoué",
+  "credentialsPlatformsSyncedOk": "Plateformes synchronisées avec succès !",
+  "credentialsDownloadingLogos": "Téléchargement des logos de la plateforme...",
+  "credentialsDownloadedLogos": "Téléchargé {count} logos",
+  "@credentialsDownloadedLogos": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "credentialsFailedDownloadLogos": "Échec lors du téléchargement des logos",
+  "credentialsApiKeySaved": "Clé API sauvegardée",
+  "credentialsNoApiKey": "Pas de clé API",
+  "credentialsResetToBuiltIn": "Réutiliser la clé API intégrée",
+  "credentialsSteamGridDbKeyValid": "La clé API SteamGridDB est valide",
+  "credentialsSteamGridDbKeyInvalid": "La clé API SteamGridDB est invalide",
+  "credentialsTmdbKeyValid": "La clé API TMDB est valide",
+  "credentialsTmdbKeyInvalid": "La clé API TMDB est invalide",
+  "credentialsComicVineKeyValid": "La clé API ComicVine est valide",
+  "credentialsComicVineKeyInvalid": "La clé API ComicVine est invalide",
+  "credentialsGoogleBooksKeyValid": "La clé API Google Books est valide",
+  "credentialsGoogleBooksKeyInvalid": "La clé API Google Books est invalide",
+  "credentialsHardcoverKeyValid": "La clé API Hardcover est valide",
+  "credentialsHardcoverKeyInvalid": "La clé API Hardcover est invalide ou a expiré",
+  "credentialsEnterSteamGridDbKeyError": "Veuillez entrer une clé API SteamGridDB",
+  "credentialsEnterTmdbKeyError": "Veuillez entrer une clé API TMDB",
+  "credentialsTmdbKeySaved": "Clé API TMDB sauvegardée",
+
+  "timeAgo": "il y a {value} {unit}",
+  "@timeAgo": {
+    "placeholders": {
+      "value": {"type": "int"},
+      "unit": {"type": "String"}
+    }
+  },
+  "timeUnitDays": "{count, plural, =1{jour} other{jours}}",
+  "@timeUnitDays": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "timeUnitHours": "{count, plural, =1{heure} other{heures}}",
+  "@timeUnitHours": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "timeUnitMinutes": "{count, plural, =1{minute} other{minutes}}",
+  "@timeUnitMinutes": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "timeJustNow": "À l'instant",
+
+  "cacheTitle": "Cache",
+  "cacheImageCache": "Cache (images)",
+  "cacheOfflineMode": "Mode hors ligne",
+  "cacheOfflineModeSubtitle": "Sauvegarder les images localement pour une utilisation hors ligne",
+  "cacheCacheFolder": "Dossier cache",
+  "cacheSelectFolder": "Sélectionnez un dossier",
+  "cacheCacheSize": "Taille du cache",
+  "cacheClearCache": "Retirer les images inutilisées",
+  "cacheClearCacheTitle": "Retirer les images inutilisées ?",
+  "cacheClearCacheMessage": "Supprime les images téléchargées pour des médias inexistants dans les collections. Vos images importées seront conservées.",
+  "cacheFolderUpdated": "Dossier cache mis à jour",
+  "cacheOrphansRemoved": "Images non utilisées supprimées : {count}",
+  "@cacheOrphansRemoved": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "cacheSelectFolderDialog": "Sélectionnez un dossier cache pour les images",
+  "cacheCacheStats": "{count} fichiers, {size}",
+  "@cacheCacheStats": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "size": {"type": "String"}
+    }
+  },
+
+  "databaseTitle": "Base de données",
+  "databaseConfiguration": "Configuration",
+  "databaseConfigSubtitle": "Exportez ou importez vos clés API et paramètres.",
+  "databaseExportConfig": "Exporter configuration",
+  "databaseImportConfig": "Importer configuration",
+  "databaseDangerZone": "Danger Zone",
+  "databaseDangerZoneMessage": "Vide toutes les collections (jeux, films, séries et tableaux). Vos paramètres et clés API seront conservés.",
+  "databaseResetDatabase": "Réinitialiser base de données",
+  "databaseResetTitle": "Réinitialiser base de données ?",
+  "databaseResetMessage": "Cela supprimera de manière permanente toutes vos collections (jeux, films, séries), progressions des épisodes et les données du tableau.\n\nVos clés API et paramètres seront préservés.\n\nCette opération est irréversible.",
+  "databaseConfigExported": "Configuration exportée vers {path}",
+  "@databaseConfigExported": {
+    "placeholders": {
+      "path": {"type": "String"}
+    }
+  },
+  "databaseConfigImported": "Configuration importée avec succès",
+  "databaseReset": "Base de données réinitialisée",
+
+  "storageLocationTitle": "Emplacement des données",
+  "storageLocationSubtitle": "Dossier qui héberge la base de données et les profils. Les dossiers liés à un service cloud (OneDrive, Syncthing) sont à éviter : la base de données pourrait être corrompue pendant l'écriture. Pour transférer des données entre appareils, exportez depuis les menus.",
+  "storageLocationDangerWarning": "Attention : changer le dossier peut entraîner une perte de données. À faire en connaissance des risques.",
+  "storageLocationFolder": "Dossier des données",
+  "storageLocationFallbackWarning": "Le dossier sélectionné est indisponible. Le dossier par défaut sera utilisé.",
+  "storageLocationChange": "Changer de dossier",
+  "storageLocationReset": "Revenir au dossier par défaut",
+  "storageLocationSelectDialog": "Sélectionner dossier",
+  "storageLocationNotWritable": "Pas de permissions d'écriture: {path}",
+  "@storageLocationNotWritable": {
+    "placeholders": {
+      "path": {"type": "String"}
+    }
+  },
+  "storageLocationPermissionTitle": "Accès au stockage requis",
+  "storageLocationPermissionMessage": "Android a besoin de la permission \"Accéder aux fichiers\" pour un dossier personnalisé. Dans la liste, trouvez Tonkatsu Box, autorisez l'accès, revenez en arrière et sélectionnez à nouveau le dossier.",
+  "storageLocationLegacyPermissionMessage": "Un dossier personnalisé requiert la permission pour accéder au stockage. Autorisez l'accès dans les paramètres de l'application, puis revenez ici et sélectionnez à nouveau le dossier.",
+  "storageLocationOpenSettings": "Ouvrir paramètres",
+  "storageLocationDbTooNew": "La base de données de ce dossier a été créée par une version ultérieure de l'application. Mettez l'application à jour avant de procéder.",
+  "storageLocationDbCorrupted": "La base de données de ce dossier est corrompue ou incomplète. Si une synchronisation est en cours, réessayez plus tard.",
+  "storageLocationUseExistingTitle": "Données existantes trouvées",
+  "storageLocationUseExistingMessage": "Le dossier sélectionné contient déjà une base de données. L'application utilisera ces données après redémarrage.",
+  "storageLocationUseExistingConfirm": "Utiliser ces données",
+  "storageLocationCopyTitle": "Copier les données déjà présentes ?",
+  "storageLocationCopyMessage": "Le dossier sélectionné est vide. Vos collections seront copiées ici; les images sauvegardées seront téléchargées. Les données de l'ancien dossier resteront intactes.",
+  "copy": "Copier",
+  "storageLocationCopyImages": "Copier aussi le cache d'images",
+  "storageLocationCopyImagesHint": "Bannières et autres images — plus lourd, mais le nouveau dossier est accessible hors-ligne sans devoir le re-télécharger",
+  "storageLocationCopyError": "Impossible de copier les données vers le dossier sélectionné",
+  "storageLocationResetTitle": "Réinitialiser le dossier de données ?",
+  "storageLocationResetMessage": "L'application réutilisera le dossier par défaut après redémarrage. Les données du dossier personnalisé resteront intactes.",
+  "storageLocationRestartTitle": "Redémarrage requis",
+  "storageLocationRestartMessage": "Le nouveau dossier de données sera utilisé après redémarrage. Redémarrer maintenant ?",
+  "storageLocationRestartNow": "Redémarrer",
+  "storageLocationRestartLater": "Le changement sera effectif après redémarrage",
+
+  "backupRestoreTile": "Restaurer l'ancienne base de données",
+  "backupNone": "Aucune sauvegarde pour le moment",
+  "backupRestoreConfirmTitle": "Restaurer l'ancienne base de données ?",
+  "backupRestoreConfirmMessage": "Les données actuelles seront remplacées par la sauvegarde du {date}. Les données remplacées seront transformées en sauvegarde, restaurer encore une fois après ça les effacera.",
+  "@backupRestoreConfirmMessage": {
+    "placeholders": {
+      "date": {"type": "String"}
+    }
+  },
+  "backupRestored": "Base de données restaurée",
+  "backupRestoreError": "Impossible de restaurer depuis la sauvegarde",
+  "backupRestartMessage": "Les données restaurées seront utilisées après redémarrage. Redémarrer maintenant ?",
+
+  "lanSyncTitle": "Synchronisation réseau",
+  "lanSyncOpenTile": "Appareils à proximité",
+  "lanSyncTileSubtitle": "Transférer des données entre appareils connectés au même réseau Wi-Fi",
+  "lanSyncVisibleAs": "Cet appareil est enregistré sous le nom {name}",
+  "@lanSyncVisibleAs": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "lanSyncNoDevices": "Aucun appareil trouvé. Accédez à cet écran sur les deux appareils connectés au réseau Wi-Fi. Les points d'accès et les VPN bloquent cette fonction.",
+  "lanSyncPull": "Cliquez pour obtenir les données",
+  "lanSyncReceiveTitle": "Remplacer les données ?",
+  "lanSyncReceiveMessage": "Les données de {device}, {date}: {collections} collections, {items} titres.\n\nLes données déjà présentes seront REMPLACÉES. Une sauvegarde sera stockée aux côtés de la base de données.",
+  "@lanSyncReceiveMessage": {
+    "placeholders": {
+      "device": {"type": "String"},
+      "date": {"type": "String"},
+      "collections": {"type": "int"},
+      "items": {"type": "int"}
+    }
+  },
+  "lanSyncReplace": "Remplacer",
+  "lanSyncWaiting": "Confirmez la demande sur {name}...",
+  "@lanSyncWaiting": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "lanSyncIncomingTitle": "Demande de données",
+  "lanSyncIncomingMessage": "{name} veut obtenir une copie de vos données. L'autorisez-vous ?",
+  "@lanSyncIncomingMessage": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "lanSyncAllow": "Autoriser",
+  "lanSyncDenied": "L'autre appareil a décliné la demande",
+  "lanSyncManifestError": "Aucune réponse de l'appareil",
+  "lanSyncStartError": "Impossible de démarrer le partage par réseau. Vérifiez votre connexion et réessayez.",
+  "lanSyncReceiveError": "Impossible d'obtenir les données",
+  "lanSyncTooNew": "Les données de cet appareil proviennent d'une version plus récente de l'application. Mettez votre application à jour.",
+  "lanSyncCorrupted": "Le transfert s'est mal passé. Veuillez réessayer.",
+  "lanSyncReceived": "Données reçues",
+  "lanSyncReceivingImages": "Transfert des images...",
+  "lanSyncReceivingSettings": "Transfert des paramètres...",
+  "lanSyncImportConfig": "Transférer aussi les paramètres",
+  "lanSyncImportConfigSubtitle": "Clés API incluses. Tout ou rien.",
+  "lanSyncImagesWarning": "Base de données reçue mais les images n'ont pas pu être transférées",
+  "lanSyncRestartMessage": "Les données seront utilisées après redémarrage. Redémarrer maintenant ?",
+  "lanSyncFirewallNote": "Windows pourrait demander une permission au niveau du pare-feu lors du premier démarrage - autorisez l'accès sur les réseaux privés.",
+
+  "folderPickerNewFolder": "Nouveau dossier",
+  "folderPickerVolumeList": "Périphériques de stockage",
+  "folderPickerInternalStorage": "Stockage interne",
+  "folderPickerSelect": "Sélectionner",
+  "folderPickerFolderName": "Nom du dossier",
+  "folderPickerInvalidName": "Nom du dossier non valide",
+  "folderPickerEmpty": "Pas de sous-dossier",
+  "folderPickerReadError": "Impossible de lire ce dossier",
+  "folderPickerCreateError": "Impossible de créer un dossier",
+
+  "traktTitle": "Import Trakt",
+  "traktImportFrom": "Importer depuis Trakt.tv",
+  "traktImportDescription": "Téléchargez vos données depuis trakt.tv/users/YOU/data and sélectionnez le fichier ZIP ci-dessous.",
+  "traktZipFile": "Fichier ZIP",
+  "traktSelectZipFile": "Sélectionnez le fichier ZIP",
+  "traktSelectZipExport": "Exporter un fichier ZIP Trakt",
+  "preview": "Prévisualisation",
+  "traktUser": "Utilisateur Trakt : {username}",
+  "@traktUser": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "traktWatchedMovies": "Films regardés",
+  "traktWatchedShows": "Séries regardées",
+  "traktRatedMovies": "Films notés",
+  "traktRatedShows": "Séries notées",
+  "traktWatchlist": "Liste de lecture",
+  "importOptions": "Options",
+  "traktImportWatched": "Importer déjà regardés",
+  "traktImportWatchedDesc": "Films et séries déjà regardés",
+  "traktImportRatings": "Importer notes",
+  "traktImportRatingsDesc": "Applique les notes utilisateurs (1 à 10)",
+  "traktImportWatchlist": "Importer liste de lecture",
+  "traktImportWatchlistDesc": "Ajoute à la liste de souhaits ou applique le statut planifié",
+  "importTargetCollection": "Sélectionner collection",
+  "importUseExistingCollection": "Utiliser une collection existante",
+  "importStart": "Commencer l'import",
+  "traktRequiresOwnTmdbKey": "Importer depuis Trakt requiert votre clé API TMDB. Ajoutez-la dans Paramètres → Identifiants.",
+  "traktInvalidExport": "Export Trakt non valide",
+
+  "kinoriumImportFrom": "Importer depuis Kinorium",
+  "kinoriumImportDescription": "Exportez votre liste depuis Kinorium (fichier CSV envoyé par e-mail) et sélectionnez-le ci-dessous.",
+  "kinoriumSelectCsvFile": "Sélectionner fichier CSV",
+  "kinoriumSelectCsvExport": "Exporter un fichier CSV Kinorium",
+  "kinoriumIsWatchlist": "Ceci est un fichier \"Liste de lecture\"",
+  "kinoriumIsWatchlistDesc": "Importer tous les films et appliquer le statut planifié au lieu de regardé",
+  "kinoriumImportNotes": "Importer acteurs et production",
+  "kinoriumImportNotesDesc": "Ajoute les réalisateurs et les acteurs aux commentaires",
+  "kinoriumImporting": "Importation depuis Kinorium...",
+  "kinoriumRecommendOwnTmdbKey": "Conseil : une clé API TMDB personnelle est recommandée pour des gros imports (Paramètres → Clés API), mais reste optionnel — la clé intégrée fonctionne aussi.",
+  "kinoriumReasonNotFound": "Introuvable sur TMDB",
+  "kinoriumReasonApiError": "Erreur renvoyée par TMDB ou limite d'utilisation — réessayez plus tard",
+  "kinoriumReasonUnsupportedType": "Format non supporté : {type}",
+  "@kinoriumReasonUnsupportedType": {
+    "placeholders": {
+      "type": {"type": "String"}
+    }
+  },
+  "kinoriumReasonDuplicate": "Doublon de \"{title}\"",
+  "@kinoriumReasonDuplicate": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
+  "traktImportedItems": "Importé {count} titres",
+  "@traktImportedItems": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "traktImporting": "Importation depuis Trakt",
+
+  "creditsTitle": "Crédits",
+  "creditsDataProviders": "Fournisseurs",
+  "creditsTmdbAttribution": "Ce produit utilise l'API de TMDB mais n'est ni approuvé ni certifié par TMDB.",
+  "creditsTvMazeAttribution": "Données pour les séries fournies par TVmaze.",
+  "creditsIgdbAttribution": "Données pour les jeux fournies par IGDB.",
+  "creditsSteamGridDbAttribution": "Illustrations fournies par SteamGridDB.",
+  "creditsVndbAttribution": "Données pour les visual novels fournies par VNDB.",
+  "creditsAniListAttribution": "Données pour les mangas fournies par AniList.",
+  "creditsMangaBakaAttribution": "Données pour les mangas fournies par MangaBaka.",
+  "creditsMangaDexAttribution": "Données pour les mangas fournies par MangaDex.",
+  "creditsKitsuAttribution": "Données pour les mangas fournies par Kitsu.",
+  "creditsOpenLibraryAttribution": "Données pour les livres fournies par Open Library (CC0 / ODbL).",
+  "creditsFantlabAttribution": "Données pour les livres fournies par Fantlab.",
+  "creditsComicVineAttribution": "Données pour les comics fournies par ComicVine (utilisation non-commerciale).",
+  "creditsGoogleBooksAttribution": "Données pour les livres fournies par Google Books.",
+  "creditsHardcoverAttribution": "Données pour les livres fournies par Hardcover.",
+  "creditsOpenSource": "Open Source",
+  "creditsOpenSourceDesc": "Tonkatsu Box is gratuit et est un logiciel open source, publié sous la Licence MIT.",
+  "creditsViewLicenses": "Voir les licences Open Source",
+  "creditsDiscord": "Rejoignez-nous sur Discord !",
+
+  "collectionsImportCollection": "Importer collection",
+  "collectionsNoCollectionsYet": "Aucune collection pour l'instant",
+  "collectionsNoCollectionsHint": "Cliquez sur + pour créer votre première collection\net commencer à organiser votre bibliothèque.",
+  "collectionsFailedToLoad": "Impossible de charger les collections",
+  "collectionsCount": "Collections ({count})",
+  "@collectionsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "collectionsUncategorized": "Sans catégorie",
+  "collectionsUncategorizedItems": "{count, plural, =1{1 titre} other{{count} titres}}",
+  "@collectionsUncategorizedItems": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "editCollection": "Modifier la collection",
+  "collectionsRenamed": "Collection mise à jour",
+  "collectionsFailedToRename": "Impossible de sauvegarder : {error}",
+  "@collectionsFailedToRename": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "collectionsDeleted": "Collection supprimée",
+  "collectionsFailedToDelete": "Impossible de supprimer : {error}",
+  "@collectionsFailedToDelete": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "collectionsFailedToCreate": "Impossible de créer une collection : {error}",
+  "@collectionsFailedToCreate": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "collectionsImported": "Importé \"{name}\" possédant {count} titres",
+  "@collectionsImported": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "count": {"type": "int"}
+    }
+  },
+  "collectionsImporting": "Importer une collection",
+
+  "importTargetTitle": "Importer vers...",
+  "importCreateNew": "Créer une nouvelle collection",
+  "importUseExisting": "Ajouter à une collection existante",
+  "importNoCollections": "Aucune collection disponible",
+  "importSelectCollection": "Sélectionner collection",
+  "importErrorLoadingCollections": "Impossible de charger les collections",
+  "importStartButton": "Importer",
+  "importUsername": "Nom d'utilisateur",
+  "importUsernameHint": "ex : votrepseudo",
+  "importMode": "Mode",
+  "importModeNewOnly": "Ajouter nouveautés",
+  "importModeNewOnlySubtitle": "Ignore les titres déjà présents dans votre collection",
+  "importModeOverwrite": "Écrire par-dessus",
+  "importModeOverwriteSubtitle": "Met à jour la progression, les statuts et les dates depuis la source",
+  "importNewCollectionName": "Nom de la collection",
+  "importNewCollectionDefault": "Importation depuis {source} — {username}",
+  "@importNewCollectionDefault": {
+    "placeholders": {
+      "source": {"type": "String"},
+      "username": {"type": "String"}
+    }
+  },
+  "importFetchingBooks": "Récupération de la bibliothèque...",
+  "importAddingItems": "Importer des titres",
+  "importProcessingItem": "Traitement : {title}",
+  "@importProcessingItem": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
+  "importImportedCount": "{count} importés",
+  "@importImportedCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importUpdatedCount": "{count} mis à jour",
+  "@importUpdatedCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importUserNotFound": "Utilisateur \"{username}\" introuvable",
+  "@importUserNotFound": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "importEmptyUsername": "Entrez un nom d'utilisateur",
+  "importFailed": "Erreur lors de l'importation : {error}",
+  "@importFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+
+  "collectionNotFound": "Collection introuvable",
+  "collectionAddItems": "Ajouter des titres",
+  "collectionSwitchToList": "Passer à Liste",
+  "collectionSwitchToBoard": "Passer à Tableau",
+  "collectionUnlockBoard": "Déverrouiller le tableau",
+  "collectionLockBoard": "Verrouiller le tableau",
+  "collectionExport": "Exporter",
+  "collectionNoItemsYet": "Vide pour le moment",
+  "collectionEmpty": "Vider la collection",
+  "collectionEmptyAddHint": "Ajoutez des titres pour commencer à construire votre collection",
+  "collectionEmptyReadonly": "Cette collection est vide.",
+  "collectionDeleteEmptyPrompt": "Cette collection est désormais vide. La supprimer ?",
+  "collectionRemoveItemTitle": "Retirer ?",
+  "collectionRemoveItemMessage": "Retirer {name} de cette collection ?",
+  "@collectionRemoveItemMessage": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "collectionMoveToCollection": "Déplacer à une collection",
+  "collectionExportFormat": "Format d'exportation",
+  "collectionChooseExportFormat": "Choisissez un format :",
+  "collectionExportLight": "Léger (.xcoll)",
+  "collectionExportLightDesc": "Titres seulement, petit fichier",
+  "collectionExportFull": "Complet (.xcollx)",
+  "collectionExportFullDesc": "Avec les images et les toiles — fonctionne hors-ligne",
+  "collectionExportIncludeUserData": "Inclure données personnelles",
+  "collectionExportIncludeUserDataDesc": "Statuts, dates, commentaires, progressions des épisodes",
+  "customItemCreate": "Créer un titre personnalisé",
+  "title": "Titre",
+  "customItemTitleHint": "ex : Jeu fait maison",
+  "customItemAltTitle": "Titre alternatif",
+  "customItemAltTitleHint": "Titre original, par exemple",
+  "customItemCoverUrl": "URL de l'image",
+  "year": "Année",
+  "genres": "Genres",
+  "customItemGenresHint": "ex : RPG, Action, Puzzle",
+  "platform": "Plateforme",
+  "customItemPlatformHint": "ex : PC, SNES, Personnalisé",
+  "format": "Format",
+  "progress": "Progression",
+  "customMarkCompleted": "Marquer comme terminé",
+  "customUnitParts": "Parties",
+  "customUnitEpisodes": "Épisodes",
+  "customUnitChapters": "Chapitres",
+  "customUnitPages": "Pages",
+  "customUnitVolumes": "Tomes",
+  "customUnitSeasons": "Saisons",
+  "description": "Description",
+  "customItemDescriptionHint": "Courte description ou commentaires",
+  "customItemMyNoteHint": "Votre commentaire à propos de ce titre",
+  "customItemTagsHint": "Séparés d'une virgule, ex : Favoris, Pile de lecture",
+  "customItemOptionalFields": "Champs supplémentaires",
+  "customItemEdit": "Modifier titre personnalisé",
+  "customItemFillFromFile": "Remplir depuis un fichier",
+  "customItemFileMultipleRows": "{count} entrées dans le fichier — la première a été utilisée",
+  "@customItemFileMultipleRows": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "customItemFileNoValidRows": "Aucune entrée valide dans le fichier",
+  "customItemAddCover": "Ajouter image",
+  "customItemCoverSource": "Source de l'image",
+  "customItemCoverRatio": "Ratio dimensions recommandé : 2:3 (ex : 600×900)",
+  "customItemCoverFromFile": "Depuis un fichier",
+  "customItemSearchHint": "Rechercher ou entrer valeur personnalisée...",
+  "customItemUseCustom": "Utiliser valeur personnalisée",
+  "customItemExternalUrl": "URL externe",
+  "customItemErrorEmptyTitle": "Titre requis",
+  "customItemCreated": "Titre personnalisé créé",
+  "customItemUpdated": "Titre personnalisé mis à jour",
+  "tagLabel": "Tag",
+  "tagsLabel": "Tags",
+  "tagCreate": "Nouveau tag",
+  "tagCreateHint": "Nom de tag",
+  "tagCreateNamed": "Créer \"{name}\"",
+  "@tagCreateNamed": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "tagRename": "Renommer tag",
+  "tagDelete": "Supprimer tag",
+  "tagDeleteConfirm": "Supprimer le tag \"{name}\"? Les titres perdront leur tag.",
+  "@tagDeleteConfirm": {
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+  "tagManage": "Gérer les tags",
+  "tagAssign": "Assigner les tags",
+  "tagNone": "Pas de tags",
+  "tagPickerTitle": "Tags",
+  "tagTextColor": "Couleur du texte",
+  "tagCreated": "Tag créé",
+  "tagRenamed": "Tag renommé",
+  "tagDeleted": "Tag supprimé",
+  "tagUpdateFailed": "Impossible de mettre à jour le tag",
+  "refreshItemFromApi": "Rafraîchir depuis la source",
+  "refreshItemSuccess": "Titre mis à jour depuis la source",
+  "refreshItemNotFound": "La source ne liste plus ce titre",
+  "refreshItemUnsupported": "Les titres personnalisés n'ont pas de source",
+  "refreshItemFailed": "Impossible de rafraîchir : {error}",
+  "@refreshItemFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "renameDialogHint": "Nom d'affichage",
+  "renameOriginalLabel": "Initial : {name}",
+  "@renameOriginalLabel": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "renameResetToOriginal": "Revenir au nom initial",
+  "renameSaved": "Renommé",
+  "tierListExportFailed": "Impossible d'exporter l'image",
+  "browseCollectionsDownloadFailedGeneric": "Impossible de télécharger la collection",
+  "tagFilterAll": "Tous les tags",
+  "tagSidebarGroup": "Groupe",
+  "colorPickerTitle": "Couleur",
+  "colorPickerNoColor": "Pas de couleur",
+  "raLinkButton": "Associer RetroAchievements",
+  "raLinkTitle": "Trouver un jeu sur RetroAchievements",
+  "raLinkSearchHint": "Rechercher par nom...",
+  "raLinkLoading": "Chargement des jeux pour {platform}...",
+  "@raLinkLoading": {"placeholders": {"platform": {"type": "String"}}},
+  "raLinkNotFound": "Aucune correspondance",
+  "raLinkSuccess": "Jeu couplé à RetroAchievements",
+  "raLinkAchievements": "{count} succès",
+  "@raLinkAchievements": {"placeholders": {"count": {"type": "int"}}},
+  "raUnlinkButton": "Dissocier",
+  "raUnlinkTitle": "Dissocier RetroAchievements",
+  "raUnlinkConfirm": "Dissocier RetroAchievements et supprimer les données pour ce jeu ?",
+  "collectionFilterByType": "Filtrer par type",
+  "collectionFilterGames": "Jeux",
+  "collectionFilterMovies": "Films",
+  "collectionFilterTvShows": "Séries",
+  "collectionFilterVisualNovels": "Visual Novels",
+  "collectionFilterBooks": "Livres",
+  "searchHint": "Recherche...",
+  "sort": "Trier",
+  "collectionFilterAscending": "Ascendant",
+  "collectionFilterDescending": "Descendant",
+  "collectionFilterFilters": "Filtres",
+  "collectionFilterClearAll": "Tout effacer",
+
+  "collectionItemMovedTo": "{name} déplacé vers {collection}",
+  "@collectionItemMovedTo": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "collection": {"type": "String"}
+    }
+  },
+  "collectionItemAlreadyExists": "{name} existe déjà dans {collection}",
+  "@collectionItemAlreadyExists": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "collection": {"type": "String"}
+    }
+  },
+  "collectionItemRemoved": "{name} retiré",
+  "@collectionItemRemoved": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+
+  "boardTab": "Tableau",
+  "imageAddedToBoard": "Image ajoutée au tableau",
+  "mapAddedToBoard": "Carte ajoutée au tableau",
+  "loading": "Chargement...",
+
+  "gameNotFound": "Jeu introuvable",
+  "movieNotFound": "Film introuvable",
+  "tvShowNotFound": "Série introuvable",
+  "animationNotFound": "Film d'animation introuvable",
+  "visualNovelNotFound": "Visual novel introuvable",
+  "mangaNotFound": "Manga introuvable",
+  "readingProgress": "Progression lecture",
+  "mangaChapters": "Chapitres",
+  "mangaVolumes": "Tomes",
+  "mangaMarkCompleted": "Marquer comme terminé",
+  "animeProgress": "Progression",
+  "animeEpisodes": "Épisodes",
+  "animeMarkCompleted": "Marquer comme terminé",
+  "bookPages": "Pages",
+  "bookIssues": "Numéros",
+  "bookMarkCompleted": "Marquer comme terminé",
+  "animeNextEpisode": "L'épisode {episode} sort bientôt",
+  "@animeNextEpisode": {
+    "placeholders": {
+      "episode": {"type": "int"}
+    }
+  },
+  "animatedMovie": "Film animé",
+  "animatedSeries": "Série animée",
+
+  "runtimeHoursMinutes": "{hours}h {minutes}min",
+  "@runtimeHoursMinutes": {
+    "placeholders": {
+      "hours": {"type": "int"},
+      "minutes": {"type": "int"}
+    }
+  },
+  "runtimeHours": "{hours}h",
+  "@runtimeHours": {
+    "placeholders": {
+      "hours": {"type": "int"}
+    }
+  },
+  "runtimeMinutes": "{minutes}min",
+  "@runtimeMinutes": {
+    "placeholders": {
+      "minutes": {"type": "int"}
+    }
+  },
+
+  "totalSeasons": "{count, plural, =1{1 saison} other{{count} saisons}}",
+  "@totalSeasons": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "totalEpisodes": "{count} épisodes",
+  "@totalEpisodes": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "seasonName": "Saison {number}",
+  "@seasonName": {
+    "placeholders": {
+      "number": {"type": "int"}
+    }
+  },
+  "episodeProgress": "Progression épisode",
+  "episodesWatchedOf": "{watched}/{total} regardé",
+  "@episodesWatchedOf": {
+    "placeholders": {
+      "watched": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "episodesWatched": "{count} regardé",
+  "@episodesWatched": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "seasonEpisodesProgress": "{watched}/{total} épisodes",
+  "@seasonEpisodesProgress": {
+    "placeholders": {
+      "watched": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "noSeasonData": "Aucune donnée sur la saison",
+  "refreshFromTmdb": "Rafraîchir depuis TMDB",
+  "markAllWatched": "Marquer tous les épisodes comme regardé",
+  "markNextWatched": "Marquer le prochain épisode",
+  "unmarkAll": "Retirer toutes les mentions regardé",
+  "noEpisodesFound": "Aucun épisode trouvé",
+  "episodeWatchedDate": "regardé le {date}",
+  "@episodeWatchedDate": {
+    "placeholders": {
+      "date": {"type": "String"}
+    }
+  },
+
+  "createCollectionTitle": "Nouvelle collection",
+  "createCollectionNameLabel": "Nom de la collection",
+  "createCollectionNameHint": "ex : Classiques de  la SNES",
+  "createCollectionEnterName": "Veuillez entrer un nom",
+  "createCollectionNameTooShort": "Le nom doit contenir au moins 2 caractères",
+  "renameCollectionTitle": "Renommer la collection",
+  "deleteCollectionTitle": "Supprimer la collection ?",
+  "deleteCollectionMessage": "Êtes-vous sûr de vouloir supprimer {name} ?\n\nCette action est irréversible.",
+  "@deleteCollectionMessage": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+
+  "canvasAddText": "Ajouter un texte",
+  "canvasAddImage": "Ajouter une image",
+  "canvasAddLink": "Ajouter un lien",
+  "canvasFindImages": "Trouver des images...",
+  "canvasBrowseMaps": "Parcourir des cartes...",
+  "canvasConnect": "Connecter",
+  "canvasBringToFront": "Amener au premier plan",
+  "canvasSendToBack": "Envoyer à l'arrière-plan",
+  "canvasEditConnection": "Modifier connexion",
+  "canvasDeleteConnection": "Supprimer connexion",
+  "canvasDeleteElement": "Supprimer l'élément",
+  "canvasDeleteElementMessage": "Êtes-vous sûr de vouloir supprimer cet élément ?",
+  "canvasAddToBoard": "Ajouter au tableau",
+
+  "editTextTitle": "Modifier le texte",
+  "textContentLabel": "Contenu du texte",
+  "fontSizeLabel": "Police (taille)",
+  "fontSizeSmall": "Petit",
+  "fontSizeMedium": "Moyen",
+  "fontSizeLarge": "Grand",
+  "fontSizeTitle": "Titre",
+
+  "editImageTitle": "Modifier l'image",
+  "imageFromUrl": "Depuis une URL",
+  "imageFromFile": "Depuis un fichier",
+  "imageUrlLabel": "URL de l'image",
+  "imageUrlHint": "https://exemple.com/image.png",
+  "imageChooseFile": "Choisir le fichier",
+  "imageChooseAnother": "Choisir un autre",
+
+  "editLinkTitle": "Modifier le lien",
+  "linkLabelOptional": "Étiquette (optionnel)",
+  "linkLabelHint": "Mon lien",
+
+  "connectionLabelHint": "ex : dépend de..., lié à...",
+  "connectionStyleLabel": "Style",
+  "connectionStyleSolid": "Épais",
+  "connectionStyleDashed": "Discontinu",
+  "connectionStyleArrow": "Flèche",
+
+  "searchTabTv": "TV",
+  "searchHintMovies": "Rechercher des films...",
+  "searchHintTv": "Rechercher des séries...",
+  "searchHintAnime": "Rechercher des animes...",
+  "searchHintGames": "Rechercher des jeux...",
+  "searchHintVisualNovels": "Rechercher des visual novels...",
+  "searchSourceVisualNovels": "V. Novels",
+  "searchSourceOpenLibrary": "OpenLibrary",
+  "searchSourceFantlab": "Fantlab",
+  "searchSourceComics": "Comics",
+  "searchHintManga": "Rechercher des mangas",
+  "searchHintBooks": "Rechercher des livres...",
+  "searchHintComics": "Rechercher des comics...",
+  "language": "Langue",
+  "bookFilterSearchBy": "Rechercher par",
+  "type": "Type",
+  "bookSearchAuthor": "Auteur",
+  "bookSearchSubject": "Sujet",
+  "bookSimilarTitle": "Livres similaires",
+  "bookMoreByAuthorTitle": "Plus de cet auteur",
+  "bookTitleCopied": "Titre copié",
+  "editionPickerTitle": "Choisir l'édition",
+  "editionPickerEmpty": "Aucune édition trouvée",
+  "fantlabTypeNovel": "Roman",
+  "fantlabTypeNovella": "Roman court",
+  "fantlabTypeShortStory": "Nouvelle",
+  "fantlabTypeCycle": "Cycle",
+  "searchSelectPlatform": "Sélectionner plateforme",
+  "searchAddToCollection": "Ajouter à la collection",
+  "searchAddedToCollection": "{name} ajouté à la collection",
+  "@searchAddedToCollection": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "searchAddedToNamed": "{name} ajouté à {collection}",
+  "@searchAddedToNamed": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "collection": {"type": "String"}
+    }
+  },
+  "searchAlreadyInCollection": "{name} déjà dans la collection",
+  "@searchAlreadyInCollection": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "searchAlreadyInNamed": "{name} déjà dans {collection}",
+  "@searchAlreadyInNamed": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "collection": {"type": "String"}
+    }
+  },
+  "searchAddedToCollections": "{name} ajouté à {count, plural, =1{1 collection} other{{count} collections}}",
+  "@searchAddedToCollections": {
+    "placeholders": {
+      "name": {"type": "String"},
+      "count": {"type": "int"}
+    }
+  },
+  "searchAlreadyInCollections": "{name} déjà dans les collections sélectionnées",
+  "@searchAlreadyInCollections": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "goToSettings": "Aller dans les Paramètres",
+  "searchMinCharsHint": "Entrez au moins 2 caractères et appuyez sur Entrer",
+  "searchNoResults": "Aucun résultat",
+  "searchNothingFoundFor": "Aucun résultat pour \"{query}\"",
+  "@searchNothingFoundFor": {
+    "placeholders": {
+      "query": {"type": "String"}
+    }
+  },
+  "searchNoInternet": "Pas de connexion Internet",
+  "searchFailed": "Échec de la recherche",
+  "searchCheckConnection": "Vérifiez votre connexion et réessayez.",
+  "copyErrorDetails": "Détails erreur de copie",
+  "errorDetailsCopied": "Détails de l'erreur copiés",
+  "errorDetailsTitle": "Détails de l'erreur",
+  "errorDetailsShow": "Détails",
+  "showMore": "Plus…",
+  "showLess": "Fermer",
+
+  "platformFilterTitle": "Sélectionner plateformes",
+  "platformFilterClearAll": "Tout effacer",
+  "platformFilterSearchHint": "Rechercher plateformes...",
+  "selectedCount": "{count} sélectionné(s)",
+  "@selectedCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "platformFilterCount": "{count} plateformes",
+  "@platformFilterCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "platformFilterShowAll": "Montrer tout",
+  "platformFilterApply": "Appliquer ({count})",
+  "@platformFilterApply": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "platformFilterNone": "Aucune plateforme trouvée",
+  "platformFilterTryDifferent": "Essayez un autre terme",
+
+  "wishlistHideResolved": "Cacher collecté",
+  "wishlistShowResolved": "Montrer collecté",
+  "wishlistClearResolved": "Effacer collecté",
+  "wishlistEmpty": "Aucun titre dans la liste de souhaits",
+  "wishlistEmptyHint": "Cliquez sur + pour ajouter quelque chose à votre liste",
+  "wishlistDeleteItem": "Supprimer titre",
+  "wishlistDeletePrompt": "Supprimer \"{name}\" de votre liste de souhaits ?",
+  "@wishlistDeletePrompt": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "wishlistClearResolvedMessage": "{count, plural, =1{Supprimer 1 titre collecté ?} other{Supprimer {count} titres collectés ?}}",
+  "@wishlistClearResolvedMessage": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "wishlistMarkResolved": "Marquer en collecté",
+  "wishlistUnresolve": "Plus collecté",
+
+  "wishlistTitleHint": "Nom de jeu, film ou série...",
+  "wishlistTitleMinChars": "Au moins 2 caractères",
+  "wishlistTypeOptional": "Type (optionnel)",
+  "any": "Tout",
+  "wishlistNoteOptional": "Commentaire (optionnel)",
+  "wishlistNoteHint": "Plateforme, année, recommandé par...",
+
+  "wishlistTagOptional": "Tag (optionnel)",
+  "wishlistTagHint": "Entrées groupées — ex : une importation par batch ou une source",
+  "wishlistTagUntagged": "Retirer tag",
+  "wishlistTagFilterLabel": "Liste",
+  "wishlistTagManage": "Gérer le tag",
+  "wishlistTagDelete": "Supprimer le tag et toutes les entrées",
+  "wishlistTagDeleteConfirm": "Supprimer le tag \"{tag}\" et {count, plural, =1{1 entrée} other{{count} entrées}}?",
+  "@wishlistTagDeleteConfirm": {
+    "placeholders": {
+      "tag": {"type": "String"},
+      "count": {"type": "int"}
+    }
+  },
+  "wishlistBulkActionsButton": "{count} correspondances",
+  "@wishlistBulkActionsButton": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "wishlistBulkApplyTag": "Appliquer un tag aux entrées visibles",
+  "wishlistBulkApplyTagHint": "{count, plural, =1{Tagger l'entrée visible en tant que} other{Tagger les {count} entrées visibles en tant que}}",
+  "@wishlistBulkApplyTagHint": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "wishlistBulkRemoveTag": "Supprimer un tag des entrées visibles",
+  "wishlistBulkDelete": "Supprimer des entrées visibles",
+  "wishlistBulkDeleteConfirm": "{count, plural, =1{Supprimer 1 entrée visible ?} other{Supprimer {count} entrées visibles ?}}",
+  "@wishlistBulkDeleteConfirm": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "apply": "Appliquer",
+
+  "welcomeStepWelcome": "Bienvenue",
+  "welcomeStepReady": "Prêt !",
+
+  "welcomeNameTitle": "Comment vous appelez-vous ?",
+  "welcomeNameSubtitle": "Votre nom apparaîtra en tant qu'auteur des collections que vous créerez",
+  "welcomeChangeLaterHint": "Vous pouvez le changer plus tard dans les Paramètres",
+  "welcomeLanguageTitle": "Choisissez votre langue",
+  "welcomeLanguageSubtitle": "Sélectionnez la langue de l'interface",
+
+  "welcomeTitle": "Tonkatsu Box vous souhaite la bienvenue",
+  "welcomeSubtitle": "Organisez vos collections de jeux, films,\nséries, animes, visual novels, mangas et livres",
+  "welcomeWhatYouCanDo": "Ce que vous pouvez faire",
+  "welcomeFeatureCollections": "Créer des collections par plateforme, genre ou n'importe quel thème",
+  "welcomeFeatureSearch": "Rechercher des jeux, films, séries, animes, visual novels, mangas & livres via des API",
+  "welcomeFeatureTracking": "Marquer votre progression, noter de 1 à 10, ajouter des commentaires",
+  "welcomeFeatureBoards": "Tableaux canvas visuels avec des illustrations",
+  "welcomeFeatureExport": "Exporter et importer — partager vos collections avec vos amis",
+  "welcomeWorksWithoutKeys": "Fonctionne sans clés API",
+  "welcomeChipImport": "Importer .xcoll",
+  "welcomeChipCanvas": "Tableaux canvas",
+  "welcomeChipRatings": "Notes et commentaires",
+  "welcomeApiKeysHint": "Les clés API sont seulement nécessaires pour rechercher des nouveaux jeux, films et séries. Vous pouvez importer des collections et les utiliser hors-ligne.",
+  "welcomeChipGames": "Jeux (IGDB)",
+  "welcomeChipMovies": "Films (TMDB)",
+  "welcomeChipTvShows": "Séries (TMDB)",
+  "welcomeChipAnime": "Animes (TMDB)",
+  "welcomeChipVisualNovels": "Visual Novels (VNDB)",
+  "welcomeChipManga": "Mangas (AniList)",
+
+  "welcomeApiTitle": "Obtenir des clés API",
+  "welcomeApiFreeHint": "Inscriptions gratuites, prend 2 à 3 minutes pour chaque site",
+  "welcomeApiIgdbTag": "IGDB",
+  "welcomeApiIgdbDesc": "Recherche de jeux",
+  "welcomeApiRequired": "REQUIS",
+  "welcomeApiTmdbTag": "TMDB",
+  "welcomeApiTmdbDesc": "Films, séries et animes",
+  "welcomeApiComicVineDesc": "Comics et romans graphiques",
+  "welcomeApiGoogleBooksDesc": "Catalogue de livres de Google",
+  "welcomeApiHardcoverDesc": "Catalogue communautaire de livres, nécessite un token personnel",
+  "welcomeApiRecommended": "RECOMMANDÉ",
+  "welcomeApiSgdbTag": "SGDB",
+  "welcomeApiSgdbDesc": "Illustrations de jeux pour les tableaux",
+  "welcomeApiOptional": "OPTIONNEL",
+  "welcomeApiBuiltInKey": "CLÉ INTÉGRÉE",
+  "welcomeApiOwnKeyHint": "Vous pouvez ajouter vos propres clés plus tard dans Paramètres pour augmenter les limites d'utilisation",
+  "welcomeApiEnterKeysHint": "Entrez les clés dans Paramètres → Identifiants plus tard",
+  "welcomeApiRateLimitHint": "Les clés intégrées sont partagées entre tous les utilisateurs et ont une limite d'utilisation. Pour une meilleure expérience, utilisez vos propres clés — c'est gratuit et prend seulement quelques minutes.",
+
+  "welcomeHowTitle": "Comment ça fonctionne",
+  "welcomeHowAppStructure": "Structure de l'application",
+  "welcomeHowMainDesc": "Toutes vos collections sur une seule page. Filtrez par type, rangez par note.",
+  "welcomeHowCollectionsDesc": "Vos collections. Créez, organisez, gérez. Affichage liste ou grille, différent pour chaque collection.",
+  "welcomeHowTierListsDesc": "Classez et comparez des titres depuis vos collections grâce à des tier lists personnalisées.",
+  "welcomeHowWishlistDesc": "Courte liste des titres à vérifier plus tard. Pas besoin d'API.",
+  "welcomeHowSearchDesc": "Trouvez des jeux, films, séries, visual novels et mangas via les API. Ajoutez les à n'importe quelle collection.",
+  "welcomeHowSettingsDesc": "Clés API, cache, exporter/importer base de données, outils debugging.",
+  "welcomeHowPersonalizationDesc": "Tous vos intêrets dans une seule page : un cloud de vos genres favoris, ainsi que des recommandations mises en avant en comparant vos notes.",
+  "@welcomeHowPersonalizationDesc": {
+    "description": "Visite guidée pour le bouton central \"Personnalisation\" (cloud + recommandations)."
+  },
+  "welcomeHowQuickStart": "Démarrage rapide",
+  "welcomeHowStep1": "Allez dans Paramètres → Identifiants, entrez vos clés API",
+  "welcomeHowStep2": "Cliquez sur Vérifier connexion, attendez que les plateformes se synchronisent",
+  "welcomeHowStep3": "Allez dans Collections → + Nouvelle collection",
+  "welcomeHowStep4": "Nommez-la, puis Ajouter des titres → Rechercher → Ajouter",
+  "welcomeHowStep5": "Notez, suivez votre progression, ajoutez des commentaires — vous êtes prêt !",
+  "welcomeHowSharing": "Partager",
+  "welcomeHowSharingDesc1": "Exporter des collections, deux formats : ",
+  "welcomeHowSharingDesc2": " (léger, métadonnées seulement) ou ",
+  "welcomeHowSharingDesc3": " (complet, images et canvas — fonctionne hors-ligne). Importer grâce à vos amis — pas besoin d'API !",
+
+  "welcomeReadyTitle": "Vous êtes prêt !",
+  "welcomeReadyMessage": "Allez dans Paramètres → Identifiants pour ajouter vos clés API ou commencer en important une collection.",
+  "welcomeReadySkip": "Passer — explorez l'application vous-même",
+  "welcomeReadyReturnHint": "Vous pouvez toujours revoir ce tutoriel depuis les Paramètres",
+
+  "welcomeStepSources": "Sources",
+  "welcomeStepTour": "Visite",
+  "welcomeChipBooks": "Livres (OpenLibrary, Fantlab)",
+
+  "welcomeSourcesTitle": "Provenance des données",
+  "welcomeSourcesSubtitle": "Ces fournisseurs alimentent la fonction recherche de l'application. La plupart fonctionnent tout de suite — les autres demandant une clé API gratuite.",
+  "welcomeSourcesNoKeyNeeded": "AUCUNE CLÉ NÉCESSAIRE",
+  "welcomeSourcesKeySaved": "Clé sauvegardée",
+  "welcomeSourcesGetKey": "Obtenir une clé",
+  "welcomeSourcesKeyOptionalHint": "Optionnel — votre clé augmente la limite d'utilisation. La recherche fonctionne sans.",
+  "welcomeSourcesHardcoverTokenHint": "Requis — la recherche et l'import sont désactivés par défaut. Les tokens expirent chaque 1er janvier.",
+
+  "welcomeSourceDescTmdb": "Films, séries et films d'animation.",
+  "welcomeSourceDescTvMaze": "Séries.",
+  "welcomeSourceDescIgdb": "Jeux vidéos, toutes plateformes confondues.",
+  "welcomeSourceDescAniList": "Animes et mangas, métadonnées enrichies.",
+  "welcomeSourceDescMangaBaka": "Mangas, manhwas, manhuas et light novels.",
+  "welcomeSourceDescMangaDex": "Un large catalogue de mangas avec des titres traduits et un compteur de chapitres.",
+  "welcomeSourceDescKitsu": "Un catalogue indépendant de mangas avec des notes et des couvertures.",
+  "welcomeSourceDescVndb": "Base de données pour les visual novels.",
+  "welcomeSourceDescOpenLibrary": "Catalogue de bibliothèque ouvert, des millions de livres.",
+  "welcomeSourceDescFantlab": "Catalogue détaillé de livres avec des notes, récompenses et cycles.",
+  "welcomeSourceDescComicVine": "Un large catalogue de comics et romans graphiques.",
+  "welcomeSourceDescGoogleBooks": "Des millions d'éditions en provenance de Google Books, recherches par titre, auteur ou ISBN.",
+  "welcomeSourceDescHardcover": "Catalogue communautaire de livres listant des cycles, genres, humeurs et notes. Nécessite un token personnel (gratuit).",
+
+  "welcomeTourTitle": "Apprenez à connaître le menu",
+  "welcomeTourSubtitle": "Une visite rapide de la navigation — cliquez sur Suivant pour passer à la suite.",
+  "welcomeTourStart": "Explorez maintenant",
+  "welcomeHowReleasesDesc": "Nouveaux épisodes et sorties pour les séries et les jeux que vous suivez.",
+
+  "updateAvailable": "Mise à jour disponible : v{version}",
+  "@updateAvailable": {
+    "placeholders": {
+      "version": {"type": "String"}
+    }
+  },
+  "updateCurrent": "Actuelle : v{version}",
+  "@updateCurrent": {
+    "placeholders": {
+      "version": {"type": "String"}
+    }
+  },
+  "updateWarningTitle": "Avant de mettre à jour",
+  "updateWarningBody": "Cette application est en développement. Les mises à jours peuvent inclure des migrations de base de données modifiant le format des données.\n\nVeuillez créer une sauvegarde avant de mettre à jour (Paramètres → Sauvegarde). Ainsi, vous pouvez restaurer vos données au moindre problème.",
+  "updateWarningProceed": "Aller à la page de release",
+
+  "chooseCollection": "Choisir collection",
+  "withoutCollection": "Sans collection",
+
+  "detailMyRating": "Ma note",
+  "detailRatingValue": "{rating}/10",
+  "@detailRatingValue": {
+    "placeholders": {
+      "rating": {"type": "String"}
+    }
+  },
+  "detailActivityProgress": "Activité et progression",
+  "detailAuthorReview": "Critique de l'auteur",
+  "detailEditAuthorReview": "Modifier la critique de l'auteur",
+  "detailWriteReviewHint": "Écrivez votre critique...",
+  "detailReviewVisibility": "Visible une fois partagé. Votre critique de ce titre.",
+  "detailNoReviewEditable": "Aucune critique. Cliquez sur Modifier pour en ajouter une.",
+  "detailNoReviewReadonly": "Aucune critique écrite par l'auteur.",
+  "detailMyNotes": "Mes commentaires",
+  "detailEditMyNotes": "Modifier mes commentaires",
+  "detailWriteNotesHint": "Écrivez vos commentaires...",
+  "detailNoNotesYet": "Aucun commentaire. Cliquez sur Modifier pour ajouter des commentaires.",
+  "detailNoNotesReadonly": "Aucun commentaire de l'auteur.",
+
+  "unknownGame": "Jeu inconnu",
+  "unknownMovie": "Film inconnu",
+  "unknownTvShow": "Série inconnue",
+  "unknownAnimation": "Film d'animation inconnu",
+  "unknownVisualNovel": "Visual novel inconnu",
+  "unknownManga": "Manga inconnu",
+  "unknownCustom": "Titre personnalisé inconnu",
+  "unknownPlatform": "Plateforme inconnue",
+  "defaultAuthor": "Utilisateur",
+
+  "errorPrefix": "Erreur : {error}",
+  "@errorPrefix": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+
+  "allItemsRatingAsc": "Note ↑",
+  "allItemsRatingDesc": "Note ↓",
+  "allItemsNoItems": "Aucun titre",
+  "allItemsNoMatch": "Aucun titre ne correspond aux filtres",
+  "allItemsAddViaCollections": "Allez dans Collections → créer une collection → ajouter des titres\nvia Recherche. Ils apparaitront ici automatiquement.",
+  "allItemsFailedToLoad": "Impossible de charger les titres",
+  "allPlatforms": "Toutes les plateformes",
+  "allItemsFilterPlatformsTitle": "Filtrer par plateforme",
+
+  "debugIgdbMedia": "IGDB Media",
+  "debugGamepad": "Manette",
+  "debugClearLogs": "Effacer journal",
+  "debugRawEvents": "Évènements bruts (Gamepads.events)",
+  "debugServiceEvents": "Évènements service (filtré)",
+  "debugEventsCount": "{count} évènements",
+  "@debugEventsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "debugPressButton": "Appuyez sur n'importe\nquel bouton sur la manette...",
+  "debugExportLog": "Exporter journal",
+  "debugLogExported": "Journal exporté vers {path}",
+  "@debugLogExported": {
+    "placeholders": {
+      "path": {"type": "String"}
+    }
+  },
+  "debugLogEmpty": "Aucun event à exporter",
+  "settingsGamepadDebug": "Debug manette",
+  "debugSearchGames": "Rechercher des jeux",
+  "debugEnterGameName": "Entrez un nom de jeu",
+  "debugEnterGameNameHint": "Entrez un nom de jeu pour lancer la recherche",
+  "debugGameId": "ID du jeu",
+  "debugEnterGameId": "Entrez une ID SteamGridDB",
+  "debugLoadTab": "Charger {tabName}",
+  "@debugLoadTab": {
+    "placeholders": {
+      "tabName": {"type": "String"}
+    }
+  },
+  "debugEnterGameIdHint": "Entrez l'ID d'un jeu et cliquez sur Charger {tabName}",
+  "@debugEnterGameIdHint": {
+    "placeholders": {
+      "tabName": {"type": "String"}
+    }
+  },
+  "debugNoImagesFound": "Aucune image trouvée",
+
+  "collectionTileStats": "{count, plural, =1{1 titre} other{{count} titres}} · {percent} terminé",
+  "@collectionTileStats": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "percent": {"type": "String"}
+    }
+  },
+  "collectionTileError": "Erreur lors du chargement des statistiques",
+
+  "activityDatesTitle": "Dates d'activité",
+  "activityDatesAdded": "Ajouté",
+  "activityDatesStarted": "Commencé",
+  "activityDatesCompleted": "Terminé",
+  "activityDatesSelectStart": "Sélectionner une date de début",
+  "activityDatesSelectCompletion": "Sélectionner une date de complétion",
+  "settingsDateFormat": "Format de la date",
+  "settingsDateFormatSubtitle": "Comment les dates sont affichées dans l'application",
+  "settingsAnimeMangaTitleLanguage": "Langue des titres pour les animes et mangas",
+  "settingsAnimeMangaTitleLanguageSubtitle": "Titre affiché pour les animes et mangas",
+  "settingsAnimeMangaTitleLanguageRomaji": "Romaji",
+  "settingsAnimeMangaTitleLanguageEnglish": "Anglais",
+  "settingsAnimeMangaTitleLanguageNative": "Original",
+  "dualDatePickerErrorEmpty": "Entrez une date",
+  "dualDatePickerErrorFormat": "Utilisez ce format : aaaa-MM-jj",
+  "dualDatePickerErrorRange": "La date n'est pas valide",
+  "activityDatesCompletionTime": "Complété en {duration}",
+  "@activityDatesCompletionTime": { "placeholders": { "duration": { "type": "String" } } },
+  "timeSpentTitle": "Temps écoulé",
+  "timeSpentAdd": "Ajouter une durée",
+  "timeSpentEdit": "Modifier temps",
+  "timeSpentHours": "Heures",
+  "timeSpentMinutes": "Minutes",
+  "durationLessThanDay": "moins d'un jour",
+  "durationOneDay": "1 jour",
+  "durationDays": "{count} jours",
+  "@durationDays": { "placeholders": { "count": { "type": "int" } } },
+  "durationWeeks": "{count} semaines",
+  "@durationWeeks": { "placeholders": { "count": { "type": "int" } } },
+  "durationMonths": "{count} mois",
+  "@durationMonths": { "placeholders": { "count": { "type": "int" } } },
+  "durationYears": "{count} années",
+  "@durationYears": { "placeholders": { "count": { "type": "String" } } },
+
+  "canvasFailedToLoad": "Impossible de charger le tableau",
+  "canvasBoardEmpty": "Le tableau est vide",
+  "canvasBoardEmptyHint": "Ajoutez des titres à la collection d'abord",
+  "canvasCenterView": "Centrer affichage",
+  "canvasResetPositions": "Réinitialiser les positions",
+  "canvasVgmapsBrowser": "Navigateur VGMaps",
+  "canvasSteamGridDbImages": "Images SteamGridDB",
+
+  "steamGridDbPanelTitle": "SteamGridDB",
+  "closePanel": "Fermer panneau",
+  "steamGridDbSearchHint": "Recherche un jeu...",
+  "steamGridDbNoApiKey": "La clé API SteamGridDB n'a pas été fournie. Configurez dans les Paramètres.",
+  "steamGridDbBackToSearch": "Retour à la recherche",
+  "steamGridDbGrids": "Grids",
+  "steamGridDbHeroes": "Heroes",
+  "steamGridDbLogos": "Logos",
+  "steamGridDbIcons": "Icons",
+  "steamGridDbSearchFirst": "Recherchez un jeu d'abord",
+
+  "vgmapsBack": "Retour",
+  "vgmapsForward": "Suivant",
+  "vgmapsHome": "Accueil",
+  "vgmapsReload": "Recharger",
+  "vgmapsCaptureImage": "Enregistrer l'image de la carte",
+  "vgmapsSearchHint": "Rechercher un jeu sur VGMaps...",
+  "vgmapsDismiss": "Rejeter",
+  "vgmapsFailedInit": "Impossible de démarrer WebView : {error}",
+  "@vgmapsFailedInit": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+
+  "discoverTitle": "Découvrir",
+  "discoverCustomize": "Personnaliser",
+  "discoverTrending": "Populaire cette semaine",
+  "discoverTopRatedMovies": "Films les mieux notés",
+  "discoverTopRatedTvShows": "Séries les mieux notées",
+  "discoverPopularTvShows": "Séries populaires",
+  "discoverUpcoming": "À venir",
+  "discoverCustomizeTitle": "Personnaliser Découvrir",
+  "discoverCustomizeHint": "Choisissez quelles sections montrer",
+  "discoverResetDefault": "Réinitialiser l'affichage",
+  "discoverAlreadyInCollection": "Déjà dans la collection",
+  "discoverShowWithBadge": "Montrer avec un badge",
+  "discoverHideCompletely": "Cacher totalement",
+
+  "recommendationsTitle": "Recommandations",
+
+  "reviewsTitle": "Critiques",
+  "reviewsShowAll": "Montrer les {count} critiques",
+  "@reviewsShowAll": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "reviewsReadMore": "Lire plus",
+  "reviewsInEnglish": "Critiques en anglais",
+
+  "settingsShowRecommendationsSubtitle": "Films et séries similaires sur les pages de détails",
+  "settingsHideEmptyMediaTypeChevrons": "Cacher les filtres sans contenu",
+  "settingsHideEmptyMediaTypeChevronsSubtitle": "Cache les filtres (Jeux, Films, etc.) qui ne contiennent aucun titre du même type.",
+  "settingsAlwaysShowSubcategories": "Toujours montrer les sous-catégories",
+  "settingsAlwaysShowSubcategoriesSubtitle": "Montre les filtres de sous-catégories (plateformes de jeux, genres de mangas/animes) sans sélectionner leur type en premier lieu.",
+  "settingsShowPlatformOverlay": "Jacquettes des plateformes de jeux",
+  "settingsShowPlatformOverlaySubtitle": "Montrer le logo de la plateforme sur la jacquette des jeux (PS5, Switch, etc.)",
+  "settingsShowBlurayOverlay": "Jacquettes Blu-ray",
+  "settingsShowBlurayOverlaySubtitle": "Montrer le logo Blu-ray sur la jacquette des films et des séries",
+  "settingsRichCollections": "Vue enrichie des collections",
+  "settingsRichCollectionsSubtitle": "Personnalisez les collections avec des jacquettes et des descriptions",
+  "settingsCardScale": "Taille jacquettes",
+  "settingsCardScaleSubtitle": "Taille des cartes dans les collections (mode grille)",
+  "collectionEditHeroImage": "Bannière",
+  "collectionEditHeroImageHint": "2560×1080 recommandé (21:9). Sujet principal sur la droite — le côté gauche est recouvert par le titre — le bas disparaît dans le fond",
+  "collectionEditHeroPick": "Choisir une image",
+  "collectionEditHeroReplace": "Remplacer l'image",
+  "collectionEditHeroRemove": "Retirer l'image",
+  "collectionEditDescriptionHint": "Un court slogan s'affichant par-dessus la bannière",
+  "collectionEditDialogTitle": "Paramètres de collection",
+  "settingsDiscordRpc": "Intégration dans Discord",
+  "settingsDiscordRpcSubtitle": "Affiche le titre regardé dans votre statut Discord",
+  "settingsDiscordRaSync": "Synchroniser RetroAchievements",
+  "settingsDiscordRaSyncSubtitle": "Affiche votre activité RetroAchievements dans votre profil Discord",
+
+  "uncategorizedBanner": "Ajouter à une collection pour débloquer l'affichage tableau et le suivi des épisodes",
+  "uncategorizedDeprecationNotice": "Cette collection sera bientôt retirée. Créez votre propre collection et déplacez les titres dedans.",
+  "@uncategorizedDeprecationNotice": {
+    "description": "Prévient que la collection Sans catégorie est obselète et sera retirée."
+  },
+  "uncategorizedDeprecationBadge": "Sera retirée",
+  "@uncategorizedDeprecationBadge": {
+    "description": "Un court avertissement sur la carte de la collection Sans catégorie pour indiquer qu'elle sera retirée."
+  },
+
+  "browseFilterGenre": "Genre",
+  "browseFilterLength": "Durée",
+  "vndbLengthVeryShort": "Très courte",
+  "vndbLengthShort": "Courte",
+  "vndbLengthMedium": "Moyenne",
+  "vndbLengthLong": "Longue",
+  "vndbLengthVeryLong": "Très longue",
+  "browseFilterAnimeAdaptation": "Adaptation anime",
+  "vndbHasAnimeAdaptation": "A une adaptation",
+  "tagPickerTitle": "Sélectionner tags",
+  "tagPickerSearchHint": "Rechercher tags",
+  "tagPickerShowSpoilers": "Montrer les tags spoiler",
+  "tagPickerShowAdult": "Montrer les tags +18",
+  "tagPickerRefresh": "Rafraîchir catalogue",
+  "tagPickerEmpty": "Aucun tag trouvé",
+  "clearAll": "Tout effacer",
+  "browseFilterSeason": "Saison",
+  "browseFilterGameMode": "Mode de jeu",
+  "browseFilterMinRating": "Note minimum",
+  "browseFilterMinVotes": "Votes minimum",
+  "seasonWinter": "Hiver",
+  "seasonSpring": "Printemps",
+  "seasonSummer": "Été",
+  "seasonFall": "Automne",
+  "animeFormatTv": "TV",
+  "animeFormatMovie": "Film",
+  "animeFormatOva": "OVA",
+  "animeFormatOna": "ONA",
+  "animeFormatSpecial": "Spécial",
+  "animeFormatTvShort": "Court épisode TV",
+  "mangaStatusPublishing": "En cours de publication",
+  "mangaStatusFinished": "Terminé",
+  "mangaStatusNotYetPublished": "Pas encore publié",
+  "mangaStatusCancelled": "Annulé",
+  "mangaStatusHiatus": "En pause",
+  "gameModeSinglePlayer": "Solo",
+  "gameModeMultiplayer": "Multijoueur",
+  "gameModeCoOperative": "Coopération",
+  "gameModeSplitScreen": "Écran partagé",
+  "gameModeMmo": "MMO",
+  "gameModeBattleRoyale": "Battle Royale",
+  "languageEnglish": "Anglais",
+  "languageJapanese": "Japonais",
+  "languageKorean": "Coréen",
+  "languageChinese": "Chinois",
+  "languageFrench": "Français",
+  "languageSpanish": "Espagnol",
+  "languageGerman": "Allemand",
+  "languageRussian": "Russe",
+  "languageItalian": "Italien",
+  "languagePortuguese": "Portugais",
+  "mangaFormatManhwa": "Manhwa",
+  "mangaFormatManhua": "Manhua",
+  "mangaFormatOneShot": "One-shot",
+  "mangaFormatNovel": "Roman",
+  "mangaFormatLightNovel": "Light Novel",
+  "browseFilterContentRating": "Classification du contenu",
+  "browseFilterDemographic": "Démographie",
+  "contentRatingSafe": "Sûr",
+  "contentRatingSuggestive": "Suggestif",
+  "contentRatingErotica": "Érotique",
+  "contentRatingPornographic": "Pornographique",
+  "browseSortRelevance": "Pertinence",
+  "browseSortPopular": "Populaire",
+  "browseSortTopRated": "Mieux noté",
+  "browseSortNewest": "Plus récent",
+  "browseSortMostVoted": "Plus de votes",
+  "browseSortMostRead": "Plus lu",
+  "browseSortTrending": "Tendance",
+  "browseSortNameAsc": "Nom (A à Z)",
+  "browseSortNameDesc": "Nom (Z à A)",
+  "browseSortRecentlyUpdated": "Récemment mis à jour",
+  "browseSortRecentlyAdded": "Récemment ajouté",
+  "browseAnimeTypeSeries": "Séries",
+  "browseAnimeTypeMovies": "Films",
+  "browseEmptyFilters": "Choisir un filtre ou rechercher",
+  "browseBackToBrowse": "Retour à la navigation",
+  "browseSortDisabledHint": "Tri impossible pendant la recherche écrite",
+
+  "animeStatusAiring": "En cours de diffusion",
+  "animeStatusFinished": "Terminé",
+  "animeStatusNotYetAired": "Pas encore diffusé",
+  "animeStatusCancelled": "Annulé",
+
+  "typeToFilterHint": "Filtrer...",
+  "appBarSearchHint": "Écrivez pour commencer la recherche",
+
+  "insertLink": "Insérer un lien",
+  "linkText": "Texte",
+  "linkHint": "Guide",
+  "urlLabel": "URL",
+  "urlHint": "https://exemple.com",
+  "markdownBold": "Gras",
+  "markdownItalic": "Italique",
+  "insert": "Insérer",
+
+  "navTierLists": "Tier lists",
+  "tierListCreate": "Nouvelle tier list",
+  "tierListCreateFromCollection": "Créer tier list",
+  "tierListNameHint": "Nom de la tier list",
+  "tierListScopeAll": "Tous les titres",
+  "tierListScopeCollection": "Depuis la collection",
+  "tierListFromCollection": "Depuis : {name}",
+  "@tierListFromCollection": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "tierListRankedCount": "{count} classés",
+  "@tierListRankedCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "tierListTitle": "Tier list",
+  "tierListUnranked": "Sans classement",
+  "exportAsImage": "Exporter en tant qu'image",
+  "tierListImageSaved": "Tier list sauvegardé en tant qu'image",
+  "tierListRename": "Renommer le tier",
+  "tierListChangeColor": "Changer la couleur",
+  "tierListMoveUp": "Monter",
+  "tierListMoveDown": "Descendre",
+  "tierListDeleteTier": "Supprimer le tier",
+  "tierListAddTier": "Ajouter un tier",
+  "tierListClearConfirm": "Retirer tous les titres des tiers ? Ils seront alors sans classement.",
+  "tierListDeleteConfirm": "Supprimer cette tier list ?",
+  "tierListEmpty": "Aucune tier list pour l'instant",
+  "tierListEmptyHint": "Cliquez sur + pour créer une tier list\net classez les titres de vos collections.",
+  "tierListAllRanked": "Tous les titres sont classés !",
+  "tierListErrorEmptyName": "Entrez un nom pour la tier list",
+  "tierListErrorNoCollection": "Sélectionnez une collection",
+  "collectionPickerFilter": "Filtrer les collections...",
+  "collectionPickerAlreadyAdded": "✓ ajouté",
+  "collectionPickerAlreadyInCount": "{count, plural, =1{Déjà dans {count} collection} other{Déjà dans {count} collections}}",
+  "@collectionPickerAlreadyInCount": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+
+  "settingsSteamImport": "Bibliothèque Steam",
+  "settingsSteamImportSubtitle": "Importez des jeux via l'API Web de Steam",
+  "settingsIgdbImport": "Liste IGDB",
+  "settingsIgdbImportSubtitle": "Importez une liste de jeux depuis IGDB (format CSV)",
+  "igdbImportTitle": "Importer une liste IGDB",
+  "igdbImportDescription": "Choisissez une liste CSV téléchargée depuis IGDB. Les jeux se voient attribués un ID par IGDB; ceux qui ne sont plus présents sur le site seront ajoutés à la liste de souhaits.",
+  "igdbImportSelectCsvFile": "Sélectionner un fichier CSV",
+  "igdbImportSelectCsvExport": "Sélectionner un fichier CSV de IGDB",
+  "igdbImportStatusLabel": "Statuts pour les jeux importés",
+  "igdbImportPlatformSelect": "Sélectionner une plateforme",
+  "importIgdbRequired": "Une connexion à IGDB est requise. Paramétrez la clé API dans Paramètres → Identifiants.",
+  "importing": "Importation...",
+  "igdbReasonNotFound": "Pas trouvé sur IGDB",
+  "steamImportTitle": "Importer la Bibliothèque Steam",
+  "importIgdbMatchNote": "Les jeux seront importés en accordance avec la base de données IGDB",
+  "steamImportApiKey": "Clé API Steam",
+  "steamImportApiKeyHint": "Obtenez une clé API gratuite sur steamcommunity.com/dev/apikey",
+  "steamImportSteamId": "ID Steam (64-bit)",
+  "steamImportSteamIdHint": "Trouvé sur steamidfinder.com",
+  "steamImportPublicWarning": "Votre profil Steam doit être public",
+  "steamImportButton": "Importer la Bibliothèque",
+  "steamImportFetchingLibrary": "Récupération de la Bibliothèque...",
+  "steamImportMatching": "Couplage des jeux avec IGDB...",
+  "steamImportLookingUp": "Recherche de : {name}",
+  "@steamImportLookingUp": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "steamImportImported": "Importés : {count}",
+  "@steamImportImported": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "steamImportWishlisted": "Ajoutés à la liste de souhaits : {count}",
+  "@steamImportWishlisted": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "steamImportUpdated": "Mis à jours : {count}",
+  "@steamImportUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importComplete": "Importation terminée !",
+  "steamImportGamesImported": "{count} jeux importés",
+  "@steamImportGamesImported": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "steamImportWishlistedInIgdb": "{count} ajoutés à la liste de souhaits",
+  "@steamImportWishlistedInIgdb": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "steamImportUpdatedDuplicates": "{count} mis à jours (déjà présents)",
+  "@steamImportUpdatedDuplicates": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "steamImportPlayedStatus": "Jeux commencés marqués comme \"En cours\"",
+  "steamImportPlaytimeComment": "Le temps de jeu sauvegardé dans les commentaires",
+  "openCollection": "Ouvrir collection",
+  "steamImportRememberCredentials": "Sauvegarder les identifiants",
+
+  "collectionListSortCreatedDate": "Date ajoutée",
+  "collectionListSortAlphabeticalAZ": "A à Z",
+  "collectionListSortAlphabeticalZA": "Z à A",
+  "collectionListViewGrid": "Affichage grille",
+  "collectionListViewList": "Affichage liste",
+  "collectionListViewTable": "Affichage tableur",
+  "collectionTableExternalRating": "Externe",
+
+  "collectionCopyToCollection": "Copier vers la collection",
+  "collectionItemCopiedTo": "{name} copier vers {collection}",
+  "collectionItemAlreadyInTarget": "{name} est déjà dans {collection}",
+
+  "openInCollection": "Ouvrir dans la collection",
+
+  "importResultTitle": "Résultats d'importation",
+  "importResultComplete": "Importation de {source} terminée !",
+  "@importResultComplete": {
+    "placeholders": {
+      "source": {"type": "String"}
+    }
+  },
+  "importResultFailed": "Importation de {source} échouée",
+  "@importResultFailed": {
+    "placeholders": {
+      "source": {"type": "String"}
+    }
+  },
+  "importResultImported": "Importé",
+  "importResultWishlisted": "Ajouté à la liste de souhaits",
+  "importResultUpdated": "Mis à jour",
+  "importResultErrors": "Erreurs ({count})",
+  "@importResultErrors": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importResultErrorsCopied": "Erreurs copiées",
+  "importResultSkipped": "{count} omis",
+  "@importResultSkipped": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "importResultOpenCollection": "Ouvrir la collection",
+  "importResultWishlistHint": "Les titres introuvables dans votre base de données ont été sauvegardés dans votre liste de souhaits.",
+  "importResultSourceCollectionFile": "Fichier de collection",
+
+  "settingsBrowseCollections": "Regarder les collections",
+  "settingsBrowseCollectionsSubtitle": "Télécharger des collections pré-établies",
+  "browseCollectionsSummary": "{count} collections, {items} titres",
+  "@browseCollectionsSummary": {
+    "placeholders": {
+      "count": {"type": "int"},
+      "items": {"type": "int"}
+    }
+  },
+  "browseCollectionsSearch": "Rechercher des collections...",
+  "browseCollectionsAllCategories": "Toutes les catégories",
+  "browseCollectionsItems": "{count} titres",
+  "@browseCollectionsItems": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "browseCollectionsFormatLight": "Léger (clés API nécessaires)",
+  "browseCollectionsFormatFull": "Complet (hors-ligne)",
+  "browseCollectionsDownloading": "Téléchargement...",
+  "browseCollectionsImportSuccess": "Collection importée : {name}",
+  "@browseCollectionsImportSuccess": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "browseCollectionsEmpty": "Aucune collection trouvée",
+  "browseCollectionsLoadError": "Impossible de charger les collections",
+  "browseCollectionsImportTarget": "Importer vers",
+  "browseCollectionsNewCollection": "Nouvelle collection",
+  "browseCollectionsExistingCollection": "Collection existante",
+  "noCollectionsYet": "Aucune collection pour l'instant",
+
+  "settingsRaImport": "RetroAchievements",
+  "settingsRaImportSubtitle": "Importer des jeux depuis RetroAchievements",
+  "raImportTitle": "Importation RetroAchievements",
+  "raGetApiKey": "Obtenez votre clé API sur retroachievements.org/controlpanel.php",
+  "raImportOptionWishlist": "Ajoutez les jeux non listés à votre liste de souhaits",
+  "raImportFetchingLibrary": "Récupération de la bibliothèque RetroAchievements...",
+  "raImportSearchingIgdb": "Recherche des jeux sur IGDB...",
+  "raImportMatching": "Correspondance : {title}",
+  "@raImportMatching": {
+    "placeholders": {
+      "title": {"type": "String"}
+    }
+  },
+  "raImportAdded": "{count} jeux ajoutés",
+  "@raImportAdded": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "raImportUpdated": "{count} jeux mis à jours",
+  "@raImportUpdated": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "raImportToWishlist": "{count} ajoutés à la liste des souhaits",
+  "@raImportToWishlist": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "raConnectionFailed": "Connexion impossible : {error}",
+  "@raConnectionFailed": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "raProfilePoints": "{points} points",
+  "@raProfilePoints": {
+    "placeholders": {
+      "points": {"type": "int"}
+    }
+  },
+  "raProfileMemberSince": "Membre depuis {date}",
+  "@raProfileMemberSince": {
+    "placeholders": {
+      "date": {"type": "String"}
+    }
+  },
+
+  "raRefresh": "Rafraîchir les succès",
+  "raOpenOnRa": "Ouvrir dans RA ↗",
+  "raHardcore": "Hardcore",
+  "raCompletion": "Complétion",
+  "raRecentUnlocks": "Obtentions récentes",
+  "raUpNext": "Suivant",
+  "raViewAll": "Voir tous les {count} succès →",
+  "@raViewAll": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "raMastered": "Maîtrisé",
+  "raHardcoreMastered": "Hardcore maîtrisé",
+  "raBeaten": "Terminé",
+  "raBeatenSoftcore": "Softcore terminé",
+  "raHardcoreBeaten": "Hardcore terminé",
+  "raYesterday": "Hier",
+  "raDaysAgo": "{days} jours auparavant",
+  "@raDaysAgo": {
+    "placeholders": {
+      "days": {"type": "int"}
+    }
+  },
+  "raPoints": "pts",
+  "raAchievements": "succès",
+  "raMissable": "MANQUABLE",
+  "raFilterEarned": "Obtenu",
+  "raFilterLocked": "Verrouillé",
+  "raFilterMissable": "Manquable",
+  "raFilterProgression": "Progression",
+  "raFilterWinCondition": "Condition de victoire",
+  "raBeatenProgress": "Progression (terminé)",
+  "raStatsAchievements": "succès",
+  "raStatsWorth": "valant",
+  "raStatsPoints": "points",
+  "raStatsUnlocked": "Déverrouillé",
+
+  "copyAsText": "Copié en tant que texte…",
+  "copiedToClipboard": "Copié {count} titres dans le presse-papiers",
+  "@copiedToClipboard": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "template": "Modèle",
+  "textExportTokens": "Tokens",
+  "textExportSortBy": "Trier par",
+  "textExportSortCurrent": "Ordre actuel",
+  "textExportSortName": "Nom (A à Z)",
+  "textExportSortYear": "Année ↓",
+  "textExportSortAdded": "Date d'ajout ↓",
+  "textExportEmptyTemplate": "Modèle vide",
+  "filtersClear": "Effacer",
+  "collectionTableColumns": "Colonnes",
+  "tableFilterHint": "Les règles de tri s'appliquent TOUTES (ET).",
+  "tableFilterAddRule": "Ajouter règle",
+  "tableFilterCondContains": "Contient",
+  "tableFilterCondEquals": "Égal à",
+  "tableFilterCondStartsWith": "Commence par",
+  "tableFilterCondEndsWith": "Termine par",
+  "tableFilterCondAtLeast": "Au moins (≥)",
+  "tableFilterCondAtMost": "Au plus (≤)",
+
+  "profiles": "Profils",
+  "currentProfile": "Actuel : {name}",
+  "@currentProfile": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "switchProfile": "Changer de profil",
+  "addProfile": "Ajouter un profil",
+  "createProfile": "Créer un profil",
+  "editProfile": "Modifier le profil",
+  "deleteProfile": "Supprimer le profil",
+  "deleteProfileConfirm": "Supprimer le profil {name}? Cela supprimera toutes les collections, la liste de souhaits et les paramètres. La suppression est définitive.",
+  "@deleteProfileConfirm": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "cannotDeleteLastProfile": "Impossible de supprimer le dernier profil",
+  "profileName": "Nom",
+  "whoIsPlayingToday": "Qui joue aujourd'hui ?",
+  "dontAskAgain": "Ne pas demander de nouveau",
+  "profileStats": "{collections} collections, {items} titres",
+  "@profileStats": {
+    "placeholders": {
+      "collections": {"type": "int"},
+      "items": {"type": "int"}
+    }
+  },
+  "switchingProfile": "Changement de profil…",
+  "appWillRestart": "L'application va redémarrer pour appliquer les changements.",
+  "profileCreated": "Profil créé",
+  "profileDeleted": "Profil supprimé",
+
+  "settingsIntegrations": "Intégrations",
+  "settingsKodiSubtitle": "Synchronisation vidéo depuis le lecteur média Kodi",
+  "settingsOn": "Marche",
+
+  "kodiConnectionTitle": "Connexion",
+  "kodiConnectionSubtitle": "Kodi HTTP JSON-RPC (Paramètres → Services → Control)",
+  "kodiHost": "Hôte",
+  "kodiPort": "Port",
+  "kodiPassword": "Mot de passe",
+  "kodiPasswordHint": "Entrez le mot de passe",
+  "kodiTestConnection": "Test de connexion",
+  "kodiConnecting": "Connexion…",
+  "kodiPingFailed": "Échec du ping — réponse inattendue",
+  "kodiConnectedTo": "Kodi {version} \"{name}\"",
+  "@kodiConnectedTo": {
+    "placeholders": {
+      "version": {"type": "String"},
+      "name": {"type": "String"}
+    }
+  },
+
+  "kodiSyncTitle": "Synchronisation",
+  "kodiTargetCollectionSubtitle": "Tous les films de Kodi se synchronisent ici",
+  "kodiTargetNotSelected": "Aucune sélection",
+  "kodiTargetDeletedLabel": "Supprimé (#{id})",
+  "@kodiTargetDeletedLabel": {
+    "placeholders": {
+      "id": {"type": "int"}
+    }
+  },
+  "kodiEnableSync": "Activer la synchronisation Kodi",
+  "kodiEnableSyncActiveSubtitle": "Actif tant que Tonkatsu est ouvert",
+  "kodiEnableSyncDisabledSubtitle": "Sélectionnez d'abord une collection",
+  "kodiSyncInterval": "Interval de synchronisation",
+  "kodiCreateSubCollections": "Créer des sous-collections importées de Kodi",
+  "kodiCreateSubCollectionsSubtitle": "ex : \"Collection Harry Potter (kodi)\"",
+  "kodiImportRatings": "Importer les notes depuis Kodi",
+  "kodiImportRatingsSubtitle": "Copier les notes utilisateurs de Kodi (1-10)",
+
+  "kodiCollectionLibraryName": "Bibliothèque Kodi",
+  "kodiCollectionCreated": "Créé \"{name}\"",
+  "@kodiCollectionCreated": {
+    "placeholders": {
+      "name": {"type": "String"}
+    }
+  },
+  "kodiTargetDeletedSnack": "La collection a été supprimée — synchronisation arrêtée",
+
+  "kodiSyncStatus": "Statut de synchronisation",
+  "kodiSyncRunning": "En cours",
+  "kodiSyncStopped": "Arrêtée",
+  "kodiLastSyncNever": "Jamais",
+  "kodiClearLastSync": "Effacer les horodatages de la dernière synchronisation",
+  "kodiClearLastSyncSubtitle": "La prochaine synchronisation récupérera tous les titres regardés",
+  "kodiLastSyncCleared": "Horodatages de la dernière synchronisation effacés",
+
+  "kodiRequestLog": "Journal de requêtes : ({count})",
+  "@kodiRequestLog": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "kodiCopyLog": "Copier le journal",
+  "kodiLogCopied": "Journal copié",
+  "kodiClearLog": "Effacer le journal",
+  "kodiNoRequests": "Aucune requête pour l'instant",
+
+  "kodiRawJsonRpc": "JSON-RPC brut",
+  "kodiMethod": "Méthode",
+  "kodiParams": "Paramètres (JSON)",
+  "kodiSend": "Envoyer",
+  "kodiCopyToClipboard": "Copier vers le presse-papiers",
+  "kodiCopiedToClipboard": "Copié vers le presse-papiers",
+  "kodiParamsNotObject": "Erreur : les paramètres doivent être un objet JSON",
+  "kodiJsonParseError": "Erreur d'analyse JSON (parse error) : {message}",
+  "@kodiJsonParseError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  },
+  "kodiRawError": "Erreur : {message}",
+  "@kodiRawError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  },
+
+  "settingsMalImport": "MyAnimeList",
+  "settingsMalImportSubtitle": "Importez des animes/mangas depuis un fichier XML",
+  "malImportTitle": "Importation MyAnimeList",
+  "malImportSubtitle": "Les animes et mangas importés seront identiques à ceux listés chez AniList",
+  "malImportPickFiles": "Ajouter fichier XML",
+  "malImportFilesHint": "Exporter fichier XML depuis myanimelist.net/panel.php?go=export",
+  "importAnimeList": "Liste d'animes",
+  "importMangaList": "Liste de mangas",
+  "malImportEntriesCount": "{count, plural, =1{1 entrée} other{{count} entrées}}",
+  "@malImportEntriesCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "malImportReadingFiles": "Lecture des fichiers...",
+  "malImportResolvingAnime": "Vérification des animes sur AniList",
+  "malImportResolvingManga": "Vérification des mangas sur AniList",
+  "malImportWishlisted": "{count} ajoutés à la liste de souhaits",
+  "@malImportWishlisted": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "malImportOverwriteExisting": "Écraser les entrées déjà existantes",
+  "malImportOverwriteExistingHint": "Si désactivé, les titres déjà présents dans la collection gardent leurs statut, note, progression, dates et commentaires. Les nouveaux titres sont tout de même importés.",
+  "malImportFailedLookup": "{count} omis (AniList injoignable)",
+  "@malImportFailedLookup": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "malImportRateLimitWait": "Limite de débit d'AniList atteinte — nouvelle tentative dans {seconds}s (tentative {attempt}/{max})",
+  "@malImportRateLimitWait": {
+    "placeholders": {
+      "seconds": {"type": "int"},
+      "attempt": {"type": "int"},
+      "max": {"type": "int"}
+    }
+  },
+  "malImportInvalidFile": "Impossible d'analyser le fichier XML : {error}",
+  "@malImportInvalidFile": {
+    "placeholders": {
+      "error": {"type": "String"}
+    }
+  },
+  "malImportFilePicked": "Choisi : {kind} ({count, plural, =1{1 entrée} other{{count} entrées}})",
+  "@malImportFilePicked": {
+    "placeholders": {
+      "kind": {"type": "String"},
+      "count": {"type": "int"}
+    }
+  },
+
+  "settingsAniListImport": "AniList",
+  "settingsAniListImportSubtitle": "Importez des listes d'animes/mangas via un nom d'utilisateur publique",
+  "settingsHardcoverImportSubtitle": "Importez une bibliothèque depuis hardcover.app via un nom d'utilisateur",
+  "hardcoverImportTitle": "Importation Hardcover",
+  "hardcoverImportSubtitle": "Récupère la bibliothèque d'un utilisateur depuis hardcover.app — seules les données publiques seront visibles par les autres utilisateurs.",
+  "hardcoverImportTokenMissing": "Le token API Hardcover n'est pas configuré. Ajoutez-le dans Paramètres → Identifiants.",
+  "aniListImportTitle": "Importation AniList",
+  "aniListImportSubtitle": "Récupère des listes publiques depuis anilist.co — aucune connexion requise",
+  "aniListImportUsername": "Nom d'utilisateur AniList",
+  "aniListImportInclude": "Ce que vous pouvez importer",
+  "aniListImportModeOverwriteSubtitle": "Mettez à jour la progression, le statut et les dates de vos titres depuis AniList",
+  "aniListImportNewCollectionDefault": "Importation AniList — {username}",
+  "@aniListImportNewCollectionDefault": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportFetchingAnime": "Récupération de la liste d'animes...",
+  "aniListImportFetchingManga": "Récupération de la liste de mangas...",
+  "aniListImportUserNotFound": "L'utilisateur \"{username}\" n'a pas été trouvé sur AniList",
+  "@aniListImportUserNotFound": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportPrivateProfile": "Le profil de \"{username}\" sur AniList est privé",
+  "@aniListImportPrivateProfile": {
+    "placeholders": {
+      "username": {"type": "String"}
+    }
+  },
+  "aniListImportEmptyUsername": "Entrez votre nom d'utilisateur AniList",
+  "aniListImportSelectAtLeastOne": "Sélectionnez les animes ou mangas à importer",
+
+  "settingsCustomCardsImport": "Cartes personnalisées",
+  "settingsCustomCardsImportSubtitle": "Importez des cartes depuis un fichier JSON ou CSV",
+  "customImportTitle": "Importer des cartes personnalisées",
+  "customImportDescription": "Chargez un fichier JSON ou CSV généré par votre propre script ou parser — chaque rangée devient une carte personnalisée. Téléchargez un modèle pour voir tous les champs et les valeurs supportés.",
+  "customImportSelectFile": "Sélectionner un fichier JSON/CSV",
+  "customImportCsvTemplate": "Modèle CSV",
+  "customImportJsonTemplate": "Modèle JSON",
+  "customImportTemplateSaved": "Modèle sauvegardé",
+  "customImportPreviewButton": "Aperçu et importer",
+  "customImportPreviewTitle": "Aperçu de l'importation",
+  "customImportSummary": "Reconnus {valid} · Erreurs {errors} · Doublons {duplicates}",
+  "@customImportSummary": {
+    "placeholders": {
+      "valid": {"type": "int"},
+      "errors": {"type": "int"},
+      "duplicates": {"type": "int"}
+    }
+  },
+  "customImportSelectNone": "Tout déselectionner",
+  "customImportSelectedCount": "{selected} sélectionné sur {total}",
+  "@customImportSelectedCount": {
+    "placeholders": {
+      "selected": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "customImportDuplicate": "Doublon — déjà dans la collection",
+  "customImportRowLabel": "Rangée {index}",
+  "@customImportRowLabel": {
+    "placeholders": {
+      "index": {"type": "int"}
+    }
+  },
+  "customImportStart": "Importer la selection",
+  "customImportImporting": "Importation des cartes personnalisées...",
+  "customImportErrorEmptyFile": "Le fichier est vide",
+  "customImportErrorInvalidJson": "JSON invalide — le fichier n'a pas pu être analysé",
+  "customImportErrorMissingColumns": "Le fichier CSV doit contenir des colonnes \"title\" et \"type\"",
+  "customImportIssueNotAnObject": "Pas un objet JSON",
+  "customImportIssueMissingTitle": "\"title\" manquant",
+  "customImportIssueMissingType": "\"type\" manquant",
+  "customImportIssueUnknownType": "Type inconnu : {value}",
+  "@customImportIssueUnknownType": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueInvalidNumber": "Valeur invalide dans \"{field}\": {value}",
+  "@customImportIssueInvalidNumber": {
+    "placeholders": {
+      "field": {"type": "String"},
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueUnknownStatus": "Statut inconnu : {value}",
+  "@customImportIssueUnknownStatus": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueUnknownFormat": "Format inconnu : {value}",
+  "@customImportIssueUnknownFormat": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueFormatNotApplicable": "\"format\" est utilisé seulement par les animes et les mangas",
+  "customImportIssueInvalidCover": "\"cover\" doit être une URL http(s)",
+  "customImportIssueInvalidDate": "Date invalide dans \"{field}\": {value} (format YYYY-MM-DD attendu)",
+  "@customImportIssueInvalidDate": {
+    "placeholders": {
+      "field": {"type": "String"},
+      "value": {"type": "String"}
+    }
+  },
+  "customImportIssueInvalidBool": "\"favorite\" doit être vrai/faux : {value}",
+  "@customImportIssueInvalidBool": {
+    "placeholders": {
+      "value": {"type": "String"}
+    }
+  },
+
+  "moodGridCreate": "Créer une grille d'humeur",
+  "moodGridCreateTitle": "Nouvelle grille d'humeur",
+  "moodGridPresetAboutMe": "À propos de moi : Tonkatsu Box",
+  "moodGridPresetAboutMeSubtitle": "1×5 — jeu, film, série, anime et manga favoris",
+  "moodGridPresetBlank": "Vide",
+  "moodGridPresetBlankSubtitle": "Une grille vide avec la taille de votre choix",
+  "moodGridRows": "Rangées",
+  "moodGridBadge": "Grille d'humeur",
+  "moodGridDeleteTitle": "Supprimer cette grille ?",
+  "moodGridDeleteMessage": "Cette grille sera supprimée. La suppression est définitive.",
+  "moodGridAddRow": "Ajouter une rangée",
+  "moodGridRemoveRow": "Retirer une rangée",
+  "moodGridAddCol": "Ajouter une colonne",
+  "moodGridRemoveCol": "Retirer une colonne",
+  "moodGridShrinkTitle": "Rétrécir la grille ?",
+  "moodGridShrinkMessage": "Les cellules en dehors des nouvelles limites seront supprimées.",
+  "moodGridShrinkConfirm": "Rétrécir",
+  "moodGridEditLabel": "Modifier l'étiquette",
+  "moodGridLabelHint": "Nom de catégorie",
+  "moodGridPickItem": "Sélectionner un titre",
+  "moodGridReplaceItem": "Remplacer le titre",
+  "moodGridClearItem": "Effacer le titre",
+  "moodGridCaptionTemplate": "Légendes de rangée",
+  "moodGridCaptionTemplateHint": "Modèle appliqué à chaque cellule. Utilisable : nom, année, genre, note.",
+  "moodGridCellLabelTemplate": "Étiquettes de la cellule",
+  "moodGridCellSize": "Taille",
+  "collection": "Collection",
+  "moodGridPickerAllCollections": "Toutes les collections",
+  "moodGridPickerSearchHint": "Rechercher par nom",
+  "moodGridPickerEmpty": "Rien à sélectionner",
+  "screenScraperSection": "API ScreenScraper",
+  "screenScraperSourceDesc": "Métadonnées de jeux + médias (jacquettes, captures d'écran, illustrations)",
+  "screenScraperUserCredsHint": "Identifiants utilisateur (ssid / sspassword). Un quota est attribué à chaque utilisateur.",
+  "screenScraperSsidLabel": "ssid",
+  "screenScraperSsidPlaceholder": "Votre identifiant ScreenScraper",
+  "screenScraperSspasswordLabel": "sspassword",
+  "screenScraperSspasswordPlaceholder": "Votre mot de passe ScreenScraper",
+  "screenScraperCheckQuota": "Vérifier le quota",
+  "screenScraperRequestsToday": "Nombre de requêtes ce jour",
+  "screenScraperPerMinLimit": "Limite par minute",
+  "screenScraperParallelThreads": "Threads parallèles",
+  "screenScraperAccountLevel": "Niveau du compte",
+  "screenScraperGalleryTitle": "Médias ScreenScraper",
+  "screenScraperScreenshotsTitle": "Captures d'écran",
+  "screenScraperLoading": "Chargement des médias ScreenScraper…",
+  "screenScraperError": "Erreur ScreenScraper : {message}",
+  "@screenScraperError": {
+    "placeholders": {
+      "message": {"type": "String"}
+    }
+  },
+  "screenScraperMediaBox": "Boîte",
+  "screenScraperMediaBoxBack": "Boîte (noire)",
+  "screenScraperMediaBox3D": "Boîte 3D",
+  "screenScraperMediaWheel": "Roue",
+  "screenScraperMediaMarquee": "Marquee",
+  "screenScraperMediaTitle": "Titre",
+  "screenScraperMediaScreenshot": "Capture d'écran",
+  "screenScraperMediaFanart": "Fanart",
+  "screenScraperMediaMix": "Mix",
+  "genreCloudTitle": "Personnalisation",
+  "genreCloudEmpty": "Aucun genre pour l'instant",
+  "genreCloudEmptyHint": "Ajoutez des titres avec des genres pour créer un cloud",
+  "genreCloudExportImage": "Sauvegarder en tant qu'image",
+  "genreCloudExportFailed": "Impossible de sauvegarder l'image",
+  "genreCloudResetView": "Recentrer",
+  "genreCloudHidden": "{count, plural, =1{1 caché (ne correspondait pas)} other{{count} cachés (ne correspondaient pas)}}",
+  "@genreCloudHidden": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "facetPlatform": "Plateformes",
+  "facetDecade": "Décennies",
+  "personalizationTabCloud": "Cloud",
+  "recommendationsEmpty": "Aucune recommandation pour l'instant",
+  "recommendationsEmptyHint": "Terminez et notez quelques films ou séries pour obtenir des recommandations",
+  "recommendationsNoCandidates": "Aucune nouvelle suggestion",
+  "recommendationsNoCandidatesHint": "Nous n'avons rien trouvé de nouveau à vous suggérer. Réessayez plus tard !",
+  "recommendationsNoApiKey": "Clé API TMDB requise",
+  "recommendationsNoApiKeyHint": "Ajoutez votre clé API TMDB dans Paramètres pour obtenir des recommandations",
+  "recommendationsBecauseLabel": "Parce que vous avez aimé",
+  "recommendationsCount": "{count, plural, =1{1 recommandation} other{{count} recommandations}}",
+  "@recommendationsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+
+  "itemMarkLike": "J'aime",
+  "itemMarkNote": "Commentaire",
+  "itemMarkNoteHint": "Écrire un commentaire…",
+  "itemMarkSectionTitle": "Commentaires et mentions J'aime",
+  "itemMarkAdd": "Ajouter un signe",
+  "itemMarkEmpty": "Aucun signe pour l'instant",
+  "itemMarkNumber": "Nombre",
+  "itemMarkNumberHint": "ex : 12",
+  "itemMarkNumberHelper": "Requis pour sauvegarder",
+  "itemMarkCustomType": "Type personnalisé",
+  "itemMarkFilterLiked": "J'aime",
+  "itemMarkFilterCommented": "Avec commentaires",
+  "itemMarkUnitLabel": "{type} {number}",
+  "@itemMarkUnitLabel": {
+    "placeholders": {
+      "type": {"type": "String"},
+      "number": {"type": "int"}
+    }
+  },
+  "itemMarkEpisodeShort": "S{season}·E{episode}",
+  "@itemMarkEpisodeShort": {
+    "placeholders": {
+      "season": {"type": "int"},
+      "episode": {"type": "int"}
+    }
+  },
+  "unitEpisode": "Épisode",
+  "unitSeason": "Saison",
+  "unitChapter": "Chapitre",
+  "unitVolume": "Tome",
+  "unitPage": "Page",
+  "unitPart": "Partie",
+  "cardLinkCopy": "Copier le lien de la carte",
+  "cardLinkCopied": "Lien de la carte copié",
+  "cardLinkNotFound": "Carte introuvable",
+  "cardLinkSearchTitle": "Partager une carte",
+  "cardLinkSearchHint": "Rechercher des cartes",
+  "shortcutsDialogTitle": "Raccourcis clavier",
+  "shortcutsGroupNavigation": "Navigation",
+  "shortcutSwitchTab": "Changer d'onglet",
+  "shortcutNextTab": "Onglet suivant",
+  "shortcutPreviousTab": "Onglet précédent",
+  "shortcutThisHelp": "Peut aider",
+  "shortcutCreateCollection": "Créer une collection",
+  "shortcutImportCollection": "Importer une collection",
+  "shortcutToggleView": "Alterner affichage",
+  "shortcutDeleteCollection": "Supprimer la collection",
+  "shortcutRenameCollection": "Renommer la collection",
+  "shortcutAddItems": "Ajouter des titres",
+  "shortcutExportCollection": "Exporter la collection",
+  "shortcutImportIntoCollection": "Importer dans la collection",
+  "shortcutToggleBoard": "Alterner Tableau/Canvas",
+  "shortcutDeleteItem": "Supprimer le titre",
+  "shortcutMoveItem": "Déplacer le titre",
+  "shortcutsGroupItemDetail": "Détails du titre",
+  "shortcutLockCanvas": "Vérrouiller/dévérrouiller le tableau",
+  "shortcutMoveToCollection": "Déplacer vers la collection",
+  "shortcutSetRating": "Noter",
+  "shortcutResetRating": "Réinitialiser la note",
+  "shortcutsGroupTierLists": "Tier lists",
+  "shortcutCreateTierList": "Créer une tier list",
+  "shortcutOpenTierList": "Ouvrir tier list",
+  "shortcutDeleteTierList": "Supprimer la tier list",
+  "shortcutsGroupTierList": "Tier list",
+  "shortcutAddItem": "Ajouter un titre",
+  "shortcutToggleCompleted": "Montrer/cacher complétés",
+  "shortcutClearCompleted": "Effacer complétés",
+  "shortcutFocusSearchField": "Focus sur la barre de recherche",
+  "shortcutClearOrBack": "Effacer / précédent",
+  "shortcutRunSearch": "Lancer la recherche",
+  "debugKeyEvents": "Événements des touches/boutons",
+  "settingsGamepadDebugSubtitle": "Enregistrer les codes des boutons de la manette"
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart' as intl;
 
 import 'app_localizations_en.dart';
 import 'app_localizations_es.dart';
+import 'app_localizations_fr.dart';
 import 'app_localizations_pt.dart';
 import 'app_localizations_ru.dart';
 import 'app_localizations_zh.dart';
@@ -98,6 +99,7 @@ abstract class S {
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
     Locale('es'),
+    Locale('fr'),
     Locale('pt'),
     Locale('ru'),
     Locale('zh'),
@@ -9178,8 +9180,14 @@ class _SDelegate extends LocalizationsDelegate<S> {
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['en', 'es', 'pt', 'ru', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+    'en',
+    'es',
+    'fr',
+    'pt',
+    'ru',
+    'zh',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_SDelegate old) => false;
@@ -9192,6 +9200,8 @@ S lookupS(Locale locale) {
       return SEn();
     case 'es':
       return SEs();
+    case 'fr':
+      return SFr();
     case 'pt':
       return SPt();
     case 'ru':

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1,0 +1,5247 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for French (`fr`).
+class SFr extends S {
+  SFr([String locale = 'fr']) : super(locale);
+
+  @override
+  String get appName => 'Tonkatsu Box';
+
+  @override
+  String get navMain => 'Accueil';
+
+  @override
+  String get navCollections => 'Collections';
+
+  @override
+  String get navWishlist => 'Liste de souhaits';
+
+  @override
+  String get navSettings => 'Paramètres';
+
+  @override
+  String get navReleases => 'Sorties';
+
+  @override
+  String get releasesEmpty => 'Aucune série suivie';
+
+  @override
+  String get releasesEmptyHint =>
+      'Cliquez sur la cloche sur une série ou un anime pour suivre les nouvelles sorties.';
+
+  @override
+  String get releasesTrackShow => 'Suivre les sorties';
+
+  @override
+  String get releasesUntrackShow => 'Arrêter de suivre';
+
+  @override
+  String get releasesViewDay => 'Jour';
+
+  @override
+  String get releasesViewWeek => 'Semaine';
+
+  @override
+  String get releasesViewMonth => 'Mois';
+
+  @override
+  String get releasesTabCalendar => 'Calendrier';
+
+  @override
+  String get releasesTabAll => 'Toutes les sorties';
+
+  @override
+  String get releasesToday => 'Aujourd\'hui';
+
+  @override
+  String get refresh => 'Rafraîchir';
+
+  @override
+  String get releasesNoEpisodes => 'Pas d\'épisodes';
+
+  @override
+  String releasesEpisode(int season, int episode) {
+    return 'Saison $season · Épisode $episode';
+  }
+
+  @override
+  String get calendarAdd => 'Ajouter au calendrier';
+
+  @override
+  String get calendarRemove => 'Retirer du calendrier';
+
+  @override
+  String get date => 'Date';
+
+  @override
+  String get calendarRepeat => 'Répéter';
+
+  @override
+  String get recurrenceOnce => 'Une fois';
+
+  @override
+  String get recurrenceWeekly => 'Hebdomadaire';
+
+  @override
+  String get recurrenceMonthly => 'Mensuel';
+
+  @override
+  String get statusNotStarted => 'Pas commencé';
+
+  @override
+  String get statusPlaying => 'Commencé';
+
+  @override
+  String get statusWatching => 'Commencé';
+
+  @override
+  String get statusInProgress => 'En cours';
+
+  @override
+  String get statusCompleted => 'Terminé';
+
+  @override
+  String get statusDropped => 'Abandonné';
+
+  @override
+  String get statusPlanned => 'Planifié';
+
+  @override
+  String get statusReplay => 'Recommencé';
+
+  @override
+  String get rewatchCountEdit => 'Nombre de re-vues';
+
+  @override
+  String get rewatchCountHint => 'Vide = non suivi';
+
+  @override
+  String get statusReplaying => 'Rejouer';
+
+  @override
+  String get statusRewatching => 'Revisionnage';
+
+  @override
+  String get statusRereading => 'Relecture';
+
+  @override
+  String get all => 'Tout';
+
+  @override
+  String get mediaTypeGame => 'Jeu';
+
+  @override
+  String get mediaTypeMovie => 'Film';
+
+  @override
+  String get mediaTypeTvShow => 'Série';
+
+  @override
+  String get mediaTypeAnimation => 'Animation';
+
+  @override
+  String get mediaTypeVisualNovel => 'Visual Novel';
+
+  @override
+  String get mediaTypeManga => 'Manga';
+
+  @override
+  String get mediaTypeAnime => 'Anime';
+
+  @override
+  String get mediaTypeBook => 'Livre';
+
+  @override
+  String get mediaTypeCustom => 'Personnalisé';
+
+  @override
+  String get sortManualDisplay => 'Manuel';
+
+  @override
+  String get sortManualDesc => 'Ordre personnalisé';
+
+  @override
+  String get sortDateDisplay => 'Date d\'ajout';
+
+  @override
+  String get sortDateDesc => 'Date d\'ajout (↓)';
+
+  @override
+  String get status => 'Statut';
+
+  @override
+  String get sortStatusDesc => 'Actif (↓)';
+
+  @override
+  String get name => 'Nom';
+
+  @override
+  String get sortNameShort => 'A à Z';
+
+  @override
+  String get rating => 'Note';
+
+  @override
+  String get sortRatingDesc => 'Note (↓)';
+
+  @override
+  String get sortFavoriteDesc => 'Favoris (↓)';
+
+  @override
+  String get sortExternalRatingDisplay => 'Note des sources';
+
+  @override
+  String get sortExternalRatingShort => 'IGDB/TMDB';
+
+  @override
+  String get sortLastActivityDisplay => 'Dernière activité';
+
+  @override
+  String get sortLastActivityShort => 'Activité';
+
+  @override
+  String get sortLastActivityDesc => 'Activité (↓)';
+
+  @override
+  String get sortStartDateDisplay => 'Date de début';
+
+  @override
+  String get sortStartDateShort => 'Commencé';
+
+  @override
+  String get sortCompletionDateDisplay => 'Date de fin';
+
+  @override
+  String get sortCompletionDateShort => 'Terminé';
+
+  @override
+  String get sortDateOldest => 'Date d\'ajout (↑)';
+
+  @override
+  String get sortStatusFinished => 'Terminé(s) (↓)';
+
+  @override
+  String get sortRatingLowest => 'Note (↑)';
+
+  @override
+  String get sortFavoriteLast => 'Favoris (↑)';
+
+  @override
+  String get searchSortRelevanceShort => 'Pert.';
+
+  @override
+  String get searchSortRatingShort => 'Note';
+
+  @override
+  String get searchSortRatingDisplay => 'Note';
+
+  @override
+  String get cancel => 'Annuler';
+
+  @override
+  String get confirm => 'OK';
+
+  @override
+  String get restore => 'Restaurer';
+
+  @override
+  String get create => 'Créer';
+
+  @override
+  String get save => 'Sauvegarder';
+
+  @override
+  String get add => 'Ajouter';
+
+  @override
+  String get delete => 'Supprimer';
+
+  @override
+  String get rename => 'Renommer';
+
+  @override
+  String get retry => 'Réessayer';
+
+  @override
+  String get edit => 'Modifier';
+
+  @override
+  String get done => 'Fait';
+
+  @override
+  String get clear => 'Effacer';
+
+  @override
+  String get reset => 'Réinitialiser';
+
+  @override
+  String get search => 'Rechercher';
+
+  @override
+  String get open => 'Ouvrir';
+
+  @override
+  String get remove => 'Retirer';
+
+  @override
+  String get moveToTop => 'Placer en haut';
+
+  @override
+  String get moveToBottom => 'Placer en bas';
+
+  @override
+  String get favorite => 'Favori';
+
+  @override
+  String get addToFavorites => 'Ajouter aux favoris';
+
+  @override
+  String get removeFromFavorites => 'Retirer des favoris';
+
+  @override
+  String bulkSelected(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sélectionnés',
+      one: '1 sélectionné',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bulkClearSelection => 'Effacer la sélection';
+
+  @override
+  String get selectAll => 'Tout sélectionner';
+
+  @override
+  String get bulkMove => 'Ajouter la sélection à la collection';
+
+  @override
+  String get bulkCopy => 'Copier la sélection et placer dans la collection';
+
+  @override
+  String get bulkChangeStatus => 'Changer statut';
+
+  @override
+  String bulkRemoveConfirm(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count titres',
+      one: '1 titre',
+    );
+    return 'Retirer $_temp0 de cette collection ?';
+  }
+
+  @override
+  String bulkResult(int done, int skipped) {
+    return 'Fait: $done • Doublon(s): $skipped';
+  }
+
+  @override
+  String bulkRemoved(int count) {
+    return 'Retiré(s): $count';
+  }
+
+  @override
+  String bulkStatusUpdated(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count titres',
+      one: '1 titre',
+    );
+    return 'Statut modifié pour $_temp0';
+  }
+
+  @override
+  String get bulkExportPngTitle => 'Exporter en PNG';
+
+  @override
+  String get columnsCount => 'Colonnes';
+
+  @override
+  String bulkExportPngItemsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count images',
+      one: '1 image',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String bulkExportPngItemsCountPreview(int total, int preview) {
+    String _temp0 = intl.Intl.pluralLogic(
+      total,
+      locale: localeName,
+      other: '$total images',
+      one: '1 image',
+    );
+    return '$_temp0 ($preview dans l\'aperçu)';
+  }
+
+  @override
+  String bulkExportPngPreparing(int done, int total) {
+    return 'Préparation des couvertures: $done / $total';
+  }
+
+  @override
+  String get bulkExportPngSave => 'Enregistrer en PNG';
+
+  @override
+  String get imageSaved => 'Image sauvegardée';
+
+  @override
+  String get bulkExportPngFailed => 'Impossible de sauvegarder l\'image';
+
+  @override
+  String get back => 'Retour';
+
+  @override
+  String get next => 'Suivant';
+
+  @override
+  String get skip => 'Passer';
+
+  @override
+  String get update => 'Mettre à jour';
+
+  @override
+  String get test => 'Test';
+
+  @override
+  String get close => 'Fermer';
+
+  @override
+  String get keep => 'Garder';
+
+  @override
+  String get change => 'Changer';
+
+  @override
+  String get settingsProfile => 'Auteur de la collection';
+
+  @override
+  String get settingsProfileSubtitle => 'Nom d\'auteur pour vos collections';
+
+  @override
+  String get settingsAuthorName => 'Nom d\'auteur';
+
+  @override
+  String get settingsCredentialsSubtitle =>
+      'Clés API pour IGDB, SteamGridDB et TMDB';
+
+  @override
+  String get settingsCacheSubtitle =>
+      'Mode hors-ligne et stockage des couvertures';
+
+  @override
+  String get settingsDatabaseSubtitle => 'Exporter, importer, réinitialiser';
+
+  @override
+  String get settingsTraktImportSubtitle =>
+      'Historique, notes, liste de visionnage';
+
+  @override
+  String get settingsKinoriumImport => 'Importer depuis Kinorium';
+
+  @override
+  String get settingsKinoriumImportSubtitle =>
+      'Films et séries via un fichier CSV';
+
+  @override
+  String get settingsDebug => 'Débug';
+
+  @override
+  String get settingsDebugSubtitle => 'Outils développeurs';
+
+  @override
+  String get settingsDebugSubtitleNoKey =>
+      'Ajoutez une clé API SteamGridDB pour accéder aux outils.';
+
+  @override
+  String get settingsLaboratory => 'Laboratoire';
+
+  @override
+  String get settingsLaboratoryCardDesigns => 'Designs des bannières';
+
+  @override
+  String get settingsLaboratoryCardDesignsSubtitle =>
+      'Mises en pages expérimentales des affiches';
+
+  @override
+  String get settingsHelp => 'Aide';
+
+  @override
+  String get settingsWelcomeGuide => 'Première utilisation';
+
+  @override
+  String get settingsWelcomeGuideSubtitle =>
+      'Première utilisation de Tonkatsu Box';
+
+  @override
+  String get settingsAbout => 'À propos';
+
+  @override
+  String get settingsVersion => 'Version';
+
+  @override
+  String get settingsCreditsLicenses => 'Crédits & Licences';
+
+  @override
+  String get settingsChangelog => 'Nouveautés';
+
+  @override
+  String get settingsChangelogEmpty => 'Aucune note de version disponible';
+
+  @override
+  String get settingsCreditsLicensesSubtitle =>
+      'TMDB, IGDB, SteamGridDB, licences open-source';
+
+  @override
+  String get settingsError => 'Erreur';
+
+  @override
+  String get settingsAppLanguage => 'Langue de l\'application';
+
+  @override
+  String get settingsConnections => 'Connexions';
+
+  @override
+  String get settingsApiKeys => 'Clés API';
+
+  @override
+  String settingsApiKeysValue(int active, int total) {
+    return '$active/$total';
+  }
+
+  @override
+  String get settingsAppearance => 'Apparence';
+
+  @override
+  String get settingsAppearanceSubtitle => 'Langue, affichage et contenu';
+
+  @override
+  String get settingsAppLanguageSubtitle => 'Langue de l\'interface';
+
+  @override
+  String get settingsContentLanguageSubtitle =>
+      'TMDB seulement pour l\'instant (films et séries)';
+
+  @override
+  String get settingsDataSources => 'Sources';
+
+  @override
+  String get settingsDataSourcesSubtitle => 'IGDB, TMDB, SteamGridDB';
+
+  @override
+  String get settingsApiKeysSubtitle =>
+      'Configurez la connexion aux bases de données';
+
+  @override
+  String get settingsStorage => 'Stockage';
+
+  @override
+  String get settingsStorageSubtitle => 'Cache (images) et base de données';
+
+  @override
+  String get settingsBackup => 'Sauvegarde';
+
+  @override
+  String get settingsBackupSubtitle => 'Sauvegarde complète et restauration';
+
+  @override
+  String get settingsBackupAll => 'Sauvegarder toutes les données';
+
+  @override
+  String get settingsBackupAllSubtitle =>
+      'Toutes les collections, liste de souhaits et paramètres';
+
+  @override
+  String get settingsRestoreBackup => 'Restaurer depuis une sauvegarde';
+
+  @override
+  String get settingsRestoreBackupSubtitle => 'Importer une sauvegarde';
+
+  @override
+  String backupSuccess(int collections, int items) {
+    return 'Sauvegarde effectuée: $collections collections, $items titres';
+  }
+
+  @override
+  String get restoreConfirmTitle => 'Restaurer la sauvegarde ?';
+
+  @override
+  String restoreConfirmBody(int collections, int items, int wishlist) {
+    return '$collections collections, $items titres, $wishlist souhaits';
+  }
+
+  @override
+  String get restoreConfirmHint =>
+      'Les collections existantes ne seront pas affectées';
+
+  @override
+  String get restoreSettings => 'Restaurer les paramètres';
+
+  @override
+  String get restoreWishlist => 'Restaurer la liste de souhaits';
+
+  @override
+  String restoreSuccess(int collections, int items) {
+    return 'Restauration effectuée : $collections collections, $items titres';
+  }
+
+  @override
+  String get restoreInvalidArchive => 'Erreur : mauvaise sauvegarde';
+
+  @override
+  String get restoreProgressTitle => 'Restauration de la sauvegarde';
+
+  @override
+  String get restoreProgressWarning =>
+      'Ne fermez pas l\'application. Cela peut prendre plusieurs minutes.';
+
+  @override
+  String get restoreStageReading => 'Lecture de la sauvegarde...';
+
+  @override
+  String restoreStageCollections(int current, int total) {
+    return 'Restauration des collections... ($current/$total)';
+  }
+
+  @override
+  String get restoreStageWishlist => 'Restauration de la liste de souhaits...';
+
+  @override
+  String get restoreStageSettings => 'Restauration des paramètres...';
+
+  @override
+  String get restoreStageFinalizing => 'Bientôt terminé...';
+
+  @override
+  String get settingsImport => 'Importer';
+
+  @override
+  String get settingsImportSubtitle =>
+      'Importer des collections depuis des services externes';
+
+  @override
+  String get settingsContentLanguage => 'Langue du contenu';
+
+  @override
+  String get settingsData => 'Données';
+
+  @override
+  String settingsCacheValue(String size) {
+    return '$size';
+  }
+
+  @override
+  String get credentialsTitle => 'Identifiants';
+
+  @override
+  String get credentialsWelcome => 'Bienvenue sur Tonkatsu Box !';
+
+  @override
+  String get credentialsWelcomeHint =>
+      'Pour commencer, vous devez inscrire vos identifiants API pour IGDB. Retrouvez vos Client ID et Client Secret sur la Console de développeur Twitch.';
+
+  @override
+  String get credentialsCopyTwitchUrl => 'Copier l\'URL de la Console Twitch';
+
+  @override
+  String credentialsUrlCopied(String url) {
+    return 'URL copiée : $url';
+  }
+
+  @override
+  String get credentialsIgdbSection => 'Identifiants pour l\'API IGDB';
+
+  @override
+  String get credentialsClientId => 'Client ID';
+
+  @override
+  String get credentialsClientIdHint => 'Entrez votre Twitch Client ID';
+
+  @override
+  String get credentialsClientSecret => 'Client Secret';
+
+  @override
+  String get credentialsClientSecretHint => 'Entrez votre Twitch Client Secret';
+
+  @override
+  String get credentialsConnectionStatus => 'Statut de connexion';
+
+  @override
+  String get credentialsPlatformsSynced => 'Plateformes synchronisées';
+
+  @override
+  String get credentialsPlatformsAvailable => 'Plateformes disponibles';
+
+  @override
+  String get credentialsLastSync => 'Dernière synchronisation';
+
+  @override
+  String get credentialsVerifyConnection => 'Vérifier connexion';
+
+  @override
+  String get credentialsRefreshPlatforms => 'Rafraîchir les plateformes';
+
+  @override
+  String get credentialsSteamGridDbSection => 'API SteamGridDB';
+
+  @override
+  String get credentialsApiKey => 'Clé API';
+
+  @override
+  String get credentialsUsingBuiltInKey => 'Utiliser la clé intégrée';
+
+  @override
+  String get credentialsEnterSteamGridDbKey =>
+      'Entrez votre clé API SteamGridDB';
+
+  @override
+  String get credentialsTmdbSection => 'API TMDB (Films et TV)';
+
+  @override
+  String get credentialsEnterTmdbKey => 'Entrez votre clé API TMDB (v3)';
+
+  @override
+  String get credentialsComicVineSection => 'API ComicVine (Comics)';
+
+  @override
+  String get credentialsEnterComicVineKey => 'Entrez votre clé API ComicVine';
+
+  @override
+  String get credentialsGoogleBooksSection => 'API Google Books (Livres)';
+
+  @override
+  String get credentialsEnterGoogleBooksKey =>
+      'Entrez votre clé API Google Books (optionnel)';
+
+  @override
+  String get credentialsHardcoverSection => 'API Hardcover (Livres)';
+
+  @override
+  String get credentialsEnterHardcoverKey => 'Entrez votre token API Hardcover';
+
+  @override
+  String get credentialsOwnKeyHint =>
+      'Pour de moins grandes restrictions d\'utilisation, nous recommandons l\'utilisation de vos propres clés API.';
+
+  @override
+  String get credentialsConnected => 'Connecté';
+
+  @override
+  String get credentialsConnectionError => 'Erreur de connexion';
+
+  @override
+  String get credentialsChecking => 'Vérification...';
+
+  @override
+  String get credentialsNotConnected => 'Pas connecté';
+
+  @override
+  String get credentialsEnterBoth =>
+      'Veuillez entrer votre Client ID et Client Secret';
+
+  @override
+  String get credentialsConnectedSynced =>
+      'Connexion établie, plateformes synchronisées !';
+
+  @override
+  String get credentialsConnectedSyncFailed =>
+      'Connecté, mais la synchronisation a échoué';
+
+  @override
+  String get credentialsPlatformsSyncedOk =>
+      'Plateformes synchronisées avec succès !';
+
+  @override
+  String get credentialsDownloadingLogos =>
+      'Téléchargement des logos de la plateforme...';
+
+  @override
+  String credentialsDownloadedLogos(int count) {
+    return 'Téléchargé $count logos';
+  }
+
+  @override
+  String get credentialsFailedDownloadLogos =>
+      'Échec lors du téléchargement des logos';
+
+  @override
+  String get credentialsApiKeySaved => 'Clé API sauvegardée';
+
+  @override
+  String get credentialsNoApiKey => 'Pas de clé API';
+
+  @override
+  String get credentialsResetToBuiltIn => 'Réutiliser la clé API intégrée';
+
+  @override
+  String get credentialsSteamGridDbKeyValid =>
+      'La clé API SteamGridDB est valide';
+
+  @override
+  String get credentialsSteamGridDbKeyInvalid =>
+      'La clé API SteamGridDB est invalide';
+
+  @override
+  String get credentialsTmdbKeyValid => 'La clé API TMDB est valide';
+
+  @override
+  String get credentialsTmdbKeyInvalid => 'La clé API TMDB est invalide';
+
+  @override
+  String get credentialsComicVineKeyValid => 'La clé API ComicVine est valide';
+
+  @override
+  String get credentialsComicVineKeyInvalid =>
+      'La clé API ComicVine est invalide';
+
+  @override
+  String get credentialsGoogleBooksKeyValid =>
+      'La clé API Google Books est valide';
+
+  @override
+  String get credentialsGoogleBooksKeyInvalid =>
+      'La clé API Google Books est invalide';
+
+  @override
+  String get credentialsHardcoverKeyValid => 'La clé API Hardcover est valide';
+
+  @override
+  String get credentialsHardcoverKeyInvalid =>
+      'La clé API Hardcover est invalide ou a expiré';
+
+  @override
+  String get credentialsEnterSteamGridDbKeyError =>
+      'Veuillez entrer une clé API SteamGridDB';
+
+  @override
+  String get credentialsEnterTmdbKeyError => 'Veuillez entrer une clé API TMDB';
+
+  @override
+  String get credentialsTmdbKeySaved => 'Clé API TMDB sauvegardée';
+
+  @override
+  String timeAgo(int value, String unit) {
+    return 'il y a $value $unit';
+  }
+
+  @override
+  String timeUnitDays(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'jours',
+      one: 'jour',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String timeUnitHours(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'heures',
+      one: 'heure',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String timeUnitMinutes(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'minutes',
+      one: 'minute',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get timeJustNow => 'À l\'instant';
+
+  @override
+  String get cacheTitle => 'Cache';
+
+  @override
+  String get cacheImageCache => 'Cache (images)';
+
+  @override
+  String get cacheOfflineMode => 'Mode hors ligne';
+
+  @override
+  String get cacheOfflineModeSubtitle =>
+      'Sauvegarder les images localement pour une utilisation hors ligne';
+
+  @override
+  String get cacheCacheFolder => 'Dossier cache';
+
+  @override
+  String get cacheSelectFolder => 'Sélectionnez un dossier';
+
+  @override
+  String get cacheCacheSize => 'Taille du cache';
+
+  @override
+  String get cacheClearCache => 'Retirer les images inutilisées';
+
+  @override
+  String get cacheClearCacheTitle => 'Retirer les images inutilisées ?';
+
+  @override
+  String get cacheClearCacheMessage =>
+      'Supprime les images téléchargées pour des médias inexistants dans les collections. Vos images importées seront conservées.';
+
+  @override
+  String get cacheFolderUpdated => 'Dossier cache mis à jour';
+
+  @override
+  String cacheOrphansRemoved(int count) {
+    return 'Images non utilisées supprimées : $count';
+  }
+
+  @override
+  String get cacheSelectFolderDialog =>
+      'Sélectionnez un dossier cache pour les images';
+
+  @override
+  String cacheCacheStats(int count, String size) {
+    return '$count fichiers, $size';
+  }
+
+  @override
+  String get databaseTitle => 'Base de données';
+
+  @override
+  String get databaseConfiguration => 'Configuration';
+
+  @override
+  String get databaseConfigSubtitle =>
+      'Exportez ou importez vos clés API et paramètres.';
+
+  @override
+  String get databaseExportConfig => 'Exporter configuration';
+
+  @override
+  String get databaseImportConfig => 'Importer configuration';
+
+  @override
+  String get databaseDangerZone => 'Danger Zone';
+
+  @override
+  String get databaseDangerZoneMessage =>
+      'Vide toutes les collections (jeux, films, séries et tableaux). Vos paramètres et clés API seront conservés.';
+
+  @override
+  String get databaseResetDatabase => 'Réinitialiser base de données';
+
+  @override
+  String get databaseResetTitle => 'Réinitialiser base de données ?';
+
+  @override
+  String get databaseResetMessage =>
+      'Cela supprimera de manière permanente toutes vos collections (jeux, films, séries), progressions des épisodes et les données du tableau.\n\nVos clés API et paramètres seront préservés.\n\nCette opération est irréversible.';
+
+  @override
+  String databaseConfigExported(String path) {
+    return 'Configuration exportée vers $path';
+  }
+
+  @override
+  String get databaseConfigImported => 'Configuration importée avec succès';
+
+  @override
+  String get databaseReset => 'Base de données réinitialisée';
+
+  @override
+  String get storageLocationTitle => 'Emplacement des données';
+
+  @override
+  String get storageLocationSubtitle =>
+      'Dossier qui héberge la base de données et les profils. Les dossiers liés à un service cloud (OneDrive, Syncthing) sont à éviter : la base de données pourrait être corrompue pendant l\'écriture. Pour transférer des données entre appareils, exportez depuis les menus.';
+
+  @override
+  String get storageLocationDangerWarning =>
+      'Attention : changer le dossier peut entraîner une perte de données. À faire en connaissance des risques.';
+
+  @override
+  String get storageLocationFolder => 'Dossier des données';
+
+  @override
+  String get storageLocationFallbackWarning =>
+      'Le dossier sélectionné est indisponible. Le dossier par défaut sera utilisé.';
+
+  @override
+  String get storageLocationChange => 'Changer de dossier';
+
+  @override
+  String get storageLocationReset => 'Revenir au dossier par défaut';
+
+  @override
+  String get storageLocationSelectDialog => 'Sélectionner dossier';
+
+  @override
+  String storageLocationNotWritable(String path) {
+    return 'Pas de permissions d\'écriture: $path';
+  }
+
+  @override
+  String get storageLocationPermissionTitle => 'Accès au stockage requis';
+
+  @override
+  String get storageLocationPermissionMessage =>
+      'Android a besoin de la permission \"Accéder aux fichiers\" pour un dossier personnalisé. Dans la liste, trouvez Tonkatsu Box, autorisez l\'accès, revenez en arrière et sélectionnez à nouveau le dossier.';
+
+  @override
+  String get storageLocationLegacyPermissionMessage =>
+      'Un dossier personnalisé requiert la permission pour accéder au stockage. Autorisez l\'accès dans les paramètres de l\'application, puis revenez ici et sélectionnez à nouveau le dossier.';
+
+  @override
+  String get storageLocationOpenSettings => 'Ouvrir paramètres';
+
+  @override
+  String get storageLocationDbTooNew =>
+      'La base de données de ce dossier a été créée par une version ultérieure de l\'application. Mettez l\'application à jour avant de procéder.';
+
+  @override
+  String get storageLocationDbCorrupted =>
+      'La base de données de ce dossier est corrompue ou incomplète. Si une synchronisation est en cours, réessayez plus tard.';
+
+  @override
+  String get storageLocationUseExistingTitle => 'Données existantes trouvées';
+
+  @override
+  String get storageLocationUseExistingMessage =>
+      'Le dossier sélectionné contient déjà une base de données. L\'application utilisera ces données après redémarrage.';
+
+  @override
+  String get storageLocationUseExistingConfirm => 'Utiliser ces données';
+
+  @override
+  String get storageLocationCopyTitle => 'Copier les données déjà présentes ?';
+
+  @override
+  String get storageLocationCopyMessage =>
+      'Le dossier sélectionné est vide. Vos collections seront copiées ici; les images sauvegardées seront téléchargées. Les données de l\'ancien dossier resteront intactes.';
+
+  @override
+  String get copy => 'Copier';
+
+  @override
+  String get storageLocationCopyImages => 'Copier aussi le cache d\'images';
+
+  @override
+  String get storageLocationCopyImagesHint =>
+      'Bannières et autres images — plus lourd, mais le nouveau dossier est accessible hors-ligne sans devoir le re-télécharger';
+
+  @override
+  String get storageLocationCopyError =>
+      'Impossible de copier les données vers le dossier sélectionné';
+
+  @override
+  String get storageLocationResetTitle =>
+      'Réinitialiser le dossier de données ?';
+
+  @override
+  String get storageLocationResetMessage =>
+      'L\'application réutilisera le dossier par défaut après redémarrage. Les données du dossier personnalisé resteront intactes.';
+
+  @override
+  String get storageLocationRestartTitle => 'Redémarrage requis';
+
+  @override
+  String get storageLocationRestartMessage =>
+      'Le nouveau dossier de données sera utilisé après redémarrage. Redémarrer maintenant ?';
+
+  @override
+  String get storageLocationRestartNow => 'Redémarrer';
+
+  @override
+  String get storageLocationRestartLater =>
+      'Le changement sera effectif après redémarrage';
+
+  @override
+  String get backupRestoreTile => 'Restaurer l\'ancienne base de données';
+
+  @override
+  String get backupNone => 'Aucune sauvegarde pour le moment';
+
+  @override
+  String get backupRestoreConfirmTitle =>
+      'Restaurer l\'ancienne base de données ?';
+
+  @override
+  String backupRestoreConfirmMessage(String date) {
+    return 'Les données actuelles seront remplacées par la sauvegarde du $date. Les données remplacées seront transformées en sauvegarde, restaurer encore une fois après ça les effacera.';
+  }
+
+  @override
+  String get backupRestored => 'Base de données restaurée';
+
+  @override
+  String get backupRestoreError =>
+      'Impossible de restaurer depuis la sauvegarde';
+
+  @override
+  String get backupRestartMessage =>
+      'Les données restaurées seront utilisées après redémarrage. Redémarrer maintenant ?';
+
+  @override
+  String get lanSyncTitle => 'Synchronisation réseau';
+
+  @override
+  String get lanSyncOpenTile => 'Appareils à proximité';
+
+  @override
+  String get lanSyncTileSubtitle =>
+      'Transférer des données entre appareils connectés au même réseau Wi-Fi';
+
+  @override
+  String lanSyncVisibleAs(String name) {
+    return 'Cet appareil est enregistré sous le nom $name';
+  }
+
+  @override
+  String get lanSyncNoDevices =>
+      'Aucun appareil trouvé. Accédez à cet écran sur les deux appareils connectés au réseau Wi-Fi. Les points d\'accès et les VPN bloquent cette fonction.';
+
+  @override
+  String get lanSyncPull => 'Cliquez pour obtenir les données';
+
+  @override
+  String get lanSyncReceiveTitle => 'Remplacer les données ?';
+
+  @override
+  String lanSyncReceiveMessage(
+    String device,
+    String date,
+    int collections,
+    int items,
+  ) {
+    return 'Les données de $device, $date: $collections collections, $items titres.\n\nLes données déjà présentes seront REMPLACÉES. Une sauvegarde sera stockée aux côtés de la base de données.';
+  }
+
+  @override
+  String get lanSyncReplace => 'Remplacer';
+
+  @override
+  String lanSyncWaiting(String name) {
+    return 'Confirmez la demande sur $name...';
+  }
+
+  @override
+  String get lanSyncIncomingTitle => 'Demande de données';
+
+  @override
+  String lanSyncIncomingMessage(String name) {
+    return '$name veut obtenir une copie de vos données. L\'autorisez-vous ?';
+  }
+
+  @override
+  String get lanSyncAllow => 'Autoriser';
+
+  @override
+  String get lanSyncDenied => 'L\'autre appareil a décliné la demande';
+
+  @override
+  String get lanSyncManifestError => 'Aucune réponse de l\'appareil';
+
+  @override
+  String get lanSyncStartError =>
+      'Impossible de démarrer le partage par réseau. Vérifiez votre connexion et réessayez.';
+
+  @override
+  String get lanSyncReceiveError => 'Impossible d\'obtenir les données';
+
+  @override
+  String get lanSyncTooNew =>
+      'Les données de cet appareil proviennent d\'une version plus récente de l\'application. Mettez votre application à jour.';
+
+  @override
+  String get lanSyncCorrupted =>
+      'Le transfert s\'est mal passé. Veuillez réessayer.';
+
+  @override
+  String get lanSyncReceived => 'Données reçues';
+
+  @override
+  String get lanSyncReceivingImages => 'Transfert des images...';
+
+  @override
+  String get lanSyncReceivingSettings => 'Transfert des paramètres...';
+
+  @override
+  String get lanSyncImportConfig => 'Transférer aussi les paramètres';
+
+  @override
+  String get lanSyncImportConfigSubtitle => 'Clés API incluses. Tout ou rien.';
+
+  @override
+  String get lanSyncImagesWarning =>
+      'Base de données reçue mais les images n\'ont pas pu être transférées';
+
+  @override
+  String get lanSyncRestartMessage =>
+      'Les données seront utilisées après redémarrage. Redémarrer maintenant ?';
+
+  @override
+  String get lanSyncFirewallNote =>
+      'Windows pourrait demander une permission au niveau du pare-feu lors du premier démarrage - autorisez l\'accès sur les réseaux privés.';
+
+  @override
+  String get folderPickerNewFolder => 'Nouveau dossier';
+
+  @override
+  String get folderPickerVolumeList => 'Périphériques de stockage';
+
+  @override
+  String get folderPickerInternalStorage => 'Stockage interne';
+
+  @override
+  String get folderPickerSelect => 'Sélectionner';
+
+  @override
+  String get folderPickerFolderName => 'Nom du dossier';
+
+  @override
+  String get folderPickerInvalidName => 'Nom du dossier non valide';
+
+  @override
+  String get folderPickerEmpty => 'Pas de sous-dossier';
+
+  @override
+  String get folderPickerReadError => 'Impossible de lire ce dossier';
+
+  @override
+  String get folderPickerCreateError => 'Impossible de créer un dossier';
+
+  @override
+  String get traktTitle => 'Import Trakt';
+
+  @override
+  String get traktImportFrom => 'Importer depuis Trakt.tv';
+
+  @override
+  String get traktImportDescription =>
+      'Téléchargez vos données depuis trakt.tv/users/YOU/data and sélectionnez le fichier ZIP ci-dessous.';
+
+  @override
+  String get traktZipFile => 'Fichier ZIP';
+
+  @override
+  String get traktSelectZipFile => 'Sélectionnez le fichier ZIP';
+
+  @override
+  String get traktSelectZipExport => 'Exporter un fichier ZIP Trakt';
+
+  @override
+  String get preview => 'Prévisualisation';
+
+  @override
+  String traktUser(String username) {
+    return 'Utilisateur Trakt : $username';
+  }
+
+  @override
+  String get traktWatchedMovies => 'Films regardés';
+
+  @override
+  String get traktWatchedShows => 'Séries regardées';
+
+  @override
+  String get traktRatedMovies => 'Films notés';
+
+  @override
+  String get traktRatedShows => 'Séries notées';
+
+  @override
+  String get traktWatchlist => 'Liste de lecture';
+
+  @override
+  String get importOptions => 'Options';
+
+  @override
+  String get traktImportWatched => 'Importer déjà regardés';
+
+  @override
+  String get traktImportWatchedDesc => 'Films et séries déjà regardés';
+
+  @override
+  String get traktImportRatings => 'Importer notes';
+
+  @override
+  String get traktImportRatingsDesc =>
+      'Applique les notes utilisateurs (1 à 10)';
+
+  @override
+  String get traktImportWatchlist => 'Importer liste de lecture';
+
+  @override
+  String get traktImportWatchlistDesc =>
+      'Ajoute à la liste de souhaits ou applique le statut planifié';
+
+  @override
+  String get importTargetCollection => 'Sélectionner collection';
+
+  @override
+  String get importUseExistingCollection => 'Utiliser une collection existante';
+
+  @override
+  String get importStart => 'Commencer l\'import';
+
+  @override
+  String get traktRequiresOwnTmdbKey =>
+      'Importer depuis Trakt requiert votre clé API TMDB. Ajoutez-la dans Paramètres → Identifiants.';
+
+  @override
+  String get traktInvalidExport => 'Export Trakt non valide';
+
+  @override
+  String get kinoriumImportFrom => 'Importer depuis Kinorium';
+
+  @override
+  String get kinoriumImportDescription =>
+      'Exportez votre liste depuis Kinorium (fichier CSV envoyé par e-mail) et sélectionnez-le ci-dessous.';
+
+  @override
+  String get kinoriumSelectCsvFile => 'Sélectionner fichier CSV';
+
+  @override
+  String get kinoriumSelectCsvExport => 'Exporter un fichier CSV Kinorium';
+
+  @override
+  String get kinoriumIsWatchlist => 'Ceci est un fichier \"Liste de lecture\"';
+
+  @override
+  String get kinoriumIsWatchlistDesc =>
+      'Importer tous les films et appliquer le statut planifié au lieu de regardé';
+
+  @override
+  String get kinoriumImportNotes => 'Importer acteurs et production';
+
+  @override
+  String get kinoriumImportNotesDesc =>
+      'Ajoute les réalisateurs et les acteurs aux commentaires';
+
+  @override
+  String get kinoriumImporting => 'Importation depuis Kinorium...';
+
+  @override
+  String get kinoriumRecommendOwnTmdbKey =>
+      'Conseil : une clé API TMDB personnelle est recommandée pour des gros imports (Paramètres → Clés API), mais reste optionnel — la clé intégrée fonctionne aussi.';
+
+  @override
+  String get kinoriumReasonNotFound => 'Introuvable sur TMDB';
+
+  @override
+  String get kinoriumReasonApiError =>
+      'Erreur renvoyée par TMDB ou limite d\'utilisation — réessayez plus tard';
+
+  @override
+  String kinoriumReasonUnsupportedType(String type) {
+    return 'Format non supporté : $type';
+  }
+
+  @override
+  String kinoriumReasonDuplicate(String title) {
+    return 'Doublon de \"$title\"';
+  }
+
+  @override
+  String traktImportedItems(int count) {
+    return 'Importé $count titres';
+  }
+
+  @override
+  String get traktImporting => 'Importation depuis Trakt';
+
+  @override
+  String get creditsTitle => 'Crédits';
+
+  @override
+  String get creditsDataProviders => 'Fournisseurs';
+
+  @override
+  String get creditsTmdbAttribution =>
+      'Ce produit utilise l\'API de TMDB mais n\'est ni approuvé ni certifié par TMDB.';
+
+  @override
+  String get creditsTvMazeAttribution =>
+      'Données pour les séries fournies par TVmaze.';
+
+  @override
+  String get creditsIgdbAttribution =>
+      'Données pour les jeux fournies par IGDB.';
+
+  @override
+  String get creditsSteamGridDbAttribution =>
+      'Illustrations fournies par SteamGridDB.';
+
+  @override
+  String get creditsVndbAttribution =>
+      'Données pour les visual novels fournies par VNDB.';
+
+  @override
+  String get creditsAniListAttribution =>
+      'Données pour les mangas fournies par AniList.';
+
+  @override
+  String get creditsMangaBakaAttribution =>
+      'Données pour les mangas fournies par MangaBaka.';
+
+  @override
+  String get creditsMangaDexAttribution =>
+      'Données pour les mangas fournies par MangaDex.';
+
+  @override
+  String get creditsKitsuAttribution =>
+      'Données pour les mangas fournies par Kitsu.';
+
+  @override
+  String get creditsOpenLibraryAttribution =>
+      'Données pour les livres fournies par Open Library (CC0 / ODbL).';
+
+  @override
+  String get creditsFantlabAttribution =>
+      'Données pour les livres fournies par Fantlab.';
+
+  @override
+  String get creditsComicVineAttribution =>
+      'Données pour les comics fournies par ComicVine (utilisation non-commerciale).';
+
+  @override
+  String get creditsGoogleBooksAttribution =>
+      'Données pour les livres fournies par Google Books.';
+
+  @override
+  String get creditsHardcoverAttribution =>
+      'Données pour les livres fournies par Hardcover.';
+
+  @override
+  String get creditsOpenSource => 'Open Source';
+
+  @override
+  String get creditsOpenSourceDesc =>
+      'Tonkatsu Box is gratuit et est un logiciel open source, publié sous la Licence MIT.';
+
+  @override
+  String get creditsViewLicenses => 'Voir les licences Open Source';
+
+  @override
+  String get creditsDiscord => 'Rejoignez-nous sur Discord !';
+
+  @override
+  String get collectionsImportCollection => 'Importer collection';
+
+  @override
+  String get collectionsNoCollectionsYet => 'Aucune collection pour l\'instant';
+
+  @override
+  String get collectionsNoCollectionsHint =>
+      'Cliquez sur + pour créer votre première collection\net commencer à organiser votre bibliothèque.';
+
+  @override
+  String get collectionsFailedToLoad => 'Impossible de charger les collections';
+
+  @override
+  String collectionsCount(int count) {
+    return 'Collections ($count)';
+  }
+
+  @override
+  String get collectionsUncategorized => 'Sans catégorie';
+
+  @override
+  String collectionsUncategorizedItems(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count titres',
+      one: '1 titre',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get editCollection => 'Modifier la collection';
+
+  @override
+  String get collectionsRenamed => 'Collection mise à jour';
+
+  @override
+  String collectionsFailedToRename(String error) {
+    return 'Impossible de sauvegarder : $error';
+  }
+
+  @override
+  String get collectionsDeleted => 'Collection supprimée';
+
+  @override
+  String collectionsFailedToDelete(String error) {
+    return 'Impossible de supprimer : $error';
+  }
+
+  @override
+  String collectionsFailedToCreate(String error) {
+    return 'Impossible de créer une collection : $error';
+  }
+
+  @override
+  String collectionsImported(String name, int count) {
+    return 'Importé \"$name\" possédant $count titres';
+  }
+
+  @override
+  String get collectionsImporting => 'Importer une collection';
+
+  @override
+  String get importTargetTitle => 'Importer vers...';
+
+  @override
+  String get importCreateNew => 'Créer une nouvelle collection';
+
+  @override
+  String get importUseExisting => 'Ajouter à une collection existante';
+
+  @override
+  String get importNoCollections => 'Aucune collection disponible';
+
+  @override
+  String get importSelectCollection => 'Sélectionner collection';
+
+  @override
+  String get importErrorLoadingCollections =>
+      'Impossible de charger les collections';
+
+  @override
+  String get importStartButton => 'Importer';
+
+  @override
+  String get importUsername => 'Nom d\'utilisateur';
+
+  @override
+  String get importUsernameHint => 'ex : votrepseudo';
+
+  @override
+  String get importMode => 'Mode';
+
+  @override
+  String get importModeNewOnly => 'Ajouter nouveautés';
+
+  @override
+  String get importModeNewOnlySubtitle =>
+      'Ignore les titres déjà présents dans votre collection';
+
+  @override
+  String get importModeOverwrite => 'Écrire par-dessus';
+
+  @override
+  String get importModeOverwriteSubtitle =>
+      'Met à jour la progression, les statuts et les dates depuis la source';
+
+  @override
+  String get importNewCollectionName => 'Nom de la collection';
+
+  @override
+  String importNewCollectionDefault(String source, String username) {
+    return 'Importation depuis $source — $username';
+  }
+
+  @override
+  String get importFetchingBooks => 'Récupération de la bibliothèque...';
+
+  @override
+  String get importAddingItems => 'Importer des titres';
+
+  @override
+  String importProcessingItem(String title) {
+    return 'Traitement : $title';
+  }
+
+  @override
+  String importImportedCount(int count) {
+    return '$count importés';
+  }
+
+  @override
+  String importUpdatedCount(int count) {
+    return '$count mis à jour';
+  }
+
+  @override
+  String importUserNotFound(String username) {
+    return 'Utilisateur \"$username\" introuvable';
+  }
+
+  @override
+  String get importEmptyUsername => 'Entrez un nom d\'utilisateur';
+
+  @override
+  String importFailed(String error) {
+    return 'Erreur lors de l\'importation : $error';
+  }
+
+  @override
+  String get collectionNotFound => 'Collection introuvable';
+
+  @override
+  String get collectionAddItems => 'Ajouter des titres';
+
+  @override
+  String get collectionSwitchToList => 'Passer à Liste';
+
+  @override
+  String get collectionSwitchToBoard => 'Passer à Tableau';
+
+  @override
+  String get collectionUnlockBoard => 'Déverrouiller le tableau';
+
+  @override
+  String get collectionLockBoard => 'Verrouiller le tableau';
+
+  @override
+  String get collectionExport => 'Exporter';
+
+  @override
+  String get collectionNoItemsYet => 'Vide pour le moment';
+
+  @override
+  String get collectionEmpty => 'Vider la collection';
+
+  @override
+  String get collectionEmptyAddHint =>
+      'Ajoutez des titres pour commencer à construire votre collection';
+
+  @override
+  String get collectionEmptyReadonly => 'Cette collection est vide.';
+
+  @override
+  String get collectionDeleteEmptyPrompt =>
+      'Cette collection est désormais vide. La supprimer ?';
+
+  @override
+  String get collectionRemoveItemTitle => 'Retirer ?';
+
+  @override
+  String collectionRemoveItemMessage(String name) {
+    return 'Retirer $name de cette collection ?';
+  }
+
+  @override
+  String get collectionMoveToCollection => 'Déplacer à une collection';
+
+  @override
+  String get collectionExportFormat => 'Format d\'exportation';
+
+  @override
+  String get collectionChooseExportFormat => 'Choisissez un format :';
+
+  @override
+  String get collectionExportLight => 'Léger (.xcoll)';
+
+  @override
+  String get collectionExportLightDesc => 'Titres seulement, petit fichier';
+
+  @override
+  String get collectionExportFull => 'Complet (.xcollx)';
+
+  @override
+  String get collectionExportFullDesc =>
+      'Avec les images et les toiles — fonctionne hors-ligne';
+
+  @override
+  String get collectionExportIncludeUserData => 'Inclure données personnelles';
+
+  @override
+  String get collectionExportIncludeUserDataDesc =>
+      'Statuts, dates, commentaires, progressions des épisodes';
+
+  @override
+  String get customItemCreate => 'Créer un titre personnalisé';
+
+  @override
+  String get title => 'Titre';
+
+  @override
+  String get customItemTitleHint => 'ex : Jeu fait maison';
+
+  @override
+  String get customItemAltTitle => 'Titre alternatif';
+
+  @override
+  String get customItemAltTitleHint => 'Titre original, par exemple';
+
+  @override
+  String get customItemCoverUrl => 'URL de l\'image';
+
+  @override
+  String get year => 'Année';
+
+  @override
+  String get genres => 'Genres';
+
+  @override
+  String get customItemGenresHint => 'ex : RPG, Action, Puzzle';
+
+  @override
+  String get platform => 'Plateforme';
+
+  @override
+  String get customItemPlatformHint => 'ex : PC, SNES, Personnalisé';
+
+  @override
+  String get format => 'Format';
+
+  @override
+  String get progress => 'Progression';
+
+  @override
+  String get customMarkCompleted => 'Marquer comme terminé';
+
+  @override
+  String get customUnitParts => 'Parties';
+
+  @override
+  String get customUnitEpisodes => 'Épisodes';
+
+  @override
+  String get customUnitChapters => 'Chapitres';
+
+  @override
+  String get customUnitPages => 'Pages';
+
+  @override
+  String get customUnitVolumes => 'Tomes';
+
+  @override
+  String get customUnitSeasons => 'Saisons';
+
+  @override
+  String get description => 'Description';
+
+  @override
+  String get customItemDescriptionHint => 'Courte description ou commentaires';
+
+  @override
+  String get customItemMyNoteHint => 'Votre commentaire à propos de ce titre';
+
+  @override
+  String get customItemTagsHint =>
+      'Séparés d\'une virgule, ex : Favoris, Pile de lecture';
+
+  @override
+  String get customItemOptionalFields => 'Champs supplémentaires';
+
+  @override
+  String get customItemEdit => 'Modifier titre personnalisé';
+
+  @override
+  String get customItemFillFromFile => 'Remplir depuis un fichier';
+
+  @override
+  String customItemFileMultipleRows(int count) {
+    return '$count entrées dans le fichier — la première a été utilisée';
+  }
+
+  @override
+  String get customItemFileNoValidRows =>
+      'Aucune entrée valide dans le fichier';
+
+  @override
+  String get customItemAddCover => 'Ajouter image';
+
+  @override
+  String get customItemCoverSource => 'Source de l\'image';
+
+  @override
+  String get customItemCoverRatio =>
+      'Ratio dimensions recommandé : 2:3 (ex : 600×900)';
+
+  @override
+  String get customItemCoverFromFile => 'Depuis un fichier';
+
+  @override
+  String get customItemSearchHint =>
+      'Rechercher ou entrer valeur personnalisée...';
+
+  @override
+  String get customItemUseCustom => 'Utiliser valeur personnalisée';
+
+  @override
+  String get customItemExternalUrl => 'URL externe';
+
+  @override
+  String get customItemErrorEmptyTitle => 'Titre requis';
+
+  @override
+  String get customItemCreated => 'Titre personnalisé créé';
+
+  @override
+  String get customItemUpdated => 'Titre personnalisé mis à jour';
+
+  @override
+  String get tagLabel => 'Tag';
+
+  @override
+  String get tagsLabel => 'Tags';
+
+  @override
+  String get tagCreate => 'Nouveau tag';
+
+  @override
+  String get tagCreateHint => 'Nom de tag';
+
+  @override
+  String tagCreateNamed(String name) {
+    return 'Créer \"$name\"';
+  }
+
+  @override
+  String get tagRename => 'Renommer tag';
+
+  @override
+  String get tagDelete => 'Supprimer tag';
+
+  @override
+  String tagDeleteConfirm(String name) {
+    return 'Supprimer le tag \"$name\"? Les titres perdront leur tag.';
+  }
+
+  @override
+  String get tagManage => 'Gérer les tags';
+
+  @override
+  String get tagAssign => 'Assigner les tags';
+
+  @override
+  String get tagNone => 'Pas de tags';
+
+  @override
+  String get tagPickerTitle => 'Sélectionner tags';
+
+  @override
+  String get tagTextColor => 'Couleur du texte';
+
+  @override
+  String get tagCreated => 'Tag créé';
+
+  @override
+  String get tagRenamed => 'Tag renommé';
+
+  @override
+  String get tagDeleted => 'Tag supprimé';
+
+  @override
+  String get tagUpdateFailed => 'Impossible de mettre à jour le tag';
+
+  @override
+  String get refreshItemFromApi => 'Rafraîchir depuis la source';
+
+  @override
+  String get refreshItemSuccess => 'Titre mis à jour depuis la source';
+
+  @override
+  String get refreshItemNotFound => 'La source ne liste plus ce titre';
+
+  @override
+  String get refreshItemUnsupported =>
+      'Les titres personnalisés n\'ont pas de source';
+
+  @override
+  String refreshItemFailed(String error) {
+    return 'Impossible de rafraîchir : $error';
+  }
+
+  @override
+  String get renameDialogHint => 'Nom d\'affichage';
+
+  @override
+  String renameOriginalLabel(String name) {
+    return 'Initial : $name';
+  }
+
+  @override
+  String get renameResetToOriginal => 'Revenir au nom initial';
+
+  @override
+  String get renameSaved => 'Renommé';
+
+  @override
+  String get tierListExportFailed => 'Impossible d\'exporter l\'image';
+
+  @override
+  String get browseCollectionsDownloadFailedGeneric =>
+      'Impossible de télécharger la collection';
+
+  @override
+  String get tagFilterAll => 'Tous les tags';
+
+  @override
+  String get tagSidebarGroup => 'Groupe';
+
+  @override
+  String get colorPickerTitle => 'Couleur';
+
+  @override
+  String get colorPickerNoColor => 'Pas de couleur';
+
+  @override
+  String get raLinkButton => 'Associer RetroAchievements';
+
+  @override
+  String get raLinkTitle => 'Trouver un jeu sur RetroAchievements';
+
+  @override
+  String get raLinkSearchHint => 'Rechercher par nom...';
+
+  @override
+  String raLinkLoading(String platform) {
+    return 'Chargement des jeux pour $platform...';
+  }
+
+  @override
+  String get raLinkNotFound => 'Aucune correspondance';
+
+  @override
+  String get raLinkSuccess => 'Jeu couplé à RetroAchievements';
+
+  @override
+  String raLinkAchievements(int count) {
+    return '$count succès';
+  }
+
+  @override
+  String get raUnlinkButton => 'Dissocier';
+
+  @override
+  String get raUnlinkTitle => 'Dissocier RetroAchievements';
+
+  @override
+  String get raUnlinkConfirm =>
+      'Dissocier RetroAchievements et supprimer les données pour ce jeu ?';
+
+  @override
+  String get collectionFilterByType => 'Filtrer par type';
+
+  @override
+  String get collectionFilterGames => 'Jeux';
+
+  @override
+  String get collectionFilterMovies => 'Films';
+
+  @override
+  String get collectionFilterTvShows => 'Séries';
+
+  @override
+  String get collectionFilterVisualNovels => 'Visual Novels';
+
+  @override
+  String get collectionFilterBooks => 'Livres';
+
+  @override
+  String get searchHint => 'Recherche...';
+
+  @override
+  String get sort => 'Trier';
+
+  @override
+  String get collectionFilterAscending => 'Ascendant';
+
+  @override
+  String get collectionFilterDescending => 'Descendant';
+
+  @override
+  String get collectionFilterFilters => 'Filtres';
+
+  @override
+  String get collectionFilterClearAll => 'Tout effacer';
+
+  @override
+  String collectionItemMovedTo(String name, String collection) {
+    return '$name déplacé vers $collection';
+  }
+
+  @override
+  String collectionItemAlreadyExists(String name, String collection) {
+    return '$name existe déjà dans $collection';
+  }
+
+  @override
+  String collectionItemRemoved(String name) {
+    return '$name retiré';
+  }
+
+  @override
+  String get boardTab => 'Tableau';
+
+  @override
+  String get imageAddedToBoard => 'Image ajoutée au tableau';
+
+  @override
+  String get mapAddedToBoard => 'Carte ajoutée au tableau';
+
+  @override
+  String get loading => 'Chargement...';
+
+  @override
+  String get gameNotFound => 'Jeu introuvable';
+
+  @override
+  String get movieNotFound => 'Film introuvable';
+
+  @override
+  String get tvShowNotFound => 'Série introuvable';
+
+  @override
+  String get animationNotFound => 'Film d\'animation introuvable';
+
+  @override
+  String get visualNovelNotFound => 'Visual novel introuvable';
+
+  @override
+  String get mangaNotFound => 'Manga introuvable';
+
+  @override
+  String get readingProgress => 'Progression lecture';
+
+  @override
+  String get mangaChapters => 'Chapitres';
+
+  @override
+  String get mangaVolumes => 'Tomes';
+
+  @override
+  String get mangaMarkCompleted => 'Marquer comme terminé';
+
+  @override
+  String get animeProgress => 'Progression';
+
+  @override
+  String get animeEpisodes => 'Épisodes';
+
+  @override
+  String get animeMarkCompleted => 'Marquer comme terminé';
+
+  @override
+  String get bookPages => 'Pages';
+
+  @override
+  String get bookIssues => 'Numéros';
+
+  @override
+  String get bookMarkCompleted => 'Marquer comme terminé';
+
+  @override
+  String animeNextEpisode(int episode) {
+    return 'L\'épisode $episode sort bientôt';
+  }
+
+  @override
+  String get animatedMovie => 'Film animé';
+
+  @override
+  String get animatedSeries => 'Série animée';
+
+  @override
+  String runtimeHoursMinutes(int hours, int minutes) {
+    return '${hours}h ${minutes}min';
+  }
+
+  @override
+  String runtimeHours(int hours) {
+    return '${hours}h';
+  }
+
+  @override
+  String runtimeMinutes(int minutes) {
+    return '${minutes}min';
+  }
+
+  @override
+  String totalSeasons(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count saisons',
+      one: '1 saison',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String totalEpisodes(int count) {
+    return '$count épisodes';
+  }
+
+  @override
+  String seasonName(int number) {
+    return 'Saison $number';
+  }
+
+  @override
+  String get episodeProgress => 'Progression épisode';
+
+  @override
+  String episodesWatchedOf(int watched, int total) {
+    return '$watched/$total regardé';
+  }
+
+  @override
+  String episodesWatched(int count) {
+    return '$count regardé';
+  }
+
+  @override
+  String seasonEpisodesProgress(int watched, int total) {
+    return '$watched/$total épisodes';
+  }
+
+  @override
+  String get noSeasonData => 'Aucune donnée sur la saison';
+
+  @override
+  String get refreshFromTmdb => 'Rafraîchir depuis TMDB';
+
+  @override
+  String get markAllWatched => 'Marquer tous les épisodes comme regardé';
+
+  @override
+  String get markNextWatched => 'Marquer le prochain épisode';
+
+  @override
+  String get unmarkAll => 'Retirer toutes les mentions regardé';
+
+  @override
+  String get noEpisodesFound => 'Aucun épisode trouvé';
+
+  @override
+  String episodeWatchedDate(String date) {
+    return 'regardé le $date';
+  }
+
+  @override
+  String get createCollectionTitle => 'Nouvelle collection';
+
+  @override
+  String get createCollectionNameLabel => 'Nom de la collection';
+
+  @override
+  String get createCollectionNameHint => 'ex : Classiques de  la SNES';
+
+  @override
+  String get createCollectionEnterName => 'Veuillez entrer un nom';
+
+  @override
+  String get createCollectionNameTooShort =>
+      'Le nom doit contenir au moins 2 caractères';
+
+  @override
+  String get renameCollectionTitle => 'Renommer la collection';
+
+  @override
+  String get deleteCollectionTitle => 'Supprimer la collection ?';
+
+  @override
+  String deleteCollectionMessage(String name) {
+    return 'Êtes-vous sûr de vouloir supprimer $name ?\n\nCette action est irréversible.';
+  }
+
+  @override
+  String get canvasAddText => 'Ajouter un texte';
+
+  @override
+  String get canvasAddImage => 'Ajouter une image';
+
+  @override
+  String get canvasAddLink => 'Ajouter un lien';
+
+  @override
+  String get canvasFindImages => 'Trouver des images...';
+
+  @override
+  String get canvasBrowseMaps => 'Parcourir des cartes...';
+
+  @override
+  String get canvasConnect => 'Connecter';
+
+  @override
+  String get canvasBringToFront => 'Amener au premier plan';
+
+  @override
+  String get canvasSendToBack => 'Envoyer à l\'arrière-plan';
+
+  @override
+  String get canvasEditConnection => 'Modifier connexion';
+
+  @override
+  String get canvasDeleteConnection => 'Supprimer connexion';
+
+  @override
+  String get canvasDeleteElement => 'Supprimer l\'élément';
+
+  @override
+  String get canvasDeleteElementMessage =>
+      'Êtes-vous sûr de vouloir supprimer cet élément ?';
+
+  @override
+  String get canvasAddToBoard => 'Ajouter au tableau';
+
+  @override
+  String get editTextTitle => 'Modifier le texte';
+
+  @override
+  String get textContentLabel => 'Contenu du texte';
+
+  @override
+  String get fontSizeLabel => 'Police (taille)';
+
+  @override
+  String get fontSizeSmall => 'Petit';
+
+  @override
+  String get fontSizeMedium => 'Moyen';
+
+  @override
+  String get fontSizeLarge => 'Grand';
+
+  @override
+  String get fontSizeTitle => 'Titre';
+
+  @override
+  String get editImageTitle => 'Modifier l\'image';
+
+  @override
+  String get imageFromUrl => 'Depuis une URL';
+
+  @override
+  String get imageFromFile => 'Depuis un fichier';
+
+  @override
+  String get imageUrlLabel => 'URL de l\'image';
+
+  @override
+  String get imageUrlHint => 'https://exemple.com/image.png';
+
+  @override
+  String get imageChooseFile => 'Choisir le fichier';
+
+  @override
+  String get imageChooseAnother => 'Choisir un autre';
+
+  @override
+  String get editLinkTitle => 'Modifier le lien';
+
+  @override
+  String get linkLabelOptional => 'Étiquette (optionnel)';
+
+  @override
+  String get linkLabelHint => 'Mon lien';
+
+  @override
+  String get connectionLabelHint => 'ex : dépend de..., lié à...';
+
+  @override
+  String get connectionStyleLabel => 'Style';
+
+  @override
+  String get connectionStyleSolid => 'Épais';
+
+  @override
+  String get connectionStyleDashed => 'Discontinu';
+
+  @override
+  String get connectionStyleArrow => 'Flèche';
+
+  @override
+  String get searchTabTv => 'TV';
+
+  @override
+  String get searchHintMovies => 'Rechercher des films...';
+
+  @override
+  String get searchHintTv => 'Rechercher des séries...';
+
+  @override
+  String get searchHintAnime => 'Rechercher des animes...';
+
+  @override
+  String get searchHintGames => 'Rechercher des jeux...';
+
+  @override
+  String get searchHintVisualNovels => 'Rechercher des visual novels...';
+
+  @override
+  String get searchSourceVisualNovels => 'V. Novels';
+
+  @override
+  String get searchSourceOpenLibrary => 'OpenLibrary';
+
+  @override
+  String get searchSourceFantlab => 'Fantlab';
+
+  @override
+  String get searchSourceComics => 'Comics';
+
+  @override
+  String get searchHintManga => 'Rechercher des mangas';
+
+  @override
+  String get searchHintBooks => 'Rechercher des livres...';
+
+  @override
+  String get searchHintComics => 'Rechercher des comics...';
+
+  @override
+  String get language => 'Langue';
+
+  @override
+  String get bookFilterSearchBy => 'Rechercher par';
+
+  @override
+  String get type => 'Type';
+
+  @override
+  String get bookSearchAuthor => 'Auteur';
+
+  @override
+  String get bookSearchSubject => 'Sujet';
+
+  @override
+  String get bookSimilarTitle => 'Livres similaires';
+
+  @override
+  String get bookMoreByAuthorTitle => 'Plus de cet auteur';
+
+  @override
+  String get bookTitleCopied => 'Titre copié';
+
+  @override
+  String get editionPickerTitle => 'Choisir l\'édition';
+
+  @override
+  String get editionPickerEmpty => 'Aucune édition trouvée';
+
+  @override
+  String get fantlabTypeNovel => 'Roman';
+
+  @override
+  String get fantlabTypeNovella => 'Roman court';
+
+  @override
+  String get fantlabTypeShortStory => 'Nouvelle';
+
+  @override
+  String get fantlabTypeCycle => 'Cycle';
+
+  @override
+  String get searchSelectPlatform => 'Sélectionner plateforme';
+
+  @override
+  String get searchAddToCollection => 'Ajouter à la collection';
+
+  @override
+  String searchAddedToCollection(String name) {
+    return '$name ajouté à la collection';
+  }
+
+  @override
+  String searchAddedToNamed(String name, String collection) {
+    return '$name ajouté à $collection';
+  }
+
+  @override
+  String searchAlreadyInCollection(String name) {
+    return '$name déjà dans la collection';
+  }
+
+  @override
+  String searchAlreadyInNamed(String name, String collection) {
+    return '$name déjà dans $collection';
+  }
+
+  @override
+  String searchAddedToCollections(String name, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count collections',
+      one: '1 collection',
+    );
+    return '$name ajouté à $_temp0';
+  }
+
+  @override
+  String searchAlreadyInCollections(String name) {
+    return '$name déjà dans les collections sélectionnées';
+  }
+
+  @override
+  String get goToSettings => 'Aller dans les Paramètres';
+
+  @override
+  String get searchMinCharsHint =>
+      'Entrez au moins 2 caractères et appuyez sur Entrer';
+
+  @override
+  String get searchNoResults => 'Aucun résultat';
+
+  @override
+  String searchNothingFoundFor(String query) {
+    return 'Aucun résultat pour \"$query\"';
+  }
+
+  @override
+  String get searchNoInternet => 'Pas de connexion Internet';
+
+  @override
+  String get searchFailed => 'Échec de la recherche';
+
+  @override
+  String get searchCheckConnection => 'Vérifiez votre connexion et réessayez.';
+
+  @override
+  String get copyErrorDetails => 'Détails erreur de copie';
+
+  @override
+  String get errorDetailsCopied => 'Détails de l\'erreur copiés';
+
+  @override
+  String get errorDetailsTitle => 'Détails de l\'erreur';
+
+  @override
+  String get errorDetailsShow => 'Détails';
+
+  @override
+  String get showMore => 'Plus…';
+
+  @override
+  String get showLess => 'Fermer';
+
+  @override
+  String get platformFilterTitle => 'Sélectionner plateformes';
+
+  @override
+  String get platformFilterClearAll => 'Tout effacer';
+
+  @override
+  String get platformFilterSearchHint => 'Rechercher plateformes...';
+
+  @override
+  String selectedCount(int count) {
+    return '$count sélectionné(s)';
+  }
+
+  @override
+  String platformFilterCount(int count) {
+    return '$count plateformes';
+  }
+
+  @override
+  String get platformFilterShowAll => 'Montrer tout';
+
+  @override
+  String platformFilterApply(int count) {
+    return 'Appliquer ($count)';
+  }
+
+  @override
+  String get platformFilterNone => 'Aucune plateforme trouvée';
+
+  @override
+  String get platformFilterTryDifferent => 'Essayez un autre terme';
+
+  @override
+  String get wishlistHideResolved => 'Cacher collecté';
+
+  @override
+  String get wishlistShowResolved => 'Montrer collecté';
+
+  @override
+  String get wishlistClearResolved => 'Effacer collecté';
+
+  @override
+  String get wishlistEmpty => 'Aucun titre dans la liste de souhaits';
+
+  @override
+  String get wishlistEmptyHint =>
+      'Cliquez sur + pour ajouter quelque chose à votre liste';
+
+  @override
+  String get wishlistDeleteItem => 'Supprimer titre';
+
+  @override
+  String wishlistDeletePrompt(String name) {
+    return 'Supprimer \"$name\" de votre liste de souhaits ?';
+  }
+
+  @override
+  String wishlistClearResolvedMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Supprimer $count titres collectés ?',
+      one: 'Supprimer 1 titre collecté ?',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get wishlistMarkResolved => 'Marquer en collecté';
+
+  @override
+  String get wishlistUnresolve => 'Plus collecté';
+
+  @override
+  String get wishlistTitleHint => 'Nom de jeu, film ou série...';
+
+  @override
+  String get wishlistTitleMinChars => 'Au moins 2 caractères';
+
+  @override
+  String get wishlistTypeOptional => 'Type (optionnel)';
+
+  @override
+  String get any => 'Tout';
+
+  @override
+  String get wishlistNoteOptional => 'Commentaire (optionnel)';
+
+  @override
+  String get wishlistNoteHint => 'Plateforme, année, recommandé par...';
+
+  @override
+  String get wishlistTagOptional => 'Tag (optionnel)';
+
+  @override
+  String get wishlistTagHint =>
+      'Entrées groupées — ex : une importation par batch ou une source';
+
+  @override
+  String get wishlistTagUntagged => 'Retirer tag';
+
+  @override
+  String get wishlistTagFilterLabel => 'Liste';
+
+  @override
+  String get wishlistTagManage => 'Gérer le tag';
+
+  @override
+  String get wishlistTagDelete => 'Supprimer le tag et toutes les entrées';
+
+  @override
+  String wishlistTagDeleteConfirm(String tag, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count entrées',
+      one: '1 entrée',
+    );
+    return 'Supprimer le tag \"$tag\" et $_temp0?';
+  }
+
+  @override
+  String wishlistBulkActionsButton(int count) {
+    return '$count correspondances';
+  }
+
+  @override
+  String get wishlistBulkApplyTag => 'Appliquer un tag aux entrées visibles';
+
+  @override
+  String wishlistBulkApplyTagHint(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Tagger les $count entrées visibles en tant que',
+      one: 'Tagger l\'entrée visible en tant que',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get wishlistBulkRemoveTag => 'Supprimer un tag des entrées visibles';
+
+  @override
+  String get wishlistBulkDelete => 'Supprimer des entrées visibles';
+
+  @override
+  String wishlistBulkDeleteConfirm(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Supprimer $count entrées visibles ?',
+      one: 'Supprimer 1 entrée visible ?',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get apply => 'Appliquer';
+
+  @override
+  String get welcomeStepWelcome => 'Bienvenue';
+
+  @override
+  String get welcomeStepReady => 'Prêt !';
+
+  @override
+  String get welcomeNameTitle => 'Comment vous appelez-vous ?';
+
+  @override
+  String get welcomeNameSubtitle =>
+      'Votre nom apparaîtra en tant qu\'auteur des collections que vous créerez';
+
+  @override
+  String get welcomeChangeLaterHint =>
+      'Vous pouvez le changer plus tard dans les Paramètres';
+
+  @override
+  String get welcomeLanguageTitle => 'Choisissez votre langue';
+
+  @override
+  String get welcomeLanguageSubtitle =>
+      'Sélectionnez la langue de l\'interface';
+
+  @override
+  String get welcomeTitle => 'Tonkatsu Box vous souhaite la bienvenue';
+
+  @override
+  String get welcomeSubtitle =>
+      'Organisez vos collections de jeux, films,\nséries, animes, visual novels, mangas et livres';
+
+  @override
+  String get welcomeWhatYouCanDo => 'Ce que vous pouvez faire';
+
+  @override
+  String get welcomeFeatureCollections =>
+      'Créer des collections par plateforme, genre ou n\'importe quel thème';
+
+  @override
+  String get welcomeFeatureSearch =>
+      'Rechercher des jeux, films, séries, animes, visual novels, mangas & livres via des API';
+
+  @override
+  String get welcomeFeatureTracking =>
+      'Marquer votre progression, noter de 1 à 10, ajouter des commentaires';
+
+  @override
+  String get welcomeFeatureBoards =>
+      'Tableaux canvas visuels avec des illustrations';
+
+  @override
+  String get welcomeFeatureExport =>
+      'Exporter et importer — partager vos collections avec vos amis';
+
+  @override
+  String get welcomeWorksWithoutKeys => 'Fonctionne sans clés API';
+
+  @override
+  String get welcomeChipImport => 'Importer .xcoll';
+
+  @override
+  String get welcomeChipCanvas => 'Tableaux canvas';
+
+  @override
+  String get welcomeChipRatings => 'Notes et commentaires';
+
+  @override
+  String get welcomeApiKeysHint =>
+      'Les clés API sont seulement nécessaires pour rechercher des nouveaux jeux, films et séries. Vous pouvez importer des collections et les utiliser hors-ligne.';
+
+  @override
+  String get welcomeChipGames => 'Jeux (IGDB)';
+
+  @override
+  String get welcomeChipMovies => 'Films (TMDB)';
+
+  @override
+  String get welcomeChipTvShows => 'Séries (TMDB)';
+
+  @override
+  String get welcomeChipAnime => 'Animes (TMDB)';
+
+  @override
+  String get welcomeChipVisualNovels => 'Visual Novels (VNDB)';
+
+  @override
+  String get welcomeChipManga => 'Mangas (AniList)';
+
+  @override
+  String get welcomeApiTitle => 'Obtenir des clés API';
+
+  @override
+  String get welcomeApiFreeHint =>
+      'Inscriptions gratuites, prend 2 à 3 minutes pour chaque site';
+
+  @override
+  String get welcomeApiIgdbTag => 'IGDB';
+
+  @override
+  String get welcomeApiIgdbDesc => 'Recherche de jeux';
+
+  @override
+  String get welcomeApiRequired => 'REQUIS';
+
+  @override
+  String get welcomeApiTmdbTag => 'TMDB';
+
+  @override
+  String get welcomeApiTmdbDesc => 'Films, séries et animes';
+
+  @override
+  String get welcomeApiComicVineDesc => 'Comics et romans graphiques';
+
+  @override
+  String get welcomeApiGoogleBooksDesc => 'Catalogue de livres de Google';
+
+  @override
+  String get welcomeApiHardcoverDesc =>
+      'Catalogue communautaire de livres, nécessite un token personnel';
+
+  @override
+  String get welcomeApiRecommended => 'RECOMMANDÉ';
+
+  @override
+  String get welcomeApiSgdbTag => 'SGDB';
+
+  @override
+  String get welcomeApiSgdbDesc => 'Illustrations de jeux pour les tableaux';
+
+  @override
+  String get welcomeApiOptional => 'OPTIONNEL';
+
+  @override
+  String get welcomeApiBuiltInKey => 'CLÉ INTÉGRÉE';
+
+  @override
+  String get welcomeApiOwnKeyHint =>
+      'Vous pouvez ajouter vos propres clés plus tard dans Paramètres pour augmenter les limites d\'utilisation';
+
+  @override
+  String get welcomeApiEnterKeysHint =>
+      'Entrez les clés dans Paramètres → Identifiants plus tard';
+
+  @override
+  String get welcomeApiRateLimitHint =>
+      'Les clés intégrées sont partagées entre tous les utilisateurs et ont une limite d\'utilisation. Pour une meilleure expérience, utilisez vos propres clés — c\'est gratuit et prend seulement quelques minutes.';
+
+  @override
+  String get welcomeHowTitle => 'Comment ça fonctionne';
+
+  @override
+  String get welcomeHowAppStructure => 'Structure de l\'application';
+
+  @override
+  String get welcomeHowMainDesc =>
+      'Toutes vos collections sur une seule page. Filtrez par type, rangez par note.';
+
+  @override
+  String get welcomeHowCollectionsDesc =>
+      'Vos collections. Créez, organisez, gérez. Affichage liste ou grille, différent pour chaque collection.';
+
+  @override
+  String get welcomeHowTierListsDesc =>
+      'Classez et comparez des titres depuis vos collections grâce à des tier lists personnalisées.';
+
+  @override
+  String get welcomeHowWishlistDesc =>
+      'Courte liste des titres à vérifier plus tard. Pas besoin d\'API.';
+
+  @override
+  String get welcomeHowSearchDesc =>
+      'Trouvez des jeux, films, séries, visual novels et mangas via les API. Ajoutez les à n\'importe quelle collection.';
+
+  @override
+  String get welcomeHowSettingsDesc =>
+      'Clés API, cache, exporter/importer base de données, outils debugging.';
+
+  @override
+  String get welcomeHowPersonalizationDesc =>
+      'Tous vos intêrets dans une seule page : un cloud de vos genres favoris, ainsi que des recommandations mises en avant en comparant vos notes.';
+
+  @override
+  String get welcomeHowQuickStart => 'Démarrage rapide';
+
+  @override
+  String get welcomeHowStep1 =>
+      'Allez dans Paramètres → Identifiants, entrez vos clés API';
+
+  @override
+  String get welcomeHowStep2 =>
+      'Cliquez sur Vérifier connexion, attendez que les plateformes se synchronisent';
+
+  @override
+  String get welcomeHowStep3 =>
+      'Allez dans Collections → + Nouvelle collection';
+
+  @override
+  String get welcomeHowStep4 =>
+      'Nommez-la, puis Ajouter des titres → Rechercher → Ajouter';
+
+  @override
+  String get welcomeHowStep5 =>
+      'Notez, suivez votre progression, ajoutez des commentaires — vous êtes prêt !';
+
+  @override
+  String get welcomeHowSharing => 'Partager';
+
+  @override
+  String get welcomeHowSharingDesc1 =>
+      'Exporter des collections, deux formats : ';
+
+  @override
+  String get welcomeHowSharingDesc2 => ' (léger, métadonnées seulement) ou ';
+
+  @override
+  String get welcomeHowSharingDesc3 =>
+      ' (complet, images et canvas — fonctionne hors-ligne). Importer grâce à vos amis — pas besoin d\'API !';
+
+  @override
+  String get welcomeReadyTitle => 'Vous êtes prêt !';
+
+  @override
+  String get welcomeReadyMessage =>
+      'Allez dans Paramètres → Identifiants pour ajouter vos clés API ou commencer en important une collection.';
+
+  @override
+  String get welcomeReadySkip => 'Passer — explorez l\'application vous-même';
+
+  @override
+  String get welcomeReadyReturnHint =>
+      'Vous pouvez toujours revoir ce tutoriel depuis les Paramètres';
+
+  @override
+  String get welcomeStepSources => 'Sources';
+
+  @override
+  String get welcomeStepTour => 'Visite';
+
+  @override
+  String get welcomeChipBooks => 'Livres (OpenLibrary, Fantlab)';
+
+  @override
+  String get welcomeSourcesTitle => 'Provenance des données';
+
+  @override
+  String get welcomeSourcesSubtitle =>
+      'Ces fournisseurs alimentent la fonction recherche de l\'application. La plupart fonctionnent tout de suite — les autres demandant une clé API gratuite.';
+
+  @override
+  String get welcomeSourcesNoKeyNeeded => 'AUCUNE CLÉ NÉCESSAIRE';
+
+  @override
+  String get welcomeSourcesKeySaved => 'Clé sauvegardée';
+
+  @override
+  String get welcomeSourcesGetKey => 'Obtenir une clé';
+
+  @override
+  String get welcomeSourcesKeyOptionalHint =>
+      'Optionnel — votre clé augmente la limite d\'utilisation. La recherche fonctionne sans.';
+
+  @override
+  String get welcomeSourcesHardcoverTokenHint =>
+      'Requis — la recherche et l\'import sont désactivés par défaut. Les tokens expirent chaque 1er janvier.';
+
+  @override
+  String get welcomeSourceDescTmdb => 'Films, séries et films d\'animation.';
+
+  @override
+  String get welcomeSourceDescTvMaze => 'Séries.';
+
+  @override
+  String get welcomeSourceDescIgdb =>
+      'Jeux vidéos, toutes plateformes confondues.';
+
+  @override
+  String get welcomeSourceDescAniList =>
+      'Animes et mangas, métadonnées enrichies.';
+
+  @override
+  String get welcomeSourceDescMangaBaka =>
+      'Mangas, manhwas, manhuas et light novels.';
+
+  @override
+  String get welcomeSourceDescMangaDex =>
+      'Un large catalogue de mangas avec des titres traduits et un compteur de chapitres.';
+
+  @override
+  String get welcomeSourceDescKitsu =>
+      'Un catalogue indépendant de mangas avec des notes et des couvertures.';
+
+  @override
+  String get welcomeSourceDescVndb => 'Base de données pour les visual novels.';
+
+  @override
+  String get welcomeSourceDescOpenLibrary =>
+      'Catalogue de bibliothèque ouvert, des millions de livres.';
+
+  @override
+  String get welcomeSourceDescFantlab =>
+      'Catalogue détaillé de livres avec des notes, récompenses et cycles.';
+
+  @override
+  String get welcomeSourceDescComicVine =>
+      'Un large catalogue de comics et romans graphiques.';
+
+  @override
+  String get welcomeSourceDescGoogleBooks =>
+      'Des millions d\'éditions en provenance de Google Books, recherches par titre, auteur ou ISBN.';
+
+  @override
+  String get welcomeSourceDescHardcover =>
+      'Catalogue communautaire de livres listant des cycles, genres, humeurs et notes. Nécessite un token personnel (gratuit).';
+
+  @override
+  String get welcomeTourTitle => 'Apprenez à connaître le menu';
+
+  @override
+  String get welcomeTourSubtitle =>
+      'Une visite rapide de la navigation — cliquez sur Suivant pour passer à la suite.';
+
+  @override
+  String get welcomeTourStart => 'Explorez maintenant';
+
+  @override
+  String get welcomeHowReleasesDesc =>
+      'Nouveaux épisodes et sorties pour les séries et les jeux que vous suivez.';
+
+  @override
+  String updateAvailable(String version) {
+    return 'Mise à jour disponible : v$version';
+  }
+
+  @override
+  String updateCurrent(String version) {
+    return 'Actuelle : v$version';
+  }
+
+  @override
+  String get updateWarningTitle => 'Avant de mettre à jour';
+
+  @override
+  String get updateWarningBody =>
+      'Cette application est en développement. Les mises à jours peuvent inclure des migrations de base de données modifiant le format des données.\n\nVeuillez créer une sauvegarde avant de mettre à jour (Paramètres → Sauvegarde). Ainsi, vous pouvez restaurer vos données au moindre problème.';
+
+  @override
+  String get updateWarningProceed => 'Aller à la page de release';
+
+  @override
+  String get chooseCollection => 'Choisir collection';
+
+  @override
+  String get withoutCollection => 'Sans collection';
+
+  @override
+  String get detailMyRating => 'Ma note';
+
+  @override
+  String detailRatingValue(String rating) {
+    return '$rating/10';
+  }
+
+  @override
+  String get detailActivityProgress => 'Activité et progression';
+
+  @override
+  String get detailAuthorReview => 'Critique de l\'auteur';
+
+  @override
+  String get detailEditAuthorReview => 'Modifier la critique de l\'auteur';
+
+  @override
+  String get detailWriteReviewHint => 'Écrivez votre critique...';
+
+  @override
+  String get detailReviewVisibility =>
+      'Visible une fois partagé. Votre critique de ce titre.';
+
+  @override
+  String get detailNoReviewEditable =>
+      'Aucune critique. Cliquez sur Modifier pour en ajouter une.';
+
+  @override
+  String get detailNoReviewReadonly => 'Aucune critique écrite par l\'auteur.';
+
+  @override
+  String get detailMyNotes => 'Mes commentaires';
+
+  @override
+  String get detailEditMyNotes => 'Modifier mes commentaires';
+
+  @override
+  String get detailWriteNotesHint => 'Écrivez vos commentaires...';
+
+  @override
+  String get detailNoNotesYet =>
+      'Aucun commentaire. Cliquez sur Modifier pour ajouter des commentaires.';
+
+  @override
+  String get detailNoNotesReadonly => 'Aucun commentaire de l\'auteur.';
+
+  @override
+  String get unknownGame => 'Jeu inconnu';
+
+  @override
+  String get unknownMovie => 'Film inconnu';
+
+  @override
+  String get unknownTvShow => 'Série inconnue';
+
+  @override
+  String get unknownAnimation => 'Film d\'animation inconnu';
+
+  @override
+  String get unknownVisualNovel => 'Visual novel inconnu';
+
+  @override
+  String get unknownManga => 'Manga inconnu';
+
+  @override
+  String get unknownCustom => 'Titre personnalisé inconnu';
+
+  @override
+  String get unknownPlatform => 'Plateforme inconnue';
+
+  @override
+  String get defaultAuthor => 'Utilisateur';
+
+  @override
+  String errorPrefix(String error) {
+    return 'Erreur : $error';
+  }
+
+  @override
+  String get allItemsRatingAsc => 'Note ↑';
+
+  @override
+  String get allItemsRatingDesc => 'Note ↓';
+
+  @override
+  String get allItemsNoItems => 'Aucun titre';
+
+  @override
+  String get allItemsNoMatch => 'Aucun titre ne correspond aux filtres';
+
+  @override
+  String get allItemsAddViaCollections =>
+      'Allez dans Collections → créer une collection → ajouter des titres\nvia Recherche. Ils apparaitront ici automatiquement.';
+
+  @override
+  String get allItemsFailedToLoad => 'Impossible de charger les titres';
+
+  @override
+  String get allPlatforms => 'Toutes les plateformes';
+
+  @override
+  String get allItemsFilterPlatformsTitle => 'Filtrer par plateforme';
+
+  @override
+  String get debugIgdbMedia => 'IGDB Media';
+
+  @override
+  String get debugGamepad => 'Manette';
+
+  @override
+  String get debugClearLogs => 'Effacer journal';
+
+  @override
+  String get debugRawEvents => 'Évènements bruts (Gamepads.events)';
+
+  @override
+  String get debugServiceEvents => 'Évènements service (filtré)';
+
+  @override
+  String debugEventsCount(int count) {
+    return '$count évènements';
+  }
+
+  @override
+  String get debugPressButton =>
+      'Appuyez sur n\'importe\nquel bouton sur la manette...';
+
+  @override
+  String get debugExportLog => 'Exporter journal';
+
+  @override
+  String debugLogExported(String path) {
+    return 'Journal exporté vers $path';
+  }
+
+  @override
+  String get debugLogEmpty => 'Aucun event à exporter';
+
+  @override
+  String get settingsGamepadDebug => 'Debug manette';
+
+  @override
+  String get debugSearchGames => 'Rechercher des jeux';
+
+  @override
+  String get debugEnterGameName => 'Entrez un nom de jeu';
+
+  @override
+  String get debugEnterGameNameHint =>
+      'Entrez un nom de jeu pour lancer la recherche';
+
+  @override
+  String get debugGameId => 'ID du jeu';
+
+  @override
+  String get debugEnterGameId => 'Entrez une ID SteamGridDB';
+
+  @override
+  String debugLoadTab(String tabName) {
+    return 'Charger $tabName';
+  }
+
+  @override
+  String debugEnterGameIdHint(String tabName) {
+    return 'Entrez l\'ID d\'un jeu et cliquez sur Charger $tabName';
+  }
+
+  @override
+  String get debugNoImagesFound => 'Aucune image trouvée';
+
+  @override
+  String collectionTileStats(int count, String percent) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count titres',
+      one: '1 titre',
+    );
+    return '$_temp0 · $percent terminé';
+  }
+
+  @override
+  String get collectionTileError =>
+      'Erreur lors du chargement des statistiques';
+
+  @override
+  String get activityDatesTitle => 'Dates d\'activité';
+
+  @override
+  String get activityDatesAdded => 'Ajouté';
+
+  @override
+  String get activityDatesStarted => 'Commencé';
+
+  @override
+  String get activityDatesCompleted => 'Terminé';
+
+  @override
+  String get activityDatesSelectStart => 'Sélectionner une date de début';
+
+  @override
+  String get activityDatesSelectCompletion =>
+      'Sélectionner une date de complétion';
+
+  @override
+  String get settingsDateFormat => 'Format de la date';
+
+  @override
+  String get settingsDateFormatSubtitle =>
+      'Comment les dates sont affichées dans l\'application';
+
+  @override
+  String get settingsAnimeMangaTitleLanguage =>
+      'Langue des titres pour les animes et mangas';
+
+  @override
+  String get settingsAnimeMangaTitleLanguageSubtitle =>
+      'Titre affiché pour les animes et mangas';
+
+  @override
+  String get settingsAnimeMangaTitleLanguageRomaji => 'Romaji';
+
+  @override
+  String get settingsAnimeMangaTitleLanguageEnglish => 'Anglais';
+
+  @override
+  String get settingsAnimeMangaTitleLanguageNative => 'Original';
+
+  @override
+  String get dualDatePickerErrorEmpty => 'Entrez une date';
+
+  @override
+  String get dualDatePickerErrorFormat => 'Utilisez ce format : aaaa-MM-jj';
+
+  @override
+  String get dualDatePickerErrorRange => 'La date n\'est pas valide';
+
+  @override
+  String activityDatesCompletionTime(String duration) {
+    return 'Complété en $duration';
+  }
+
+  @override
+  String get timeSpentTitle => 'Temps écoulé';
+
+  @override
+  String get timeSpentAdd => 'Ajouter une durée';
+
+  @override
+  String get timeSpentEdit => 'Modifier temps';
+
+  @override
+  String get timeSpentHours => 'Heures';
+
+  @override
+  String get timeSpentMinutes => 'Minutes';
+
+  @override
+  String get durationLessThanDay => 'moins d\'un jour';
+
+  @override
+  String get durationOneDay => '1 jour';
+
+  @override
+  String durationDays(int count) {
+    return '$count jours';
+  }
+
+  @override
+  String durationWeeks(int count) {
+    return '$count semaines';
+  }
+
+  @override
+  String durationMonths(int count) {
+    return '$count mois';
+  }
+
+  @override
+  String durationYears(String count) {
+    return '$count années';
+  }
+
+  @override
+  String get canvasFailedToLoad => 'Impossible de charger le tableau';
+
+  @override
+  String get canvasBoardEmpty => 'Le tableau est vide';
+
+  @override
+  String get canvasBoardEmptyHint =>
+      'Ajoutez des titres à la collection d\'abord';
+
+  @override
+  String get canvasCenterView => 'Centrer affichage';
+
+  @override
+  String get canvasResetPositions => 'Réinitialiser les positions';
+
+  @override
+  String get canvasVgmapsBrowser => 'Navigateur VGMaps';
+
+  @override
+  String get canvasSteamGridDbImages => 'Images SteamGridDB';
+
+  @override
+  String get steamGridDbPanelTitle => 'SteamGridDB';
+
+  @override
+  String get closePanel => 'Fermer panneau';
+
+  @override
+  String get steamGridDbSearchHint => 'Recherche un jeu...';
+
+  @override
+  String get steamGridDbNoApiKey =>
+      'La clé API SteamGridDB n\'a pas été fournie. Configurez dans les Paramètres.';
+
+  @override
+  String get steamGridDbBackToSearch => 'Retour à la recherche';
+
+  @override
+  String get steamGridDbGrids => 'Grids';
+
+  @override
+  String get steamGridDbHeroes => 'Heroes';
+
+  @override
+  String get steamGridDbLogos => 'Logos';
+
+  @override
+  String get steamGridDbIcons => 'Icons';
+
+  @override
+  String get steamGridDbSearchFirst => 'Recherchez un jeu d\'abord';
+
+  @override
+  String get vgmapsBack => 'Retour';
+
+  @override
+  String get vgmapsForward => 'Suivant';
+
+  @override
+  String get vgmapsHome => 'Accueil';
+
+  @override
+  String get vgmapsReload => 'Recharger';
+
+  @override
+  String get vgmapsCaptureImage => 'Enregistrer l\'image de la carte';
+
+  @override
+  String get vgmapsSearchHint => 'Rechercher un jeu sur VGMaps...';
+
+  @override
+  String get vgmapsDismiss => 'Rejeter';
+
+  @override
+  String vgmapsFailedInit(String error) {
+    return 'Impossible de démarrer WebView : $error';
+  }
+
+  @override
+  String get discoverTitle => 'Découvrir';
+
+  @override
+  String get discoverCustomize => 'Personnaliser';
+
+  @override
+  String get discoverTrending => 'Populaire cette semaine';
+
+  @override
+  String get discoverTopRatedMovies => 'Films les mieux notés';
+
+  @override
+  String get discoverTopRatedTvShows => 'Séries les mieux notées';
+
+  @override
+  String get discoverPopularTvShows => 'Séries populaires';
+
+  @override
+  String get discoverUpcoming => 'À venir';
+
+  @override
+  String get discoverCustomizeTitle => 'Personnaliser Découvrir';
+
+  @override
+  String get discoverCustomizeHint => 'Choisissez quelles sections montrer';
+
+  @override
+  String get discoverResetDefault => 'Réinitialiser l\'affichage';
+
+  @override
+  String get discoverAlreadyInCollection => 'Déjà dans la collection';
+
+  @override
+  String get discoverShowWithBadge => 'Montrer avec un badge';
+
+  @override
+  String get discoverHideCompletely => 'Cacher totalement';
+
+  @override
+  String get recommendationsTitle => 'Recommandations';
+
+  @override
+  String get reviewsTitle => 'Critiques';
+
+  @override
+  String reviewsShowAll(int count) {
+    return 'Montrer les $count critiques';
+  }
+
+  @override
+  String get reviewsReadMore => 'Lire plus';
+
+  @override
+  String get reviewsInEnglish => 'Critiques en anglais';
+
+  @override
+  String get settingsShowRecommendationsSubtitle =>
+      'Films et séries similaires sur les pages de détails';
+
+  @override
+  String get settingsHideEmptyMediaTypeChevrons =>
+      'Cacher les filtres sans contenu';
+
+  @override
+  String get settingsHideEmptyMediaTypeChevronsSubtitle =>
+      'Cache les filtres (Jeux, Films, etc.) qui ne contiennent aucun titre du même type.';
+
+  @override
+  String get settingsAlwaysShowSubcategories =>
+      'Toujours montrer les sous-catégories';
+
+  @override
+  String get settingsAlwaysShowSubcategoriesSubtitle =>
+      'Montre les filtres de sous-catégories (plateformes de jeux, genres de mangas/animes) sans sélectionner leur type en premier lieu.';
+
+  @override
+  String get settingsShowPlatformOverlay =>
+      'Jacquettes des plateformes de jeux';
+
+  @override
+  String get settingsShowPlatformOverlaySubtitle =>
+      'Montrer le logo de la plateforme sur la jacquette des jeux (PS5, Switch, etc.)';
+
+  @override
+  String get settingsShowBlurayOverlay => 'Jacquettes Blu-ray';
+
+  @override
+  String get settingsShowBlurayOverlaySubtitle =>
+      'Montrer le logo Blu-ray sur la jacquette des films et des séries';
+
+  @override
+  String get settingsRichCollections => 'Vue enrichie des collections';
+
+  @override
+  String get settingsRichCollectionsSubtitle =>
+      'Personnalisez les collections avec des jacquettes et des descriptions';
+
+  @override
+  String get settingsCardScale => 'Taille jacquettes';
+
+  @override
+  String get settingsCardScaleSubtitle =>
+      'Taille des cartes dans les collections (mode grille)';
+
+  @override
+  String get collectionEditHeroImage => 'Bannière';
+
+  @override
+  String get collectionEditHeroImageHint =>
+      '2560×1080 recommandé (21:9). Sujet principal sur la droite — le côté gauche est recouvert par le titre — le bas disparaît dans le fond';
+
+  @override
+  String get collectionEditHeroPick => 'Choisir une image';
+
+  @override
+  String get collectionEditHeroReplace => 'Remplacer l\'image';
+
+  @override
+  String get collectionEditHeroRemove => 'Retirer l\'image';
+
+  @override
+  String get collectionEditDescriptionHint =>
+      'Un court slogan s\'affichant par-dessus la bannière';
+
+  @override
+  String get collectionEditDialogTitle => 'Paramètres de collection';
+
+  @override
+  String get settingsDiscordRpc => 'Intégration dans Discord';
+
+  @override
+  String get settingsDiscordRpcSubtitle =>
+      'Affiche le titre regardé dans votre statut Discord';
+
+  @override
+  String get settingsDiscordRaSync => 'Synchroniser RetroAchievements';
+
+  @override
+  String get settingsDiscordRaSyncSubtitle =>
+      'Affiche votre activité RetroAchievements dans votre profil Discord';
+
+  @override
+  String get uncategorizedBanner =>
+      'Ajouter à une collection pour débloquer l\'affichage tableau et le suivi des épisodes';
+
+  @override
+  String get uncategorizedDeprecationNotice =>
+      'Cette collection sera bientôt retirée. Créez votre propre collection et déplacez les titres dedans.';
+
+  @override
+  String get uncategorizedDeprecationBadge => 'Sera retirée';
+
+  @override
+  String get browseFilterGenre => 'Genre';
+
+  @override
+  String get browseFilterLength => 'Durée';
+
+  @override
+  String get vndbLengthVeryShort => 'Très courte';
+
+  @override
+  String get vndbLengthShort => 'Courte';
+
+  @override
+  String get vndbLengthMedium => 'Moyenne';
+
+  @override
+  String get vndbLengthLong => 'Longue';
+
+  @override
+  String get vndbLengthVeryLong => 'Très longue';
+
+  @override
+  String get browseFilterAnimeAdaptation => 'Adaptation anime';
+
+  @override
+  String get vndbHasAnimeAdaptation => 'A une adaptation';
+
+  @override
+  String get tagPickerSearchHint => 'Rechercher tags';
+
+  @override
+  String get tagPickerShowSpoilers => 'Montrer les tags spoiler';
+
+  @override
+  String get tagPickerShowAdult => 'Montrer les tags +18';
+
+  @override
+  String get tagPickerRefresh => 'Rafraîchir catalogue';
+
+  @override
+  String get tagPickerEmpty => 'Aucun tag trouvé';
+
+  @override
+  String get clearAll => 'Tout effacer';
+
+  @override
+  String get browseFilterSeason => 'Saison';
+
+  @override
+  String get browseFilterGameMode => 'Mode de jeu';
+
+  @override
+  String get browseFilterMinRating => 'Note minimum';
+
+  @override
+  String get browseFilterMinVotes => 'Votes minimum';
+
+  @override
+  String get seasonWinter => 'Hiver';
+
+  @override
+  String get seasonSpring => 'Printemps';
+
+  @override
+  String get seasonSummer => 'Été';
+
+  @override
+  String get seasonFall => 'Automne';
+
+  @override
+  String get animeFormatTv => 'TV';
+
+  @override
+  String get animeFormatMovie => 'Film';
+
+  @override
+  String get animeFormatOva => 'OVA';
+
+  @override
+  String get animeFormatOna => 'ONA';
+
+  @override
+  String get animeFormatSpecial => 'Spécial';
+
+  @override
+  String get animeFormatTvShort => 'Court épisode TV';
+
+  @override
+  String get mangaStatusPublishing => 'En cours de publication';
+
+  @override
+  String get mangaStatusFinished => 'Terminé';
+
+  @override
+  String get mangaStatusNotYetPublished => 'Pas encore publié';
+
+  @override
+  String get mangaStatusCancelled => 'Annulé';
+
+  @override
+  String get mangaStatusHiatus => 'En pause';
+
+  @override
+  String get gameModeSinglePlayer => 'Solo';
+
+  @override
+  String get gameModeMultiplayer => 'Multijoueur';
+
+  @override
+  String get gameModeCoOperative => 'Coopération';
+
+  @override
+  String get gameModeSplitScreen => 'Écran partagé';
+
+  @override
+  String get gameModeMmo => 'MMO';
+
+  @override
+  String get gameModeBattleRoyale => 'Battle Royale';
+
+  @override
+  String get languageEnglish => 'Anglais';
+
+  @override
+  String get languageJapanese => 'Japonais';
+
+  @override
+  String get languageKorean => 'Coréen';
+
+  @override
+  String get languageChinese => 'Chinois';
+
+  @override
+  String get languageFrench => 'Français';
+
+  @override
+  String get languageSpanish => 'Espagnol';
+
+  @override
+  String get languageGerman => 'Allemand';
+
+  @override
+  String get languageRussian => 'Russe';
+
+  @override
+  String get languageItalian => 'Italien';
+
+  @override
+  String get languagePortuguese => 'Portugais';
+
+  @override
+  String get mangaFormatManhwa => 'Manhwa';
+
+  @override
+  String get mangaFormatManhua => 'Manhua';
+
+  @override
+  String get mangaFormatOneShot => 'One-shot';
+
+  @override
+  String get mangaFormatNovel => 'Roman';
+
+  @override
+  String get mangaFormatLightNovel => 'Light Novel';
+
+  @override
+  String get browseFilterContentRating => 'Classification du contenu';
+
+  @override
+  String get browseFilterDemographic => 'Démographie';
+
+  @override
+  String get contentRatingSafe => 'Sûr';
+
+  @override
+  String get contentRatingSuggestive => 'Suggestif';
+
+  @override
+  String get contentRatingErotica => 'Érotique';
+
+  @override
+  String get contentRatingPornographic => 'Pornographique';
+
+  @override
+  String get browseSortRelevance => 'Pertinence';
+
+  @override
+  String get browseSortPopular => 'Populaire';
+
+  @override
+  String get browseSortTopRated => 'Mieux noté';
+
+  @override
+  String get browseSortNewest => 'Plus récent';
+
+  @override
+  String get browseSortMostVoted => 'Plus de votes';
+
+  @override
+  String get browseSortMostRead => 'Plus lu';
+
+  @override
+  String get browseSortTrending => 'Tendance';
+
+  @override
+  String get browseSortNameAsc => 'Nom (A à Z)';
+
+  @override
+  String get browseSortNameDesc => 'Nom (Z à A)';
+
+  @override
+  String get browseSortRecentlyUpdated => 'Récemment mis à jour';
+
+  @override
+  String get browseSortRecentlyAdded => 'Récemment ajouté';
+
+  @override
+  String get browseAnimeTypeSeries => 'Séries';
+
+  @override
+  String get browseAnimeTypeMovies => 'Films';
+
+  @override
+  String get browseEmptyFilters => 'Choisir un filtre ou rechercher';
+
+  @override
+  String get browseBackToBrowse => 'Retour à la navigation';
+
+  @override
+  String get browseSortDisabledHint =>
+      'Tri impossible pendant la recherche écrite';
+
+  @override
+  String get animeStatusAiring => 'En cours de diffusion';
+
+  @override
+  String get animeStatusFinished => 'Terminé';
+
+  @override
+  String get animeStatusNotYetAired => 'Pas encore diffusé';
+
+  @override
+  String get animeStatusCancelled => 'Annulé';
+
+  @override
+  String get typeToFilterHint => 'Filtrer...';
+
+  @override
+  String get appBarSearchHint => 'Écrivez pour commencer la recherche';
+
+  @override
+  String get insertLink => 'Insérer un lien';
+
+  @override
+  String get linkText => 'Texte';
+
+  @override
+  String get linkHint => 'Guide';
+
+  @override
+  String get urlLabel => 'URL';
+
+  @override
+  String get urlHint => 'https://exemple.com';
+
+  @override
+  String get markdownBold => 'Gras';
+
+  @override
+  String get markdownItalic => 'Italique';
+
+  @override
+  String get insert => 'Insérer';
+
+  @override
+  String get navTierLists => 'Tier lists';
+
+  @override
+  String get tierListCreate => 'Nouvelle tier list';
+
+  @override
+  String get tierListCreateFromCollection => 'Créer tier list';
+
+  @override
+  String get tierListNameHint => 'Nom de la tier list';
+
+  @override
+  String get tierListScopeAll => 'Tous les titres';
+
+  @override
+  String get tierListScopeCollection => 'Depuis la collection';
+
+  @override
+  String tierListFromCollection(String name) {
+    return 'Depuis : $name';
+  }
+
+  @override
+  String tierListRankedCount(int count) {
+    return '$count classés';
+  }
+
+  @override
+  String get tierListTitle => 'Tier list';
+
+  @override
+  String get tierListUnranked => 'Sans classement';
+
+  @override
+  String get exportAsImage => 'Exporter en tant qu\'image';
+
+  @override
+  String get tierListImageSaved => 'Tier list sauvegardé en tant qu\'image';
+
+  @override
+  String get tierListRename => 'Renommer le tier';
+
+  @override
+  String get tierListChangeColor => 'Changer la couleur';
+
+  @override
+  String get tierListMoveUp => 'Monter';
+
+  @override
+  String get tierListMoveDown => 'Descendre';
+
+  @override
+  String get tierListDeleteTier => 'Supprimer le tier';
+
+  @override
+  String get tierListAddTier => 'Ajouter un tier';
+
+  @override
+  String get tierListClearConfirm =>
+      'Retirer tous les titres des tiers ? Ils seront alors sans classement.';
+
+  @override
+  String get tierListDeleteConfirm => 'Supprimer cette tier list ?';
+
+  @override
+  String get tierListEmpty => 'Aucune tier list pour l\'instant';
+
+  @override
+  String get tierListEmptyHint =>
+      'Cliquez sur + pour créer une tier list\net classez les titres de vos collections.';
+
+  @override
+  String get tierListAllRanked => 'Tous les titres sont classés !';
+
+  @override
+  String get tierListErrorEmptyName => 'Entrez un nom pour la tier list';
+
+  @override
+  String get tierListErrorNoCollection => 'Sélectionnez une collection';
+
+  @override
+  String get collectionPickerFilter => 'Filtrer les collections...';
+
+  @override
+  String get collectionPickerAlreadyAdded => '✓ ajouté';
+
+  @override
+  String collectionPickerAlreadyInCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Déjà dans $count collections',
+      one: 'Déjà dans $count collection',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get settingsSteamImport => 'Bibliothèque Steam';
+
+  @override
+  String get settingsSteamImportSubtitle =>
+      'Importez des jeux via l\'API Web de Steam';
+
+  @override
+  String get settingsIgdbImport => 'Liste IGDB';
+
+  @override
+  String get settingsIgdbImportSubtitle =>
+      'Importez une liste de jeux depuis IGDB (format CSV)';
+
+  @override
+  String get igdbImportTitle => 'Importer une liste IGDB';
+
+  @override
+  String get igdbImportDescription =>
+      'Choisissez une liste CSV téléchargée depuis IGDB. Les jeux se voient attribués un ID par IGDB; ceux qui ne sont plus présents sur le site seront ajoutés à la liste de souhaits.';
+
+  @override
+  String get igdbImportSelectCsvFile => 'Sélectionner un fichier CSV';
+
+  @override
+  String get igdbImportSelectCsvExport => 'Sélectionner un fichier CSV de IGDB';
+
+  @override
+  String get igdbImportStatusLabel => 'Statuts pour les jeux importés';
+
+  @override
+  String get igdbImportPlatformSelect => 'Sélectionner une plateforme';
+
+  @override
+  String get importIgdbRequired =>
+      'Une connexion à IGDB est requise. Paramétrez la clé API dans Paramètres → Identifiants.';
+
+  @override
+  String get importing => 'Importation...';
+
+  @override
+  String get igdbReasonNotFound => 'Pas trouvé sur IGDB';
+
+  @override
+  String get steamImportTitle => 'Importer la Bibliothèque Steam';
+
+  @override
+  String get importIgdbMatchNote =>
+      'Les jeux seront importés en accordance avec la base de données IGDB';
+
+  @override
+  String get steamImportApiKey => 'Clé API Steam';
+
+  @override
+  String get steamImportApiKeyHint =>
+      'Obtenez une clé API gratuite sur steamcommunity.com/dev/apikey';
+
+  @override
+  String get steamImportSteamId => 'ID Steam (64-bit)';
+
+  @override
+  String get steamImportSteamIdHint => 'Trouvé sur steamidfinder.com';
+
+  @override
+  String get steamImportPublicWarning => 'Votre profil Steam doit être public';
+
+  @override
+  String get steamImportButton => 'Importer la Bibliothèque';
+
+  @override
+  String get steamImportFetchingLibrary => 'Récupération de la Bibliothèque...';
+
+  @override
+  String get steamImportMatching => 'Couplage des jeux avec IGDB...';
+
+  @override
+  String steamImportLookingUp(String name) {
+    return 'Recherche de : $name';
+  }
+
+  @override
+  String steamImportImported(int count) {
+    return 'Importés : $count';
+  }
+
+  @override
+  String steamImportWishlisted(int count) {
+    return 'Ajoutés à la liste de souhaits : $count';
+  }
+
+  @override
+  String steamImportUpdated(int count) {
+    return 'Mis à jours : $count';
+  }
+
+  @override
+  String get importComplete => 'Importation terminée !';
+
+  @override
+  String steamImportGamesImported(int count) {
+    return '$count jeux importés';
+  }
+
+  @override
+  String steamImportWishlistedInIgdb(int count) {
+    return '$count ajoutés à la liste de souhaits';
+  }
+
+  @override
+  String steamImportUpdatedDuplicates(int count) {
+    return '$count mis à jours (déjà présents)';
+  }
+
+  @override
+  String get steamImportPlayedStatus =>
+      'Jeux commencés marqués comme \"En cours\"';
+
+  @override
+  String get steamImportPlaytimeComment =>
+      'Le temps de jeu sauvegardé dans les commentaires';
+
+  @override
+  String get openCollection => 'Ouvrir collection';
+
+  @override
+  String get steamImportRememberCredentials => 'Sauvegarder les identifiants';
+
+  @override
+  String get collectionListSortCreatedDate => 'Date ajoutée';
+
+  @override
+  String get collectionListSortAlphabeticalAZ => 'A à Z';
+
+  @override
+  String get collectionListSortAlphabeticalZA => 'Z à A';
+
+  @override
+  String get collectionListViewGrid => 'Affichage grille';
+
+  @override
+  String get collectionListViewList => 'Affichage liste';
+
+  @override
+  String get collectionListViewTable => 'Affichage tableur';
+
+  @override
+  String get collectionTableExternalRating => 'Externe';
+
+  @override
+  String get collectionCopyToCollection => 'Copier vers la collection';
+
+  @override
+  String collectionItemCopiedTo(Object collection, Object name) {
+    return '$name copier vers $collection';
+  }
+
+  @override
+  String collectionItemAlreadyInTarget(Object collection, Object name) {
+    return '$name est déjà dans $collection';
+  }
+
+  @override
+  String get openInCollection => 'Ouvrir dans la collection';
+
+  @override
+  String get importResultTitle => 'Résultats d\'importation';
+
+  @override
+  String importResultComplete(String source) {
+    return 'Importation de $source terminée !';
+  }
+
+  @override
+  String importResultFailed(String source) {
+    return 'Importation de $source échouée';
+  }
+
+  @override
+  String get importResultImported => 'Importé';
+
+  @override
+  String get importResultWishlisted => 'Ajouté à la liste de souhaits';
+
+  @override
+  String get importResultUpdated => 'Mis à jour';
+
+  @override
+  String importResultErrors(int count) {
+    return 'Erreurs ($count)';
+  }
+
+  @override
+  String get importResultErrorsCopied => 'Erreurs copiées';
+
+  @override
+  String importResultSkipped(int count) {
+    return '$count omis';
+  }
+
+  @override
+  String get importResultOpenCollection => 'Ouvrir la collection';
+
+  @override
+  String get importResultWishlistHint =>
+      'Les titres introuvables dans votre base de données ont été sauvegardés dans votre liste de souhaits.';
+
+  @override
+  String get importResultSourceCollectionFile => 'Fichier de collection';
+
+  @override
+  String get settingsBrowseCollections => 'Regarder les collections';
+
+  @override
+  String get settingsBrowseCollectionsSubtitle =>
+      'Télécharger des collections pré-établies';
+
+  @override
+  String browseCollectionsSummary(int count, int items) {
+    return '$count collections, $items titres';
+  }
+
+  @override
+  String get browseCollectionsSearch => 'Rechercher des collections...';
+
+  @override
+  String get browseCollectionsAllCategories => 'Toutes les catégories';
+
+  @override
+  String browseCollectionsItems(int count) {
+    return '$count titres';
+  }
+
+  @override
+  String get browseCollectionsFormatLight => 'Léger (clés API nécessaires)';
+
+  @override
+  String get browseCollectionsFormatFull => 'Complet (hors-ligne)';
+
+  @override
+  String get browseCollectionsDownloading => 'Téléchargement...';
+
+  @override
+  String browseCollectionsImportSuccess(String name) {
+    return 'Collection importée : $name';
+  }
+
+  @override
+  String get browseCollectionsEmpty => 'Aucune collection trouvée';
+
+  @override
+  String get browseCollectionsLoadError =>
+      'Impossible de charger les collections';
+
+  @override
+  String get browseCollectionsImportTarget => 'Importer vers';
+
+  @override
+  String get browseCollectionsNewCollection => 'Nouvelle collection';
+
+  @override
+  String get browseCollectionsExistingCollection => 'Collection existante';
+
+  @override
+  String get noCollectionsYet => 'Aucune collection pour l\'instant';
+
+  @override
+  String get settingsRaImport => 'RetroAchievements';
+
+  @override
+  String get settingsRaImportSubtitle =>
+      'Importer des jeux depuis RetroAchievements';
+
+  @override
+  String get raImportTitle => 'Importation RetroAchievements';
+
+  @override
+  String get raGetApiKey =>
+      'Obtenez votre clé API sur retroachievements.org/controlpanel.php';
+
+  @override
+  String get raImportOptionWishlist =>
+      'Ajoutez les jeux non listés à votre liste de souhaits';
+
+  @override
+  String get raImportFetchingLibrary =>
+      'Récupération de la bibliothèque RetroAchievements...';
+
+  @override
+  String get raImportSearchingIgdb => 'Recherche des jeux sur IGDB...';
+
+  @override
+  String raImportMatching(String title) {
+    return 'Correspondance : $title';
+  }
+
+  @override
+  String raImportAdded(int count) {
+    return '$count jeux ajoutés';
+  }
+
+  @override
+  String raImportUpdated(int count) {
+    return '$count jeux mis à jours';
+  }
+
+  @override
+  String raImportToWishlist(int count) {
+    return '$count ajoutés à la liste des souhaits';
+  }
+
+  @override
+  String raConnectionFailed(String error) {
+    return 'Connexion impossible : $error';
+  }
+
+  @override
+  String raProfilePoints(int points) {
+    return '$points points';
+  }
+
+  @override
+  String raProfileMemberSince(String date) {
+    return 'Membre depuis $date';
+  }
+
+  @override
+  String get raRefresh => 'Rafraîchir les succès';
+
+  @override
+  String get raOpenOnRa => 'Ouvrir dans RA ↗';
+
+  @override
+  String get raHardcore => 'Hardcore';
+
+  @override
+  String get raCompletion => 'Complétion';
+
+  @override
+  String get raRecentUnlocks => 'Obtentions récentes';
+
+  @override
+  String get raUpNext => 'Suivant';
+
+  @override
+  String raViewAll(int count) {
+    return 'Voir tous les $count succès →';
+  }
+
+  @override
+  String get raMastered => 'Maîtrisé';
+
+  @override
+  String get raHardcoreMastered => 'Hardcore maîtrisé';
+
+  @override
+  String get raBeaten => 'Terminé';
+
+  @override
+  String get raBeatenSoftcore => 'Softcore terminé';
+
+  @override
+  String get raHardcoreBeaten => 'Hardcore terminé';
+
+  @override
+  String get raYesterday => 'Hier';
+
+  @override
+  String raDaysAgo(int days) {
+    return '$days jours auparavant';
+  }
+
+  @override
+  String get raPoints => 'pts';
+
+  @override
+  String get raAchievements => 'succès';
+
+  @override
+  String get raMissable => 'MANQUABLE';
+
+  @override
+  String get raFilterEarned => 'Obtenu';
+
+  @override
+  String get raFilterLocked => 'Verrouillé';
+
+  @override
+  String get raFilterMissable => 'Manquable';
+
+  @override
+  String get raFilterProgression => 'Progression';
+
+  @override
+  String get raFilterWinCondition => 'Condition de victoire';
+
+  @override
+  String get raBeatenProgress => 'Progression (terminé)';
+
+  @override
+  String get raStatsAchievements => 'succès';
+
+  @override
+  String get raStatsWorth => 'valant';
+
+  @override
+  String get raStatsPoints => 'points';
+
+  @override
+  String get raStatsUnlocked => 'Déverrouillé';
+
+  @override
+  String get copyAsText => 'Copié en tant que texte…';
+
+  @override
+  String copiedToClipboard(int count) {
+    return 'Copié $count titres dans le presse-papiers';
+  }
+
+  @override
+  String get template => 'Modèle';
+
+  @override
+  String get textExportTokens => 'Tokens';
+
+  @override
+  String get textExportSortBy => 'Trier par';
+
+  @override
+  String get textExportSortCurrent => 'Ordre actuel';
+
+  @override
+  String get textExportSortName => 'Nom (A à Z)';
+
+  @override
+  String get textExportSortYear => 'Année ↓';
+
+  @override
+  String get textExportSortAdded => 'Date d\'ajout ↓';
+
+  @override
+  String get textExportEmptyTemplate => 'Modèle vide';
+
+  @override
+  String get filtersClear => 'Effacer';
+
+  @override
+  String get collectionTableColumns => 'Colonnes';
+
+  @override
+  String get tableFilterHint => 'Les règles de tri s\'appliquent TOUTES (ET).';
+
+  @override
+  String get tableFilterAddRule => 'Ajouter règle';
+
+  @override
+  String get tableFilterCondContains => 'Contient';
+
+  @override
+  String get tableFilterCondEquals => 'Égal à';
+
+  @override
+  String get tableFilterCondStartsWith => 'Commence par';
+
+  @override
+  String get tableFilterCondEndsWith => 'Termine par';
+
+  @override
+  String get tableFilterCondAtLeast => 'Au moins (≥)';
+
+  @override
+  String get tableFilterCondAtMost => 'Au plus (≤)';
+
+  @override
+  String get profiles => 'Profils';
+
+  @override
+  String currentProfile(String name) {
+    return 'Actuel : $name';
+  }
+
+  @override
+  String get switchProfile => 'Changer de profil';
+
+  @override
+  String get addProfile => 'Ajouter un profil';
+
+  @override
+  String get createProfile => 'Créer un profil';
+
+  @override
+  String get editProfile => 'Modifier le profil';
+
+  @override
+  String get deleteProfile => 'Supprimer le profil';
+
+  @override
+  String deleteProfileConfirm(String name) {
+    return 'Supprimer le profil $name? Cela supprimera toutes les collections, la liste de souhaits et les paramètres. La suppression est définitive.';
+  }
+
+  @override
+  String get cannotDeleteLastProfile =>
+      'Impossible de supprimer le dernier profil';
+
+  @override
+  String get profileName => 'Nom';
+
+  @override
+  String get whoIsPlayingToday => 'Qui joue aujourd\'hui ?';
+
+  @override
+  String get dontAskAgain => 'Ne pas demander de nouveau';
+
+  @override
+  String profileStats(int collections, int items) {
+    return '$collections collections, $items titres';
+  }
+
+  @override
+  String get switchingProfile => 'Changement de profil…';
+
+  @override
+  String get appWillRestart =>
+      'L\'application va redémarrer pour appliquer les changements.';
+
+  @override
+  String get profileCreated => 'Profil créé';
+
+  @override
+  String get profileDeleted => 'Profil supprimé';
+
+  @override
+  String get settingsIntegrations => 'Intégrations';
+
+  @override
+  String get settingsKodiSubtitle =>
+      'Synchronisation vidéo depuis le lecteur média Kodi';
+
+  @override
+  String get settingsOn => 'Marche';
+
+  @override
+  String get kodiConnectionTitle => 'Connexion';
+
+  @override
+  String get kodiConnectionSubtitle =>
+      'Kodi HTTP JSON-RPC (Paramètres → Services → Control)';
+
+  @override
+  String get kodiHost => 'Hôte';
+
+  @override
+  String get kodiPort => 'Port';
+
+  @override
+  String get kodiPassword => 'Mot de passe';
+
+  @override
+  String get kodiPasswordHint => 'Entrez le mot de passe';
+
+  @override
+  String get kodiTestConnection => 'Test de connexion';
+
+  @override
+  String get kodiConnecting => 'Connexion…';
+
+  @override
+  String get kodiPingFailed => 'Échec du ping — réponse inattendue';
+
+  @override
+  String kodiConnectedTo(String version, String name) {
+    return 'Kodi $version \"$name\"';
+  }
+
+  @override
+  String get kodiSyncTitle => 'Synchronisation';
+
+  @override
+  String get kodiTargetCollectionSubtitle =>
+      'Tous les films de Kodi se synchronisent ici';
+
+  @override
+  String get kodiTargetNotSelected => 'Aucune sélection';
+
+  @override
+  String kodiTargetDeletedLabel(int id) {
+    return 'Supprimé (#$id)';
+  }
+
+  @override
+  String get kodiEnableSync => 'Activer la synchronisation Kodi';
+
+  @override
+  String get kodiEnableSyncActiveSubtitle =>
+      'Actif tant que Tonkatsu est ouvert';
+
+  @override
+  String get kodiEnableSyncDisabledSubtitle =>
+      'Sélectionnez d\'abord une collection';
+
+  @override
+  String get kodiSyncInterval => 'Interval de synchronisation';
+
+  @override
+  String get kodiCreateSubCollections =>
+      'Créer des sous-collections importées de Kodi';
+
+  @override
+  String get kodiCreateSubCollectionsSubtitle =>
+      'ex : \"Collection Harry Potter (kodi)\"';
+
+  @override
+  String get kodiImportRatings => 'Importer les notes depuis Kodi';
+
+  @override
+  String get kodiImportRatingsSubtitle =>
+      'Copier les notes utilisateurs de Kodi (1-10)';
+
+  @override
+  String get kodiCollectionLibraryName => 'Bibliothèque Kodi';
+
+  @override
+  String kodiCollectionCreated(String name) {
+    return 'Créé \"$name\"';
+  }
+
+  @override
+  String get kodiTargetDeletedSnack =>
+      'La collection a été supprimée — synchronisation arrêtée';
+
+  @override
+  String get kodiSyncStatus => 'Statut de synchronisation';
+
+  @override
+  String get kodiSyncRunning => 'En cours';
+
+  @override
+  String get kodiSyncStopped => 'Arrêtée';
+
+  @override
+  String get kodiLastSyncNever => 'Jamais';
+
+  @override
+  String get kodiClearLastSync =>
+      'Effacer les horodatages de la dernière synchronisation';
+
+  @override
+  String get kodiClearLastSyncSubtitle =>
+      'La prochaine synchronisation récupérera tous les titres regardés';
+
+  @override
+  String get kodiLastSyncCleared =>
+      'Horodatages de la dernière synchronisation effacés';
+
+  @override
+  String kodiRequestLog(int count) {
+    return 'Journal de requêtes : ($count)';
+  }
+
+  @override
+  String get kodiCopyLog => 'Copier le journal';
+
+  @override
+  String get kodiLogCopied => 'Journal copié';
+
+  @override
+  String get kodiClearLog => 'Effacer le journal';
+
+  @override
+  String get kodiNoRequests => 'Aucune requête pour l\'instant';
+
+  @override
+  String get kodiRawJsonRpc => 'JSON-RPC brut';
+
+  @override
+  String get kodiMethod => 'Méthode';
+
+  @override
+  String get kodiParams => 'Paramètres (JSON)';
+
+  @override
+  String get kodiSend => 'Envoyer';
+
+  @override
+  String get kodiCopyToClipboard => 'Copier vers le presse-papiers';
+
+  @override
+  String get kodiCopiedToClipboard => 'Copié vers le presse-papiers';
+
+  @override
+  String get kodiParamsNotObject =>
+      'Erreur : les paramètres doivent être un objet JSON';
+
+  @override
+  String kodiJsonParseError(String message) {
+    return 'Erreur d\'analyse JSON (parse error) : $message';
+  }
+
+  @override
+  String kodiRawError(String message) {
+    return 'Erreur : $message';
+  }
+
+  @override
+  String get settingsMalImport => 'MyAnimeList';
+
+  @override
+  String get settingsMalImportSubtitle =>
+      'Importez des animes/mangas depuis un fichier XML';
+
+  @override
+  String get malImportTitle => 'Importation MyAnimeList';
+
+  @override
+  String get malImportSubtitle =>
+      'Les animes et mangas importés seront identiques à ceux listés chez AniList';
+
+  @override
+  String get malImportPickFiles => 'Ajouter fichier XML';
+
+  @override
+  String get malImportFilesHint =>
+      'Exporter fichier XML depuis myanimelist.net/panel.php?go=export';
+
+  @override
+  String get importAnimeList => 'Liste d\'animes';
+
+  @override
+  String get importMangaList => 'Liste de mangas';
+
+  @override
+  String malImportEntriesCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count entrées',
+      one: '1 entrée',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get malImportReadingFiles => 'Lecture des fichiers...';
+
+  @override
+  String get malImportResolvingAnime => 'Vérification des animes sur AniList';
+
+  @override
+  String get malImportResolvingManga => 'Vérification des mangas sur AniList';
+
+  @override
+  String malImportWishlisted(int count) {
+    return '$count ajoutés à la liste de souhaits';
+  }
+
+  @override
+  String get malImportOverwriteExisting =>
+      'Écraser les entrées déjà existantes';
+
+  @override
+  String get malImportOverwriteExistingHint =>
+      'Si désactivé, les titres déjà présents dans la collection gardent leurs statut, note, progression, dates et commentaires. Les nouveaux titres sont tout de même importés.';
+
+  @override
+  String malImportFailedLookup(int count) {
+    return '$count omis (AniList injoignable)';
+  }
+
+  @override
+  String malImportRateLimitWait(int seconds, int attempt, int max) {
+    return 'Limite de débit d\'AniList atteinte — nouvelle tentative dans ${seconds}s (tentative $attempt/$max)';
+  }
+
+  @override
+  String malImportInvalidFile(String error) {
+    return 'Impossible d\'analyser le fichier XML : $error';
+  }
+
+  @override
+  String malImportFilePicked(String kind, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count entrées',
+      one: '1 entrée',
+    );
+    return 'Choisi : $kind ($_temp0)';
+  }
+
+  @override
+  String get settingsAniListImport => 'AniList';
+
+  @override
+  String get settingsAniListImportSubtitle =>
+      'Importez des listes d\'animes/mangas via un nom d\'utilisateur publique';
+
+  @override
+  String get settingsHardcoverImportSubtitle =>
+      'Importez une bibliothèque depuis hardcover.app via un nom d\'utilisateur';
+
+  @override
+  String get hardcoverImportTitle => 'Importation Hardcover';
+
+  @override
+  String get hardcoverImportSubtitle =>
+      'Récupère la bibliothèque d\'un utilisateur depuis hardcover.app — seules les données publiques seront visibles par les autres utilisateurs.';
+
+  @override
+  String get hardcoverImportTokenMissing =>
+      'Le token API Hardcover n\'est pas configuré. Ajoutez-le dans Paramètres → Identifiants.';
+
+  @override
+  String get aniListImportTitle => 'Importation AniList';
+
+  @override
+  String get aniListImportSubtitle =>
+      'Récupère des listes publiques depuis anilist.co — aucune connexion requise';
+
+  @override
+  String get aniListImportUsername => 'Nom d\'utilisateur AniList';
+
+  @override
+  String get aniListImportInclude => 'Ce que vous pouvez importer';
+
+  @override
+  String get aniListImportModeOverwriteSubtitle =>
+      'Mettez à jour la progression, le statut et les dates de vos titres depuis AniList';
+
+  @override
+  String aniListImportNewCollectionDefault(String username) {
+    return 'Importation AniList — $username';
+  }
+
+  @override
+  String get aniListImportFetchingAnime =>
+      'Récupération de la liste d\'animes...';
+
+  @override
+  String get aniListImportFetchingManga =>
+      'Récupération de la liste de mangas...';
+
+  @override
+  String aniListImportUserNotFound(String username) {
+    return 'L\'utilisateur \"$username\" n\'a pas été trouvé sur AniList';
+  }
+
+  @override
+  String aniListImportPrivateProfile(String username) {
+    return 'Le profil de \"$username\" sur AniList est privé';
+  }
+
+  @override
+  String get aniListImportEmptyUsername =>
+      'Entrez votre nom d\'utilisateur AniList';
+
+  @override
+  String get aniListImportSelectAtLeastOne =>
+      'Sélectionnez les animes ou mangas à importer';
+
+  @override
+  String get settingsCustomCardsImport => 'Cartes personnalisées';
+
+  @override
+  String get settingsCustomCardsImportSubtitle =>
+      'Importez des cartes depuis un fichier JSON ou CSV';
+
+  @override
+  String get customImportTitle => 'Importer des cartes personnalisées';
+
+  @override
+  String get customImportDescription =>
+      'Chargez un fichier JSON ou CSV généré par votre propre script ou parser — chaque rangée devient une carte personnalisée. Téléchargez un modèle pour voir tous les champs et les valeurs supportés.';
+
+  @override
+  String get customImportSelectFile => 'Sélectionner un fichier JSON/CSV';
+
+  @override
+  String get customImportCsvTemplate => 'Modèle CSV';
+
+  @override
+  String get customImportJsonTemplate => 'Modèle JSON';
+
+  @override
+  String get customImportTemplateSaved => 'Modèle sauvegardé';
+
+  @override
+  String get customImportPreviewButton => 'Aperçu et importer';
+
+  @override
+  String get customImportPreviewTitle => 'Aperçu de l\'importation';
+
+  @override
+  String customImportSummary(int valid, int errors, int duplicates) {
+    return 'Reconnus $valid · Erreurs $errors · Doublons $duplicates';
+  }
+
+  @override
+  String get customImportSelectNone => 'Tout déselectionner';
+
+  @override
+  String customImportSelectedCount(int selected, int total) {
+    return '$selected sélectionné sur $total';
+  }
+
+  @override
+  String get customImportDuplicate => 'Doublon — déjà dans la collection';
+
+  @override
+  String customImportRowLabel(int index) {
+    return 'Rangée $index';
+  }
+
+  @override
+  String get customImportStart => 'Importer la selection';
+
+  @override
+  String get customImportImporting =>
+      'Importation des cartes personnalisées...';
+
+  @override
+  String get customImportErrorEmptyFile => 'Le fichier est vide';
+
+  @override
+  String get customImportErrorInvalidJson =>
+      'JSON invalide — le fichier n\'a pas pu être analysé';
+
+  @override
+  String get customImportErrorMissingColumns =>
+      'Le fichier CSV doit contenir des colonnes \"title\" et \"type\"';
+
+  @override
+  String get customImportIssueNotAnObject => 'Pas un objet JSON';
+
+  @override
+  String get customImportIssueMissingTitle => '\"title\" manquant';
+
+  @override
+  String get customImportIssueMissingType => '\"type\" manquant';
+
+  @override
+  String customImportIssueUnknownType(String value) {
+    return 'Type inconnu : $value';
+  }
+
+  @override
+  String customImportIssueInvalidNumber(String field, String value) {
+    return 'Valeur invalide dans \"$field\": $value';
+  }
+
+  @override
+  String customImportIssueUnknownStatus(String value) {
+    return 'Statut inconnu : $value';
+  }
+
+  @override
+  String customImportIssueUnknownFormat(String value) {
+    return 'Format inconnu : $value';
+  }
+
+  @override
+  String get customImportIssueFormatNotApplicable =>
+      '\"format\" est utilisé seulement par les animes et les mangas';
+
+  @override
+  String get customImportIssueInvalidCover =>
+      '\"cover\" doit être une URL http(s)';
+
+  @override
+  String customImportIssueInvalidDate(String field, String value) {
+    return 'Date invalide dans \"$field\": $value (format YYYY-MM-DD attendu)';
+  }
+
+  @override
+  String customImportIssueInvalidBool(String value) {
+    return '\"favorite\" doit être vrai/faux : $value';
+  }
+
+  @override
+  String get moodGridCreate => 'Créer une grille d\'humeur';
+
+  @override
+  String get moodGridCreateTitle => 'Nouvelle grille d\'humeur';
+
+  @override
+  String get moodGridPresetAboutMe => 'À propos de moi : Tonkatsu Box';
+
+  @override
+  String get moodGridPresetAboutMeSubtitle =>
+      '1×5 — jeu, film, série, anime et manga favoris';
+
+  @override
+  String get moodGridPresetBlank => 'Vide';
+
+  @override
+  String get moodGridPresetBlankSubtitle =>
+      'Une grille vide avec la taille de votre choix';
+
+  @override
+  String get moodGridRows => 'Rangées';
+
+  @override
+  String get moodGridBadge => 'Grille d\'humeur';
+
+  @override
+  String get moodGridDeleteTitle => 'Supprimer cette grille ?';
+
+  @override
+  String get moodGridDeleteMessage =>
+      'Cette grille sera supprimée. La suppression est définitive.';
+
+  @override
+  String get moodGridAddRow => 'Ajouter une rangée';
+
+  @override
+  String get moodGridRemoveRow => 'Retirer une rangée';
+
+  @override
+  String get moodGridAddCol => 'Ajouter une colonne';
+
+  @override
+  String get moodGridRemoveCol => 'Retirer une colonne';
+
+  @override
+  String get moodGridShrinkTitle => 'Rétrécir la grille ?';
+
+  @override
+  String get moodGridShrinkMessage =>
+      'Les cellules en dehors des nouvelles limites seront supprimées.';
+
+  @override
+  String get moodGridShrinkConfirm => 'Rétrécir';
+
+  @override
+  String get moodGridEditLabel => 'Modifier l\'étiquette';
+
+  @override
+  String get moodGridLabelHint => 'Nom de catégorie';
+
+  @override
+  String get moodGridPickItem => 'Sélectionner un titre';
+
+  @override
+  String get moodGridReplaceItem => 'Remplacer le titre';
+
+  @override
+  String get moodGridClearItem => 'Effacer le titre';
+
+  @override
+  String get moodGridCaptionTemplate => 'Légendes de rangée';
+
+  @override
+  String get moodGridCaptionTemplateHint =>
+      'Modèle appliqué à chaque cellule. Utilisable : nom, année, genre, note.';
+
+  @override
+  String get moodGridCellLabelTemplate => 'Étiquettes de la cellule';
+
+  @override
+  String get moodGridCellSize => 'Taille';
+
+  @override
+  String get collection => 'Collection';
+
+  @override
+  String get moodGridPickerAllCollections => 'Toutes les collections';
+
+  @override
+  String get moodGridPickerSearchHint => 'Rechercher par nom';
+
+  @override
+  String get moodGridPickerEmpty => 'Rien à sélectionner';
+
+  @override
+  String get screenScraperSection => 'API ScreenScraper';
+
+  @override
+  String get screenScraperSourceDesc =>
+      'Métadonnées de jeux + médias (jacquettes, captures d\'écran, illustrations)';
+
+  @override
+  String get screenScraperUserCredsHint =>
+      'Identifiants utilisateur (ssid / sspassword). Un quota est attribué à chaque utilisateur.';
+
+  @override
+  String get screenScraperSsidLabel => 'ssid';
+
+  @override
+  String get screenScraperSsidPlaceholder => 'Votre identifiant ScreenScraper';
+
+  @override
+  String get screenScraperSspasswordLabel => 'sspassword';
+
+  @override
+  String get screenScraperSspasswordPlaceholder =>
+      'Votre mot de passe ScreenScraper';
+
+  @override
+  String get screenScraperCheckQuota => 'Vérifier le quota';
+
+  @override
+  String get screenScraperRequestsToday => 'Nombre de requêtes ce jour';
+
+  @override
+  String get screenScraperPerMinLimit => 'Limite par minute';
+
+  @override
+  String get screenScraperParallelThreads => 'Threads parallèles';
+
+  @override
+  String get screenScraperAccountLevel => 'Niveau du compte';
+
+  @override
+  String get screenScraperGalleryTitle => 'Médias ScreenScraper';
+
+  @override
+  String get screenScraperScreenshotsTitle => 'Captures d\'écran';
+
+  @override
+  String get screenScraperLoading => 'Chargement des médias ScreenScraper…';
+
+  @override
+  String screenScraperError(String message) {
+    return 'Erreur ScreenScraper : $message';
+  }
+
+  @override
+  String get screenScraperMediaBox => 'Boîte';
+
+  @override
+  String get screenScraperMediaBoxBack => 'Boîte (noire)';
+
+  @override
+  String get screenScraperMediaBox3D => 'Boîte 3D';
+
+  @override
+  String get screenScraperMediaWheel => 'Roue';
+
+  @override
+  String get screenScraperMediaMarquee => 'Marquee';
+
+  @override
+  String get screenScraperMediaTitle => 'Titre';
+
+  @override
+  String get screenScraperMediaScreenshot => 'Capture d\'écran';
+
+  @override
+  String get screenScraperMediaFanart => 'Fanart';
+
+  @override
+  String get screenScraperMediaMix => 'Mix';
+
+  @override
+  String get genreCloudTitle => 'Personnalisation';
+
+  @override
+  String get genreCloudEmpty => 'Aucun genre pour l\'instant';
+
+  @override
+  String get genreCloudEmptyHint =>
+      'Ajoutez des titres avec des genres pour créer un cloud';
+
+  @override
+  String get genreCloudExportImage => 'Sauvegarder en tant qu\'image';
+
+  @override
+  String get genreCloudExportFailed => 'Impossible de sauvegarder l\'image';
+
+  @override
+  String get genreCloudResetView => 'Recentrer';
+
+  @override
+  String genreCloudHidden(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count cachés (ne correspondaient pas)',
+      one: '1 caché (ne correspondait pas)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get facetPlatform => 'Plateformes';
+
+  @override
+  String get facetDecade => 'Décennies';
+
+  @override
+  String get personalizationTabCloud => 'Cloud';
+
+  @override
+  String get recommendationsEmpty => 'Aucune recommandation pour l\'instant';
+
+  @override
+  String get recommendationsEmptyHint =>
+      'Terminez et notez quelques films ou séries pour obtenir des recommandations';
+
+  @override
+  String get recommendationsNoCandidates => 'Aucune nouvelle suggestion';
+
+  @override
+  String get recommendationsNoCandidatesHint =>
+      'Nous n\'avons rien trouvé de nouveau à vous suggérer. Réessayez plus tard !';
+
+  @override
+  String get recommendationsNoApiKey => 'Clé API TMDB requise';
+
+  @override
+  String get recommendationsNoApiKeyHint =>
+      'Ajoutez votre clé API TMDB dans Paramètres pour obtenir des recommandations';
+
+  @override
+  String get recommendationsBecauseLabel => 'Parce que vous avez aimé';
+
+  @override
+  String recommendationsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count recommandations',
+      one: '1 recommandation',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get itemMarkLike => 'J\'aime';
+
+  @override
+  String get itemMarkNote => 'Commentaire';
+
+  @override
+  String get itemMarkNoteHint => 'Écrire un commentaire…';
+
+  @override
+  String get itemMarkSectionTitle => 'Commentaires et mentions J\'aime';
+
+  @override
+  String get itemMarkAdd => 'Ajouter un signe';
+
+  @override
+  String get itemMarkEmpty => 'Aucun signe pour l\'instant';
+
+  @override
+  String get itemMarkNumber => 'Nombre';
+
+  @override
+  String get itemMarkNumberHint => 'ex : 12';
+
+  @override
+  String get itemMarkNumberHelper => 'Requis pour sauvegarder';
+
+  @override
+  String get itemMarkCustomType => 'Type personnalisé';
+
+  @override
+  String get itemMarkFilterLiked => 'J\'aime';
+
+  @override
+  String get itemMarkFilterCommented => 'Avec commentaires';
+
+  @override
+  String itemMarkUnitLabel(String type, int number) {
+    return '$type $number';
+  }
+
+  @override
+  String itemMarkEpisodeShort(int season, int episode) {
+    return 'S$season·E$episode';
+  }
+
+  @override
+  String get unitEpisode => 'Épisode';
+
+  @override
+  String get unitSeason => 'Saison';
+
+  @override
+  String get unitChapter => 'Chapitre';
+
+  @override
+  String get unitVolume => 'Tome';
+
+  @override
+  String get unitPage => 'Page';
+
+  @override
+  String get unitPart => 'Partie';
+
+  @override
+  String get cardLinkCopy => 'Copier le lien de la carte';
+
+  @override
+  String get cardLinkCopied => 'Lien de la carte copié';
+
+  @override
+  String get cardLinkNotFound => 'Carte introuvable';
+
+  @override
+  String get cardLinkSearchTitle => 'Partager une carte';
+
+  @override
+  String get cardLinkSearchHint => 'Rechercher des cartes';
+
+  @override
+  String get shortcutsDialogTitle => 'Raccourcis clavier';
+
+  @override
+  String get shortcutsGroupNavigation => 'Navigation';
+
+  @override
+  String get shortcutSwitchTab => 'Changer d\'onglet';
+
+  @override
+  String get shortcutNextTab => 'Onglet suivant';
+
+  @override
+  String get shortcutPreviousTab => 'Onglet précédent';
+
+  @override
+  String get shortcutThisHelp => 'Peut aider';
+
+  @override
+  String get shortcutCreateCollection => 'Créer une collection';
+
+  @override
+  String get shortcutImportCollection => 'Importer une collection';
+
+  @override
+  String get shortcutToggleView => 'Alterner affichage';
+
+  @override
+  String get shortcutDeleteCollection => 'Supprimer la collection';
+
+  @override
+  String get shortcutRenameCollection => 'Renommer la collection';
+
+  @override
+  String get shortcutAddItems => 'Ajouter des titres';
+
+  @override
+  String get shortcutExportCollection => 'Exporter la collection';
+
+  @override
+  String get shortcutImportIntoCollection => 'Importer dans la collection';
+
+  @override
+  String get shortcutToggleBoard => 'Alterner Tableau/Canvas';
+
+  @override
+  String get shortcutDeleteItem => 'Supprimer le titre';
+
+  @override
+  String get shortcutMoveItem => 'Déplacer le titre';
+
+  @override
+  String get shortcutsGroupItemDetail => 'Détails du titre';
+
+  @override
+  String get shortcutLockCanvas => 'Vérrouiller/dévérrouiller le tableau';
+
+  @override
+  String get shortcutMoveToCollection => 'Déplacer vers la collection';
+
+  @override
+  String get shortcutSetRating => 'Noter';
+
+  @override
+  String get shortcutResetRating => 'Réinitialiser la note';
+
+  @override
+  String get shortcutsGroupTierLists => 'Tier lists';
+
+  @override
+  String get shortcutCreateTierList => 'Créer une tier list';
+
+  @override
+  String get shortcutOpenTierList => 'Ouvrir tier list';
+
+  @override
+  String get shortcutDeleteTierList => 'Supprimer la tier list';
+
+  @override
+  String get shortcutsGroupTierList => 'Tier list';
+
+  @override
+  String get shortcutAddItem => 'Ajouter un titre';
+
+  @override
+  String get shortcutToggleCompleted => 'Montrer/cacher complétés';
+
+  @override
+  String get shortcutClearCompleted => 'Effacer complétés';
+
+  @override
+  String get shortcutFocusSearchField => 'Focus sur la barre de recherche';
+
+  @override
+  String get shortcutClearOrBack => 'Effacer / précédent';
+
+  @override
+  String get shortcutRunSearch => 'Lancer la recherche';
+
+  @override
+  String get debugKeyEvents => 'Événements des touches/boutons';
+
+  @override
+  String get settingsGamepadDebugSubtitle =>
+      'Enregistrer les codes des boutons de la manette';
+}


### PR DESCRIPTION
## Summary

Complete French translation of the app (`app_fr.arb`, 1674 keys), 
with the locale enabled via `flutter gen-l10n`.

## Changes

- Full translation of every string in `app_fr.arb`
- Handled French-specific plural rules (e.g. added an `=0` case where 
  the English source only distinguished `=1`/`other`)
- Generated `app_localizations_fr.dart` and updated 
  `app_localizations.dart` to register French as a supported locale


## Testing

- [x] `flutter gen-l10n` ran without errors
- [x] `.arb` file validated (valid JSON, placeholders consistent with 
      the English source)