### PR TITLE
fix(import,collections): resolve media by source and align filter counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,85 +7,55 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
-### Changed
-
-- **Move the database schema and migrations into a pure-Dart `core` package**
-
-  No user-visible change. The migration chain and the DDL helpers now live in
-  `packages/core`, a plain Dart package with no Flutter dependency, so the
-  planned selfhost server can build and upgrade the same database without a
-  Flutter SDK. The schema itself is untouched: all 62 files moved verbatim.
-
-  * packages/core/pubspec.yaml: New pure-Dart package `core`, depending only on
-    `sqflite_common_ffi`.
-  * packages/core/lib/database/schema.dart (DatabaseSchema),
-    packages/core/lib/database/migrations/migration.dart (Migration,
-    Migration.addColumnIfAbsent), migration_registry.dart (MigrationRegistry.all,
-    MigrationRegistry.pending, MigrationRegistry.latestVersion),
-    migration_v1.dart through migration_v60.dart (MigrationV1 … MigrationV60):
-    Moved unchanged from lib/core/database/.
-  * pubspec.yaml: Add the `core` path dependency.
-  * lib/core/database/database_service.dart (DatabaseService),
-    lib/core/services/db_sync_service.dart (DbSyncService),
-    lib/core/services/storage_root.dart: Import Migration and MigrationRegistry
-    from `package:core`.
-  * test/core/database/migrations/migration_chain_test.dart: New coverage that
-    the registry is ascending and gapless, that pending() returns the right
-    slice, and that replaying the whole chain on an empty database builds every
-    table the app queries.
-
-- **Make all models pure Dart: move UI mapping out of the model layer**
-
-  No user-visible change. Colors, icons and localized labels that lived
-  inside model classes moved to extension files so the model layer no
-  longer depends on Flutter — groundwork for sharing models with the
-  planned selfhost server.
-
-  * lib/shared/constants/item_status_ui.dart (ItemStatusUi),
-    data_source_ui.dart (DataSourceUi), collection_item_ui.dart
-    (CollectionItemUi), canvas_item_ui.dart (CanvasItemUi), profile_ui.dart
-    (ProfileUi), platform_ui.dart (PlatformUi), tier_definition_ui.dart
-    (TierDefinitionUi), media_type_ui.dart (MediaTypeUi),
-    collection_sort_mode_ui.dart (CollectionSortModeUi),
-    collection_list_sort_mode_ui.dart (CollectionListSortModeUi),
-    calendar_recurrence_ui.dart (CalendarRecurrenceUi): New presentation
-    extensions holding the moved getters and localized-label methods
-    (color, materialIcon, cardSubcategoryLabel,
-    localizedLabel, genericLabel, placeholderIcon, mediaPlaceholderIcon,
-    familyColor, displayColor, localizedDisplayLabel, localizedShortLabel,
-    localizedDirectionLabel, localizedDescription).
-  * lib/shared/utils/color_hex.dart (ColorHex.fromHex, ColorHex.toHex): New
-    hex-string color codec, replacing Profile.hexToColor / colorToHex and a
-    private duplicate in edit_connection_dialog.dart.
-  * lib/shared/models/item_status.dart (ItemStatus), data_source.dart
-    (DataSource.colorValue), profile.dart (Profile), collection_item.dart
-    (CollectionItem), canvas_item.dart (CanvasItem), platform.dart
-    (Platform), tier_definition.dart (TierDefinition.colorValue),
-    media_type.dart (MediaType), collection_sort_mode.dart
-    (CollectionSortMode), collection_list_sort_mode.dart
-    (CollectionListSortMode), search_sort.dart (SearchSortField),
-    card_link.dart, calendar_recurrence.dart (CalendarRecurrence): Flutter,
-    dart:ui and l10n imports removed; DataSource and TierDefinition store
-    the color as an ARGB int; unused SearchSortField.localizedShortLabel
-    and localizedDisplayLabel deleted as dead code.
-  * lib/shared/constants/media_type_theme.dart
-    (MediaTypeTheme.placeholderIconFor): New shared outlined-icon mapping;
-    collection_item_ui.dart, canvas_item_ui.dart and
-    lib/features/releases/screens/releases_screen.dart
-    (_ReleasesScreenState._placeholderIcon) delegate to it instead of
-    keeping three hand-maintained copies.
-  * lib/features/tier_lists/providers/tier_list_detail_provider.dart
-    (TierListDetailNotifier.updateTierDefinition,
-    TierListDetailNotifier.addTier): Convert the picked Color to an ARGB
-    int at the UI boundary.
-  * lib/features/settings/widgets/edit_profile_dialog.dart,
-    create_profile_dialog.dart, lib/features/settings/screens/
-    profiles_screen.dart, lib/features/splash/screens/
-    profile_picker_screen.dart: Switch to ColorHex and Profile.displayColor.
-  * Consumer widgets across lib/features/ and lib/shared/widgets/: one-line
-    imports of the new extension files.
-
 ### Added
+
+- **Favourites filter inside a collection**
+
+  The chevron bar in a collection gains the Favorite segment that All Items
+  already had, so a collection can be narrowed to its favourites without
+  leaving for the global screen. It combines with the type, subfilter, tag,
+  status and search filters, and the type counts follow it like they follow
+  the rest.
+
+  * lib/features/collections/helpers/collection_filters.dart
+    (CollectionFilters.favoriteOnly): New filter field, applied alongside the
+    others so grid, table and counts share one definition.
+  * lib/features/collections/widgets/collection_filter_bar.dart
+    (CollectionFilterBar.filterFavoriteOnly,
+    CollectionFilterBar.onFavoriteToggled): New segment after the status
+    dropdown, tinted with the favourite accent.
+  * lib/features/collections/screens/collection_screen.dart
+    (_CollectionScreenState._filterFavoriteOnly): Holds the toggle, like the
+    collection's other filters it resets when the screen is reopened.
+
+- **A light `.xcoll` restores items from every source, not just TMDB and AniList**
+
+  Importing a light file refetches each item from the provider it actually
+  came from. Before, everything went to one API per media type: a TVmaze show
+  was looked up in TMDB by the same number, which imported a different show
+  under that id, and a Kitsu or MangaDex title had the same problem with
+  AniList. Books were not fetched at all and always arrived as "Unknown".
+
+  Book and MangaDex ids can't be reversed (`external_id` is a hash of the
+  provider's own id), so light exports now also carry `native_id`. Files
+  exported by earlier versions don't have it — their books and MangaDex manga
+  stay unresolved instead of being fetched from the wrong provider, and can be
+  fixed with a refresh of the item.
+
+  * lib/core/services/import_service.dart (ImportService._fetchMediaFromApi,
+    ImportService._fetchTvShow, ImportService._fetchMangaRefs,
+    ImportService._fetchOneManga, ImportService._fetchAnimeRefs,
+    ImportService._fetchOneAnime, ImportService._fetchBookRefs,
+    ImportService._fetchOneBook, _MediaRef): Group items by
+    `(media type, source)` and route each group to its own API; AniList still
+    resolves its ids in one batched query. A provider that fails or is not
+    wired only drops its own items.
+  * lib/shared/models/collection_item.dart (CollectionItem.exportNativeId,
+    CollectionItem.toExport): Carry `native_id` for books and MangaDex manga.
+  * lib/shared/models/manga.dart (Manga.mangaDexUuid): Recover the UUID from
+    the cached `externalUrl`; collection_actions.dart uses it too instead of
+    splitting the URL itself.
+  * docs/RCOLL_FORMAT.md: Document `native_id` and the per-source hydration.
 
 - **Tag several selected items at once**
 
@@ -128,7 +98,7 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   language to `fr-FR`. Contributed by @GreenStatik (#384).
 
   * lib/l10n/app_fr.arb, lib/l10n/app_localizations_fr.dart (SFr): New —
-    full fr translation (all 1510 keys) and its generated delegate.
+    full fr translation (all 1517 keys) and its generated delegate.
   * lib/l10n/app_localizations.dart (S.supportedLocales,
     _SDelegate.isSupported, lookupS): Register the `fr` locale.
   * lib/features/settings/screens/settings_screen.dart (_kAppLanguageNames):
@@ -149,6 +119,12 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   the release calendar. Search by title only — TVmaze has no genre or other
   filters — and TV only, no films.
 
+  Because two providers can hand out the same number, TV posters are now
+  cached per source the way anime and manga covers already are. Posters saved
+  under the old key won't be found, so each one downloads again the first time
+  its card is shown. Animated series and films are untouched — they only come
+  from TMDB, so their cached posters stay valid.
+
   * lib/core/api/tvmaze_api.dart (TvMazeApi, tvMazeApiProvider),
     lib/core/api/tvmaze/ (TvMazeHttpClient, TvMazeShowApi,
     TvMazeApiException): New TVmaze REST client.
@@ -168,6 +144,18 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     shared mapping helpers.
   * lib/features/search/sources/tvmaze_tv_source.dart (TvMazeTvSource),
     search_sources.dart (searchSources): New title-search source, registered.
+  * lib/features/collections/helpers/collection_actions.dart
+    (_refreshItemWork): Route TV show refresh through the item's own episode
+    source instead of always TMDB.
+  * lib/shared/utils/cover_image_id.dart (coverImageId): Namespace
+    `MediaType.tvShow` covers by source; documents why animation stays bare.
+  * lib/shared/models/canvas_item.dart (CanvasItem.mediaCacheId),
+    lib/features/search/handlers/tv_show_handler.dart,
+    lib/features/search/widgets/browse_grid.dart, item_details_sheet.dart,
+    discover_row.dart, lib/features/collections/widgets/
+    recommendations_section.dart, lib/features/recommendations/widgets/
+    recommendation_row.dart: Build the cache id through `coverImageId` instead
+    of the bare TMDB id, so the write and read sides stay in step.
   * lib/shared/constants/source_catalog.dart (kDataSourceCatalog),
     lib/features/welcome/widgets/welcome_step_sources.dart,
     lib/features/settings/content/credits_content.dart: Catalog, onboarding
@@ -320,6 +308,9 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
   * lib/core/database/migrations/migration_v58.dart (MigrationV58): New —
     `cell_label_template` column on `mood_grids`.
+  * lib/features/mood_grids/services/mood_grid_caption.dart
+    (kMoodGridCaptionTokens, renderRowCaption): New shared template renderer
+    used by row captions and the auto-filled cell labels.
   * lib/core/database/migrations/migration_registry.dart
     (MigrationRegistry.all), lib/core/database/database_service.dart:
     Register v58, bump version to 58.
@@ -362,7 +353,7 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   TMDB content language to `pt-BR`. Contributed by @bonbj (#370).
 
   * lib/l10n/app_pt.arb, lib/l10n/app_localizations_pt.dart (SPt): New —
-    full pt translation (all 1498 keys) and its generated delegate.
+    full pt translation (all 1517 keys) and its generated delegate.
   * lib/l10n/app_localizations.dart (S.supportedLocales,
     _SDelegate.isSupported, lookupS): Register the `pt` locale.
   * lib/features/settings/screens/settings_screen.dart: Add Português
@@ -398,9 +389,8 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * lib/core/database/migrations/migration_v60.dart (MigrationV60): Rebuild
     `anime_cache` with a composite `(id, source)` primary key, rename the old
     source-material column to `source_material`, and add source-aware
-    `collection_items` anime indexes (also restoring `book` to the generic
-    index exclusion list); registered in migration_registry.dart and
-    database_service.dart (version 60).
+    `collection_items` anime indexes; registered in migration_registry.dart
+    and database_service.dart (version 60).
   * lib/shared/models/anime.dart (Anime.source, Anime.sourceMaterial,
     Anime.fromKitsu, Anime.fromDb, Anime.toDb, Anime.copyWith): Add the
     provider `source` field; the former source-material `source` becomes
@@ -413,8 +403,19 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     `(id, source)` when hydrating.
   * lib/shared/models/collection_item.dart: Resolve an anime item's source
     from its record instead of hard-coding AniList.
-  * lib/shared/utils/cover_image_id.dart (coverImageId): Namespace anime
-    covers by source, like manga.
+  * lib/shared/utils/cover_image_id.dart (coverImageId),
+    lib/shared/models/canvas_item.dart (CanvasItem.mediaCacheId): Namespace
+    anime covers by source, like manga.
+  * lib/core/services/import_service.dart (ImportService._itemMappingKeys,
+    ImportService._registerItemMapping, ImportService._resolveMappedItem),
+    lib/data/repositories/collection_repository.dart
+    (CollectionRepository.findItem), lib/core/database/database_service.dart
+    (DatabaseService.findCollectionItem): Resolve an imported item by
+    `(id, source)`, so restoring a file that holds the same numeric id from
+    two providers writes each one's status, tags and tier placement onto its
+    own item instead of collapsing both onto the first.
+  * lib/core/services/export_service.dart: Tier-list entries carry the item's
+    source for the same reason; docs/RCOLL_FORMAT.md documents the field.
   * lib/core/services/export_service.dart (ExportService._collectMediaData):
     Key exported anime by `source:externalId`.
   * lib/features/collections/helpers/collection_actions.dart: Route anime
@@ -434,6 +435,38 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     lists anime and manga.
 
 ### Fixed
+
+- **Type counts in a collection follow the subfilters**
+
+  Picking a subfilter inside a collection — a game platform, a manga or anime
+  format — narrowed the grid but not the number on the media-type chevron. A
+  collection with 12 anime still read "Anime (12)" after filtering down to the
+  2 TV ones, which made the count look broken. The All Items screen already
+  counted this way; the collection bar applied only the status filter.
+
+  * lib/features/collections/widgets/collection_filter_bar.dart
+    (_CollectionFilterBarState._typeCounts): Tally the items that survive
+    `CollectionFilters` with every active filter except the type one, instead
+    of re-implementing a status-only count. Chevron visibility still uses the
+    unfiltered totals, so a subfilter can't make a chevron disappear.
+
+- **The collection picker sorts by date the same way the Collections screen does**
+
+  Picking "Newest first" on the Collections screen and then opening the
+  picker (add to collection, move, filters) listed the collections oldest
+  first, so a freshly created collection sat at the bottom and the sort had
+  to be flipped by hand to find it. The two screens carried their own
+  comparators and the picker's date branch read the shared descending flag
+  the other way round; alphabetical order was never affected. Both now share
+  one comparator, so they can't drift apart again.
+
+  * lib/shared/models/collection_list_sort_mode.dart
+    (CollectionListSortMode.compare): New shared comparator; documents that
+    the persisted flag means Z→A for names and oldest-first for dates.
+  * lib/features/collections/screens/home_screen.dart
+    (_HomeScreenState._sortCollections),
+    lib/shared/widgets/collection_picker_dialog.dart
+    (_CollectionPickerContentState._sortedCollections): Both delegate to it.
 
 - **Search filter accent follows the source's media type**
 
@@ -493,6 +526,19 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   flow does, and the episode tracker recovers missing totals from the
   seasons cache for already-affected databases.
 
+  * lib/core/database/sparse_upsert.dart (buildPreservingUpsert): New
+    `INSERT OR REPLACE` builder that keeps the cached column when the
+    incoming value is NULL.
+  * lib/core/database/dao/tv_show_dao.dart, manga_dao.dart, book_dao.dart:
+    Upserts preserve totals via buildPreservingUpsert.
+  * lib/core/services/tv_show_cache_warmer.dart (TvShowCacheWarmer.warm,
+    tvShowCacheWarmerProvider): New best-effort warmer filling show details,
+    seasons and episodes after an add; called from
+    lib/features/search/handlers/tv_show_handler.dart and
+    lib/features/collections/screens/item_detail_screen.dart.
+  * lib/features/collections/providers/episode_tracker_provider.dart
+    (EpisodeTrackerNotifier): Recover missing totals from the seasons cache.
+
 - **Moving a TV show between collections takes its watch progress along**
 
   Removing a show (or moving it to "uncategorized") keeps the marks, so
@@ -538,6 +584,21 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     badge shrinks on very narrow cards instead of overflowing.
 
 ### Changed
+
+- **Internal groundwork for the planned selfhost server**
+
+  No user-visible change. The database schema and migration chain moved
+  verbatim into `packages/core`, a pure-Dart package with no Flutter
+  dependency, and the model layer (`lib/shared/models/`) dropped its
+  Flutter / l10n imports — colors, icons and localized labels now live in
+  UI extension files under `lib/shared/constants/`.
+
+  * packages/core/: New package holding schema.dart and migrations
+    (MigrationRegistry, MigrationV1 … MigrationV60), moved unchanged from
+    lib/core/database/.
+  * lib/shared/constants/*_ui.dart, lib/shared/utils/color_hex.dart
+    (ColorHex): New presentation extensions and hex color codec replacing
+    the in-model getters.
 
 - **Provider identity (name, group, brand icon) now comes from DataSource**
 

--- a/docs/RCOLL_FORMAT.md
+++ b/docs/RCOLL_FORMAT.md
@@ -45,6 +45,17 @@ Tonkatsu Box supports two file formats for sharing collections.
     {
       "media_type": "visual_novel",
       "external_id": 17
+    },
+    {
+      "media_type": "tv_show",
+      "external_id": 42987,
+      "source": "tvmaze"
+    },
+    {
+      "media_type": "book",
+      "external_id": 8193465,
+      "source": "openLibrary",
+      "native_id": "OL8193465W"
     }
   ]
 }
@@ -114,7 +125,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
       { "tmdb_id": 550, "title": "Movie Title", "overview": "...", "poster_url": "/poster.jpg", "genres": "[\"Action\",\"Drama\"]", "runtime": 139, ... }
     ],
     "tv_shows": [
-      { "tmdb_id": 1399, "title": "TV Show", "total_seasons": 8, "total_episodes": 73, "genres": "[\"Drama\"]", ... }
+      { "tmdb_id": 1399, "source": "tmdb", "title": "TV Show", "total_seasons": 8, "total_episodes": 73, "genres": "[\"Drama\"]", ... }
     ],
     "visual_novels": [
       { "id": "v17", "numeric_id": 17, "title": "Ever17", "alt_title": "Ever17 -the out of infinity-", "rating": 85.5, "vote_count": 1200, "released": "2002-08-29", "tags": "[\"Sci-fi\",\"Mystery\"]", ... }
@@ -123,10 +134,10 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
       { "id": 30002, "source": "anilist", "title": "Berserk", "title_english": "Berserk", "title_native": "ベルセルク", "cover_url": "https://...", "genres": "[\"Action\",\"Drama\"]", "average_score": 93, "format": "MANGA", "country_of_origin": "JP", ... }
     ],
     "tv_seasons": [
-      { "tmdb_show_id": 1399, "season_number": 1, "name": "Season 1", "episode_count": 10, "poster_url": "https://image.tmdb.org/t/p/w500/...", "air_date": "2011-04-17" }
+      { "tmdb_show_id": 1399, "source": "tmdb", "season_number": 1, "name": "Season 1", "episode_count": 10, "poster_url": "https://image.tmdb.org/t/p/w500/...", "air_date": "2011-04-17" }
     ],
     "tv_episodes": [
-      { "tmdb_show_id": 1399, "season_number": 1, "episode_number": 1, "name": "Winter Is Coming", "overview": "...", "air_date": "2011-04-17", "still_url": "https://image.tmdb.org/t/p/w300/...", "runtime": 62 }
+      { "tmdb_show_id": 1399, "source": "tmdb", "season_number": 1, "episode_number": 1, "name": "Winter Is Coming", "overview": "...", "air_date": "2011-04-17", "still_url": "https://image.tmdb.org/t/p/w300/...", "runtime": 62 }
     ]
   }
 }
@@ -148,7 +159,7 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 | items | array | yes | List of collection items |
 | canvas | object | no | Collection-level canvas (full only) |
 | images | object | no | Base64 cover images (full only) |
-| media | object | no | Embedded Game/Movie/TvShow/VisualNovel/Manga/TvSeason/TvEpisode data for offline import (full only) |
+| media | object | no | Embedded Game/Movie/TvShow/VisualNovel/Manga/Anime/Book/TvSeason/TvEpisode data for offline import (full only) |
 | tags | array | no | Global tag definitions used by the collection's items (full only). Each: `{ name, color?, text_color?, sort_order }` |
 | tracker_data | array | no | Tracker progress data for games (full + user_data only). Each entry is a `tracker_game_data` row: `{ tracker_type, game_id, tracker_game_id, achievements_earned, achievements_total, ... }` |
 
@@ -156,9 +167,10 @@ Includes everything from light export plus `canvas`, `images`, and `media`:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| media_type | string | yes | `"game"`, `"movie"`, `"tv_show"`, `"animation"`, `"visual_novel"`, or `"manga"` |
+| media_type | string | yes | `"game"`, `"movie"`, `"tv_show"`, `"animation"`, `"visual_novel"`, `"manga"`, `"anime"`, `"book"`, or `"custom"` |
 | external_id | number | yes | IGDB ID (games), TMDB ID (movies/TV), VNDB numeric ID (visual novels), or provider ID (manga / anime: AniList, MangaBaka, MangaDex, Kitsu) |
-| source | string | no | Provider discriminator for multi-source media (manga, anime): identity is `(external_id, source)`. Absent/`null` for single-source media and legacy files, treated as `"anilist"` (manga before v44, anime before v60) |
+| source | string | no | Provider discriminator for multi-source media (manga, anime, book, tv_show): identity is `(external_id, source)`. Absent/`null` for single-source media and legacy files; defaults per type: manga/anime `"anilist"`, books `"openLibrary"`, TV shows `"tmdb"` |
+| native_id | string | no | The provider's own id, when `external_id` can't reproduce it: books (`"OL8193465W"`, `"4050-86463"`) and MangaDex manga (its UUID), whose `external_id` is a hash. A light import needs it to refetch the item; files written before it exist leave those items unresolved |
 | platform_id | number | no | IGDB platform ID (games) or AnimationSource (animation: 0=movie, 1=tvShow) |
 | comment | string | no | Author's comment |
 | user_rating | number | no | User rating (1.0–10.0, one decimal). Integers from v2 files load as doubles |
@@ -255,9 +267,9 @@ Contains tier list data for the exported collection. Only present when the colle
 | name | string | Tier list name |
 | collection_id | int? | Source collection ID (null for global) |
 | definitions | array | Tier definitions: `{ tier_key, label, color (0xAARRGGBB int), sort_order }` |
-| entries | array | Items placed in tiers: `{ collection_item_id, tier_key, sort_order, external_id, media_type, platform_id? }` |
+| entries | array | Items placed in tiers: `{ collection_item_id, tier_key, sort_order, external_id, media_type, platform_id?, source? }` |
 
-Entries include `external_id`, `media_type`, and optional `platform_id` fields for cross-collection resolution on import. The import process builds an `itemIdMapping` (`"media_type:external_id[:platform_id]" → newItemId`) and resolves entries via this map rather than raw collection_item_id values. For games, the key includes `platform_id` to distinguish the same game on different platforms; lookup falls back to a key without platform for backward compatibility with older exports. Animation items are stored in `movies` (animated films) or `tv_shows` (animated series) based on their `AnimationSource`. Visual novel items are stored in `visual_novels` with VNDB string IDs (e.g. "v17"). Manga items are stored in `mangas` with AniList integer IDs. Seasons are preloaded when a TV show or animation series is added to a collection. Episodes are included from the local cache for each TV show in the collection.
+Entries include `external_id`, `media_type`, and optional `platform_id` / `source` fields for cross-collection resolution on import. The import process builds an `itemIdMapping` (`"media_type:external_id[:platform_id][@source]" → newItemId`) and resolves entries via this map rather than raw collection_item_id values. For games, the key includes `platform_id` to distinguish the same game on different platforms; for multi-source media it includes `source`, without which two titles sharing a numeric id across providers (an AniList and a Kitsu anime) would collapse onto one item. Lookup falls back to the keys without platform and source for backward compatibility with older exports. Animation items are stored in `movies` (animated films) or `tv_shows` (animated series) based on their `AnimationSource`. Visual novel items are stored in `visual_novels` with VNDB string IDs (e.g. "v17"). Manga items are stored in `mangas` with AniList integer IDs. Seasons are preloaded when a TV show or animation series is added to a collection. Episodes are included from the local cache for each TV show in the collection.
 
 ### Tags Object
 
@@ -292,7 +304,9 @@ Contains RetroAchievements (or other tracker) progress data for games in the col
 
 On import, tracker data is upserted into `tracker_game_data` via `TrackerDao.upsertGameDataBatch()`. This preserves the RA achievements section in game detail cards without requiring a re-import from RetroAchievements.
 
-When `media` is present during import, data is restored directly from the file via `fromDb()` — no API calls to IGDB/TMDB/VNDB are needed. TV seasons and episodes are also restored if present. When `media` is absent (light export or older full exports), the app fetches data from APIs as before.
+When `media` is present during import, data is restored directly from the file via `fromDb()` — no API calls to IGDB/TMDB/VNDB are needed. TV seasons and episodes are also restored if present.
+
+When `media` is absent (light export or older full exports), the app refetches each item from the provider named by its `source`: TMDB or TVmaze for shows, AniList or Kitsu for anime, AniList / MangaBaka / MangaDex / Kitsu for manga, and the five book providers. A missing `source` falls back to the media type's default (`tmdb` for shows, `anilist` for manga and anime), which is what pre-0.40 files carry. Books and MangaDex manga also need `native_id`; without it the item is left unresolved rather than fetched from the wrong provider. One provider failing only drops its own items — the rest of the import continues.
 
 ---
 

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:core/database/migrations/migration.dart';
 import 'package:core/database/migrations/migration_registry.dart';
+import 'package:core/database/migrations/migration_runner.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -277,19 +278,31 @@ class DatabaseService {
     _log.info('Creating database schema v$version');
     // Single source of truth: a fresh DB is built by running the whole
     // migration chain (v1..N) in order, exactly like an upgrade from zero.
-    for (final Migration migration in MigrationRegistry.all) {
-      await migration.migrate(db);
-    }
+    await MigrationRunner.run(
+      db,
+      MigrationRegistry.all,
+      fromVersion: 0,
+      toVersion: version,
+      onFailure: _logMigrationFailure,
+    );
   }
 
   Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
     _log.info('Upgrading database from v$oldVersion to v$newVersion');
-    for (final Migration migration in MigrationRegistry.pending(oldVersion)) {
-      _log.fine('Running migration v${migration.version}: ${migration.description}');
-      await migration.migrate(db);
-    }
+    await MigrationRunner.run(
+      db,
+      MigrationRegistry.pending(oldVersion),
+      fromVersion: oldVersion,
+      toVersion: newVersion,
+      onStart: (Migration m) =>
+          _log.fine('Running migration v${m.version}: ${m.description}'),
+      onFailure: _logMigrationFailure,
+    );
     _log.info('Database upgrade complete');
   }
+
+  void _logMigrationFailure(MigrationFailure failure, StackTrace stack) =>
+      _log.severe('Migration v${failure.version} failed', failure, stack);
 
   Future<List<Collection>> getAllCollections() =>
       collectionDao.getAllCollections();
@@ -399,12 +412,14 @@ class DatabaseService {
     required MediaType mediaType,
     required int externalId,
     int? platformId,
+    DataSource? source,
   }) =>
       collectionDao.findCollectionItem(
         collectionId: collectionId,
         mediaType: mediaType,
         externalId: externalId,
         platformId: platformId,
+        source: source,
       );
 
   Future<int?> addItemToCollection({

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -738,6 +738,11 @@ class ExportService {
         if (item.platformId != null) {
           entryData['platform_id'] = item.platformId;
         }
+        // Without it, two same-id titles from different providers resolve to
+        // one item on import and only one keeps its tier placement.
+        if (item.source != null) {
+          entryData['source'] = item.source!.name;
+        }
         exportedEntries.add(entryData);
       }
 

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -31,9 +31,19 @@ import '../../shared/models/manga.dart';
 import '../../shared/models/tag.dart';
 import '../../shared/models/tracker_game_data.dart';
 import '../../shared/models/visual_novel.dart';
+import '../../shared/models/data_source.dart';
 import '../api/anilist_api.dart';
+import '../api/comicvine_api.dart';
+import '../api/fantlab_api.dart';
+import '../api/google_books_api.dart';
+import '../api/hardcover_api.dart';
 import '../api/igdb_api.dart';
+import '../api/kitsu_api.dart';
+import '../api/mangabaka_api.dart';
+import '../api/mangadex_api.dart';
+import '../api/openlibrary_api.dart';
 import '../api/tmdb_api.dart';
+import '../api/tvmaze_api.dart';
 import '../api/vndb_api.dart';
 import '../database/dao/global_tag_dao.dart';
 import '../database/dao/tracker_dao.dart';
@@ -50,6 +60,15 @@ final Provider<ImportService> importServiceProvider =
     tmdbApi: ref.watch(tmdbApiProvider),
     vndbApi: ref.watch(vndbApiProvider),
     aniListApi: ref.watch(aniListApiProvider),
+    tvMazeApi: ref.watch(tvMazeApiProvider),
+    kitsuApi: ref.watch(kitsuApiProvider),
+    mangaBakaApi: ref.watch(mangaBakaApiProvider),
+    mangaDexApi: ref.watch(mangaDexApiProvider),
+    openLibraryApi: ref.watch(openLibraryApiProvider),
+    googleBooksApi: ref.watch(googleBooksApiProvider),
+    comicVineApi: ref.watch(comicVineApiProvider),
+    hardcoverApi: ref.watch(hardcoverApiProvider),
+    fantlabApi: ref.watch(fantlabApiProvider),
     database: ref.watch(databaseServiceProvider),
     canvasRepository: ref.watch(canvasRepositoryProvider),
     imageCacheService: ref.watch(imageCacheServiceProvider),
@@ -186,6 +205,15 @@ class ImportService {
     TmdbApi? tmdbApi,
     VndbApi? vndbApi,
     AniListApi? aniListApi,
+    TvMazeApi? tvMazeApi,
+    KitsuApi? kitsuApi,
+    MangaBakaApi? mangaBakaApi,
+    MangaDexApi? mangaDexApi,
+    OpenLibraryApi? openLibraryApi,
+    GoogleBooksApi? googleBooksApi,
+    ComicVineApi? comicVineApi,
+    HardcoverApi? hardcoverApi,
+    FantlabApi? fantlabApi,
     CanvasRepository? canvasRepository,
     ImageCacheService? imageCacheService,
     TrackerDao? trackerDao,
@@ -195,6 +223,15 @@ class ImportService {
         _tmdbApi = tmdbApi,
         _vndbApi = vndbApi,
         _aniListApi = aniListApi,
+        _tvMazeApi = tvMazeApi,
+        _kitsuApi = kitsuApi,
+        _mangaBakaApi = mangaBakaApi,
+        _mangaDexApi = mangaDexApi,
+        _openLibraryApi = openLibraryApi,
+        _googleBooksApi = googleBooksApi,
+        _comicVineApi = comicVineApi,
+        _hardcoverApi = hardcoverApi,
+        _fantlabApi = fantlabApi,
         _database = database,
         _canvasRepository = canvasRepository,
         _imageCacheService = imageCacheService,
@@ -206,6 +243,15 @@ class ImportService {
   final TmdbApi? _tmdbApi;
   final VndbApi? _vndbApi;
   final AniListApi? _aniListApi;
+  final TvMazeApi? _tvMazeApi;
+  final KitsuApi? _kitsuApi;
+  final MangaBakaApi? _mangaBakaApi;
+  final MangaDexApi? _mangaDexApi;
+  final OpenLibraryApi? _openLibraryApi;
+  final GoogleBooksApi? _googleBooksApi;
+  final ComicVineApi? _comicVineApi;
+  final HardcoverApi? _hardcoverApi;
+  final FantlabApi? _fantlabApi;
   final DatabaseService _database;
   final CanvasRepository? _canvasRepository;
   final ImageCacheService? _imageCacheService;
@@ -347,8 +393,8 @@ class ImportService {
         ));
       }
 
-      // Maps (media_type:external_id[:platform_id]) to new collection_item_id
-      // for tier-list/tag entries to resolve.
+      // Item keys (see _itemMappingKeys) to new collection_item_id, so
+      // tier-list and tag entries can resolve their item.
       final Map<String, int> itemIdMapping = <String, int>{};
       int addedCount = 0;
       int updatedCount = 0;
@@ -375,17 +421,7 @@ class ImportService {
 
         if (itemId != null) {
           addedCount++;
-          final String key = _itemMappingKey(
-            parsed.mediaType,
-            parsed.externalId,
-            parsed.platformId,
-          );
-          itemIdMapping[key] = itemId;
-          // Fallback key without platform for backwards compatibility with
-          // old exports where tier-list/tag entries lack platform_id.
-          final String fallbackKey =
-              '${parsed.mediaType.value}:${parsed.externalId}';
-          itemIdMapping.putIfAbsent(fallbackKey, () => itemId);
+          _registerItemMapping(itemIdMapping, parsed, itemId);
 
           if (xcoll.includesUserData && _hasUserData(parsed)) {
             await _restoreUserData(itemId, parsed);
@@ -418,17 +454,10 @@ class ImportService {
             mediaType: parsed.mediaType,
             externalId: parsed.externalId,
             platformId: parsed.platformId,
+            source: parsed.source,
           );
           if (existing != null) {
-            final String key = _itemMappingKey(
-              parsed.mediaType,
-              parsed.externalId,
-              parsed.platformId,
-            );
-            itemIdMapping[key] = existing.id;
-            final String fallbackKey =
-                '${parsed.mediaType.value}:${parsed.externalId}';
-            itemIdMapping.putIfAbsent(fallbackKey, () => existing.id);
+            _registerItemMapping(itemIdMapping, parsed, existing.id);
 
             // Marks are idempotent (insertMarks replaces on the unique key),
             // so re-importing onto an existing item merges, not duplicates.
@@ -530,6 +559,7 @@ class ImportService {
       mediaType: parsed.mediaType,
       externalId: parsed.externalId,
       platformId: parsed.platformId,
+      source: parsed.source,
     );
     if (existing == null) return false;
 
@@ -855,52 +885,63 @@ class ImportService {
     }
   }
 
-  /// Online fallback for light exports or legacy full exports without
-  /// an embedded `media` section.
+  /// Online fallback for light exports or legacy full exports without an
+  /// embedded `media` section. Items are grouped by (media type, source) and
+  /// each group is refetched from the provider that owns it: sending a TVmaze
+  /// show id to TMDB caches a different show under that id.
   Future<void> _fetchMediaFromApi(
     List<Map<String, dynamic>> items, {
     ImportProgressCallback? onProgress,
   }) async {
-    final List<Map<String, dynamic>> gameItems = <Map<String, dynamic>>[];
-    final List<Map<String, dynamic>> movieItems = <Map<String, dynamic>>[];
-    final List<Map<String, dynamic>> tvShowItems = <Map<String, dynamic>>[];
-    final List<Map<String, dynamic>> vnItems = <Map<String, dynamic>>[];
-    final List<Map<String, dynamic>> mangaItems = <Map<String, dynamic>>[];
-    final List<Map<String, dynamic>> animeItems = <Map<String, dynamic>>[];
+    final List<int> gameIds = <int>[];
+    final List<int> movieIds = <int>[];
+    final List<String> vnIds = <String>[];
+    final List<_MediaRef> tvRefs = <_MediaRef>[];
+    final List<_MediaRef> mangaRefs = <_MediaRef>[];
+    final List<_MediaRef> animeRefs = <_MediaRef>[];
+    final List<_MediaRef> bookRefs = <_MediaRef>[];
 
     for (final Map<String, dynamic> item in items) {
       final MediaType? mediaType =
           MediaType.tryFromString(item['media_type'] as String);
+      final int? externalId = item['external_id'] as int?;
+      if (mediaType == null || externalId == null) continue;
+
+      final _MediaRef ref = _MediaRef(
+        externalId: externalId,
+        source: DataSource.fromNameOr(
+          item['source'] as String?,
+          mediaType.defaultSource,
+        ),
+        nativeId: item['native_id'] as String?,
+      );
+
       switch (mediaType) {
         case MediaType.game:
-          gameItems.add(item);
+          gameIds.add(externalId);
         case MediaType.movie:
-          movieItems.add(item);
+          movieIds.add(externalId);
         case MediaType.tvShow:
-          tvShowItems.add(item);
+          tvRefs.add(ref);
         case MediaType.animation:
-          final int? platformId = item['platform_id'] as int?;
-          if (platformId == AnimationSource.tvShow) {
-            tvShowItems.add(item);
+          // Animated films live in the movie cache, series in the show cache.
+          if ((item['platform_id'] as int?) == AnimationSource.tvShow) {
+            tvRefs.add(ref);
           } else {
-            movieItems.add(item);
+            movieIds.add(externalId);
           }
         case MediaType.visualNovel:
-          vnItems.add(item);
+          vnIds.add('v$externalId');
         case MediaType.manga:
-          mangaItems.add(item);
+          mangaRefs.add(ref);
         case MediaType.anime:
-          animeItems.add(item);
+          animeRefs.add(ref);
         case MediaType.book:
+          bookRefs.add(ref);
         case MediaType.custom:
-        case null:
           break;
       }
     }
-
-    final List<int> gameIds = gameItems
-        .map((Map<String, dynamic> i) => i['external_id'] as int)
-        .toList();
 
     onProgress?.call(ImportProgress(
       stage: ImportStage.fetchingGames,
@@ -914,11 +955,7 @@ class ImportService {
       games = await _igdbApi.getGamesByIds(gameIds);
     }
 
-    final List<int> movieIds = movieItems
-        .map((Map<String, dynamic> i) => i['external_id'] as int)
-        .toList();
     final List<Movie> movies = <Movie>[];
-
     if (movieIds.isNotEmpty && _tmdbApi != null) {
       final TmdbApi tmdbApi = _tmdbApi;
       onProgress?.call(ImportProgress(
@@ -945,43 +982,29 @@ class ImportService {
       }
     }
 
-    final List<int> tvShowIds = tvShowItems
-        .map((Map<String, dynamic> i) => i['external_id'] as int)
-        .toList();
     final List<TvShow> tvShows = <TvShow>[];
-
-    if (tvShowIds.isNotEmpty && _tmdbApi != null) {
-      final TmdbApi tmdbApi = _tmdbApi;
+    if (tvRefs.isNotEmpty) {
       onProgress?.call(ImportProgress(
         stage: ImportStage.fetchingTvShows,
         current: 0,
-        total: tvShowIds.length,
-        message: 'Fetching ${tvShowIds.length} TV shows from TMDB...',
+        total: tvRefs.length,
+        message: 'Fetching ${tvRefs.length} TV shows...',
       ));
 
-      for (int i = 0; i < tvShowIds.length; i++) {
-        try {
-          final TvShow? tvShow = await tmdbApi.getTvShow(tvShowIds[i]);
-          if (tvShow != null) {
-            tvShows.add(tvShow);
-          }
-        } on TmdbApiException {
-          // Skip unavailable TV shows so one failure doesn't abort the batch.
+      for (int i = 0; i < tvRefs.length; i++) {
+        final TvShow? show = await _fetchTvShow(tvRefs[i]);
+        if (show != null) {
+          tvShows.add(show);
         }
         onProgress?.call(ImportProgress(
           stage: ImportStage.fetchingTvShows,
           current: i + 1,
-          total: tvShowIds.length,
+          total: tvRefs.length,
         ));
       }
     }
 
-    final List<String> vnIds = vnItems
-        .where((Map<String, dynamic> i) => i['external_id'] != null)
-        .map((Map<String, dynamic> i) => 'v${i['external_id'] as int}')
-        .toList();
     List<VisualNovel> visualNovels = <VisualNovel>[];
-
     if (vnIds.isNotEmpty && _vndbApi != null) {
       final VndbApi vndbApi = _vndbApi;
       onProgress?.call(ImportProgress(
@@ -1003,88 +1026,37 @@ class ImportService {
       ));
     }
 
-    final List<int> mangaIds = mangaItems
-        .where((Map<String, dynamic> i) => i['external_id'] != null)
-        .map((Map<String, dynamic> i) => i['external_id'] as int)
-        .toList();
-    List<Manga> mangas = <Manga>[];
-
-    if (mangaIds.isNotEmpty && _aniListApi != null) {
-      final AniListApi aniListApi = _aniListApi;
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.fetchingManga,
-        current: 0,
-        total: mangaIds.length,
-        message: 'Fetching ${mangaIds.length} manga from AniList...',
-      ));
-
-      try {
-        mangas = await aniListApi.getMangaByIds(
-          mangaIds,
-          onRateLimit: (Duration wait, int attempt) => onProgress?.call(
-            ImportProgress(
-              stage: ImportStage.fetchingManga,
-              current: 0,
-              total: mangaIds.length,
-              message: 'Rate limited, waiting ${wait.inSeconds}s '
-                  '(attempt $attempt)...',
-            ),
-          ),
-        );
-      } on AniListApiException catch (e) {
-        _log.warning('Failed to fetch manga: ${e.message}');
-      }
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.fetchingManga,
-        current: mangaIds.length,
-        total: mangaIds.length,
-      ));
-    }
-
-    final List<int> animeIds = animeItems
-        .where((Map<String, dynamic> i) => i['external_id'] != null)
-        .map((Map<String, dynamic> i) => i['external_id'] as int)
-        .toList();
-    List<Anime> animes = <Anime>[];
-
-    if (animeIds.isNotEmpty && _aniListApi != null) {
-      final AniListApi aniListApi = _aniListApi;
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.fetchingAnime,
-        current: 0,
-        total: animeIds.length,
-        message: 'Fetching ${animeIds.length} anime from AniList...',
-      ));
-
-      try {
-        animes = await aniListApi.getAnimeByIds(
-          animeIds,
-          onRateLimit: (Duration wait, int attempt) => onProgress?.call(
-            ImportProgress(
-              stage: ImportStage.fetchingAnime,
-              current: 0,
-              total: animeIds.length,
-              message: 'Rate limited, waiting ${wait.inSeconds}s '
-                  '(attempt $attempt)...',
-            ),
-          ),
-        );
-      } on AniListApiException catch (e) {
-        _log.warning('Failed to fetch anime: ${e.message}');
-      }
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.fetchingAnime,
-        current: animeIds.length,
-        total: animeIds.length,
-      ));
-    }
+    final AniListApi? aniList = _aniListApi;
+    final List<Manga> mangas = await _fetchByRefs<Manga>(
+      mangaRefs,
+      stage: ImportStage.fetchingManga,
+      label: 'manga',
+      aniListBatch: (List<int> ids,
+              void Function(Duration, int) onRateLimit) async =>
+          aniList?.getMangaByIds(ids, onRateLimit: onRateLimit) ?? <Manga>[],
+      fetchOne: _fetchOneManga,
+      onProgress: onProgress,
+    );
+    final List<Anime> animes = await _fetchByRefs<Anime>(
+      animeRefs,
+      stage: ImportStage.fetchingAnime,
+      label: 'anime',
+      aniListBatch: (List<int> ids,
+              void Function(Duration, int) onRateLimit) async =>
+          aniList?.getAnimeByIds(ids, onRateLimit: onRateLimit) ?? <Anime>[],
+      fetchOne: _fetchOneAnime,
+      onProgress: onProgress,
+    );
+    final List<Book> books =
+        await _fetchBookRefs(bookRefs, onProgress: onProgress);
 
     final int totalMedia = games.length +
         movies.length +
         tvShows.length +
         visualNovels.length +
         mangas.length +
-        animes.length;
+        animes.length +
+        books.length;
     onProgress?.call(ImportProgress(
       stage: ImportStage.cachingMedia,
       current: 0,
@@ -1092,64 +1064,217 @@ class ImportService {
     ));
 
     int cachedCount = 0;
-    for (final Game game in games) {
-      await _database.gameDao.upsertGame(game);
-      cachedCount++;
+    void reportCached(int added) {
+      cachedCount += added;
       onProgress?.call(ImportProgress(
         stage: ImportStage.cachingMedia,
         current: cachedCount,
         total: totalMedia,
       ));
+    }
+
+    for (final Game game in games) {
+      await _database.gameDao.upsertGame(game);
+      reportCached(1);
     }
 
     if (movies.isNotEmpty) {
       await _database.movieDao.upsertMovies(movies);
-      cachedCount += movies.length;
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.cachingMedia,
-        current: cachedCount,
-        total: totalMedia,
-      ));
+      reportCached(movies.length);
     }
 
     if (tvShows.isNotEmpty) {
       await _database.tvShowDao.upsertTvShows(tvShows);
-      cachedCount += tvShows.length;
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.cachingMedia,
-        current: cachedCount,
-        total: totalMedia,
-      ));
+      reportCached(tvShows.length);
     }
 
     if (visualNovels.isNotEmpty) {
       await _database.visualNovelDao.upsertVisualNovels(visualNovels);
-      cachedCount += visualNovels.length;
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.cachingMedia,
-        current: cachedCount,
-        total: totalMedia,
-      ));
+      reportCached(visualNovels.length);
     }
 
     if (mangas.isNotEmpty) {
       await _database.mangaDao.upsertMangas(mangas);
-      cachedCount += mangas.length;
-      onProgress?.call(ImportProgress(
-        stage: ImportStage.cachingMedia,
-        current: cachedCount,
-        total: totalMedia,
-      ));
+      reportCached(mangas.length);
     }
 
     if (animes.isNotEmpty) {
       await _database.animeDao.upsertAnimes(animes);
-      cachedCount += animes.length;
+      reportCached(animes.length);
+    }
+
+    if (books.isNotEmpty) {
+      await _database.bookDao.upsertBooks(books);
+      reportCached(books.length);
+    }
+  }
+
+  Future<TvShow?> _fetchTvShow(_MediaRef ref) async {
+    try {
+      if (ref.source == DataSource.tvmaze) {
+        return await _tvMazeApi?.getShow(ref.externalId);
+      }
+      return await _tmdbApi?.getTvShow(ref.externalId);
+    } on Exception catch (e) {
+      // One unavailable show must not abort the batch.
+      _log.warning('Failed to fetch TV show ${ref.externalId} '
+          'from ${ref.source.name}: $e');
+      return null;
+    }
+  }
+
+  /// AniList resolves its ids in one batched query; every other provider only
+  /// answers per id, so they go one by one. Shared by manga and anime, whose
+  /// progress accounting and rate-limit reporting must not drift apart.
+  Future<List<T>> _fetchByRefs<T>(
+    List<_MediaRef> refs, {
+    required ImportStage stage,
+    required String label,
+    required Future<List<T>> Function(
+      List<int> ids,
+      void Function(Duration wait, int attempt) onRateLimit,
+    ) aniListBatch,
+    required Future<T?> Function(_MediaRef ref) fetchOne,
+    ImportProgressCallback? onProgress,
+  }) async {
+    if (refs.isEmpty) return <T>[];
+
+    final List<T> result = <T>[];
+    int done = 0;
+    void report({String? message}) => onProgress?.call(ImportProgress(
+          stage: stage,
+          current: done,
+          total: refs.length,
+          message: message,
+        ));
+    report(message: 'Fetching ${refs.length} $label...');
+
+    final List<_MediaRef> byId = <_MediaRef>[];
+    final List<int> aniListIds = <int>[];
+    for (final _MediaRef ref in refs) {
+      if (ref.source == DataSource.anilist) {
+        aniListIds.add(ref.externalId);
+      } else {
+        byId.add(ref);
+      }
+    }
+
+    if (aniListIds.isNotEmpty) {
+      try {
+        result.addAll(await aniListBatch(
+          aniListIds,
+          (Duration wait, int attempt) => report(
+            message: 'Rate limited, waiting ${wait.inSeconds}s '
+                '(attempt $attempt)...',
+          ),
+        ));
+      } on AniListApiException catch (e) {
+        _log.warning('Failed to fetch $label from AniList: ${e.message}');
+      }
+      done += aniListIds.length;
+      report();
+    }
+
+    for (final _MediaRef ref in byId) {
+      final T? item = await fetchOne(ref);
+      if (item != null) {
+        result.add(item);
+      }
+      done++;
+      report();
+    }
+    return result;
+  }
+
+  Future<Manga?> _fetchOneManga(_MediaRef ref) async {
+    try {
+      switch (ref.source) {
+        case DataSource.mangabaka:
+          return await _mangaBakaApi?.getById(ref.externalId);
+        case DataSource.kitsu:
+          return await _kitsuApi?.getMangaById(ref.externalId);
+        case DataSource.mangadex:
+          // MangaDex is keyed by a UUID and external_id is only its hash, so
+          // files written before native_id can't be resolved.
+          final String? uuid = ref.nativeId;
+          return uuid != null ? await _mangaDexApi?.getByUuid(uuid) : null;
+        default:
+          return await _aniListApi?.getMangaById(ref.externalId);
+      }
+    } on Exception catch (e) {
+      _log.warning('Failed to fetch manga ${ref.externalId} '
+          'from ${ref.source.name}: $e');
+      return null;
+    }
+  }
+
+  Future<Anime?> _fetchOneAnime(_MediaRef ref) async {
+    try {
+      if (ref.source == DataSource.kitsu) {
+        return await _kitsuApi?.getAnimeById(ref.externalId);
+      }
+      return await _aniListApi?.getAnimeById(ref.externalId);
+    } on Exception catch (e) {
+      _log.warning('Failed to fetch anime ${ref.externalId} '
+          'from ${ref.source.name}: $e');
+      return null;
+    }
+  }
+
+  Future<List<Book>> _fetchBookRefs(
+    List<_MediaRef> refs, {
+    ImportProgressCallback? onProgress,
+  }) async {
+    if (refs.isEmpty) return const <Book>[];
+
+    final List<Book> result = <Book>[];
+    onProgress?.call(ImportProgress(
+      stage: ImportStage.fetchingBooks,
+      current: 0,
+      total: refs.length,
+      message: 'Fetching ${refs.length} books...',
+    ));
+
+    for (int i = 0; i < refs.length; i++) {
+      final Book? book = await _fetchOneBook(refs[i]);
+      if (book != null) {
+        result.add(book);
+      }
       onProgress?.call(ImportProgress(
-        stage: ImportStage.cachingMedia,
-        current: cachedCount,
-        total: totalMedia,
+        stage: ImportStage.fetchingBooks,
+        current: i + 1,
+        total: refs.length,
       ));
+    }
+    return result;
+  }
+
+  Future<Book?> _fetchOneBook(_MediaRef ref) async {
+    // Every book provider is keyed by its own string id; external_id is
+    // derived from it and can't be turned back, so files written before
+    // native_id existed leave their books unresolved.
+    final String? nativeId = ref.nativeId;
+    if (nativeId == null) return null;
+
+    try {
+      switch (ref.source) {
+        case DataSource.openLibrary:
+          return await _openLibraryApi?.getWork(nativeId);
+        case DataSource.googleBooks:
+          return await _googleBooksApi?.getVolume(nativeId);
+        case DataSource.comicVine:
+          return await _comicVineApi?.getVolume(nativeId);
+        case DataSource.hardcover:
+          return await _hardcoverApi?.getBook(nativeId);
+        case DataSource.fantlab:
+          return await _fantlabApi?.getWork(nativeId);
+        default:
+          return null;
+      }
+    } on Exception catch (e) {
+      _log.warning('Failed to fetch book $nativeId '
+          'from ${ref.source.name}: $e');
+      return null;
     }
   }
 
@@ -1371,7 +1496,7 @@ class ImportService {
     }
   }
 
-  /// [itemIdMapping]: 'media_type:external_id[:platform_id]' -> new collection_item_id.
+  /// [itemIdMapping]: item keys (see [_itemMappingKeys]) -> collection_item_id.
   Future<void> _importTierLists(
     List<Map<String, dynamic>> tierListsData,
     int collectionId,
@@ -1409,11 +1534,13 @@ class ImportService {
 
         if (externalId == null || mediaType == null) continue;
 
-        // Try platform-qualified key, then fall back for legacy exports.
-        final String keyWithPlatform = '$mediaType:$externalId:$platformId';
-        final String keyWithout = '$mediaType:$externalId';
-        final int? newItemId =
-            itemIdMapping[keyWithPlatform] ?? itemIdMapping[keyWithout];
+        final int? newItemId = _resolveMappedItem(
+          itemIdMapping,
+          mediaType: mediaType,
+          externalId: externalId,
+          platformId: platformId,
+          source: entryData['source'] as String?,
+        );
         if (newItemId == null) continue;
 
         final String tierKey = entryData['tier_key'] as String;
@@ -1473,11 +1600,13 @@ class ImportService {
       final int? platformId = itemData['platform_id'] as int?;
       if (mediaType == null || externalId == null) continue;
 
-      // Try platform-qualified key, then fall back for legacy exports.
-      final String keyWithPlatform = '$mediaType:$externalId:$platformId';
-      final String keyWithout = '$mediaType:$externalId';
-      final int? itemId =
-          itemIdMapping[keyWithPlatform] ?? itemIdMapping[keyWithout];
+      final int? itemId = _resolveMappedItem(
+        itemIdMapping,
+        mediaType: mediaType,
+        externalId: externalId,
+        platformId: platformId,
+        source: itemData['source'] as String?,
+      );
       if (itemId == null) continue;
 
       // Imported items are freshly created, so a replace-set write is safe
@@ -1497,17 +1626,64 @@ class ImportService {
     }
   }
 
-  /// Games include platform_id in the key to distinguish per-platform versions;
-  /// other media types use only media_type:external_id.
-  static String _itemMappingKey(
-    MediaType mediaType,
-    int externalId,
+  /// Keys an imported item is filed under so tier-list and tag entries can
+  /// find it. `exact` qualifies by provider, without which an AniList and a
+  /// Kitsu title sharing a numeric id collapse onto one item; `shared` keys
+  /// stay for legacy exports whose entries carry no source.
+  static ({List<String> exact, List<String> shared}) _itemMappingKeys({
+    required String mediaType,
+    required int externalId,
     int? platformId,
+    String? source,
+  }) {
+    final String withPlatform = '$mediaType:$externalId:$platformId';
+    final String bare = '$mediaType:$externalId';
+    return (
+      exact: source == null
+          ? const <String>[]
+          : <String>['$withPlatform@$source', '$bare@$source'],
+      shared: <String>[withPlatform, bare],
+    );
+  }
+
+  static void _registerItemMapping(
+    Map<String, int> mapping,
+    CollectionItem item,
+    int itemId,
   ) {
-    if (mediaType == MediaType.game && platformId != null) {
-      return '${mediaType.value}:$externalId:$platformId';
+    final ({List<String> exact, List<String> shared}) keys = _itemMappingKeys(
+      mediaType: item.mediaType.value,
+      externalId: item.externalId,
+      platformId: item.platformId,
+      source: item.source?.name,
+    );
+    for (final String key in keys.exact) {
+      mapping[key] = itemId;
     }
-    return '${mediaType.value}:$externalId';
+    // A shared key can name several items (same id from two providers, an
+    // animation held as both a movie and a show) — the first one wins.
+    for (final String key in keys.shared) {
+      mapping.putIfAbsent(key, () => itemId);
+    }
+  }
+
+  static int? _resolveMappedItem(
+    Map<String, int> mapping, {
+    required String mediaType,
+    required int externalId,
+    int? platformId,
+    String? source,
+  }) {
+    final ({List<String> exact, List<String> shared}) keys = _itemMappingKeys(
+      mediaType: mediaType,
+      externalId: externalId,
+      platformId: platformId,
+      source: source,
+    );
+    for (final String key in <String>[...keys.exact, ...keys.shared]) {
+      if (mapping[key] case final int id) return id;
+    }
+    return null;
   }
 
   Future<void> _importTrackerData(
@@ -1566,4 +1742,19 @@ class ImportService {
     if (dot == -1) return 'png';
     return key.substring(dot + 1).toLowerCase();
   }
+}
+
+/// One item's media reference from an export file. [nativeId] is the
+/// provider's own string id, carried by light exports for sources whose API
+/// can't be reached with the numeric [externalId].
+class _MediaRef {
+  const _MediaRef({
+    required this.externalId,
+    required this.source,
+    this.nativeId,
+  });
+
+  final int externalId;
+  final DataSource source;
+  final String? nativeId;
 }

--- a/lib/data/repositories/collection_repository.dart
+++ b/lib/data/repositories/collection_repository.dart
@@ -156,12 +156,14 @@ class CollectionRepository {
     required MediaType mediaType,
     required int externalId,
     int? platformId,
+    DataSource? source,
   }) async {
     return _db.findCollectionItem(
       collectionId: collectionId,
       mediaType: mediaType,
       externalId: externalId,
       platformId: platformId,
+      source: source,
     );
   }
 

--- a/lib/features/collections/helpers/collection_actions.dart
+++ b/lib/features/collections/helpers/collection_actions.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/api/anilist_api.dart';
+import '../../../core/api/episode_source/tv_episode_source.dart';
 import '../../../core/api/comicvine_api.dart';
 import '../../../core/api/google_books_api.dart';
 import '../../../core/api/hardcover_api.dart';
@@ -648,8 +649,10 @@ class CollectionActions {
           await db.movieDao.upsertMovie(movie);
         case MediaType.tvShow:
         case MediaType.animation:
-          final TvShow? show =
-              await ref.read(tmdbApiProvider).getTvShow(item.externalId);
+          final TvEpisodeSource api = ref.read(tvEpisodeSourceResolverProvider)(
+            item.source ?? item.mediaType.defaultSource,
+          );
+          final TvShow? show = await api.getShow(item.externalId);
           if (show == null) return _RefreshOutcome.notFound();
           await db.tvShowDao.upsertTvShow(show);
         case MediaType.anime:
@@ -677,10 +680,8 @@ class CollectionActions {
                   .read(kitsuApiProvider)
                   .getMangaById(item.externalId);
             case DataSource.mangadex:
-              // The numeric id is a hash of the UUID; the UUID itself lives in
-              // the cached externalUrl (`.../title/{uuid}`).
-              final String? uuid = item.manga?.externalUrl?.split('/').last;
-              manga = (uuid != null && uuid.isNotEmpty)
+              final String? uuid = item.manga?.mangaDexUuid;
+              manga = uuid != null
                   ? await ref.read(mangaDexApiProvider).getByUuid(uuid)
                   : null;
             default:

--- a/lib/features/collections/helpers/collection_filters.dart
+++ b/lib/features/collections/helpers/collection_filters.dart
@@ -13,6 +13,7 @@ class CollectionFilters {
     this.animeFormats = const <String>{},
     this.tagIds = const <int>{},
     this.status,
+    this.favoriteOnly = false,
     this.searchQuery = '',
   });
 
@@ -28,6 +29,10 @@ class CollectionFilters {
   /// Selected global tag ids; an item passes when it carries ANY of them (OR).
   final Set<int> tagIds;
   final ItemStatus? status;
+
+  /// Keeps only favourites when true.
+  final bool favoriteOnly;
+
   final String searchQuery;
 
   /// [itemTags] is the item id → global tag ids map from `itemTagsProvider`.
@@ -71,6 +76,11 @@ class CollectionFilters {
       result = result
           .where((CollectionItem item) => item.status == status)
           .toList();
+    }
+
+    if (favoriteOnly) {
+      result =
+          result.where((CollectionItem item) => item.isFavorite).toList();
     }
 
     if (searchQuery.isEmpty) return result;

--- a/lib/features/collections/screens/collection_screen.dart
+++ b/lib/features/collections/screens/collection_screen.dart
@@ -93,6 +93,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
   Set<int> _filterTagIds = <int>{};
   bool _groupByTags = false;
   ItemStatus? _filterStatus;
+  bool _filterFavoriteOnly = false;
   ItemStatus? _tableFilterStatus;
   CollectionItem? _focusedItem;
 
@@ -184,6 +185,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       animeFormats: _filterAnimeFormats,
       tagIds: _filterTagIds,
       status: _filterStatus,
+      favoriteOnly: _filterFavoriteOnly,
       searchQuery: searchQuery,
     );
     final S l = S.of(context);
@@ -337,10 +339,13 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       filterAnimeFormats: _filterAnimeFormats,
       filterTagIds: _filterTagIds,
       filterStatus: _filterStatus,
+      filterFavoriteOnly: _filterFavoriteOnly,
       effectiveStatusForCounts: _effectiveStatusForChevrons,
       tags: tags,
       searchQuery: searchQuery,
       groupByTags: _groupByTags,
+      onFavoriteToggled: () =>
+          setState(() => _filterFavoriteOnly = !_filterFavoriteOnly),
       onGroupToggled: () {
         setState(() {
           _groupByTags = !_groupByTags;
@@ -463,6 +468,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
       animeFormats: _filterAnimeFormats,
       tagIds: _filterTagIds,
       status: _filterStatus,
+      favoriteOnly: _filterFavoriteOnly,
       searchQuery: searchQuery,
     );
 

--- a/lib/features/collections/screens/home_screen.dart
+++ b/lib/features/collections/screens/home_screen.dart
@@ -194,16 +194,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     bool descending,
   ) {
     final List<Collection> sorted = List<Collection>.of(collections);
-    switch (mode) {
-      case CollectionListSortMode.createdDate:
-        sorted.sort((Collection a, Collection b) => descending
-            ? a.createdAt.compareTo(b.createdAt)
-            : b.createdAt.compareTo(a.createdAt));
-      case CollectionListSortMode.alphabetical:
-        sorted.sort((Collection a, Collection b) => descending
-            ? b.name.toLowerCase().compareTo(a.name.toLowerCase())
-            : a.name.toLowerCase().compareTo(b.name.toLowerCase()));
-    }
+    sorted.sort((Collection a, Collection b) =>
+        mode.compare(a, b, descending: descending));
     return sorted;
   }
 

--- a/lib/features/collections/widgets/collection_filter_bar.dart
+++ b/lib/features/collections/widgets/collection_filter_bar.dart
@@ -17,7 +17,9 @@ import '../../../shared/utils/media_format.dart';
 import '../../../shared/widgets/chevron_filter_bar.dart';
 import '../../../shared/widgets/filter_subfilter_bar.dart';
 import '../../settings/providers/settings_provider.dart';
+import '../helpers/collection_filters.dart';
 import '../providers/collections_provider.dart';
+import '../providers/item_tags_provider.dart';
 import 'collection_filter_sheet.dart';
 import '../../../shared/constants/collection_sort_mode_ui.dart';
 
@@ -32,6 +34,7 @@ class CollectionFilterBar extends ConsumerStatefulWidget {
     required this.filterAnimeFormats,
     required this.filterTagIds,
     required this.filterStatus,
+    this.filterFavoriteOnly = false,
     this.effectiveStatusForCounts,
     required this.tags,
     this.searchQuery = '',
@@ -41,6 +44,7 @@ class CollectionFilterBar extends ConsumerStatefulWidget {
     required this.onAnimeFormatToggled,
     required this.onTagToggled,
     required this.onStatusChanged,
+    required this.onFavoriteToggled,
     required this.onGroupToggled,
     this.groupByTags = false,
     super.key,
@@ -67,6 +71,9 @@ class CollectionFilterBar extends ConsumerStatefulWidget {
 
   final ItemStatus? filterStatus;
 
+  /// Show only favourites.
+  final bool filterFavoriteOnly;
+
   /// Status that drives chevron counts when it diverges from [filterStatus]
   /// (e.g. the table column header cycled a local filter). Falls back to
   /// [filterStatus] when null.
@@ -88,6 +95,8 @@ class CollectionFilterBar extends ConsumerStatefulWidget {
   final ValueChanged<int?> onTagToggled;
 
   final ValueChanged<ItemStatus?> onStatusChanged;
+
+  final VoidCallback onFavoriteToggled;
 
   final VoidCallback onGroupToggled;
 
@@ -246,6 +255,19 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
                 compact: compact,
                 subtitle: l.status,
                 onChanged: widget.onStatusChanged,
+              ),
+            ),
+            Expanded(
+              child: ChevronSegment(
+                label: l.favorite,
+                icon: Icons.favorite,
+                selected: widget.filterFavoriteOnly,
+                accentColor: AppColors.favorite,
+                isFirst: false,
+                isLast: false,
+                onTap: widget.onFavoriteToggled,
+                compact: compact,
+                tintWhenInactive: true,
               ),
             ),
             if (useTagSheetButton)
@@ -461,16 +483,35 @@ class _CollectionFilterBarState extends ConsumerState<CollectionFilterBar> {
         MediaType.custom: stats?.customCount,
       };
     }
+    // Count what the grid actually shows: every active filter except the type
+    // one, so picking a subfilter (platform, manga / anime format) narrows the
+    // chevron numbers instead of leaving them at the unfiltered total.
+    final List<CollectionItem> visible = CollectionFilters(
+      platformIds: widget.filterPlatformIds,
+      mangaFormats: widget.filterMangaFormats,
+      animeFormats: widget.filterAnimeFormats,
+      tagIds: widget.filterTagIds,
+      status: statusFilter,
+      favoriteOnly: widget.filterFavoriteOnly,
+      searchQuery: widget.searchQuery,
+    ).apply(
+      items,
+      widget.tags,
+      ref.watch(itemTagsProvider).valueOrNull ?? const <int, List<int>>{},
+      animeMangaTitleLanguage: ref.watch(
+        settingsNotifierProvider
+            .select((SettingsState s) => s.animeMangaTitleLanguage),
+      ),
+    );
+
     // Count by effective type so a custom item that masquerades as e.g. anime
     // is tallied under Anime, matching what the type filter will show.
     final Map<MediaType, int> tally = <MediaType, int>{
       for (final MediaType t in MediaType.values) t: 0,
     };
-    for (final CollectionItem item in items) {
-      if (statusFilter == null || item.status == statusFilter) {
-        for (final MediaType bucket in item.filterTypeBuckets) {
-          tally[bucket] = tally[bucket]! + 1;
-        }
+    for (final CollectionItem item in visible) {
+      for (final MediaType bucket in item.filterTypeBuckets) {
+        tally[bucket] = tally[bucket]! + 1;
       }
     }
     return tally;

--- a/lib/features/collections/widgets/recommendations_section.dart
+++ b/lib/features/collections/widgets/recommendations_section.dart
@@ -13,6 +13,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../core/services/image_cache_service.dart';
+import '../../../shared/utils/cover_image_id.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../../shared/widgets/scrollable_row_with_arrows.dart';
 import '../../search/widgets/item_details_sheet.dart';
@@ -146,7 +147,11 @@ class RecommendationsSection extends ConsumerWidget {
                   apiRating: s.rating,
                   icon: Icons.tv_outlined,
                   cacheImageType: ImageType.tvShowPoster,
-                  cacheImageId: s.tmdbId.toString(),
+                  cacheImageId: coverImageId(
+                    mediaType: MediaType.tvShow,
+                    externalId: s.tmdbId,
+                    source: s.source,
+                  ),
                   onAddToCollection: () => _showTvShowDetails(context, s),
                   isOwned: ownedIds.contains(s.tmdbId),
                 ),

--- a/lib/features/recommendations/widgets/recommendation_row.dart
+++ b/lib/features/recommendations/widgets/recommendation_row.dart
@@ -6,6 +6,7 @@ import '../../../shared/models/media_type.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/utils/cover_image_id.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../../shared/widgets/scrollable_row_with_arrows.dart';
 import '../providers/recommendations_provider.dart';
@@ -163,7 +164,12 @@ class _RecommendationRowWidgetState extends State<RecommendationRowWidget> {
                           cacheImageType: isMovie
                               ? ImageType.moviePoster
                               : ImageType.tvShowPoster,
-                          cacheImageId: item.tmdbId.toString(),
+                          cacheImageId: isMovie
+                              ? item.tmdbId.toString()
+                              : coverImageId(
+                                  mediaType: MediaType.tvShow,
+                                  externalId: item.tmdbId,
+                                ),
                           mediaType: item.mediaType,
                           year: item.year,
                           // Predicted personal rating in the badge; TMDB rating

--- a/lib/features/search/handlers/tv_show_handler.dart
+++ b/lib/features/search/handlers/tv_show_handler.dart
@@ -6,6 +6,7 @@ import '../../../core/services/image_cache_service.dart';
 import '../../../core/services/tv_show_cache_warmer.dart';
 import '../../../shared/models/media_type.dart';
 import '../../../shared/models/tv_show.dart';
+import '../../../shared/utils/cover_image_id.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../services/search_collection_adder.dart';
 import '../widgets/item_details_sheet.dart';
@@ -79,7 +80,11 @@ class TvShowHandler implements MediaActionHandler {
       title: tvShow.title,
       upsert: () => _ref.read(tvShowDaoProvider).upsertTvShow(tvShow),
       imageType: ImageType.tvShowPoster,
-      imageId: tvShow.tmdbId.toString(),
+      imageId: coverImageId(
+        mediaType: mediaType,
+        externalId: tvShow.tmdbId,
+        source: tvShow.source,
+      ),
       imageUrl: tvShow.posterUrl,
       afterAdd: () => _ref.read(tvShowCacheWarmerProvider).warm(tvShow.tmdbId, tvShow.source),
     );
@@ -118,7 +123,11 @@ class TvShowHandler implements MediaActionHandler {
       title: tvShow.title,
       upsert: () => _ref.read(tvShowDaoProvider).upsertTvShow(tvShow),
       imageType: ImageType.tvShowPoster,
-      imageId: tvShow.tmdbId.toString(),
+      imageId: coverImageId(
+        mediaType: mediaType,
+        externalId: tvShow.tmdbId,
+        source: tvShow.source,
+      ),
       imageUrl: tvShow.posterUrl,
       afterAdd: () => _ref.read(tvShowCacheWarmerProvider).warm(tvShow.tmdbId, tvShow.source),
     );

--- a/lib/features/search/widgets/browse_grid.dart
+++ b/lib/features/search/widgets/browse_grid.dart
@@ -323,7 +323,11 @@ class _BrowseGridState extends ConsumerState<BrowseGrid> {
         title: item.title,
         imageUrl: item.posterUrl ?? '',
         cacheImageType: ImageType.tvShowPoster,
-        cacheImageId: item.tmdbId.toString(),
+        cacheImageId: coverImageId(
+          mediaType: MediaType.tvShow,
+          externalId: item.tmdbId,
+          source: item.source,
+        ),
         apiRating: item.rating,
         year: item.firstAirYear,
         mediaType: mediaType,

--- a/lib/features/search/widgets/discover_row.dart
+++ b/lib/features/search/widgets/discover_row.dart
@@ -6,6 +6,8 @@ import '../../../core/services/image_cache_service.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/models/media_type.dart';
+import '../../../shared/utils/cover_image_id.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../../shared/widgets/scrollable_row_with_arrows.dart';
 
@@ -132,7 +134,12 @@ class _DiscoverRowState extends State<DiscoverRow> {
                     cacheImageType: item.isMovie
                         ? ImageType.moviePoster
                         : ImageType.tvShowPoster,
-                    cacheImageId: item.tmdbId.toString(),
+                    cacheImageId: item.isMovie
+                        ? item.tmdbId.toString()
+                        : coverImageId(
+                            mediaType: MediaType.tvShow,
+                            externalId: item.tmdbId,
+                          ),
                     year: item.year,
                     apiRating: double.tryParse(item.rating ?? ''),
                     isInCollection: item.isOwned,

--- a/lib/features/search/widgets/item_details_sheet.dart
+++ b/lib/features/search/widgets/item_details_sheet.dart
@@ -102,7 +102,11 @@ class ItemDetailsSheet extends StatelessWidget {
       extraInfoIcon: icon,
       posterUrl: tvShow.posterUrl,
       cacheImageType: ImageType.tvShowPoster,
-      cacheImageId: tvShow.tmdbId.toString(),
+      cacheImageId: coverImageId(
+        mediaType: MediaType.tvShow,
+        externalId: tvShow.tmdbId,
+        source: tvShow.source,
+      ),
       externalUrl: tvShow.externalUrl,
       dataSource: tvShow.source,
       backdropUrl: tvShow.backdropUrl,

--- a/lib/shared/models/canvas_item.dart
+++ b/lib/shared/models/canvas_item.dart
@@ -268,7 +268,11 @@ class CanvasItem with Exportable {
     return switch (itemType) {
       CanvasItemType.game => (game?.id ?? 0).toString(),
       CanvasItemType.movie => (movie?.tmdbId ?? 0).toString(),
-      CanvasItemType.tvShow => (tvShow?.tmdbId ?? 0).toString(),
+      CanvasItemType.tvShow => cover_id.coverImageId(
+          mediaType: MediaType.tvShow,
+          externalId: tvShow?.tmdbId ?? 0,
+          source: tvShow?.source,
+        ),
       CanvasItemType.animation => tvShow != null
           ? (tvShow?.tmdbId ?? 0).toString()
           : (movie?.tmdbId ?? 0).toString(),
@@ -279,7 +283,11 @@ class CanvasItem with Exportable {
           externalId: manga?.id ?? 0,
           source: manga?.source,
         ),
-      CanvasItemType.anime => (anime?.id ?? 0).toString(),
+      CanvasItemType.anime => cover_id.coverImageId(
+          mediaType: MediaType.anime,
+          externalId: anime?.id ?? 0,
+          source: anime?.source,
+        ),
       CanvasItemType.book => cover_id.coverImageId(
           mediaType: MediaType.book,
           externalId: book?.externalIdInt ?? 0,

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -669,11 +669,21 @@ class CollectionItem with Exportable {
   /// When [includeUserData] is true the export carries personal fields
   /// (status, dates, notes, season/episode progress, sort order) on top of
   /// the bare media reference suitable for sharing.
+  /// Provider-native id for sources whose API is keyed by a string the numeric
+  /// [externalId] can't reproduce — a hash (MangaDex, Google Books) or an OLID.
+  /// A light export carries it so import can refetch from the right provider.
+  String? get exportNativeId {
+    if (mediaType == MediaType.book) return book?.nativeId;
+    if (mediaType == MediaType.manga) return manga?.mangaDexUuid;
+    return null;
+  }
+
   @override
   Map<String, dynamic> toExport({bool includeUserData = false}) {
     final Map<String, dynamic> data = <String, dynamic>{
       'media_type': mediaType.value,
       'external_id': externalId,
+      'native_id': ?exportNativeId,
       'platform_id': platformId,
       'source': source?.name,
       'comment': authorComment,

--- a/lib/shared/models/collection_list_sort_mode.dart
+++ b/lib/shared/models/collection_list_sort_mode.dart
@@ -1,3 +1,5 @@
+import 'collection.dart';
+
 /// Sort mode for the collection list on the Home screen.
 enum CollectionListSortMode {
   /// By creation date (created_at, newest first by default).
@@ -10,6 +12,26 @@ enum CollectionListSortMode {
 
   /// Stored value for SharedPreferences.
   final String value;
+
+  /// Orders collections for every place that lists them — the Collections
+  /// screen and the collection picker share this so they can't drift apart.
+  ///
+  /// [descending] is the stored `collection_list_sort_desc` flag. It reads as
+  /// Z→A for [alphabetical] and as oldest-first for [createdDate]: the date
+  /// meaning is the opposite of the flag's name, but it is what users already
+  /// have persisted and what `localizedDescription` says, so it stays.
+  int compare(Collection a, Collection b, {required bool descending}) {
+    switch (this) {
+      case CollectionListSortMode.createdDate:
+        return descending
+            ? a.createdAt.compareTo(b.createdAt)
+            : b.createdAt.compareTo(a.createdAt);
+      case CollectionListSortMode.alphabetical:
+        return descending
+            ? b.name.toLowerCase().compareTo(a.name.toLowerCase())
+            : a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    }
+  }
 
   /// Returns [createdDate] for unknown stored values.
   static CollectionListSortMode fromString(String value) {

--- a/lib/shared/models/manga.dart
+++ b/lib/shared/models/manga.dart
@@ -504,6 +504,15 @@ class Manga {
   /// Transient — not persisted (only present on fresh API responses).
   final String? bannerUrl;
 
+  /// MangaDex's own UUID, recovered from [externalUrl]
+  /// (`https://mangadex.org/title/{uuid}`). The numeric [id] is a hash of it,
+  /// so this is the only way back to the provider's API.
+  String? get mangaDexUuid {
+    if (source != DataSource.mangadex) return null;
+    final String? last = externalUrl?.split('/').last;
+    return (last != null && last.isNotEmpty) ? last : null;
+  }
+
   double? get rating10 =>
       averageScore != null ? averageScore! / 10.0 : null;
 

--- a/lib/shared/utils/cover_image_id.dart
+++ b/lib/shared/utils/cover_image_id.dart
@@ -3,10 +3,14 @@ import '../models/media_type.dart';
 
 /// Canonical image-cache id for a media cover.
 ///
-/// Anime, manga and books are multi-provider: their providers can share a
-/// numeric `externalId`, so covers are namespaced by source (`anilist_1995` /
-/// `mangabaka_1995`) to avoid one overwriting the other. Every other media type
-/// keeps the bare external id.
+/// Anime, manga, books and TV shows are multi-provider: their providers can
+/// share a numeric `externalId`, so covers are namespaced by source
+/// (`anilist_1995` / `mangabaka_1995` / `tvmaze_1399`) to avoid one
+/// overwriting the other. Every other media type keeps the bare external id.
+///
+/// Animation stays bare on purpose: it only ever comes from TMDB, and
+/// namespacing it would orphan every cached animation poster and split the
+/// cache entry an animated film shares with the same film added as a movie.
 ///
 /// MUST be used by both the write side (download/save) and the read side
 /// (display) so the keys line up.
@@ -18,6 +22,9 @@ String coverImageId({
 }) {
   if (mediaType == MediaType.manga || mediaType == MediaType.anime) {
     return '${(source ?? DataSource.anilist).name}_$externalId';
+  }
+  if (mediaType == MediaType.tvShow) {
+    return '${(source ?? DataSource.tmdb).name}_$externalId';
   }
   if (mediaType == MediaType.book) {
     final String base =

--- a/lib/shared/widgets/collection_picker_dialog.dart
+++ b/lib/shared/widgets/collection_picker_dialog.dart
@@ -134,16 +134,8 @@ class _CollectionPickerContentState extends State<_CollectionPickerContent> {
   List<Collection> get _sortedCollections {
     final List<Collection> filtered = List<Collection>.of(_filteredCollections);
 
-    filtered.sort((Collection a, Collection b) {
-      final int result;
-      switch (_sortMode) {
-        case CollectionListSortMode.alphabetical:
-          result = a.name.toLowerCase().compareTo(b.name.toLowerCase());
-        case CollectionListSortMode.createdDate:
-          result = a.createdAt.compareTo(b.createdAt);
-      }
-      return _descending ? -result : result;
-    });
+    filtered.sort((Collection a, Collection b) =>
+        _sortMode.compare(a, b, descending: _descending));
 
     // Already-added collections sink to the bottom of the list.
     final List<Collection> available = filtered

--- a/packages/core/lib/database/migrations/migration_runner.dart
+++ b/packages/core/lib/database/migrations/migration_runner.dart
@@ -1,0 +1,86 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migration.dart';
+
+/// A migration that threw, wrapped so the reason reads before the stack trace.
+///
+/// The raw SQLite error names a table and a constraint but not the migration,
+/// which is only recoverable from the stack frames. On the startup error screen
+/// that is the difference between "the v57 upgrade failed" and an unreadable
+/// wall of SQL.
+class MigrationFailure implements Exception {
+  const MigrationFailure({
+    required this.version,
+    required this.description,
+    required this.fromVersion,
+    required this.toVersion,
+    required this.cause,
+  });
+
+  /// Version of the migration that threw.
+  final int version;
+
+  /// That migration's own description.
+  final String description;
+
+  /// Schema version the run started from; 0 for a database built from scratch.
+  final int fromVersion;
+
+  /// Schema version the run was heading to.
+  final int toVersion;
+
+  /// The original error.
+  final Object cause;
+
+  /// True when the run was building a fresh database rather than upgrading.
+  bool get isFreshInstall => fromVersion == 0;
+
+  @override
+  String toString() {
+    final String headline = isFreshInstall
+        ? 'Database creation (v$toVersion) failed on migration v$version'
+        : 'Database upgrade v$fromVersion → v$toVersion failed on '
+            'migration v$version';
+    final String reassurance = isFreshInstall
+        ? 'The database was not created.'
+        : 'Your data was not changed — the upgrade was rolled back.';
+    return '$headline\n($description)\n$reassurance\n\n$cause';
+  }
+}
+
+/// Runs a migration chain, reporting which migration failed.
+///
+/// Shared by the app's `onCreate` / `onUpgrade` and, later, by the selfhost
+/// server, so both surface the same message.
+abstract final class MigrationRunner {
+  /// Runs [migrations] in order against [db].
+  ///
+  /// [onStart] fires before each migration, for logging. Throws
+  /// [MigrationFailure] with the original stack trace if one of them throws.
+  static Future<void> run(
+    Database db,
+    Iterable<Migration> migrations, {
+    required int fromVersion,
+    required int toVersion,
+    void Function(Migration migration)? onStart,
+    void Function(MigrationFailure failure, StackTrace stack)? onFailure,
+  }) async {
+    for (final Migration migration in migrations) {
+      onStart?.call(migration);
+      try {
+        await migration.migrate(db);
+      } catch (error, stack) {
+        final MigrationFailure failure = MigrationFailure(
+          version: migration.version,
+          description: migration.description,
+          fromVersion: fromVersion,
+          toVersion: toVersion,
+          cause: error,
+        );
+        onFailure?.call(failure, stack);
+        // Keep the original stack: its frames name the failing statement.
+        Error.throwWithStackTrace(failure, stack);
+      }
+    }
+  }
+}

--- a/packages/core/lib/database/migrations/migration_v57.dart
+++ b/packages/core/lib/database/migrations/migration_v57.dart
@@ -72,17 +72,20 @@ class MigrationV57 extends Migration {
     // unique indexes that include source.
     await db.execute('DROP INDEX IF EXISTS idx_ci_coll_other');
     await db.execute('DROP INDEX IF EXISTS idx_ci_uncat_other');
+    // Keep 'book' excluded (source-aware since v48): re-including it here
+    // would make this CREATE UNIQUE INDEX throw on legal cross-source book
+    // duplicates and roll back the whole upgrade.
     await db.execute('''
       CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_coll_other
       ON collection_items(collection_id, media_type, external_id)
       WHERE collection_id IS NOT NULL
-        AND media_type NOT IN ('game', 'manga', 'tv_show')
+        AND media_type NOT IN ('game', 'manga', 'book', 'tv_show')
     ''');
     await db.execute('''
       CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_uncat_other
       ON collection_items(media_type, external_id)
       WHERE collection_id IS NULL
-        AND media_type NOT IN ('game', 'manga', 'tv_show')
+        AND media_type NOT IN ('game', 'manga', 'book', 'tv_show')
     ''');
     await db.execute('''
       CREATE UNIQUE INDEX IF NOT EXISTS idx_ci_coll_tv

--- a/test/core/database/migrations/migration_runner_test.dart
+++ b/test/core/database/migrations/migration_runner_test.dart
@@ -1,0 +1,159 @@
+import 'package:core/database/migrations/migration.dart';
+import 'package:core/database/migrations/migration_runner.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _RecordingMigration extends Migration {
+  _RecordingMigration(this.version, this.log);
+
+  @override
+  final int version;
+
+  final List<int> log;
+
+  @override
+  String get description => 'migration v$version';
+
+  @override
+  Future<void> migrate(Database db) async => log.add(version);
+}
+
+class _ThrowingMigration extends Migration {
+  _ThrowingMigration(this.version, this.error);
+
+  @override
+  final int version;
+
+  final Object error;
+
+  @override
+  String get description => 'rebuilds everything';
+
+  @override
+  Future<void> migrate(Database db) async => throw error;
+}
+
+void main() {
+  sqfliteFfiInit();
+  final DatabaseFactory factory = databaseFactoryFfi;
+
+  Future<Database> openDb() => factory.openDatabase(
+        inMemoryDatabasePath,
+        options: OpenDatabaseOptions(version: 1),
+      );
+
+  group('MigrationRunner.run', () {
+    late Database db;
+
+    setUp(() async => db = await openDb());
+    tearDown(() async => db.close());
+
+    test('runs every migration in order', () async {
+      final List<int> ran = <int>[];
+
+      await MigrationRunner.run(
+        db,
+        <Migration>[
+          _RecordingMigration(1, ran),
+          _RecordingMigration(2, ran),
+          _RecordingMigration(3, ran),
+        ],
+        fromVersion: 0,
+        toVersion: 3,
+      );
+
+      expect(ran, <int>[1, 2, 3]);
+    });
+
+    test('reports the migration that threw and stops the chain', () async {
+      final List<int> ran = <int>[];
+
+      await expectLater(
+        MigrationRunner.run(
+          db,
+          <Migration>[
+            _RecordingMigration(56, ran),
+            _ThrowingMigration(57, Exception('UNIQUE constraint failed')),
+            _RecordingMigration(58, ran),
+          ],
+          fromVersion: 55,
+          toVersion: 58,
+        ),
+        throwsA(isA<MigrationFailure>()
+            .having((MigrationFailure f) => f.version, 'version', 57)
+            .having((MigrationFailure f) => f.fromVersion, 'fromVersion', 55)
+            .having((MigrationFailure f) => f.toVersion, 'toVersion', 58)),
+      );
+
+      expect(ran, <int>[56], reason: 'v58 must not run after v57 failed');
+    });
+
+    test('keeps the original error as the cause', () async {
+      final Exception cause = Exception('boom');
+
+      await expectLater(
+        MigrationRunner.run(
+          db,
+          <Migration>[_ThrowingMigration(57, cause)],
+          fromVersion: 56,
+          toVersion: 57,
+        ),
+        throwsA(isA<MigrationFailure>()
+            .having((MigrationFailure f) => f.cause, 'cause', same(cause))),
+      );
+    });
+
+    test('notifies onStart before each migration and onFailure once',
+        () async {
+      final List<int> started = <int>[];
+      final List<MigrationFailure> failures = <MigrationFailure>[];
+
+      await MigrationRunner.run(
+        db,
+        <Migration>[
+          _ThrowingMigration(57, Exception('boom')),
+        ],
+        fromVersion: 56,
+        toVersion: 60,
+        onStart: (Migration m) => started.add(m.version),
+        onFailure: (MigrationFailure f, StackTrace s) => failures.add(f),
+      ).onError<MigrationFailure>((_, _) {});
+
+      expect(started, <int>[57]);
+      expect(failures, hasLength(1));
+    });
+  });
+
+  group('MigrationFailure', () {
+    test('upgrade message names the versions, the migration and the rollback',
+        () {
+      final String text = const MigrationFailure(
+        version: 57,
+        description: 'Show source: (tmdb_id, source) PK',
+        fromVersion: 56,
+        toVersion: 60,
+        cause: 'UNIQUE constraint failed',
+      ).toString();
+
+      expect(text, startsWith('Database upgrade v56 → v60 failed on '
+          'migration v57'));
+      expect(text, contains('Show source: (tmdb_id, source) PK'));
+      expect(text, contains('rolled back'));
+      expect(text, contains('UNIQUE constraint failed'));
+    });
+
+    test('fresh install message does not promise a rollback', () {
+      const MigrationFailure failure = MigrationFailure(
+        version: 3,
+        description: 'adds a table',
+        fromVersion: 0,
+        toVersion: 60,
+        cause: 'disk full',
+      );
+
+      expect(failure.isFreshInstall, isTrue);
+      expect(failure.toString(), contains('Database creation (v60) failed'));
+      expect(failure.toString(), isNot(contains('rolled back')));
+    });
+  });
+}

--- a/test/core/database/migrations/migration_v57_test.dart
+++ b/test/core/database/migrations/migration_v57_test.dart
@@ -46,17 +46,29 @@ void main() {
               source TEXT
             )
           ''');
+          // Index shape as of v48..v56: book carved out into source-aware
+          // indexes, excluded from the generic ones.
           await db.execute('''
             CREATE UNIQUE INDEX idx_ci_coll_other
             ON collection_items(collection_id, media_type, external_id)
             WHERE collection_id IS NOT NULL
-              AND media_type NOT IN ('game', 'manga')
+              AND media_type NOT IN ('game', 'manga', 'book')
           ''');
           await db.execute('''
             CREATE UNIQUE INDEX idx_ci_uncat_other
             ON collection_items(media_type, external_id)
             WHERE collection_id IS NULL
-              AND media_type NOT IN ('game', 'manga')
+              AND media_type NOT IN ('game', 'manga', 'book')
+          ''');
+          await db.execute('''
+            CREATE UNIQUE INDEX idx_ci_coll_book
+            ON collection_items(collection_id, media_type, external_id, COALESCE(source, 'openLibrary'))
+            WHERE collection_id IS NOT NULL AND media_type = 'book'
+          ''');
+          await db.execute('''
+            CREATE UNIQUE INDEX idx_ci_uncat_book
+            ON collection_items(media_type, external_id, COALESCE(source, 'openLibrary'))
+            WHERE collection_id IS NULL AND media_type = 'book'
           ''');
           await db.execute('''
             CREATE TABLE mood_grid_cells (
@@ -131,6 +143,21 @@ void main() {
         'collection_id': 1,
         'media_type': 'movie',
         'external_id': 42,
+      });
+      // Legal since v48: same numeric book id from two sources in one
+      // collection. The rebuilt generic index must keep excluding 'book',
+      // or this data aborts the whole upgrade.
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'book',
+        'external_id': 777,
+        'source': 'openLibrary',
+      });
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': 1,
+        'media_type': 'book',
+        'external_id': 777,
+        'source': 'googleBooks',
       });
       await db.insert('mood_grid_cells', <String, Object?>{
         'media_type': 'tv_show',
@@ -321,6 +348,24 @@ void main() {
           'media_type': 'tv_show',
           'external_id': 100,
           'source': 'tmdb',
+        }),
+        throwsA(isA<DatabaseException>()),
+      );
+    });
+
+    test('cross-source book duplicates survive the index rebuild', () async {
+      final List<Map<String, Object?>> books = await db.query(
+        'collection_items',
+        where: 'media_type = ? AND external_id = ?',
+        whereArgs: <Object?>['book', 777],
+      );
+      expect(books, hasLength(2));
+      await expectLater(
+        db.insert('collection_items', <String, Object?>{
+          'collection_id': 1,
+          'media_type': 'book',
+          'external_id': 777,
+          'source': 'openLibrary',
         }),
         throwsA(isA<DatabaseException>()),
       );

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -576,7 +576,7 @@ void main() {
             )).thenAnswer((_) async => movieBytes);
         when(() => mockImageCache.readImageBytes(
               ImageType.tvShowPoster,
-              '300',
+              'tmdb_300',
             )).thenAnswer((_) async => tvShowBytes);
 
         when(() => mockCanvasRepo.getGameCanvasItems(any()))
@@ -614,7 +614,7 @@ void main() {
         expect(xcoll.images.length, equals(3));
         expect(xcoll.images.containsKey('game_covers/100'), isTrue);
         expect(xcoll.images.containsKey('movie_posters/200'), isTrue);
-        expect(xcoll.images.containsKey('tv_show_posters/300'), isTrue);
+        expect(xcoll.images.containsKey('tv_show_posters/tmdb_300'), isTrue);
       });
 
       test('без imageCacheService should return пустой images', () async {

--- a/test/core/services/import_service_test.dart
+++ b/test/core/services/import_service_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tonkatsu_box/core/services/image_cache_service.dart';
 import 'package:tonkatsu_box/core/api/igdb_api.dart';
 import 'package:tonkatsu_box/core/api/tmdb_api.dart';
+import 'package:tonkatsu_box/core/database/dao/global_tag_dao.dart';
 import 'package:tonkatsu_box/core/services/import_service.dart';
 import 'package:tonkatsu_box/core/services/xcoll_file.dart';
 import 'package:tonkatsu_box/shared/models/canvas_connection.dart';
@@ -19,6 +20,8 @@ import 'package:tonkatsu_box/shared/models/game.dart';
 import 'package:tonkatsu_box/shared/models/item_mark.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/movie.dart';
+import 'package:tonkatsu_box/shared/models/tag.dart';
+import 'package:tonkatsu_box/shared/models/tier_list.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
 
 import '../../helpers/test_helpers.dart';
@@ -3062,6 +3065,486 @@ void main() {
         expect(result.success, isTrue);
         verify(() => mockTvShowDao.markEpisodeWatchedAt(
             5, DataSource.tmdb, 1399, 1, 1, 1700000000 * 1000)).called(1);
+      });
+    });
+
+    group('multi-source item identity', () {
+      late ImportService sutV2;
+      late MockGlobalTagDao mockTagDao;
+
+      setUp(() {
+        mockTagDao = MockGlobalTagDao();
+        when(() => mockDb.globalTagDao).thenReturn(mockTagDao);
+        sutV2 = ImportService(
+          repository: mockRepo,
+          igdbApi: mockApi,
+          tmdbApi: mockTmdb,
+          database: mockDb,
+        );
+      });
+
+      // A non-empty media map keeps the import off the network APIs.
+      const Map<String, dynamic> noMedia = <String, dynamic>{
+        'animes': <dynamic>[],
+      };
+
+      test('should resolve an existing item by its own source', () async {
+        final XcollFile xcoll = XcollFile(
+          version: 3,
+          format: ExportFormat.full,
+          name: 'Import',
+          author: 'Author',
+          created: testDate,
+          media: noMedia,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 123,
+              'source': 'kitsu',
+              'comment': 'Kitsu review',
+            },
+          ],
+        );
+
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => null);
+        when(() => mockRepo.findItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+            )).thenAnswer((_) async => createTestCollectionItem(
+              id: 42,
+              mediaType: MediaType.anime,
+              externalId: 123,
+            ));
+        when(() => mockDb.updateItemAuthorComment(any(), any()))
+            .thenAnswer((_) async {});
+
+        final ImportResult result =
+            await sutV2.importFromXcoll(xcoll, collectionId: 5);
+
+        expect(result.success, isTrue);
+        final List<DataSource?> lookedUpSources = verify(() => mockRepo.findItem(
+              collectionId: 5,
+              mediaType: MediaType.anime,
+              externalId: 123,
+              platformId: null,
+              source: captureAny(named: 'source'),
+            )).captured.cast<DataSource?>();
+        expect(lookedUpSources, isNotEmpty);
+        expect(lookedUpSources, everyElement(DataSource.kitsu));
+      });
+
+      test('should tag each source separately when two share an id', () async {
+        final XcollFile xcoll = XcollFile(
+          version: 3,
+          format: ExportFormat.full,
+          name: 'Import',
+          author: 'Author',
+          created: testDate,
+          media: noMedia,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 555,
+              'source': 'anilist',
+              'tag_names': <String>['Fav'],
+            },
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 555,
+              'source': 'kitsu',
+              'tag_names': <String>['Meh'],
+            },
+          ],
+          tags: const <Map<String, dynamic>>[
+            <String, dynamic>{'name': 'Fav', 'sort_order': 0},
+            <String, dynamic>{'name': 'Meh', 'sort_order': 1},
+          ],
+        );
+
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((Invocation invocation) async =>
+            invocation.namedArguments[const Symbol('source')] ==
+                    DataSource.kitsu
+                ? 22
+                : 11);
+        when(() => mockTagDao.resolveOrCreateAll(any()))
+            .thenAnswer((_) async => <String, int>{
+                  GlobalTagDao.nameKey('Fav'): 1,
+                  GlobalTagDao.nameKey('Meh'): 2,
+                });
+        when(mockTagDao.getAll).thenAnswer((_) async => <Tag>[
+              createTestTag(id: 1, name: 'Fav'),
+              createTestTag(id: 2, name: 'Meh', sortOrder: 1),
+            ]);
+        when(() => mockTagDao.setItemTags(any(), any()))
+            .thenAnswer((_) async {});
+        when(() => mockTagDao.setItemTagPositions(any(), any()))
+            .thenAnswer((_) async {});
+
+        final ImportResult result =
+            await sutV2.importFromXcoll(xcoll, collectionId: 5);
+
+        expect(result.success, isTrue);
+        verify(() => mockTagDao.setItemTags(11, <int>{1})).called(1);
+        verify(() => mockTagDao.setItemTags(22, <int>{2})).called(1);
+      });
+
+      test('should place each source in its own tier when they share an id',
+          () async {
+        final XcollFile xcoll = XcollFile(
+          version: 3,
+          format: ExportFormat.full,
+          name: 'Import',
+          author: 'Author',
+          created: testDate,
+          media: noMedia,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 555,
+              'source': 'anilist',
+            },
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 555,
+              'source': 'kitsu',
+            },
+          ],
+          tierLists: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'name': 'Ranked',
+              'entries': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'media_type': 'anime',
+                  'external_id': 555,
+                  'source': 'kitsu',
+                  'tier_key': 'S',
+                  'sort_order': 0,
+                },
+              ],
+            },
+          ],
+        );
+
+        final MockTierListDao mockTierListDao = MockTierListDao();
+        when(() => mockDb.tierListDao).thenReturn(mockTierListDao);
+        when(() => mockTierListDao.createTierList(any(),
+                collectionId: any(named: 'collectionId')))
+            .thenAnswer((_) async => TierList(
+                  id: 7,
+                  name: 'Ranked',
+                  createdAt: testDate,
+                ));
+        when(() => mockTierListDao.setItemTier(any(), any(), any(), any()))
+            .thenAnswer((_) async {});
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((Invocation invocation) async =>
+            invocation.namedArguments[const Symbol('source')] ==
+                    DataSource.kitsu
+                ? 22
+                : 11);
+
+        final ImportResult result =
+            await sutV2.importFromXcoll(xcoll, collectionId: 5);
+
+        expect(result.success, isTrue);
+        verify(() => mockTierListDao.setItemTier(7, 22, 'S', 0)).called(1);
+        verifyNever(() => mockTierListDao.setItemTier(7, 11, any(), any()));
+      });
+
+      test('should fall back to the bare key for a legacy sourceless entry',
+          () async {
+        final XcollFile xcoll = XcollFile(
+          version: 3,
+          format: ExportFormat.full,
+          name: 'Import',
+          author: 'Author',
+          created: testDate,
+          media: noMedia,
+          items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 555,
+              'tag_names': <String>['Fav'],
+            },
+          ],
+          tags: const <Map<String, dynamic>>[
+            <String, dynamic>{'name': 'Fav', 'sort_order': 0},
+          ],
+        );
+
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 11);
+        when(() => mockTagDao.resolveOrCreateAll(any())).thenAnswer(
+            (_) async => <String, int>{GlobalTagDao.nameKey('Fav'): 1});
+        when(mockTagDao.getAll)
+            .thenAnswer((_) async => <Tag>[createTestTag(id: 1, name: 'Fav')]);
+        when(() => mockTagDao.setItemTags(any(), any()))
+            .thenAnswer((_) async {});
+
+        final ImportResult result =
+            await sutV2.importFromXcoll(xcoll, collectionId: 5);
+
+        expect(result.success, isTrue);
+        verify(() => mockTagDao.setItemTags(11, <int>{1})).called(1);
+      });
+    });
+
+    group('light import hydration by source', () {
+      late ImportService sutLight;
+      late MockAniListApi mockAniList;
+      late MockTvMazeApi mockTvMaze;
+      late MockKitsuApi mockKitsu;
+      late MockMangaDexApi mockMangaDex;
+      late MockOpenLibraryApi mockOpenLibrary;
+      late MockMangaDao mockMangaDao;
+      late MockAnimeDao mockAnimeDao;
+      late MockBookDao mockBookDao;
+
+      setUp(() {
+        mockAniList = MockAniListApi();
+        mockTvMaze = MockTvMazeApi();
+        mockKitsu = MockKitsuApi();
+        mockMangaDex = MockMangaDexApi();
+        mockOpenLibrary = MockOpenLibraryApi();
+
+        mockMangaDao = MockMangaDao();
+        mockAnimeDao = MockAnimeDao();
+        mockBookDao = MockBookDao();
+        when(() => mockDb.mangaDao).thenReturn(mockMangaDao);
+        when(() => mockDb.animeDao).thenReturn(mockAnimeDao);
+        when(() => mockDb.bookDao).thenReturn(mockBookDao);
+        when(() => mockMangaDao.upsertMangas(any())).thenAnswer((_) async {});
+        when(() => mockAnimeDao.upsertAnimes(any())).thenAnswer((_) async {});
+        when(() => mockBookDao.upsertBooks(any())).thenAnswer((_) async {});
+        when(() => mockTvShowDao.upsertTvShows(any())).thenAnswer((_) async {});
+
+        when(() => mockRepo.getById(5))
+            .thenAnswer((_) async => createTestCollection(id: 5));
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 1);
+
+        sutLight = ImportService(
+          repository: mockRepo,
+          igdbApi: mockApi,
+          tmdbApi: mockTmdb,
+          aniListApi: mockAniList,
+          tvMazeApi: mockTvMaze,
+          kitsuApi: mockKitsu,
+          mangaDexApi: mockMangaDex,
+          openLibraryApi: mockOpenLibrary,
+          database: mockDb,
+        );
+      });
+
+      XcollFile lightFile(List<Map<String, dynamic>> items) => XcollFile(
+            version: 3,
+            format: ExportFormat.light,
+            name: 'Light',
+            author: 'Author',
+            created: testDate,
+            items: items,
+          );
+
+      test('сериал TVmaze тянется из TVmaze, а не из TMDB', () async {
+        when(() => mockTvMaze.getShow(42987))
+            .thenAnswer((_) async => createTestTvShow(tmdbId: 42987));
+
+        final ImportResult result = await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'tv_show',
+              'external_id': 42987,
+              'source': 'tvmaze',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verify(() => mockTvMaze.getShow(42987)).called(1);
+        verifyNever(() => mockTmdb.getTvShow(any()));
+      });
+
+      test('сериал без source остаётся на TMDB (старые файлы)', () async {
+        when(() => mockTmdb.getTvShow(70523))
+            .thenAnswer((_) async => createTestTvShow(tmdbId: 70523));
+
+        await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{'media_type': 'tv_show', 'external_id': 70523},
+          ]),
+          collectionId: 5,
+        );
+
+        verify(() => mockTmdb.getTvShow(70523)).called(1);
+        verifyNever(() => mockTvMaze.getShow(any()));
+      });
+
+      test('аниме Kitsu тянется из Kitsu, а не из AniList', () async {
+        when(() => mockKitsu.getAnimeById(8000)).thenAnswer(
+            (_) async => createTestAnime(id: 8000, source: DataSource.kitsu));
+
+        await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 8000,
+              'source': 'kitsu',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        verify(() => mockKitsu.getAnimeById(8000)).called(1);
+        verifyNever(() => mockAniList.getAnimeByIds(any(),
+            onRateLimit: any(named: 'onRateLimit')));
+      });
+
+      test('манга MangaDex резолвится по native_id', () async {
+        when(() => mockMangaDex.getByUuid('uuid-1'))
+            .thenAnswer((_) async => createTestManga(id: 777));
+
+        await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'manga',
+              'external_id': 3151439834073630622,
+              'source': 'mangadex',
+              'native_id': 'uuid-1',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        verify(() => mockMangaDex.getByUuid('uuid-1')).called(1);
+        verifyNever(() => mockAniList.getMangaById(any()));
+      });
+
+      test('манга MangaDex без native_id пропускается, а не идёт в AniList',
+          () async {
+        await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'manga',
+              'external_id': 3151439834073630622,
+              'source': 'mangadex',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        verifyNever(() => mockMangaDex.getByUuid(any()));
+        verifyNever(() => mockAniList.getMangaById(any()));
+        verifyNever(() => mockMangaDao.upsertMangas(any()));
+      });
+
+      test('книга OpenLibrary резолвится по native_id', () async {
+        when(() => mockOpenLibrary.getWork('OL8193465W')).thenAnswer(
+            (_) async => createTestBook(id: '8193465', nativeId: 'OL8193465W'));
+
+        await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'book',
+              'external_id': 8193465,
+              'source': 'openLibrary',
+              'native_id': 'OL8193465W',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        verify(() => mockOpenLibrary.getWork('OL8193465W')).called(1);
+        verify(() => mockBookDao.upsertBooks(any())).called(1);
+      });
+
+      test('книга без native_id ничего не запрашивает', () async {
+        await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'book',
+              'external_id': 8193465,
+              'source': 'openLibrary',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        verifyNever(() => mockOpenLibrary.getWork(any()));
+        verifyNever(() => mockBookDao.upsertBooks(any()));
+      });
+
+      test('сбой одного источника не роняет остальные', () async {
+        when(() => mockTvMaze.getShow(1)).thenThrow(Exception('network down'));
+        when(() => mockTmdb.getTvShow(2))
+            .thenAnswer((_) async => createTestTvShow(tmdbId: 2));
+
+        final ImportResult result = await sutLight.importFromXcoll(
+          lightFile(const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'tv_show',
+              'external_id': 1,
+              'source': 'tvmaze',
+            },
+            <String, dynamic>{
+              'media_type': 'tv_show',
+              'external_id': 2,
+              'source': 'tmdb',
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verify(() => mockTvShowDao.upsertTvShows(any())).called(1);
       });
     });
   });

--- a/test/features/collections/helpers/collection_filters_test.dart
+++ b/test/features/collections/helpers/collection_filters_test.dart
@@ -17,6 +17,7 @@ void main() {
       String? name,
       String? userComment,
       String? authorComment,
+      bool isFavorite = false,
     }) =>
         createTestCollectionItem(
           id: id,
@@ -27,6 +28,7 @@ void main() {
           overrideName: name,
           userComment: userComment,
           authorComment: authorComment,
+          isFavorite: isFavorite,
         );
 
     final List<Tag> tags = <Tag>[
@@ -117,6 +119,29 @@ void main() {
         make(id: 2, status: ItemStatus.inProgress),
       ];
       final List<CollectionItem> r = const CollectionFilters(
+        status: ItemStatus.completed,
+      ).apply(items, tags, noLinks);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('filters by favourite', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, isFavorite: true),
+        make(id: 2),
+      ];
+      final List<CollectionItem> r =
+          const CollectionFilters(favoriteOnly: true).apply(items, tags, noLinks);
+      expect(r.map((CollectionItem i) => i.id), <int>[1]);
+    });
+
+    test('favourite combines with the other filters', () {
+      final List<CollectionItem> items = <CollectionItem>[
+        make(id: 1, isFavorite: true, status: ItemStatus.completed),
+        make(id: 2, isFavorite: true, status: ItemStatus.inProgress),
+        make(id: 3, status: ItemStatus.completed),
+      ];
+      final List<CollectionItem> r = const CollectionFilters(
+        favoriteOnly: true,
         status: ItemStatus.completed,
       ).apply(items, tags, noLinks);
       expect(r.map((CollectionItem i) => i.id), <int>[1]);

--- a/test/features/collections/widgets/collection_filter_bar_test.dart
+++ b/test/features/collections/widgets/collection_filter_bar_test.dart
@@ -206,7 +206,9 @@ Widget _buildFilterBar({
   ValueChanged<String?>? onAnimeFormatToggled,
   ValueChanged<int?>? onTagToggled,
   ValueChanged<ItemStatus?>? onStatusChanged,
+  VoidCallback? onFavoriteToggled,
   ItemStatus? filterStatus,
+  bool filterFavoriteOnly = false,
 }) {
   return CollectionFilterBar(
     collectionId: collectionId,
@@ -218,6 +220,7 @@ Widget _buildFilterBar({
     filterAnimeFormats: filterAnimeFormats,
     filterTagIds: filterTagIds,
     filterStatus: filterStatus,
+    filterFavoriteOnly: filterFavoriteOnly,
     tags: tags,
     searchQuery: searchQuery,
     onTypeToggled: onTypeToggled ?? (_) {},
@@ -226,6 +229,7 @@ Widget _buildFilterBar({
     onAnimeFormatToggled: onAnimeFormatToggled ?? (_) {},
     onTagToggled: onTagToggled ?? (_) {},
     onStatusChanged: onStatusChanged ?? (_) {},
+    onFavoriteToggled: onFavoriteToggled ?? () {},
     onGroupToggled: () {},
   );
 }
@@ -534,6 +538,147 @@ void main() {
           expect(find.byType(FilterTabChip), findsNothing);
         },
       );
+    });
+
+    group('счётчики типов', () {
+      testWidgets(
+        'формат-субфильтр сужает счётчик у шеврона, а не только сетку',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            _buildTestApp(
+              overrides: _defaultOverrides(),
+              child: _buildFilterBar(
+                filterTypes: <MediaType>{MediaType.manga},
+                filterMangaFormats: <String>{'MANHWA'},
+                itemsAsync:
+                    AsyncData<List<CollectionItem>>(_mangaItemsWithFormats),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Из двух манг под MANHWA попадает одна — счётчик обязан это
+          // отражать, иначе он расходится с тем, что видно на экране.
+          expect(find.textContaining('(1)'), findsOneWidget);
+          expect(find.textContaining('(2)'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'без субфильтра счётчик показывает все элементы типа',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            _buildTestApp(
+              overrides: _defaultOverrides(),
+              child: _buildFilterBar(
+                filterTypes: <MediaType>{MediaType.manga},
+                itemsAsync:
+                    AsyncData<List<CollectionItem>>(_mangaItemsWithFormats),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.textContaining('(2)'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'статус-фильтр тоже сужает счётчик',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            _buildTestApp(
+              overrides: _defaultOverrides(),
+              child: _buildFilterBar(
+                filterTypes: <MediaType>{MediaType.manga},
+                filterStatus: ItemStatus.completed,
+                itemsAsync:
+                    AsyncData<List<CollectionItem>>(_mangaItemsWithFormats),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.textContaining('(1)'), findsOneWidget);
+        },
+      );
+    });
+
+    group('фильтр избранного', () {
+      testWidgets('тап по сегменту зовёт onFavoriteToggled',
+          (WidgetTester tester) async {
+        int calls = 0;
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            overrides: _defaultOverrides(),
+            child: _buildFilterBar(onFavoriteToggled: () => calls++),
+          ),
+        );
+        await tester.pumpAndSettle();
+        // Не-compact режим рисует подпись, иконка появляется только в compact.
+        await tester.tap(find.text('Favorite'));
+        await tester.pumpAndSettle();
+
+        expect(calls, 1);
+      });
+
+      testWidgets('строка шевронов не переполняется на ширине телефона',
+          (WidgetTester tester) async {
+        tester.view.physicalSize = const Size(360, 640);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            overrides: _defaultOverrides(),
+            child: _buildFilterBar(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('счётчик типа учитывает избранное',
+          (WidgetTester tester) async {
+        final List<CollectionItem> items = <CollectionItem>[
+          CollectionItem(
+            id: 40,
+            collectionId: _testCollectionId,
+            mediaType: MediaType.manga,
+            externalId: 800,
+            status: ItemStatus.notStarted,
+            addedAt: DateTime(2024),
+            isFavorite: true,
+            manga: const Manga(id: 800, title: 'Favourite'),
+          ),
+          CollectionItem(
+            id: 41,
+            collectionId: _testCollectionId,
+            mediaType: MediaType.manga,
+            externalId: 801,
+            status: ItemStatus.notStarted,
+            addedAt: DateTime(2024),
+            manga: const Manga(id: 801, title: 'Plain'),
+          ),
+        ];
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            overrides: _defaultOverrides(),
+            child: _buildFilterBar(
+              filterTypes: <MediaType>{MediaType.manga},
+              filterFavoriteOnly: true,
+              itemsAsync: AsyncData<List<CollectionItem>>(items),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('(1)'), findsOneWidget);
+        expect(find.textContaining('(2)'), findsNothing);
+      });
     });
 
     group('always show subcategories setting', () {

--- a/test/helpers/builders.dart
+++ b/test/helpers/builders.dart
@@ -277,6 +277,7 @@ VisualNovel createTestVisualNovel({
 
 Manga createTestManga({
   int id = 500,
+  DataSource source = DataSource.anilist,
   String title = 'Test Manga',
   String? description,
   String? coverUrl,
@@ -285,9 +286,11 @@ Manga createTestManga({
   int? volumes,
   String? format,
   List<String>? genres,
+  String? externalUrl,
 }) {
   return Manga(
     id: id,
+    source: source,
     title: title,
     description: description,
     coverUrl: coverUrl,
@@ -296,6 +299,7 @@ Manga createTestManga({
     volumes: volumes,
     format: format,
     genres: genres,
+    externalUrl: externalUrl,
   );
 }
 

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -17,6 +17,7 @@ import 'package:tonkatsu_box/shared/models/platform.dart';
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
+import 'package:tonkatsu_box/core/database/dao/global_tag_dao.dart';
 import 'package:tonkatsu_box/core/services/image_cache_service.dart';
 import 'package:tonkatsu_box/shared/models/ra_game_progress.dart';
 import 'package:tonkatsu_box/shared/models/tracker_game_data.dart';
@@ -55,6 +56,7 @@ void registerAllFallbacks() {
   registerFallbackValue(const <int>{});
 
   registerFallbackValue(<TierDefinition>[]);
+  registerFallbackValue(<TagSeed>[]);
 
   registerFallbackValue(const RaGameProgress(
     gameId: 0,

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -13,6 +13,7 @@ import 'package:tonkatsu_box/core/api/igdb_api.dart';
 import 'package:tonkatsu_box/core/api/kitsu_api.dart';
 import 'package:tonkatsu_box/core/api/kodi_api.dart';
 import 'package:tonkatsu_box/core/api/mangadex_api.dart';
+import 'package:tonkatsu_box/core/api/openlibrary_api.dart';
 import 'package:tonkatsu_box/core/database/dao/mangadex_tag_dao.dart';
 import 'package:tonkatsu_box/core/api/steamgriddb_api.dart';
 import 'package:tonkatsu_box/core/services/kodi_sync_service.dart';
@@ -170,6 +171,8 @@ class MockGoogleBooksApi extends Mock implements GoogleBooksApi {}
 class MockHardcoverApi extends Mock implements HardcoverApi {}
 
 class MockMangaDexApi extends Mock implements MangaDexApi {}
+
+class MockOpenLibraryApi extends Mock implements OpenLibraryApi {}
 
 class MockMangaDexTagDao extends Mock implements MangaDexTagDao {}
 

--- a/test/shared/models/canvas_item_test.dart
+++ b/test/shared/models/canvas_item_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/core/services/image_cache_service.dart';
 import 'package:tonkatsu_box/shared/models/canvas_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/visual_novel.dart';
 
@@ -677,6 +678,32 @@ void main() {
           createdAt: testDate,
         );
         expect(item.mediaCacheId, '0');
+      });
+
+      test('mediaCacheId should namespace anime covers by source', () {
+        final CanvasItem item = CanvasItem(
+          id: 1,
+          collectionId: 10,
+          itemType: CanvasItemType.anime,
+          x: 0,
+          y: 0,
+          createdAt: testDate,
+          anime: createTestAnime(id: 123, source: DataSource.kitsu),
+        );
+        expect(item.mediaCacheId, 'kitsu_123');
+      });
+
+      test('mediaCacheId should use the anilist namespace by default', () {
+        final CanvasItem item = CanvasItem(
+          id: 1,
+          collectionId: 10,
+          itemType: CanvasItemType.anime,
+          x: 0,
+          y: 0,
+          createdAt: testDate,
+          anime: createTestAnime(id: 123),
+        );
+        expect(item.mediaCacheId, 'anilist_123');
       });
 
       test('mediaPlaceholderIcon should return Icons.menu_book', () {

--- a/test/shared/models/collection_item_test.dart
+++ b/test/shared/models/collection_item_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/shared/models/anime.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/custom_media.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/game.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/manga.dart';
@@ -9,6 +10,8 @@ import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/movie.dart';
 import 'package:tonkatsu_box/shared/models/platform.dart';
 import 'package:tonkatsu_box/shared/models/tv_show.dart';
+
+import '../../helpers/test_helpers.dart';
 
 void main() {
   group('CollectionItem', () {
@@ -468,6 +471,51 @@ void main() {
     });
 
     group('toExport', () {
+      test('книга несёт native_id — без него её не перезапросить', () {
+        final CollectionItem item = CollectionItem(
+          id: 1,
+          collectionId: 10,
+          mediaType: MediaType.book,
+          externalId: 8193465,
+          source: DataSource.openLibrary,
+          status: ItemStatus.notStarted,
+          addedAt: testAddedAt,
+          book: createTestBook(id: '8193465', nativeId: 'OL8193465W'),
+        );
+
+        expect(item.toExport()['native_id'], 'OL8193465W');
+      });
+
+      test('манга MangaDex несёт UUID, у остальных источников поля нет', () {
+        final CollectionItem mangaDex = CollectionItem(
+          id: 2,
+          collectionId: 10,
+          mediaType: MediaType.manga,
+          externalId: 3151439834073630622,
+          source: DataSource.mangadex,
+          status: ItemStatus.notStarted,
+          addedAt: testAddedAt,
+          manga: createTestManga(
+            id: 3151439834073630622,
+            source: DataSource.mangadex,
+            externalUrl: 'https://mangadex.org/title/uuid-1',
+          ),
+        );
+        final CollectionItem aniList = CollectionItem(
+          id: 3,
+          collectionId: 10,
+          mediaType: MediaType.manga,
+          externalId: 97700,
+          source: DataSource.anilist,
+          status: ItemStatus.notStarted,
+          addedAt: testAddedAt,
+          manga: createTestManga(id: 97700),
+        );
+
+        expect(mangaDex.toExport()['native_id'], 'uuid-1');
+        expect(aniList.toExport().containsKey('native_id'), isFalse);
+      });
+
       test('должен конвертировать game элемент в JSON', () {
         final CollectionItem item = CollectionItem(
           id: 1,

--- a/test/shared/models/collection_list_sort_mode_test.dart
+++ b/test/shared/models/collection_list_sort_mode_test.dart
@@ -1,8 +1,58 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/collection.dart';
 import 'package:tonkatsu_box/shared/models/collection_list_sort_mode.dart';
 
 void main() {
+  int nextId = 0;
+  Collection collection(String name, DateTime createdAt) => Collection(
+        id: ++nextId,
+        name: name,
+        author: 'User',
+        type: CollectionType.own,
+        createdAt: createdAt,
+      );
+
   group('CollectionListSortMode', () {
+    group('compare', () {
+      final Collection older = collection('Older', DateTime(2025, 1, 1));
+      final Collection newer = collection('Newer', DateTime(2026, 6, 1));
+
+      test('createdDate без descending ставит новые выше', () {
+        final List<Collection> sorted = <Collection>[older, newer]
+          ..sort((Collection a, Collection b) => CollectionListSortMode
+              .createdDate
+              .compare(a, b, descending: false));
+
+        expect(sorted.first, same(newer));
+      });
+
+      test('createdDate с descending ставит старые выше', () {
+        final List<Collection> sorted = <Collection>[newer, older]
+          ..sort((Collection a, Collection b) => CollectionListSortMode
+              .createdDate
+              .compare(a, b, descending: true));
+
+        expect(sorted.first, same(older));
+      });
+
+      test('alphabetical сортирует A→Z, с descending — Z→A', () {
+        final Collection apple = collection('Apple', DateTime(2026, 1, 1));
+        final Collection banana = collection('banana', DateTime(2026, 1, 2));
+
+        final List<Collection> asc = <Collection>[banana, apple]
+          ..sort((Collection a, Collection b) => CollectionListSortMode
+              .alphabetical
+              .compare(a, b, descending: false));
+        final List<Collection> desc = <Collection>[apple, banana]
+          ..sort((Collection a, Collection b) => CollectionListSortMode
+              .alphabetical
+              .compare(a, b, descending: true));
+
+        expect(asc.first, same(apple));
+        expect(desc.first, same(banana));
+      });
+    });
+
     group('значения enum', () {
       test('should contain 2 значения', () {
         expect(CollectionListSortMode.values.length, 2);

--- a/test/shared/utils/cover_image_id_test.dart
+++ b/test/shared/utils/cover_image_id_test.dart
@@ -106,11 +106,47 @@ void main() {
       );
     });
 
-    test('non-manga types keep the bare external id', () {
+    test('namespaces TV shows by source', () {
+      expect(
+        coverImageId(
+          mediaType: MediaType.tvShow,
+          externalId: 1399,
+          source: DataSource.tvmaze,
+        ),
+        'tvmaze_1399',
+      );
+      expect(
+        coverImageId(
+          mediaType: MediaType.tvShow,
+          externalId: 1399,
+          source: DataSource.tmdb,
+        ),
+        'tmdb_1399',
+      );
+    });
+
+    test('TV show with null source defaults to tmdb', () {
+      expect(
+        coverImageId(mediaType: MediaType.tvShow, externalId: 1399),
+        'tmdb_1399',
+      );
+    });
+
+    test('animation stays bare — it only comes from TMDB', () {
+      expect(
+        coverImageId(
+          mediaType: MediaType.animation,
+          externalId: 1399,
+          source: DataSource.tmdb,
+        ),
+        '1399',
+      );
+    });
+
+    test('single-source types keep the bare external id', () {
       for (final MediaType type in <MediaType>[
         MediaType.game,
         MediaType.movie,
-        MediaType.tvShow,
         MediaType.visualNovel,
       ]) {
         expect(

--- a/test/shared/widgets/collection_picker_dialog_test.dart
+++ b/test/shared/widgets/collection_picker_dialog_test.dart
@@ -657,7 +657,7 @@ void main() {
       });
 
       testWidgets(
-          'должен сортировать по дате создания (ascending)',
+          'дата без descending — новые сверху, как на экране коллекций',
           (WidgetTester tester) async {
         final Collection cOldest = Collection(
           id: 1,
@@ -691,15 +691,15 @@ void main() {
           ),
         );
 
-        final Offset posOldest = tester.getCenter(find.text('Oldest'));
-        final Offset posMiddle = tester.getCenter(find.text('Middle'));
         final Offset posNewest = tester.getCenter(find.text('Newest'));
-        expect(posOldest.dy, lessThan(posMiddle.dy));
-        expect(posMiddle.dy, lessThan(posNewest.dy));
+        final Offset posMiddle = tester.getCenter(find.text('Middle'));
+        final Offset posOldest = tester.getCenter(find.text('Oldest'));
+        expect(posNewest.dy, lessThan(posMiddle.dy));
+        expect(posMiddle.dy, lessThan(posOldest.dy));
       });
 
       testWidgets(
-          'должен сортировать по дате создания descending (новые сверху)',
+          'дата с descending — старые сверху, как на экране коллекций',
           (WidgetTester tester) async {
         final Collection cOldest = Collection(
           id: 1,
@@ -726,9 +726,9 @@ void main() {
           ),
         );
 
-        final Offset posNewest = tester.getCenter(find.text('Newest'));
         final Offset posOldest = tester.getCenter(find.text('Oldest'));
-        expect(posNewest.dy, lessThan(posOldest.dy));
+        final Offset posNewest = tester.getCenter(find.text('Newest'));
+        expect(posOldest.dy, lessThan(posNewest.dy));
       });
 
       testWidgets(


### PR DESCRIPTION
Follow-up to the release 0.40 audit.

A light .xcoll now refetches each item from the provider it came from instead of sending every id to one API per media type, and books are hydrated at all. Book and MangaDex ids can't be reversed, so light exports carry native_id.

TV posters are cached per source, so a TMDB and a TVmaze show sharing a number no longer overwrite each other's picture.

The collection picker sorts by date the way the Collections screen does; both now share one comparator. Type counts inside a collection follow the active subfilters, and the chevron bar gains the favourites filter that All Items already had.

A failed migration reports which one failed and whether the upgrade rolled back, instead of leaving that in the sixth stack frame.