### PR TITLE
feat(collections): add and remove tags across a selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,39 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Tag several selected items at once**
+
+  The selection toolbar in a collection and on All Items gains add-tags and
+  remove-tags actions, so a tag no longer has to be applied item by item.
+  Both open the same tag picker used for a single item, with nothing
+  pre-checked: the selection's items carry different tags, so a checked box
+  means "apply to all of them" rather than "this item has it". Adding is
+  additive and removing only drops the tags you picked, so tags assigned per
+  item and their manual order survive either way.
+
+  On a narrow window the toolbar now stacks: the counter keeps its own line
+  and the actions get theirs, instead of the actions being squeezed into a
+  sliver of scrollable space on a phone.
+
+  * lib/core/database/dao/global_tag_dao.dart (GlobalTagDao.addTagsToItems,
+    GlobalTagDao.removeTagsFromItems): New batched link writes over an item
+    list and a tag set — one `INSERT OR IGNORE` batch and one chunked
+    `DELETE`, so neither grows a query per item.
+  * lib/features/collections/providers/item_tags_provider.dart
+    (ItemTagsNotifier.addTagsToItems, ItemTagsNotifier.removeTagsFromItems,
+    ItemTagsNotifier._syncItems): Bulk map updates — one write plus one
+    read-back that keeps the in-memory tag order identical to the DAO's, then
+    a single state update. Return how many links actually changed.
+  * lib/features/collections/widgets/bulk_action_bar.dart (BulkActionBar,
+    BulkActionBar._handleTags, BulkActionBar._buildSelectionControls,
+    BulkActionBar._buildActionStrip): Add the two tag actions; split the bar
+    into a selection-controls row and an action strip laid out in one or two
+    rows by width; ellipsize the counter so it can't push Select all off the
+    edge.
+  * lib/features/collections/widgets/tag_picker_dialog.dart (TagPickerDialog):
+    Accept an optional title and confirm label so a bulk caller can say what
+    the picked tags will do.
+
 - **French (fr) interface localization**
 
   The app interface is now available in French alongside English, Russian,

--- a/lib/core/database/dao/global_tag_dao.dart
+++ b/lib/core/database/dao/global_tag_dao.dart
@@ -271,6 +271,52 @@ class GlobalTagDao {
     await batch.commit(noResult: true);
   }
 
+  /// Links every tag in [tagIds] to every item in [itemIds] in one batch.
+  /// Additive like [addTagToItems]: surviving links keep their manual
+  /// position, new ones get `NULL` and land after the positioned tags.
+  Future<void> addTagsToItems(List<int> itemIds, Set<int> tagIds) async {
+    if (itemIds.isEmpty || tagIds.isEmpty) return;
+    final Database db = await _getDatabase();
+    final Batch batch = db.batch();
+    for (final int itemId in itemIds) {
+      for (final int tagId in tagIds) {
+        batch.rawInsert(
+          'INSERT OR IGNORE INTO item_tags (item_id, tag_id) VALUES (?, ?)',
+          <Object?>[itemId, tagId],
+        );
+      }
+    }
+    await batch.commit(noResult: true);
+  }
+
+  /// Unlinks every tag in [tagIds] from every item in [itemIds]. The tags
+  /// themselves survive even when no item is left carrying them.
+  Future<void> removeTagsFromItems(
+    List<int> itemIds,
+    Set<int> tagIds,
+  ) async {
+    if (itemIds.isEmpty || tagIds.isEmpty) return;
+    final Database db = await _getDatabase();
+    final String tagPlaceholders =
+        List<String>.filled(tagIds.length, '?').join(', ');
+    // Both id lists bind into the same statement, so the item chunk has to
+    // leave room for the tag ids under the variable limit.
+    final int room = kInClauseChunkSize - tagIds.length;
+    await queryByIdsInChunks<void>(
+      itemIds,
+      (List<int> chunk) async {
+        await db.rawDelete(
+          'DELETE FROM item_tags WHERE item_id IN '
+          '(${List<String>.filled(chunk.length, '?').join(', ')}) '
+          'AND tag_id IN ($tagPlaceholders)',
+          <Object?>[...chunk, ...tagIds],
+        );
+        return const <void>[];
+      },
+      chunkSize: room < 1 ? 1 : room,
+    );
+  }
+
   /// Persists a manual reorder: [orderedIds] in their new display order.
   Future<void> setSortOrders(List<int> orderedIds) async {
     if (orderedIds.isEmpty) return;

--- a/lib/features/collections/providers/item_tags_provider.dart
+++ b/lib/features/collections/providers/item_tags_provider.dart
@@ -39,6 +39,53 @@ class ItemTagsNotifier extends AsyncNotifier<Map<int, List<int>>> {
     state = AsyncData<Map<int, List<int>>>(next);
   }
 
+  /// Adds [tagIds] to every item in [itemIds], leaving their other tags
+  /// alone. Returns how many links were actually created — items that
+  /// already carried a tag are not counted.
+  Future<int> addTagsToItems(Iterable<int> itemIds, Set<int> tagIds) async {
+    final List<int> targets = itemIds.toList(growable: false);
+    if (targets.isEmpty || tagIds.isEmpty) return 0;
+    final GlobalTagDao dao = ref.read(globalTagDaoProvider);
+    await dao.addTagsToItems(targets, tagIds);
+    return _syncItems(dao, targets);
+  }
+
+  /// Removes [tagIds] from every item in [itemIds]. Returns how many links
+  /// were actually dropped.
+  Future<int> removeTagsFromItems(
+    Iterable<int> itemIds,
+    Set<int> tagIds,
+  ) async {
+    final List<int> targets = itemIds.toList(growable: false);
+    if (targets.isEmpty || tagIds.isEmpty) return 0;
+    final GlobalTagDao dao = ref.read(globalTagDaoProvider);
+    await dao.removeTagsFromItems(targets, tagIds);
+    return _syncItems(dao, targets);
+  }
+
+  /// Re-reads the tag lists of [itemIds] in one query and patches the map in
+  /// a single state update. Reading back rather than guessing keeps the
+  /// in-memory order identical to the DAO's, which mixes manual positions
+  /// with the global-order fallback.
+  Future<int> _syncItems(GlobalTagDao dao, List<int> itemIds) async {
+    final Map<int, List<int>> fresh = await dao.getTagIdsForItems(itemIds);
+    final Map<int, List<int>> next = _copy();
+    int changed = 0;
+    for (final int itemId in itemIds) {
+      final int before = next[itemId]?.length ?? 0;
+      final List<int>? after = fresh[itemId];
+      if (after == null || after.isEmpty) {
+        next.remove(itemId);
+        changed += before;
+      } else {
+        next[itemId] = after;
+        changed += (after.length - before).abs();
+      }
+    }
+    state = AsyncData<Map<int, List<int>>>(next);
+    return changed;
+  }
+
   /// Persists a manual per-item reorder of the item's tags.
   Future<void> reorderItemTags(int itemId, List<int> orderedTagIds) async {
     final GlobalTagDao dao = ref.read(globalTagDaoProvider);

--- a/lib/features/collections/widgets/bulk_action_bar.dart
+++ b/lib/features/collections/widgets/bulk_action_bar.dart
@@ -14,8 +14,13 @@ import '../../../shared/widgets/collection_picker_dialog.dart';
 import '../../../shared/widgets/confirm_dialog.dart';
 import '../helpers/bulk_operations.dart';
 import '../providers/collections_provider.dart';
+import '../providers/item_tags_provider.dart';
 import 'bulk_export/bulk_poster_export_dialog.dart';
+import 'tag_picker_dialog.dart';
 import '../../../shared/constants/item_status_ui.dart';
+
+/// Below this width the counter and the actions stop fitting on one line.
+const double _kTwoRowBreakpoint = 620;
 
 /// Selection toolbar that works both inside a single collection and on All
 /// Items. When [collectionId] is set the bar excludes that collection from
@@ -72,85 +77,128 @@ class BulkActionBar extends ConsumerWidget {
           horizontal: AppSpacing.md,
           vertical: AppSpacing.xs,
         ),
-        child: Row(
-          children: <Widget>[
-            _CloseButton(onPressed: onClearSelection),
-            const SizedBox(width: AppSpacing.sm),
-            Text(
-              l.bulkSelected(count),
-              style: AppTypography.body.copyWith(
-                color: AppColors.brand,
-                fontWeight: FontWeight.w600,
-              ),
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            // One row cannot hold the counter and every action on a phone:
+            // the counter wins the width and the actions scroll away almost
+            // entirely. Below the threshold they get a row of their own.
+            if (constraints.maxWidth < _kTwoRowBreakpoint) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Row(children: _buildSelectionControls(l, count)),
+                  _buildActionStrip(context, ref, l, isManualSort),
+                ],
+              );
+            }
+            return Row(
+              children: <Widget>[
+                ..._buildSelectionControls(l, count),
+                Expanded(
+                  child: _buildActionStrip(context, ref, l, isManualSort),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildSelectionControls(S l, int count) {
+    return <Widget>[
+      _CloseButton(onPressed: onClearSelection),
+      const SizedBox(width: AppSpacing.sm),
+      // Flexible so a long localized counter ellipsizes instead of pushing
+      // the Select all button off the edge on a narrow screen.
+      Flexible(
+        child: Text(
+          l.bulkSelected(count),
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.body.copyWith(
+            color: AppColors.brand,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      if (onSelectAllVisible != null && (visibleCount ?? 0) > count) ...<Widget>[
+        const SizedBox(width: AppSpacing.sm),
+        TextButton(
+          onPressed: onSelectAllVisible,
+          style: TextButton.styleFrom(
+            foregroundColor: AppColors.brand,
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: Text(l.selectAll),
+        ),
+      ],
+    ];
+  }
+
+  Widget _buildActionStrip(
+    BuildContext context,
+    WidgetRef ref,
+    S l,
+    bool isManualSort,
+  ) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      reverse: true,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          _BarAction(
+            icon: Icons.drive_file_move_outlined,
+            tooltip: l.collectionMoveToCollection,
+            onTap: () => _handleMove(context, ref),
+          ),
+          _BarAction(
+            icon: Icons.copy_outlined,
+            tooltip: l.collectionCopyToCollection,
+            onTap: () => _handleClone(context, ref),
+          ),
+          _StatusMenuAction(
+            onSelected: (ItemStatus s) => _handleStatus(context, ref, s),
+          ),
+          _BarAction(
+            icon: Icons.new_label_outlined,
+            tooltip: l.bulkAddTags,
+            onTap: () => _handleTags(context, ref, add: true),
+          ),
+          _BarAction(
+            icon: Icons.label_off_outlined,
+            tooltip: l.bulkRemoveTags,
+            onTap: () => _handleTags(context, ref, add: false),
+          ),
+          _BarAction(
+            icon: Icons.image_outlined,
+            tooltip: l.bulkExportPngTitle,
+            onTap: () => _handleExportPng(context),
+          ),
+          if (isManualSort) ...<Widget>[
+            const _BarDivider(),
+            _BarAction(
+              icon: Icons.vertical_align_top,
+              tooltip: l.moveToTop,
+              onTap: () => _handleMoveToTop(ref),
             ),
-            if (onSelectAllVisible != null &&
-                (visibleCount ?? 0) > count) ...<Widget>[
-              const SizedBox(width: AppSpacing.sm),
-              TextButton(
-                onPressed: onSelectAllVisible,
-                style: TextButton.styleFrom(
-                  foregroundColor: AppColors.brand,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.sm,
-                  ),
-                  minimumSize: Size.zero,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-                child: Text(l.selectAll),
-              ),
-            ],
-            Expanded(
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                reverse: true,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: <Widget>[
-                    _BarAction(
-                      icon: Icons.drive_file_move_outlined,
-                      tooltip: l.collectionMoveToCollection,
-                      onTap: () => _handleMove(context, ref),
-                    ),
-                    _BarAction(
-                      icon: Icons.copy_outlined,
-                      tooltip: l.collectionCopyToCollection,
-                      onTap: () => _handleClone(context, ref),
-                    ),
-                    _StatusMenuAction(
-                      onSelected: (ItemStatus s) =>
-                          _handleStatus(context, ref, s),
-                    ),
-                    _BarAction(
-                      icon: Icons.image_outlined,
-                      tooltip: l.bulkExportPngTitle,
-                      onTap: () => _handleExportPng(context),
-                    ),
-                    if (isManualSort) ...<Widget>[
-                      const _BarDivider(),
-                      _BarAction(
-                        icon: Icons.vertical_align_top,
-                        tooltip: l.moveToTop,
-                        onTap: () => _handleMoveToTop(ref),
-                      ),
-                      _BarAction(
-                        icon: Icons.vertical_align_bottom,
-                        tooltip: l.moveToBottom,
-                        onTap: () => _handleMoveToBottom(ref),
-                      ),
-                    ],
-                    const _BarDivider(),
-                    _BarAction(
-                      icon: Icons.delete_outline,
-                      tooltip: l.remove,
-                      danger: true,
-                      onTap: () => _handleRemove(context, ref),
-                    ),
-                  ],
-                ),
-              ),
+            _BarAction(
+              icon: Icons.vertical_align_bottom,
+              tooltip: l.moveToBottom,
+              onTap: () => _handleMoveToBottom(ref),
             ),
           ],
-        ),
+          const _BarDivider(),
+          _BarAction(
+            icon: Icons.delete_outline,
+            tooltip: l.remove,
+            danger: true,
+            onTap: () => _handleRemove(context, ref),
+          ),
+        ],
       ),
     );
   }
@@ -224,6 +272,44 @@ class BulkActionBar extends ConsumerWidget {
     context.showSnack(
       l.bulkStatusUpdated(changed),
       type: SnackType.success,
+    );
+  }
+
+  /// Adds or drops the picked tags across the selection, leaving each item's
+  /// other tags untouched — the bar never replaces a whole tag set, because
+  /// that would wipe tags the user assigned per item.
+  Future<void> _handleTags(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool add,
+  }) async {
+    final S l = S.of(context);
+    final int count = items.length;
+    final Set<int>? picked = await TagPickerDialog.show(
+      context,
+      // Selected items carry different tags, so there is no shared state to
+      // pre-check. Here a checked box means "apply to all", not the
+      // single-item "this item has the tag".
+      initialSelection: const <int>{},
+      title: add ? l.bulkAddTagsTitle(count) : l.bulkRemoveTagsTitle(count),
+      confirmLabel: add ? l.add : l.remove,
+    );
+    if (picked == null || picked.isEmpty || !context.mounted) return;
+
+    final ItemTagsNotifier tags = ref.read(itemTagsProvider.notifier);
+    final Iterable<int> ids = items.map((CollectionItem i) => i.id);
+    final int changed = add
+        ? await tags.addTagsToItems(ids, picked)
+        : await tags.removeTagsFromItems(ids, picked);
+    onClearSelection();
+    if (!context.mounted) return;
+    context.showSnack(
+      switch (changed) {
+        0 => l.bulkTagsUnchanged,
+        _ when add => l.bulkTagsAdded(changed),
+        _ => l.bulkTagsRemoved(changed),
+      },
+      type: changed == 0 ? SnackType.info : SnackType.success,
     );
   }
 

--- a/lib/features/collections/widgets/tag_picker_dialog.dart
+++ b/lib/features/collections/widgets/tag_picker_dialog.dart
@@ -16,19 +16,40 @@ import '../providers/global_tags_provider.dart';
 /// "Create «query»" row appears at the top of the list.
 ///
 /// Returns the chosen tag id set, or `null` when dismissed.
+///
+/// A bulk caller opens it with an empty [initialSelection] — a selection's
+/// items carry different tags, so there is no common state to show — and
+/// passes its own [title] and [confirmLabel], because there an unchecked box
+/// means "leave alone" rather than the single-item "remove this tag".
 class TagPickerDialog extends ConsumerStatefulWidget {
-  const TagPickerDialog({required this.initialSelection, super.key});
+  const TagPickerDialog({
+    required this.initialSelection,
+    this.title,
+    this.confirmLabel,
+    super.key,
+  });
 
   final Set<int> initialSelection;
+
+  /// Defaults to the neutral "select tags" wording.
+  final String? title;
+
+  /// Defaults to "Apply".
+  final String? confirmLabel;
 
   static Future<Set<int>?> show(
     BuildContext context, {
     required Set<int> initialSelection,
+    String? title,
+    String? confirmLabel,
   }) {
     return showDialog<Set<int>>(
       context: context,
-      builder: (BuildContext context) =>
-          TagPickerDialog(initialSelection: initialSelection),
+      builder: (BuildContext context) => TagPickerDialog(
+        initialSelection: initialSelection,
+        title: title,
+        confirmLabel: confirmLabel,
+      ),
     );
   }
 
@@ -104,7 +125,7 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
         AppSpacing.md,
         0,
       ),
-      title: Text(l.tagPickerTitle),
+      title: Text(widget.title ?? l.tagPickerTitle),
       content: SizedBox(
         width: 360,
         child: SingleChildScrollView(
@@ -194,7 +215,7 @@ class _TagPickerDialogState extends ConsumerState<TagPickerDialog> {
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(_selected),
-          child: Text(l.apply),
+          child: Text(widget.confirmLabel ?? l.apply),
         ),
       ],
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -148,6 +148,33 @@
       "count": {"type": "int"}
     }
   },
+  "bulkAddTags": "Add tags",
+  "bulkRemoveTags": "Remove tags",
+  "bulkAddTagsTitle": "Add tags to {count, plural, =1{1 item} other{{count} items}}",
+  "@bulkAddTagsTitle": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkRemoveTagsTitle": "Remove tags from {count, plural, =1{1 item} other{{count} items}}",
+  "@bulkRemoveTagsTitle": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkTagsAdded": "Tags added: {count}",
+  "@bulkTagsAdded": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkTagsRemoved": "Tags removed: {count}",
+  "@bulkTagsRemoved": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "bulkTagsUnchanged": "Nothing to change",
   "bulkExportPngTitle": "Export as PNG",
   "columnsCount": "Columns",
   "bulkExportPngItemsCount": "{count, plural, =1{1 item} other{{count} items}}",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -148,6 +148,13 @@
       "count": {"type": "int"}
     }
   },
+  "bulkAddTags": "Añadir etiquetas",
+  "bulkRemoveTags": "Quitar etiquetas",
+  "bulkAddTagsTitle": "Añadir etiquetas a {count, plural, =1{1 elemento} other{{count} elementos}}",
+  "bulkRemoveTagsTitle": "Quitar etiquetas de {count, plural, =1{1 elemento} other{{count} elementos}}",
+  "bulkTagsAdded": "Etiquetas añadidas: {count}",
+  "bulkTagsRemoved": "Etiquetas quitadas: {count}",
+  "bulkTagsUnchanged": "Nada que cambiar",
   "bulkExportPngTitle": "Exportar como PNG",
   "columnsCount": "Columnas",
   "bulkExportPngItemsCount": "{count, plural, =1{1 elemento} other{{count} elementos}}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -148,6 +148,13 @@
       "count": {"type": "int"}
     }
   },
+  "bulkAddTags": "Ajouter des tags",
+  "bulkRemoveTags": "Retirer des tags",
+  "bulkAddTagsTitle": "Ajouter des tags à {count, plural, =1{1 élément} other{{count} éléments}}",
+  "bulkRemoveTagsTitle": "Retirer des tags de {count, plural, =1{1 élément} other{{count} éléments}}",
+  "bulkTagsAdded": "Tags ajoutés : {count}",
+  "bulkTagsRemoved": "Tags retirés : {count}",
+  "bulkTagsUnchanged": "Rien à modifier",
   "bulkExportPngTitle": "Exporter en PNG",
   "columnsCount": "Colonnes",
   "bulkExportPngItemsCount": "{count, plural, =1{1 image} other{{count} images}}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -747,6 +747,48 @@ abstract class S {
   /// **'Status updated for {count, plural, =1{1 item} other{{count} items}}'**
   String bulkStatusUpdated(int count);
 
+  /// No description provided for @bulkAddTags.
+  ///
+  /// In en, this message translates to:
+  /// **'Add tags'**
+  String get bulkAddTags;
+
+  /// No description provided for @bulkRemoveTags.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove tags'**
+  String get bulkRemoveTags;
+
+  /// No description provided for @bulkAddTagsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add tags to {count, plural, =1{1 item} other{{count} items}}'**
+  String bulkAddTagsTitle(int count);
+
+  /// No description provided for @bulkRemoveTagsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove tags from {count, plural, =1{1 item} other{{count} items}}'**
+  String bulkRemoveTagsTitle(int count);
+
+  /// No description provided for @bulkTagsAdded.
+  ///
+  /// In en, this message translates to:
+  /// **'Tags added: {count}'**
+  String bulkTagsAdded(int count);
+
+  /// No description provided for @bulkTagsRemoved.
+  ///
+  /// In en, this message translates to:
+  /// **'Tags removed: {count}'**
+  String bulkTagsRemoved(int count);
+
+  /// No description provided for @bulkTagsUnchanged.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing to change'**
+  String get bulkTagsUnchanged;
+
   /// No description provided for @bulkExportPngTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -361,6 +361,47 @@ class SEn extends S {
   }
 
   @override
+  String get bulkAddTags => 'Add tags';
+
+  @override
+  String get bulkRemoveTags => 'Remove tags';
+
+  @override
+  String bulkAddTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items',
+      one: '1 item',
+    );
+    return 'Add tags to $_temp0';
+  }
+
+  @override
+  String bulkRemoveTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count items',
+      one: '1 item',
+    );
+    return 'Remove tags from $_temp0';
+  }
+
+  @override
+  String bulkTagsAdded(int count) {
+    return 'Tags added: $count';
+  }
+
+  @override
+  String bulkTagsRemoved(int count) {
+    return 'Tags removed: $count';
+  }
+
+  @override
+  String get bulkTagsUnchanged => 'Nothing to change';
+
+  @override
   String get bulkExportPngTitle => 'Export as PNG';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -361,6 +361,47 @@ class SEs extends S {
   }
 
   @override
+  String get bulkAddTags => 'Añadir etiquetas';
+
+  @override
+  String get bulkRemoveTags => 'Quitar etiquetas';
+
+  @override
+  String bulkAddTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count elementos',
+      one: '1 elemento',
+    );
+    return 'Añadir etiquetas a $_temp0';
+  }
+
+  @override
+  String bulkRemoveTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count elementos',
+      one: '1 elemento',
+    );
+    return 'Quitar etiquetas de $_temp0';
+  }
+
+  @override
+  String bulkTagsAdded(int count) {
+    return 'Etiquetas añadidas: $count';
+  }
+
+  @override
+  String bulkTagsRemoved(int count) {
+    return 'Etiquetas quitadas: $count';
+  }
+
+  @override
+  String get bulkTagsUnchanged => 'Nada que cambiar';
+
+  @override
   String get bulkExportPngTitle => 'Exportar como PNG';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -361,6 +361,47 @@ class SFr extends S {
   }
 
   @override
+  String get bulkAddTags => 'Ajouter des tags';
+
+  @override
+  String get bulkRemoveTags => 'Retirer des tags';
+
+  @override
+  String bulkAddTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count éléments',
+      one: '1 élément',
+    );
+    return 'Ajouter des tags à $_temp0';
+  }
+
+  @override
+  String bulkRemoveTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count éléments',
+      one: '1 élément',
+    );
+    return 'Retirer des tags de $_temp0';
+  }
+
+  @override
+  String bulkTagsAdded(int count) {
+    return 'Tags ajoutés : $count';
+  }
+
+  @override
+  String bulkTagsRemoved(int count) {
+    return 'Tags retirés : $count';
+  }
+
+  @override
+  String get bulkTagsUnchanged => 'Rien à modifier';
+
+  @override
   String get bulkExportPngTitle => 'Exporter en PNG';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -361,6 +361,47 @@ class SPt extends S {
   }
 
   @override
+  String get bulkAddTags => 'Adicionar tags';
+
+  @override
+  String get bulkRemoveTags => 'Remover tags';
+
+  @override
+  String bulkAddTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens',
+      one: '1 item',
+    );
+    return 'Adicionar tags a $_temp0';
+  }
+
+  @override
+  String bulkRemoveTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count itens',
+      one: '1 item',
+    );
+    return 'Remover tags de $_temp0';
+  }
+
+  @override
+  String bulkTagsAdded(int count) {
+    return 'Tags adicionadas: $count';
+  }
+
+  @override
+  String bulkTagsRemoved(int count) {
+    return 'Tags removidas: $count';
+  }
+
+  @override
+  String get bulkTagsUnchanged => 'Nada a alterar';
+
+  @override
   String get bulkExportPngTitle => 'Exportar como PNG';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -367,6 +367,49 @@ class SRu extends S {
   }
 
   @override
+  String get bulkAddTags => 'Добавить теги';
+
+  @override
+  String get bulkRemoveTags => 'Удалить теги';
+
+  @override
+  String bulkAddTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count элементам',
+      few: '$count элементам',
+      one: '1 элементу',
+    );
+    return 'Добавить теги к $_temp0';
+  }
+
+  @override
+  String bulkRemoveTagsTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count элементов',
+      few: '$count элементов',
+      one: '1 элемента',
+    );
+    return 'Удалить теги у $_temp0';
+  }
+
+  @override
+  String bulkTagsAdded(int count) {
+    return 'Добавлено тегов: $count';
+  }
+
+  @override
+  String bulkTagsRemoved(int count) {
+    return 'Удалено тегов: $count';
+  }
+
+  @override
+  String get bulkTagsUnchanged => 'Нечего менять';
+
+  @override
   String get bulkExportPngTitle => 'Экспорт в PNG';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -342,6 +342,35 @@ class SZh extends S {
   }
 
   @override
+  String get bulkAddTags => '添加标签';
+
+  @override
+  String get bulkRemoveTags => '移除标签';
+
+  @override
+  String bulkAddTagsTitle(int count) {
+    return '为 $count 项添加标签';
+  }
+
+  @override
+  String bulkRemoveTagsTitle(int count) {
+    return '从 $count 项移除标签';
+  }
+
+  @override
+  String bulkTagsAdded(int count) {
+    return '已添加标签：$count';
+  }
+
+  @override
+  String bulkTagsRemoved(int count) {
+    return '已移除标签：$count';
+  }
+
+  @override
+  String get bulkTagsUnchanged => '无需更改';
+
+  @override
   String get bulkExportPngTitle => '导出为 PNG';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -155,6 +155,13 @@
       }
     }
   },
+  "bulkAddTags": "Adicionar tags",
+  "bulkRemoveTags": "Remover tags",
+  "bulkAddTagsTitle": "Adicionar tags a {count, plural, =1{1 item} other{{count} itens}}",
+  "bulkRemoveTagsTitle": "Remover tags de {count, plural, =1{1 item} other{{count} itens}}",
+  "bulkTagsAdded": "Tags adicionadas: {count}",
+  "bulkTagsRemoved": "Tags removidas: {count}",
+  "bulkTagsUnchanged": "Nada a alterar",
   "bulkExportPngTitle": "Exportar como PNG",
   "columnsCount": "Colunas",
   "bulkExportPngItemsCount": "{count, plural, =1{1 item} other{{count} itens}}",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -148,6 +148,13 @@
       "count": {"type": "int"}
     }
   },
+  "bulkAddTags": "Добавить теги",
+  "bulkRemoveTags": "Удалить теги",
+  "bulkAddTagsTitle": "Добавить теги к {count, plural, =1{1 элементу} few{{count} элементам} other{{count} элементам}}",
+  "bulkRemoveTagsTitle": "Удалить теги у {count, plural, =1{1 элемента} few{{count} элементов} other{{count} элементов}}",
+  "bulkTagsAdded": "Добавлено тегов: {count}",
+  "bulkTagsRemoved": "Удалено тегов: {count}",
+  "bulkTagsUnchanged": "Нечего менять",
   "bulkExportPngTitle": "Экспорт в PNG",
   "columnsCount": "Колонок",
   "bulkExportPngItemsCount": "{count, plural, =1{1 элемент} few{{count} элемента} many{{count} элементов} other{{count} элементов}}",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -148,6 +148,13 @@
       "count": {"type": "int"}
     }
   },
+  "bulkAddTags": "添加标签",
+  "bulkRemoveTags": "移除标签",
+  "bulkAddTagsTitle": "为 {count} 项添加标签",
+  "bulkRemoveTagsTitle": "从 {count} 项移除标签",
+  "bulkTagsAdded": "已添加标签：{count}",
+  "bulkTagsRemoved": "已移除标签：{count}",
+  "bulkTagsUnchanged": "无需更改",
   "bulkExportPngTitle": "导出为 PNG",
   "columnsCount": "列数",
   "bulkExportPngItemsCount": "{count} 个项目",

--- a/test/core/database/dao/global_tag_dao_test.dart
+++ b/test/core/database/dao/global_tag_dao_test.dart
@@ -3,6 +3,7 @@ import 'package:core/database/migrations/migration_v56.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:tonkatsu_box/core/database/dao/global_tag_dao.dart';
+import 'package:tonkatsu_box/core/database/query_chunk.dart';
 import 'package:tonkatsu_box/shared/models/tag.dart';
 
 void main() {
@@ -219,6 +220,108 @@ void main() {
         await dao.addTagToItems(<int>[], owned.id);
 
         expect(await dao.getTagIdsByItem(1), isEmpty);
+      });
+
+      test('addTagsToItems links every tag to every item additively',
+          () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        final Tag c = await dao.create('c');
+        await dao.setItemTags(1, <int>{a.id});
+
+        await dao.addTagsToItems(<int>[1, 2], <int>{b.id, c.id});
+
+        expect(await dao.getTagIdsByItem(1), <int>[a.id, b.id, c.id]);
+        expect(await dao.getTagIdsByItem(2), <int>[b.id, c.id]);
+      });
+
+      test('addTagsToItems is idempotent for already linked pairs', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        await dao.setItemTags(1, <int>{a.id});
+
+        await dao.addTagsToItems(<int>[1], <int>{a.id, b.id});
+        await dao.addTagsToItems(<int>[1], <int>{a.id, b.id});
+
+        expect(await dao.getTagIdsByItem(1), <int>[a.id, b.id]);
+      });
+
+      test('addTagsToItems with no items or no tags is a no-op', () async {
+        final Tag a = await dao.create('a');
+        await dao.addTagsToItems(<int>[], <int>{a.id});
+        await dao.addTagsToItems(<int>[1], <int>{});
+
+        expect(await dao.getTagIdsByItem(1), isEmpty);
+      });
+
+      test('removeTagsFromItems drops only the named pairs', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        final Tag c = await dao.create('c');
+        await dao.setItemTags(1, <int>{a.id, b.id, c.id});
+        await dao.setItemTags(2, <int>{a.id, b.id});
+        await dao.setItemTags(3, <int>{c.id});
+
+        await dao.removeTagsFromItems(<int>[1, 2], <int>{a.id, c.id});
+
+        expect(await dao.getTagIdsByItem(1), <int>[b.id]);
+        expect(await dao.getTagIdsByItem(2), <int>[b.id]);
+        // Item 3 was not in the id list, so its link survives.
+        expect(await dao.getTagIdsByItem(3), <int>[c.id]);
+      });
+
+      test('removeTagsFromItems can leave an item with no tags', () async {
+        final Tag a = await dao.create('a');
+        await dao.setItemTags(1, <int>{a.id});
+
+        await dao.removeTagsFromItems(<int>[1], <int>{a.id});
+
+        expect(await dao.getTagIdsByItem(1), isEmpty);
+      });
+
+      test('removeTagsFromItems keeps the tag itself in the registry',
+          () async {
+        final Tag a = await dao.create('a');
+        await dao.setItemTags(1, <int>{a.id});
+
+        await dao.removeTagsFromItems(<int>[1], <int>{a.id});
+
+        expect(await dao.getById(a.id), isNotNull);
+      });
+
+      test('removeTagsFromItems ignores unlinked pairs', () async {
+        final Tag a = await dao.create('a');
+        final Tag b = await dao.create('b');
+        await dao.setItemTags(1, <int>{a.id});
+
+        await expectLater(
+          dao.removeTagsFromItems(<int>[1, 2], <int>{b.id}),
+          completes,
+        );
+        expect(await dao.getTagIdsByItem(1), <int>[a.id]);
+      });
+
+      test('removeTagsFromItems with no items or no tags is a no-op',
+          () async {
+        final Tag a = await dao.create('a');
+        await dao.setItemTags(1, <int>{a.id});
+
+        await dao.removeTagsFromItems(<int>[], <int>{a.id});
+        await dao.removeTagsFromItems(<int>[1], <int>{});
+
+        expect(await dao.getTagIdsByItem(1), <int>[a.id]);
+      });
+
+      test('removeTagsFromItems chunks past the bound-parameter limit',
+          () async {
+        final Tag a = await dao.create('a');
+        final List<int> itemIds =
+            List<int>.generate(kInClauseChunkSize + 50, (int i) => i + 1);
+        await dao.addTagsToItems(itemIds, <int>{a.id});
+
+        await dao.removeTagsFromItems(itemIds, <int>{a.id});
+
+        expect(await dao.getTagIdsForItems(itemIds), isEmpty);
       });
     });
 

--- a/test/features/collections/providers/item_tags_provider_test.dart
+++ b/test/features/collections/providers/item_tags_provider_test.dart
@@ -116,6 +116,107 @@ void main() {
       });
     });
 
+    group('bulk tag changes', () {
+      setUp(() {
+        when(() => mockDao.getAllItemTags()).thenAnswer(
+          (_) async => <int, List<int>>{
+            1: <int>[10],
+            2: <int>[10, 20],
+          },
+        );
+        when(() => mockDao.addTagsToItems(any(), any()))
+            .thenAnswer((_) async {});
+        when(() => mockDao.removeTagsFromItems(any(), any()))
+            .thenAnswer((_) async {});
+      });
+
+      test('addTagsToItems writes once and re-reads once', () async {
+        await load();
+        when(() => mockDao.getTagIdsForItems(any())).thenAnswer(
+          (_) async => <int, List<int>>{
+            1: <int>[10, 20],
+            2: <int>[10, 20],
+          },
+        );
+
+        await container
+            .read(itemTagsProvider.notifier)
+            .addTagsToItems(<int>[1, 2], <int>{20});
+
+        verify(() => mockDao.addTagsToItems(<int>[1, 2], <int>{20})).called(1);
+        verify(() => mockDao.getTagIdsForItems(<int>[1, 2])).called(1);
+        verifyNever(() => mockDao.setItemTags(any(), any()));
+        verifyNever(() => mockDao.getTagIdsByItem(any()));
+      });
+
+      test('addTagsToItems counts only links that were missing', () async {
+        await load();
+        when(() => mockDao.getTagIdsForItems(any())).thenAnswer(
+          (_) async => <int, List<int>>{
+            1: <int>[10, 20],
+            2: <int>[10, 20],
+          },
+        );
+
+        final int changed = await container
+            .read(itemTagsProvider.notifier)
+            .addTagsToItems(<int>[1, 2], <int>{20});
+
+        // Item 2 already carried tag 20, so only item 1 gained a link.
+        expect(changed, 1);
+      });
+
+      test('addTagsToItems takes the dao order, not the requested one',
+          () async {
+        await load();
+        when(() => mockDao.getTagIdsForItems(any())).thenAnswer(
+          (_) async => <int, List<int>>{
+            1: <int>[30, 10],
+            2: <int>[10, 20],
+          },
+        );
+
+        await container
+            .read(itemTagsProvider.notifier)
+            .addTagsToItems(<int>[1], <int>{30});
+
+        expect(container.read(itemTagsProvider).valueOrNull?[1], <int>[30, 10]);
+      });
+
+      test('removeTagsFromItems drops items left without tags', () async {
+        await load();
+        when(() => mockDao.getTagIdsForItems(any())).thenAnswer(
+          (_) async => <int, List<int>>{
+            2: <int>[20],
+          },
+        );
+
+        final int changed = await container
+            .read(itemTagsProvider.notifier)
+            .removeTagsFromItems(<int>[1, 2], <int>{10});
+
+        expect(changed, 2);
+        expect(container.read(itemTagsProvider).valueOrNull, <int, List<int>>{
+          2: <int>[20],
+        });
+      });
+
+      test('both operations no-op on an empty selection or empty tag set',
+          () async {
+        await load();
+
+        final ItemTagsNotifier notifier =
+            container.read(itemTagsProvider.notifier);
+        expect(await notifier.addTagsToItems(<int>[], <int>{10}), 0);
+        expect(await notifier.addTagsToItems(<int>[1], <int>{}), 0);
+        expect(await notifier.removeTagsFromItems(<int>[], <int>{10}), 0);
+        expect(await notifier.removeTagsFromItems(<int>[1], <int>{}), 0);
+
+        verifyNever(() => mockDao.addTagsToItems(any(), any()));
+        verifyNever(() => mockDao.removeTagsFromItems(any(), any()));
+      });
+    });
+
     test('dropTagEverywhere removes the tag, keeping list order', () async {
       when(() => mockDao.getAllItemTags()).thenAnswer(
         (_) async => <int, List<int>>{

--- a/test/features/collections/widgets/bulk_action_bar_test.dart
+++ b/test/features/collections/widgets/bulk_action_bar_test.dart
@@ -69,4 +69,89 @@ void main() {
       expect(selectAllButton(), findsNothing);
     });
   });
+
+  group('BulkActionBar tag actions', () {
+    final List<CollectionItem> twoSelected = <CollectionItem>[
+      createTestCollectionItem(id: 1),
+      createTestCollectionItem(id: 2),
+    ];
+
+    testWidgets('should offer both add-tags and remove-tags actions',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        BulkActionBar(
+          items: twoSelected,
+          onClearSelection: () {},
+        ),
+        wrapInScaffold: true,
+      );
+
+      expect(find.byIcon(Icons.new_label_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.label_off_outlined), findsOneWidget);
+    });
+
+    testWidgets('should open the tag picker from the add-tags action',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        BulkActionBar(
+          items: twoSelected,
+          onClearSelection: () {},
+        ),
+        wrapInScaffold: true,
+      );
+
+      await tester.tap(find.byIcon(Icons.new_label_outlined));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('BulkActionBar layout', () {
+    final List<CollectionItem> oneSelected = <CollectionItem>[
+      createTestCollectionItem(id: 1),
+    ];
+
+    Future<void> pumpAt(WidgetTester tester, Size size) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpApp(
+        BulkActionBar(
+          items: oneSelected,
+          visibleCount: 9,
+          onSelectAllVisible: () {},
+          onClearSelection: () {},
+        ),
+        wrapInScaffold: true,
+      );
+    }
+
+    testWidgets('should stack the counter above the actions on a phone',
+        (WidgetTester tester) async {
+      await pumpAt(tester, const Size(360, 640));
+
+      // Two rows: the counter keeps its width and the actions get their own
+      // line instead of being squeezed into a sliver of scrollable space.
+      expect(find.byType(Column), findsWidgets);
+      final Offset counter = tester.getCenter(find.byType(Text).first);
+      final Offset actions =
+          tester.getCenter(find.byIcon(Icons.delete_outline));
+      expect(actions.dy, greaterThan(counter.dy));
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('should keep everything on one line on a wide window',
+        (WidgetTester tester) async {
+      await pumpAt(tester, const Size(1280, 800));
+
+      final Offset counter = tester.getCenter(find.byType(Text).first);
+      final Offset actions =
+          tester.getCenter(find.byIcon(Icons.delete_outline));
+      expect(actions.dy, closeTo(counter.dy, 1.0));
+      expect(tester.takeException(), isNull);
+    });
+  });
 }


### PR DESCRIPTION
The selection toolbar gains add-tags and remove-tags actions, so a tag no longer has to be applied item by item. Both reuse the single-item tag picker with nothing pre-checked — the selection's items carry different tags, so a checked box means "apply to all of them". Adding is additive and removing drops only the picked tags, so per-item tags and their manual order survive either way.

Writes stay flat: one INSERT OR IGNORE batch or one chunked DELETE, then a single read-back that keeps the in-memory tag order identical to the DAO's, instead of a query and a rebuild per selected item.

On a narrow window the toolbar stacks the counter and the actions into two rows; on one row the actions were squeezed into a sliver of scrollable space on a phone.