### PR TITLE
feat(collections,kitsu): run Kitsu anime on the episode tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ## [Unreleased]
 
+### Added
+
+- **Kitsu anime run on the season-and-episode tracker, like TV series**
+
+  A Kitsu anime opens the same season accordion TV shows use: episode tiles with
+  a preview frame, title, air date, runtime and synopsis, a watched checkbox,
+  likes and per-episode notes. Marking an episode moves the item to In progress,
+  marking every episode completes it, and the card badge shows watched of total.
+  Episodes without a preview frame borrow the season poster.
+
+  Seasons come from Kitsu's own episode data, so long titles keep their real
+  structure (Bleach: 16 seasons, 366 episodes) instead of one flat list.
+  Episode numbering stays absolute the way anime is usually counted. AniList
+  anime keep the flat counter — only Kitsu ships per-episode metadata.
+
+  * lib/core/api/kitsu/kitsu_episode_api.dart (KitsuEpisodeApi.getAllEpisodes,
+    KitsuEpisodeApi.getEpisodeCount): New. Kitsu caps a page at 20 episodes and
+    has no season filter, so the full list is fetched — page one carries
+    `meta.count` and the rest go out in parallel batches.
+  * lib/core/api/kitsu_api.dart (KitsuApi.getAnimeEpisodes,
+    KitsuApi.getAnimeEpisodeCount): Expose the episode API on the facade.
+  * lib/core/api/episode_source/kitsu_episode_source.dart (KitsuEpisodeSource):
+    New. Groups episodes into real seasons, falls back to a single synthesized
+    season when the list is unavailable, and memoizes both the anime record and
+    the episode list per show.
+  * lib/core/api/episode_source/tv_episode_source.dart
+    (tvEpisodeSourceResolverProvider): Route `DataSource.kitsu` to the new source.
+  * lib/shared/models/tv_episode.dart (TvEpisode.tryFromKitsu): New factory;
+    Kitsu's synopsis is plain text, so no HTML stripping.
+  * lib/shared/models/collection_item.dart (CollectionItem.usesEpisodeTracker,
+    CollectionItem.usesEpisodeTrackerFor): New single definition of "progress
+    lives in the episode tracker", replacing the condition that was spelled out
+    separately in the detail config and the card badge.
+  * lib/shared/models/media_type.dart (MediaType.mayUseEpisodeTracker): New
+    coarse check for callers that only know the type, such as cache invalidation.
+  * lib/features/collections/widgets/item_detail/item_detail_media_config.dart
+    (ItemDetailMediaConfig.from): Kitsu anime get the tracker section instead of
+    the flat progress widget.
+  * lib/features/collections/widgets/episode_tracker_section.dart
+    (EpisodeTile.seasonPosterUrl): Stand-in image when an episode has no still
+    of its own; cached under the season's id so it is not mistaken for the
+    episode's own frame.
+  * lib/features/collections/providers/episode_tracker_provider.dart
+    (EpisodeTrackerNotifier._updateAutoStatus): Find the item through
+    `usesEpisodeTracker` and read the episode total from the anime record, so
+    status updates work without a cached show row.
+  * lib/features/collections/helpers/tracker_card_progress.dart
+    (trackerCardProgress): Same predicate, plus the anime episode count as the
+    total.
+  * lib/shared/utils/item_card_progress.dart (itemCardProgress): Kitsu anime
+    fall through to the tracker badge instead of the item counter.
+  * lib/core/services/export_service.dart (ExportService._attachWatchedEpisodes),
+    lib/core/services/import_service.dart
+    (ImportService._importWatchedEpisodes): Backups carry and restore watched
+    episodes for Kitsu anime, which the tv-only gate skipped.
+  * lib/core/database/dao/collection_dao.dart (CollectionDao._loadItemMeta,
+    CollectionDao._transferWatchedEpisodes, CollectionDao._hasTvSibling): Moving
+    a Kitsu anime between collections carries its marks; `_loadItemMeta` now
+    selects `platform_id`, which the animated-series check needs.
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier._invalidateEpisodeTrackers),
+    lib/features/collections/helpers/bulk_operations.dart
+    (BulkOperations._invalidateAfterMutation): Refresh live trackers after an
+    anime move too.
+  * test/helpers/fallbacks.dart (registerAllFallbacks): Register an `Anime`
+    fallback for mocktail.
+
 ## [0.40.0] - 2026-07-26
 
 ### Added

--- a/lib/core/api/episode_source/kitsu_episode_source.dart
+++ b/lib/core/api/episode_source/kitsu_episode_source.dart
@@ -1,0 +1,153 @@
+import '../../../shared/models/anime.dart';
+import '../../../shared/models/data_source.dart';
+import '../../../shared/models/tv_episode.dart';
+import '../../../shared/models/tv_season.dart';
+import '../../../shared/models/tv_show.dart';
+import '../kitsu_api.dart';
+import 'tv_episode_source.dart';
+
+/// [TvEpisodeSource] backed by Kitsu anime episodes.
+///
+/// Kitsu has no seasons endpoint and no per-season episode filter, so seasons
+/// are synthesized and [getSeasonEpisodes] fetches the full list once per anime
+/// and filters in memory (the shape [TvMazeEpisodeSource] already uses). Both
+/// the anime record and the episode list are memoized per show id so opening a
+/// card does not repeat requests; a failed fetch is dropped so the next call
+/// retries.
+class KitsuEpisodeSource implements TvEpisodeSource {
+  KitsuEpisodeSource(this._api);
+
+  /// Kitsu splits long-running titles into separate anime records, so a record
+  /// nearly always carries a single season.
+  static const int _synthesizedSeason = 1;
+
+  final KitsuApi _api;
+
+  int? _animeId;
+  Future<Anime?>? _anime;
+
+  int? _episodesShowId;
+  Future<List<TvEpisode>>? _episodes;
+
+  @override
+  Future<TvShow?> getShow(int showId) async {
+    final Anime? anime = await _animeRecord(showId);
+    return anime == null ? null : _asTvShow(anime);
+  }
+
+  /// Seasons come from the episodes themselves — Kitsu has no seasons endpoint,
+  /// and long-running records really do carry several seasons (Bleach: 16, with
+  /// `number` counting absolutely across all of them). That costs the full
+  /// episode list here, but the caller persists the result and the list is
+  /// memoized, so expanding a season afterwards needs no further requests.
+  ///
+  /// Falls back to one synthesized season when the list is unavailable, so an
+  /// API failure still renders a tracker instead of nothing.
+  @override
+  Future<List<TvSeason>> getSeasons(int showId) async {
+    final Anime? anime = await _animeRecord(showId);
+
+    List<TvEpisode> episodes;
+    try {
+      episodes = await _allEpisodes(showId);
+    } on Object {
+      episodes = const <TvEpisode>[];
+    }
+
+    if (episodes.isEmpty) {
+      return <TvSeason>[
+        _season(
+          showId,
+          _synthesizedSeason,
+          anime?.episodes ?? await _api.getAnimeEpisodeCount(showId),
+          anime,
+        ),
+      ];
+    }
+
+    final Map<int, int> countBySeason = <int, int>{};
+    for (final TvEpisode ep in episodes) {
+      countBySeason[ep.seasonNumber] = (countBySeason[ep.seasonNumber] ?? 0) + 1;
+    }
+
+    final List<int> numbers = countBySeason.keys.toList()..sort();
+    return <TvSeason>[
+      for (final int number in numbers)
+        _season(showId, number, countBySeason[number], anime),
+    ];
+  }
+
+  TvSeason _season(int showId, int number, int? episodeCount, Anime? anime) =>
+      TvSeason(
+        tmdbShowId: showId,
+        seasonNumber: number,
+        episodeCount: episodeCount,
+        posterUrl: anime?.coverUrl,
+        source: DataSource.kitsu,
+      );
+
+  @override
+  Future<List<TvEpisode>> getSeasonEpisodes(
+    int showId,
+    int seasonNumber,
+  ) async {
+    final List<TvEpisode> all = await _allEpisodes(showId);
+    final List<TvEpisode> ofSeason = all
+        .where((TvEpisode e) => e.seasonNumber == seasonNumber)
+        .toList();
+
+    // Records whose episodes carry a different season number would otherwise
+    // render an empty tracker, since the season list only holds the
+    // synthesized one.
+    if (ofSeason.isEmpty && seasonNumber == _synthesizedSeason) return all;
+    return ofSeason;
+  }
+
+  Future<Anime?> _animeRecord(int showId) {
+    if (_animeId != showId || _anime == null) {
+      _animeId = showId;
+      _anime = _api.getAnimeById(showId).catchError((Object e) {
+        if (_animeId == showId) {
+          _animeId = null;
+          _anime = null;
+        }
+        throw e;
+      });
+    }
+    return _anime!;
+  }
+
+  Future<List<TvEpisode>> _allEpisodes(int showId) {
+    if (_episodesShowId != showId || _episodes == null) {
+      _episodesShowId = showId;
+      _episodes = _api.getAnimeEpisodes(showId).catchError((Object e) {
+        if (_episodesShowId == showId) {
+          _episodesShowId = null;
+          _episodes = null;
+        }
+        throw e;
+      });
+    }
+    return _episodes!;
+  }
+
+  TvShow _asTvShow(Anime anime) {
+    return TvShow(
+      tmdbId: anime.id,
+      title: anime.title,
+      originalTitle: anime.titleNative,
+      posterUrl: anime.coverUrl,
+      backdropUrl: anime.bannerUrl,
+      overview: anime.description,
+      genres: anime.genres,
+      firstAirYear: anime.startYear,
+      // Season count is unknown from the anime record alone — it only shows up
+      // in the episode list, and this must not drag that in.
+      totalEpisodes: anime.episodes,
+      rating: anime.rating10,
+      status: anime.status,
+      externalUrl: anime.externalUrl,
+      source: DataSource.kitsu,
+    );
+  }
+}

--- a/lib/core/api/episode_source/tv_episode_source.dart
+++ b/lib/core/api/episode_source/tv_episode_source.dart
@@ -4,8 +4,10 @@ import '../../../shared/models/data_source.dart';
 import '../../../shared/models/tv_episode.dart';
 import '../../../shared/models/tv_season.dart';
 import '../../../shared/models/tv_show.dart';
+import '../kitsu_api.dart';
 import '../tmdb_api.dart';
 import '../tvmaze_api.dart';
+import 'kitsu_episode_source.dart';
 import 'tmdb_episode_source.dart';
 import 'tvmaze_episode_source.dart';
 
@@ -30,6 +32,11 @@ final Provider<TvEpisodeSource Function(DataSource)>
       TmdbEpisodeSource(ref.watch(tmdbApiProvider));
   final TvMazeEpisodeSource tvmaze =
       TvMazeEpisodeSource(ref.watch(tvMazeApiProvider));
-  return (DataSource source) =>
-      source == DataSource.tvmaze ? tvmaze : tmdb;
+  final KitsuEpisodeSource kitsu =
+      KitsuEpisodeSource(ref.watch(kitsuApiProvider));
+  return (DataSource source) => switch (source) {
+        DataSource.tvmaze => tvmaze,
+        DataSource.kitsu => kitsu,
+        _ => tmdb,
+      };
 });

--- a/lib/core/api/kitsu/kitsu_episode_api.dart
+++ b/lib/core/api/kitsu/kitsu_episode_api.dart
@@ -1,0 +1,100 @@
+import 'dart:math' as math;
+
+import 'package:dio/dio.dart';
+
+import '../../../shared/models/tv_episode.dart';
+import 'kitsu_http_client.dart';
+
+/// Anime episodes on Kitsu (`/anime/{id}/episodes`, JSON:API).
+///
+/// The endpoint caps a page at 20 items and has no season filter, so a full
+/// list is the only way to get one season. Page one carries `meta.count`, the
+/// remaining pages go out in parallel batches — that keeps even the outliers
+/// (One Piece, ~70 pages) down to seconds instead of a serial crawl.
+class KitsuEpisodeApi {
+  KitsuEpisodeApi(this._client);
+
+  /// Kitsu rejects `page[limit]` above 20 with a 400.
+  static const int _pageLimit = 20;
+
+  /// In-flight page requests per anime.
+  static const int _maxConcurrentPages = 6;
+
+  final KitsuHttpClient _client;
+
+  /// Total episode count in one tiny request, for anime whose cached
+  /// `episodeCount` is null (ongoing and unaired titles).
+  Future<int?> getEpisodeCount(int animeId) async {
+    try {
+      final Map<String, dynamic> page = await _page(animeId, 0, limit: 1);
+      return _client.totalCount(page);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return null;
+      throw _client.handleDioException(e, 'Failed to load Kitsu episodes');
+    }
+  }
+
+  /// Every episode of an anime, ordered by season then episode number.
+  Future<List<TvEpisode>> getAllEpisodes(int animeId) async {
+    try {
+      final Map<String, dynamic> firstPage = await _page(animeId, 0);
+      final List<TvEpisode> episodes = _parse(firstPage, animeId);
+      final int total = _client.totalCount(firstPage) ?? episodes.length;
+
+      final List<int> offsets = <int>[
+        for (int offset = _pageLimit; offset < total; offset += _pageLimit)
+          offset,
+      ];
+
+      for (int i = 0; i < offsets.length; i += _maxConcurrentPages) {
+        final List<int> batch = offsets.sublist(
+          i,
+          math.min(i + _maxConcurrentPages, offsets.length),
+        );
+        final List<Map<String, dynamic>> pages = await Future.wait(
+          batch.map((int offset) => _page(animeId, offset)),
+        );
+        for (final Map<String, dynamic> page in pages) {
+          episodes.addAll(_parse(page, animeId));
+        }
+      }
+
+      episodes.sort((TvEpisode a, TvEpisode b) {
+        final int bySeason = a.seasonNumber.compareTo(b.seasonNumber);
+        return bySeason != 0
+            ? bySeason
+            : a.episodeNumber.compareTo(b.episodeNumber);
+      });
+      return episodes;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to load Kitsu episodes');
+    }
+  }
+
+  Future<Map<String, dynamic>> _page(
+    int animeId,
+    int offset, {
+    int limit = _pageLimit,
+  }) async {
+    final Response<dynamic> resp = await _client.get(
+      'anime/$animeId/episodes',
+      queryParameters: <String, dynamic>{
+        'page[limit]': limit,
+        'page[offset]': offset,
+      },
+    );
+    return (resp.data as Map<String, dynamic>?) ?? <String, dynamic>{};
+  }
+
+  static List<TvEpisode> _parse(Map<String, dynamic> page, int animeId) {
+    final List<dynamic> rows = (page['data'] as List<dynamic>?) ?? <dynamic>[];
+    final List<TvEpisode> out = <TvEpisode>[];
+    for (final Map<String, dynamic> row
+        in rows.whereType<Map<String, dynamic>>()) {
+      final TvEpisode? episode =
+          TvEpisode.tryFromKitsu(row, showId: animeId);
+      if (episode != null) out.add(episode);
+    }
+    return out;
+  }
+}

--- a/lib/core/api/kitsu_api.dart
+++ b/lib/core/api/kitsu_api.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../shared/models/anime.dart';
 import '../../shared/models/manga.dart';
+import '../../shared/models/tv_episode.dart';
 import 'kitsu/kitsu_anime_api.dart';
+import 'kitsu/kitsu_episode_api.dart';
 import 'kitsu/kitsu_http_client.dart';
 import 'kitsu/kitsu_manga_api.dart';
 
@@ -16,11 +18,13 @@ class KitsuApi {
   KitsuApi({Dio? dio}) : _client = KitsuHttpClient(dio: dio) {
     _manga = KitsuMangaApi(_client);
     _anime = KitsuAnimeApi(_client);
+    _episodes = KitsuEpisodeApi(_client);
   }
 
   final KitsuHttpClient _client;
   late final KitsuMangaApi _manga;
   late final KitsuAnimeApi _anime;
+  late final KitsuEpisodeApi _episodes;
 
   Future<(List<Manga>, bool hasMore, int totalPages)> browseManga({
     String? query,
@@ -59,6 +63,11 @@ class KitsuApi {
       );
 
   Future<Anime?> getAnimeById(int id) => _anime.getById(id);
+
+  Future<List<TvEpisode>> getAnimeEpisodes(int id) =>
+      _episodes.getAllEpisodes(id);
+
+  Future<int?> getAnimeEpisodeCount(int id) => _episodes.getEpisodeCount(id);
 
   void dispose() => _client.dispose();
 }

--- a/lib/core/database/dao/collection_dao.dart
+++ b/lib/core/database/dao/collection_dao.dart
@@ -562,7 +562,15 @@ class CollectionDao {
   ) async {
     final List<Map<String, dynamic>> rows = await db.query(
       'collection_items',
-      columns: <String>['collection_id', 'media_type', 'external_id', 'source'],
+      columns: <String>[
+        'collection_id',
+        'media_type',
+        'external_id',
+        'source',
+        // Tells an animated series from an animated movie; only the former
+        // carries watch marks.
+        'platform_id',
+      ],
       where: 'id = ?',
       whereArgs: <Object?>[id],
       limit: 1,
@@ -570,9 +578,10 @@ class CollectionDao {
     return rows.isEmpty ? null : rows.first;
   }
 
-  /// Whether another tv/animation item for the same show remains in the
+  /// Whether another tracker-backed item for the same show remains in the
   /// collection — it shares the watch marks, so they must not be
-  /// moved/deleted.
+  /// moved/deleted. Kitsu anime included: marks are keyed by
+  /// `(collection, source, show)`, not by item.
   Future<bool> _hasTvSibling(
     DatabaseExecutor db,
     int collectionId,
@@ -583,7 +592,7 @@ class CollectionDao {
       'collection_items',
       columns: <String>['id'],
       where: 'collection_id = ? AND external_id = ? '
-          "AND media_type IN ('tv_show', 'animation') "
+          "AND media_type IN ('tv_show', 'animation', 'anime') "
           "AND COALESCE(source, 'tmdb') = ?",
       whereArgs: <Object?>[
         collectionId,
@@ -620,7 +629,14 @@ class CollectionDao {
     Map<String, dynamic> movedItem,
     int? targetCollectionId,
   ) async {
-    if (!MediaType.fromString(movedItem['media_type'] as String).isTvBacked) {
+    if (!CollectionItem.usesEpisodeTrackerFor(
+      mediaType: MediaType.fromString(movedItem['media_type'] as String),
+      source: DataSource.fromNameOr(
+        movedItem['source'] as String?,
+        DataSource.tmdb,
+      ),
+      platformId: movedItem['platform_id'] as int?,
+    )) {
       return;
     }
     final int? oldCollectionId = movedItem['collection_id'] as int?;

--- a/lib/core/services/export_service.dart
+++ b/lib/core/services/export_service.dart
@@ -336,7 +336,7 @@ class ExportService {
     if (db == null) return;
     for (int i = 0; i < items.length; i++) {
       final CollectionItem item = items[i];
-      if (!item.mediaType.isTvBacked) continue;
+      if (!item.usesEpisodeTracker) continue;
       // Resolve the source exactly like import will: parsed items carry no
       // joined show, so their dataSource collapses to the raw column.
       final DataSource source = item.source ?? DataSource.tmdb;

--- a/lib/core/services/import_service.dart
+++ b/lib/core/services/import_service.dart
@@ -1475,7 +1475,7 @@ class ImportService {
     int collectionId,
     CollectionItem parsed,
   ) async {
-    if (!parsed.mediaType.isTvBacked) return;
+    if (!parsed.usesEpisodeTracker) return;
     final List<dynamic>? raw =
         itemData['_watched_episodes'] as List<dynamic>?;
     if (raw == null || raw.isEmpty) return;

--- a/lib/features/collections/helpers/bulk_operations.dart
+++ b/lib/features/collections/helpers/bulk_operations.dart
@@ -211,7 +211,7 @@ class BulkOperations {
     }
     // Bulk moves transfer watched marks in the DB; live trackers keep the
     // old in-memory state until invalidated.
-    if (affectedTypes.any((MediaType t) => t.isTvBacked)) {
+    if (affectedTypes.any((MediaType t) => t.mayUseEpisodeTracker)) {
       ref.invalidate(episodeTrackerNotifierProvider);
     }
     for (final MediaType t in affectedTypes) {

--- a/lib/features/collections/helpers/tracker_card_progress.dart
+++ b/lib/features/collections/helpers/tracker_card_progress.dart
@@ -10,7 +10,7 @@ import '../providers/episode_tracker_provider.dart';
 ItemCardProgress? trackerCardProgress(WidgetRef ref, CollectionItem item) {
   final int? collectionId = item.collectionId;
   if (collectionId == null) return null;
-  if (!item.mediaType.isTvBacked) return null;
+  if (!item.usesEpisodeTracker) return null;
   final EpisodeTrackerState trackerState =
       ref.watch(episodeTrackerNotifierProvider((
     collectionId: collectionId,
@@ -19,7 +19,8 @@ ItemCardProgress? trackerCardProgress(WidgetRef ref, CollectionItem item) {
   )));
   final int watched = trackerState.totalWatchedCount;
   if (watched == 0) return null;
-  final int cachedTotal = item.tvShow?.totalEpisodes ?? 0;
+  final int cachedTotal =
+      item.tvShow?.totalEpisodes ?? item.anime?.episodes ?? 0;
   final int total =
       cachedTotal > 0 ? cachedTotal : trackerState.totalEpisodes ?? 0;
   return ItemCardProgress(

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -776,7 +776,7 @@ class CollectionItemsNotifier
   /// so the show would keep showing zero progress in the target collection
   /// until restart. Invalidating the family reloads every live tracker.
   void _invalidateEpisodeTrackers(MediaType mediaType) {
-    if (mediaType.isTvBacked) {
+    if (mediaType.mayUseEpisodeTracker) {
       ref.invalidate(episodeTrackerNotifierProvider);
     }
   }

--- a/lib/features/collections/providers/episode_tracker_provider.dart
+++ b/lib/features/collections/providers/episode_tracker_provider.dart
@@ -397,17 +397,22 @@ class EpisodeTrackerNotifier
     for (final CollectionItem ci in items) {
       if (ci.externalId == _showId &&
           ci.dataSource == _source &&
-          ci.mediaType.isTvBacked) {
+          ci.usesEpisodeTracker) {
         targetItem = ci;
         break;
       }
     }
     if (targetItem == null) return;
 
+    // Kitsu anime have no cached `tvShow` row, but the anime record already
+    // carries the episode count — that spares a request on every toggle.
     int totalInShow = _cachedTotalEpisodes ??
-        targetItem.tvShow?.totalEpisodes ?? 0;
+        targetItem.tvShow?.totalEpisodes ??
+        targetItem.anime?.episodes ??
+        0;
     int totalSeasons = _cachedTotalSeasons ??
-        targetItem.tvShow?.totalSeasons ?? 0;
+        targetItem.tvShow?.totalSeasons ??
+        0;
 
     // Fetch missing totals from the source API once per session, so a
     // toggle doesn't turn into a network call every time.

--- a/lib/features/collections/widgets/episode_tracker_section.dart
+++ b/lib/features/collections/widgets/episode_tracker_section.dart
@@ -787,6 +787,7 @@ class _SeasonExpansionTileState extends ConsumerState<SeasonExpansionTile> {
                 trackerArg: trackerArg,
                 itemId: itemId,
                 accentColor: accentColor,
+                seasonPosterUrl: season.posterUrl,
               ))
         else if (episodes != null && episodes.isEmpty)
           Padding(
@@ -813,11 +814,15 @@ class EpisodeTile extends ConsumerStatefulWidget {
     required this.itemId,
     required this.accentColor,
     this.watchedAt,
+    this.seasonPosterUrl,
     super.key,
   });
 
   /// Episode data.
   final TvEpisode episode;
+
+  /// Stands in when the episode has no still of its own.
+  final String? seasonPosterUrl;
 
   /// Whether the episode has been watched.
   final bool isWatched;
@@ -878,6 +883,11 @@ class _EpisodeTileState extends ConsumerState<EpisodeTile> {
 
     final String? overview = episode.overview;
 
+    // Kitsu ships stills for some episodes only; the season poster keeps the
+    // rows aligned instead of leaving a ragged gap where a still is missing.
+    final bool hasOwnStill = episode.stillUrl != null;
+    final String? stillUrl = episode.stillUrl ?? widget.seasonPosterUrl;
+
     void toggle() {
       ref
           .read(episodeTrackerNotifierProvider(widget.trackerArg).notifier)
@@ -894,7 +904,7 @@ class _EpisodeTileState extends ConsumerState<EpisodeTile> {
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            if (episode.stillUrl != null) ...<Widget>[
+            if (stillUrl != null) ...<Widget>[
               // Watched episodes get a dimmed still with a check badge,
               // matching the struck-through title; the row tap toggles.
               Stack(
@@ -905,10 +915,19 @@ class _EpisodeTileState extends ConsumerState<EpisodeTile> {
                       borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
                       child: CachedImage(
                         imageType: ImageType.tvEpisodeStill,
-                        imageId: '${widget.trackerArg.source.name}_'
-                            '${episode.tmdbShowId}_'
-                            's${episode.seasonNumber}e${episode.episodeNumber}',
-                        remoteUrl: episode.stillUrl!,
+                        // Keyed by what is actually shown: a season poster
+                        // standing in for a still must not be cached under the
+                        // episode's own id, or it would stick once the real
+                        // still appears.
+                        imageId: hasOwnStill
+                            ? '${widget.trackerArg.source.name}_'
+                                '${episode.tmdbShowId}_'
+                                's${episode.seasonNumber}'
+                                'e${episode.episodeNumber}'
+                            : '${widget.trackerArg.source.name}_'
+                                '${episode.tmdbShowId}_'
+                                's${episode.seasonNumber}_poster',
+                        remoteUrl: stillUrl,
                         width: 96,
                         height: 54,
                         fit: BoxFit.cover,

--- a/lib/features/collections/widgets/item_detail/item_detail_media_config.dart
+++ b/lib/features/collections/widgets/item_detail/item_detail_media_config.dart
@@ -66,11 +66,12 @@ class ItemDetailMediaConfig {
       accentColor: MediaTypeTheme.colorFor(item.displayMediaType),
       infoChips: _buildChips(item, context),
       description: item.itemDescription,
-      hasEpisodeTracker: item.mediaType == MediaType.tvShow ||
-          (item.mediaType == MediaType.animation &&
-              item.platformId == AnimationSource.tvShow),
+      hasEpisodeTracker: item.usesEpisodeTracker,
       hasMangaProgress: item.mediaType == MediaType.manga,
-      hasAnimeProgress: item.mediaType == MediaType.anime,
+      // Kitsu anime moved to the season grid; AniList anime stay on the flat
+      // counter.
+      hasAnimeProgress:
+          item.mediaType == MediaType.anime && !item.usesEpisodeTracker,
       hasBookProgress: item.mediaType == MediaType.book,
       hasCustomProgress: item.mediaType == MediaType.custom &&
           (item.customUnitTotal != null || item.customUnitGroupTotal != null),

--- a/lib/shared/models/collection_item.dart
+++ b/lib/shared/models/collection_item.dart
@@ -505,6 +505,38 @@ class CollectionItem with Exportable {
           ? customMedia!.displayType!
           : mediaType;
 
+  /// Whether progress lives in the episode tracker (`watched_episodes`) rather
+  /// than in the item's own counter. Drives the tracker section, the card
+  /// badge, automatic status updates and mark transfer, so they all agree.
+  bool get usesEpisodeTracker => usesEpisodeTrackerFor(
+        mediaType: mediaType,
+        source: dataSource,
+        platformId: platformId,
+      );
+
+  /// [usesEpisodeTracker] for callers holding raw parts instead of an item —
+  /// DAO rows during a move, for instance.
+  ///
+  /// Kitsu anime qualify: Kitsu ships per-episode metadata. AniList anime keep
+  /// the flat counter.
+  static bool usesEpisodeTrackerFor({
+    required MediaType mediaType,
+    required DataSource source,
+    int? platformId,
+  }) =>
+      switch (mediaType) {
+        MediaType.tvShow => true,
+        MediaType.animation => platformId == AnimationSource.tvShow,
+        MediaType.anime => source == DataSource.kitsu,
+        MediaType.game ||
+        MediaType.movie ||
+        MediaType.visualNovel ||
+        MediaType.manga ||
+        MediaType.book ||
+        MediaType.custom =>
+          false,
+      };
+
   /// External page URL of the active media (IGDB / TMDB / AniList / …).
   /// Custom items carry their own user-entered link.
   String? get externalUrl => switch (mediaType) {

--- a/lib/shared/models/media_type.dart
+++ b/lib/shared/models/media_type.dart
@@ -41,6 +41,11 @@ enum MediaType {
   bool get isTvBacked =>
       this == MediaType.tvShow || this == MediaType.animation;
 
+  /// Whether items of this type *may* carry episode-tracker marks — the source
+  /// decides per item (see `CollectionItem.usesEpisodeTracker`). For coarse
+  /// decisions like cache invalidation, where only the type is known.
+  bool get mayUseEpisodeTracker => isTvBacked || this == MediaType.anime;
+
   /// Whether identity is `(externalId, source)` rather than `externalId`
   /// alone: several providers serve this type and their numeric ids collide.
   /// Animation is excluded on purpose — it only ever comes from TMDB.

--- a/lib/shared/models/tv_episode.dart
+++ b/lib/shared/models/tv_episode.dart
@@ -77,6 +77,53 @@ class TvEpisode {
     );
   }
 
+  /// From a Kitsu `episodes` resource; null when the episode number is missing.
+  ///
+  /// Kitsu's `synopsis` is plain text, so no HTML stripping. Episodes without a
+  /// `seasonNumber` fall into season 1 — the synthesized season Kitsu anime use.
+  static TvEpisode? tryFromKitsu(
+    Map<String, dynamic> json, {
+    required int showId,
+  }) {
+    final Map<String, dynamic> attrs =
+        (json['attributes'] as Map<String, dynamic>?) ??
+            const <String, dynamic>{};
+
+    final int? number = (attrs['number'] as num?)?.toInt();
+    if (number == null) return null;
+
+    final Map<String, dynamic> titles =
+        (attrs['titles'] as Map<String, dynamic>?) ?? const <String, dynamic>{};
+    final String? airdate = attrs['airdate'] as String?;
+    final Map<String, dynamic>? thumbnail =
+        attrs['thumbnail'] as Map<String, dynamic>?;
+
+    return TvEpisode(
+      tmdbShowId: showId,
+      seasonNumber: (attrs['seasonNumber'] as num?)?.toInt() ?? 1,
+      episodeNumber: number,
+      name: _firstNonEmpty(<Object?>[
+            attrs['canonicalTitle'],
+            titles['en_us'],
+            titles['en_jp'],
+            titles['ja_jp'],
+          ]) ??
+          '',
+      overview: _firstNonEmpty(<Object?>[attrs['synopsis']]),
+      airDate: (airdate == null || airdate.isEmpty) ? null : airdate,
+      stillUrl: _firstNonEmpty(<Object?>[thumbnail?['original']]),
+      runtime: (attrs['length'] as num?)?.toInt(),
+      source: DataSource.kitsu,
+    );
+  }
+
+  static String? _firstNonEmpty(List<Object?> values) {
+    for (final Object? value in values) {
+      if (value is String && value.isNotEmpty) return value;
+    }
+    return null;
+  }
+
   /// Show id in the [source] provider's namespace.
   final int tmdbShowId;
 

--- a/lib/shared/utils/item_card_progress.dart
+++ b/lib/shared/utils/item_card_progress.dart
@@ -34,6 +34,9 @@ ItemCardProgress? itemCardProgress(CollectionItem item) {
   } else {
     switch (type) {
       case MediaType.anime:
+        // Kitsu anime run on the episode tracker, so their progress lives in
+        // `watched_episodes` — same reason TV shows are excluded here.
+        if (item.usesEpisodeTracker) return null;
         fineTotal = item.anime?.episodes;
       case MediaType.manga:
         fineTotal = item.manga?.chapters;

--- a/test/core/api/episode_source/kitsu_episode_source_test.dart
+++ b/test/core/api/episode_source/kitsu_episode_source_test.dart
@@ -1,0 +1,276 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/episode_source/kitsu_episode_source.dart';
+import 'package:tonkatsu_box/core/api/episode_source/tmdb_episode_source.dart';
+import 'package:tonkatsu_box/core/api/episode_source/tv_episode_source.dart';
+import 'package:tonkatsu_box/core/api/kitsu_api.dart';
+import 'package:tonkatsu_box/core/api/tmdb_api.dart';
+import 'package:tonkatsu_box/core/api/tvmaze_api.dart';
+import 'package:tonkatsu_box/shared/models/anime.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+import 'package:tonkatsu_box/shared/models/tv_season.dart';
+import 'package:tonkatsu_box/shared/models/tv_show.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockKitsuApi mockApi;
+  late KitsuEpisodeSource source;
+
+  setUp(() {
+    mockApi = MockKitsuApi();
+    source = KitsuEpisodeSource(mockApi);
+  });
+
+  TvEpisode ep(int season, int number) => TvEpisode(
+        tmdbShowId: 7442,
+        seasonNumber: season,
+        episodeNumber: number,
+        name: 'S${season}E$number',
+        source: DataSource.kitsu,
+      );
+
+  group('getSeasons', () {
+    test('one season for a record whose episodes are all season 1', () async {
+      when(() => mockApi.getAnimeById(7442)).thenAnswer(
+        (_) async => createTestAnime(
+          id: 7442,
+          source: DataSource.kitsu,
+          episodes: 25,
+          coverUrl: 'https://kitsu/poster.jpg',
+        ),
+      );
+      when(() => mockApi.getAnimeEpisodes(7442))
+          .thenAnswer((_) async => <TvEpisode>[ep(1, 1), ep(1, 2)]);
+
+      final List<TvSeason> seasons = await source.getSeasons(7442);
+
+      expect(seasons, hasLength(1));
+      expect(seasons.single.seasonNumber, 1);
+      expect(seasons.single.episodeCount, 2);
+      expect(seasons.single.posterUrl, 'https://kitsu/poster.jpg');
+      expect(seasons.single.source, DataSource.kitsu);
+    });
+
+    test('real seasons, ordered, with their own episode counts', () async {
+      // Bleach-shaped: several seasons, absolute episode numbering.
+      when(() => mockApi.getAnimeById(244)).thenAnswer(
+        (_) async =>
+            createTestAnime(id: 244, source: DataSource.kitsu, episodes: 366),
+      );
+      when(() => mockApi.getAnimeEpisodes(244)).thenAnswer(
+        (_) async => <TvEpisode>[
+          ep(2, 21),
+          ep(1, 1),
+          ep(3, 42),
+          ep(2, 22),
+        ],
+      );
+
+      final List<TvSeason> seasons = await source.getSeasons(244);
+
+      expect(seasons.map((TvSeason s) => s.seasonNumber), <int>[1, 2, 3]);
+      expect(seasons.map((TvSeason s) => s.episodeCount), <int>[1, 2, 1]);
+    });
+
+    test('shares the fetch with getSeasonEpisodes — one request', () async {
+      when(() => mockApi.getAnimeById(7442)).thenAnswer(
+        (_) async =>
+            createTestAnime(id: 7442, source: DataSource.kitsu, episodes: 2),
+      );
+      when(() => mockApi.getAnimeEpisodes(7442))
+          .thenAnswer((_) async => <TvEpisode>[ep(1, 1), ep(2, 2)]);
+
+      await source.getSeasons(7442);
+      await source.getSeasonEpisodes(7442, 2);
+
+      verify(() => mockApi.getAnimeEpisodes(7442)).called(1);
+    });
+
+    test('falls back to one season when the episode list fails', () async {
+      when(() => mockApi.getAnimeById(1)).thenAnswer(
+        (_) async =>
+            createTestAnime(id: 1, source: DataSource.kitsu, episodes: 12),
+      );
+      when(() => mockApi.getAnimeEpisodes(1)).thenThrow(Exception('offline'));
+
+      final List<TvSeason> seasons = await source.getSeasons(1);
+
+      expect(seasons, hasLength(1));
+      expect(seasons.single.seasonNumber, 1);
+      expect(seasons.single.episodeCount, 12);
+    });
+
+    test('asks for the count when the record has none and the list is empty',
+        () async {
+      when(() => mockApi.getAnimeById(1)).thenAnswer(
+        (_) async => createTestAnime(id: 1, source: DataSource.kitsu),
+      );
+      when(() => mockApi.getAnimeEpisodes(1))
+          .thenAnswer((_) async => <TvEpisode>[]);
+      when(() => mockApi.getAnimeEpisodeCount(1)).thenAnswer((_) async => 1390);
+
+      final List<TvSeason> seasons = await source.getSeasons(1);
+
+      expect(seasons.single.episodeCount, 1390);
+    });
+
+    test('still yields a season when the anime is unknown', () async {
+      when(() => mockApi.getAnimeById(1)).thenAnswer((_) async => null);
+      when(() => mockApi.getAnimeEpisodes(1))
+          .thenAnswer((_) async => <TvEpisode>[]);
+      when(() => mockApi.getAnimeEpisodeCount(1)).thenAnswer((_) async => null);
+
+      final List<TvSeason> seasons = await source.getSeasons(1);
+
+      expect(seasons, hasLength(1));
+      expect(seasons.single.episodeCount, isNull);
+    });
+  });
+
+  group('getSeasonEpisodes', () {
+    test('filters the flat list by season number', () async {
+      when(() => mockApi.getAnimeEpisodes(7442)).thenAnswer(
+        (_) async => <TvEpisode>[ep(1, 1), ep(2, 1), ep(2, 2)],
+      );
+
+      final List<TvEpisode> season2 = await source.getSeasonEpisodes(7442, 2);
+
+      expect(season2, hasLength(2));
+      expect(season2.every((TvEpisode e) => e.seasonNumber == 2), isTrue);
+    });
+
+    test('returns everything when no episode carries the synthesized season',
+        () async {
+      when(() => mockApi.getAnimeEpisodes(7442))
+          .thenAnswer((_) async => <TvEpisode>[ep(2, 1), ep(2, 2)]);
+
+      final List<TvEpisode> season1 = await source.getSeasonEpisodes(7442, 1);
+
+      expect(season1, hasLength(2));
+    });
+
+    test('an empty other season stays empty', () async {
+      when(() => mockApi.getAnimeEpisodes(7442))
+          .thenAnswer((_) async => <TvEpisode>[ep(1, 1)]);
+
+      expect(await source.getSeasonEpisodes(7442, 3), isEmpty);
+    });
+
+    test('fetches the list once across seasons of the same anime', () async {
+      when(() => mockApi.getAnimeEpisodes(7442))
+          .thenAnswer((_) async => <TvEpisode>[ep(1, 1), ep(2, 1)]);
+
+      await source.getSeasonEpisodes(7442, 1);
+      await source.getSeasonEpisodes(7442, 2);
+
+      verify(() => mockApi.getAnimeEpisodes(7442)).called(1);
+    });
+
+    test('re-fetches after a failure instead of caching the error', () async {
+      int calls = 0;
+      when(() => mockApi.getAnimeEpisodes(7442)).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('network');
+        return <TvEpisode>[ep(1, 1)];
+      });
+
+      await expectLater(
+        source.getSeasonEpisodes(7442, 1),
+        throwsA(isA<Exception>()),
+      );
+      expect(await source.getSeasonEpisodes(7442, 1), hasLength(1));
+      expect(calls, 2);
+    });
+
+    test('a different anime refetches', () async {
+      when(() => mockApi.getAnimeEpisodes(any()))
+          .thenAnswer((_) async => <TvEpisode>[ep(1, 1)]);
+
+      await source.getSeasonEpisodes(7442, 1);
+      await source.getSeasonEpisodes(1, 1);
+
+      verify(() => mockApi.getAnimeEpisodes(7442)).called(1);
+      verify(() => mockApi.getAnimeEpisodes(1)).called(1);
+    });
+  });
+
+  group('getShow', () {
+    test('maps the anime record onto TvShow', () async {
+      when(() => mockApi.getAnimeById(7442)).thenAnswer(
+        (_) async => const Anime(
+          id: 7442,
+          source: DataSource.kitsu,
+          title: 'Shingeki no Kyojin',
+          titleNative: '進撃の巨人',
+          description: 'Titans.',
+          coverUrl: 'https://kitsu/poster.jpg',
+          bannerUrl: 'https://kitsu/banner.jpg',
+          averageScore: 84,
+          episodes: 25,
+          status: 'FINISHED',
+          startYear: 2013,
+          genres: <String>['Action'],
+          externalUrl: 'https://kitsu.io/anime/attack-on-titan',
+        ),
+      );
+
+      final TvShow? show = await source.getShow(7442);
+
+      expect(show, isNotNull);
+      expect(show!.tmdbId, 7442);
+      expect(show.title, 'Shingeki no Kyojin');
+      expect(show.originalTitle, '進撃の巨人');
+      expect(show.posterUrl, 'https://kitsu/poster.jpg');
+      expect(show.backdropUrl, 'https://kitsu/banner.jpg');
+      expect(show.totalSeasons, isNull);
+      expect(show.totalEpisodes, 25);
+      expect(show.rating, closeTo(8.4, 0.001));
+      expect(show.firstAirYear, 2013);
+      expect(show.genres, <String>['Action']);
+      expect(show.externalUrl, 'https://kitsu.io/anime/attack-on-titan');
+      expect(show.source, DataSource.kitsu);
+    });
+
+    test('null when the anime is gone', () async {
+      when(() => mockApi.getAnimeById(1)).thenAnswer((_) async => null);
+      expect(await source.getShow(1), isNull);
+    });
+
+    test('shares the record with getSeasons — one request', () async {
+      when(() => mockApi.getAnimeById(7442)).thenAnswer(
+        (_) async =>
+            createTestAnime(id: 7442, source: DataSource.kitsu, episodes: 25),
+      );
+      when(() => mockApi.getAnimeEpisodes(7442))
+          .thenAnswer((_) async => <TvEpisode>[ep(1, 1)]);
+
+      await source.getShow(7442);
+      await source.getSeasons(7442);
+
+      verify(() => mockApi.getAnimeById(7442)).called(1);
+    });
+  });
+
+  group('tvEpisodeSourceResolverProvider', () {
+    test('routes kitsu to KitsuEpisodeSource, others unchanged', () {
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          tmdbApiProvider.overrideWithValue(MockTmdbApi()),
+          tvMazeApiProvider.overrideWithValue(MockTvMazeApi()),
+          kitsuApiProvider.overrideWithValue(mockApi),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final TvEpisodeSource Function(DataSource) resolve =
+          container.read(tvEpisodeSourceResolverProvider);
+
+      expect(resolve(DataSource.kitsu), isA<KitsuEpisodeSource>());
+      expect(resolve(DataSource.tmdb), isA<TmdbEpisodeSource>());
+      expect(resolve(DataSource.anilist), isA<TmdbEpisodeSource>());
+    });
+  });
+}

--- a/test/core/api/kitsu/kitsu_episode_api_test.dart
+++ b/test/core/api/kitsu/kitsu_episode_api_test.dart
@@ -1,0 +1,189 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/kitsu_api.dart';
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  late MockDio mockDio;
+  late KitsuApi api;
+
+  setUpAll(registerAllFallbacks);
+
+  setUp(() {
+    mockDio = MockDio();
+    api = KitsuApi(dio: mockDio);
+  });
+
+  Map<String, dynamic> episode(int number) => <String, dynamic>{
+        'id': '$number',
+        'type': 'episodes',
+        'attributes': <String, dynamic>{
+          'seasonNumber': 1,
+          'number': number,
+          'canonicalTitle': 'Episode $number',
+        },
+      };
+
+  Response<dynamic> page(List<Map<String, dynamic>> rows, int count) =>
+      Response<dynamic>(
+        data: <String, dynamic>{
+          'data': rows,
+          'meta': <String, dynamic>{'count': count},
+        },
+        statusCode: 200,
+        requestOptions: RequestOptions(path: ''),
+      );
+
+  /// Answers each request from [byOffset], keyed by the `page[offset]` sent.
+  void stubPages(Map<int, Response<dynamic>> byOffset) {
+    when(() => mockDio.get<dynamic>(
+          any(),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+        )).thenAnswer((Invocation inv) async {
+      final Map<String, dynamic> qp =
+          inv.namedArguments[const Symbol('queryParameters')]
+              as Map<String, dynamic>;
+      final int offset = (qp['page[offset]'] as int?) ?? 0;
+      return byOffset[offset]!;
+    });
+  }
+
+  group('getAnimeEpisodes', () {
+    test('returns the single page when the total fits in one', () async {
+      stubPages(<int, Response<dynamic>>{
+        0: page(<Map<String, dynamic>>[episode(1), episode(2)], 2),
+      });
+
+      final List<TvEpisode> episodes = await api.getAnimeEpisodes(7442);
+
+      expect(episodes, hasLength(2));
+      expect(episodes.map((TvEpisode e) => e.episodeNumber), <int>[1, 2]);
+      verify(() => mockDio.get<dynamic>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).called(1);
+    });
+
+    test('pages through the rest and orders by season then number', () async {
+      stubPages(<int, Response<dynamic>>{
+        0: page(<Map<String, dynamic>>[
+          for (int i = 1; i <= 20; i++) episode(i),
+        ], 45),
+        20: page(<Map<String, dynamic>>[
+          for (int i = 21; i <= 40; i++) episode(i),
+        ], 45),
+        40: page(<Map<String, dynamic>>[
+          for (int i = 41; i <= 45; i++) episode(i),
+        ], 45),
+      });
+
+      final List<TvEpisode> episodes = await api.getAnimeEpisodes(7442);
+
+      expect(episodes, hasLength(45));
+      expect(
+        episodes.map((TvEpisode e) => e.episodeNumber),
+        List<int>.generate(45, (int i) => i + 1),
+      );
+    });
+
+    test('requests 20 per page — Kitsu rejects more', () async {
+      stubPages(<int, Response<dynamic>>{
+        0: page(<Map<String, dynamic>>[episode(1)], 1),
+      });
+
+      await api.getAnimeEpisodes(1);
+
+      final Map<String, dynamic> qp = verify(() => mockDio.get<dynamic>(
+            any(),
+            queryParameters: captureAny(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).captured.single as Map<String, dynamic>;
+      expect(qp['page[limit]'], 20);
+    });
+
+    test('skips episodes without a number instead of failing', () async {
+      stubPages(<int, Response<dynamic>>{
+        0: page(<Map<String, dynamic>>[
+          episode(1),
+          <String, dynamic>{
+            'id': 'x',
+            'type': 'episodes',
+            'attributes': <String, dynamic>{'canonicalTitle': 'No number'},
+          },
+        ], 2),
+      });
+
+      expect(await api.getAnimeEpisodes(1), hasLength(1));
+    });
+
+    test('falls back to the row count when meta.count is absent', () async {
+      when(() => mockDio.get<dynamic>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => Response<dynamic>(
+            data: <String, dynamic>{
+              'data': <Map<String, dynamic>>[episode(1)],
+            },
+            statusCode: 200,
+            requestOptions: RequestOptions(path: ''),
+          ));
+
+      expect(await api.getAnimeEpisodes(1), hasLength(1));
+    });
+
+    test('wraps transport failures in KitsuApiException', () async {
+      when(() => mockDio.get<dynamic>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: ''),
+        type: DioExceptionType.connectionError,
+      ));
+
+      expect(
+        () => api.getAnimeEpisodes(1),
+        throwsA(isA<KitsuApiException>()),
+      );
+    });
+  });
+
+  group('getAnimeEpisodeCount', () {
+    test('reads meta.count from a one-item request', () async {
+      stubPages(<int, Response<dynamic>>{
+        0: page(<Map<String, dynamic>>[episode(1)], 1390),
+      });
+
+      expect(await api.getAnimeEpisodeCount(7442), 1390);
+
+      final Map<String, dynamic> qp = verify(() => mockDio.get<dynamic>(
+            any(),
+            queryParameters: captureAny(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).captured.single as Map<String, dynamic>;
+      expect(qp['page[limit]'], 1);
+    });
+
+    test('returns null for an unknown anime', () async {
+      when(() => mockDio.get<dynamic>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+            options: any(named: 'options'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: ''),
+        response: Response<dynamic>(
+          statusCode: 404,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      ));
+
+      expect(await api.getAnimeEpisodeCount(1), isNull);
+    });
+  });
+}

--- a/test/core/database/dao/collection_dao_test.dart
+++ b/test/core/database/dao/collection_dao_test.dart
@@ -1400,6 +1400,7 @@ void main() {
               'media_type',
               'external_id',
               'source',
+              'platform_id',
             ],
             where: 'id = ?',
             whereArgs: <Object?>[1],

--- a/test/core/database/dao/collection_dao_watched_transfer_test.dart
+++ b/test/core/database/dao/collection_dao_watched_transfer_test.dart
@@ -12,6 +12,7 @@ import 'package:tonkatsu_box/core/database/dao/movie_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/tv_show_dao.dart';
 import 'package:tonkatsu_box/core/database/dao/visual_novel_dao.dart';
 import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/media_type.dart';
 
 void main() {
   setUpAll(() {
@@ -209,6 +210,65 @@ void main() {
 
       expect(ok, isTrue);
       expect(await watchedCount(2, 500), 1);
+    });
+
+    test('should move marks for a kitsu anime', () async {
+      await insertItem(
+        id: 10,
+        collectionId: 1,
+        mediaType: 'anime',
+        externalId: 244,
+        source: 'kitsu',
+      );
+      await insertWatched(collectionId: 1, showId: 244, source: 'kitsu');
+
+      await dao.updateItemCollectionId(10, 2);
+
+      expect(await watchedCount(1, 244), 0);
+      expect(await watchedCount(2, 244), 1);
+    });
+
+    test('should not touch marks for an anilist anime', () async {
+      await insertItem(
+        id: 10,
+        collectionId: 1,
+        mediaType: 'anime',
+        externalId: 600,
+        source: 'anilist',
+      );
+      await insertWatched(collectionId: 1, showId: 600, source: 'anilist');
+
+      await dao.updateItemCollectionId(10, 2);
+
+      expect(await watchedCount(1, 600), 1);
+      expect(await watchedCount(2, 600), 0);
+    });
+
+    test('should move marks for an animated series but not an animated movie',
+        () async {
+      await insertItem(
+        id: 10,
+        collectionId: 1,
+        mediaType: 'animation',
+        externalId: 700,
+        platformId: AnimationSource.tvShow,
+      );
+      await insertItem(
+        id: 11,
+        collectionId: 1,
+        mediaType: 'animation',
+        externalId: 800,
+        platformId: AnimationSource.movie,
+      );
+      await insertWatched(collectionId: 1, showId: 700);
+      await insertWatched(collectionId: 1, showId: 800);
+
+      await dao.updateItemCollectionId(10, 2);
+      await dao.updateItemCollectionId(11, 3);
+
+      expect(await watchedCount(2, 700), 1);
+      expect(await watchedCount(1, 800), 1);
+      expect(await watchedCount(3, 800), 0);
     });
 
     test('should not touch marks when moving a non-tv item', () async {

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -2163,6 +2163,61 @@ void main() {
         expect(xcoll.items[1].containsKey('_watched_episodes'), isFalse);
       });
 
+      test('should attach _watched_episodes for kitsu anime', () async {
+        when(() => mockItemMarkDao.getMarksForItems(any()))
+            .thenAnswer((_) async => <ItemMark>[]);
+        when(() => mockTvShowDao.getWatchedEpisodes(1, DataSource.kitsu, 244))
+            .thenAnswer(
+          (_) async => <(int, int), DateTime?>{
+            (2, 21): DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          },
+        );
+
+        final XcollFile xcoll = await sutMarks.createFullExport(
+          createTestCollection(),
+          <CollectionItem>[
+            createTestCollectionItem(
+              id: 1,
+              mediaType: MediaType.anime,
+              externalId: 244,
+              source: DataSource.kitsu,
+              anime: createTestAnime(id: 244, source: DataSource.kitsu),
+            ),
+          ],
+          1,
+          includeUserData: true,
+        );
+
+        final List<dynamic> watched =
+            xcoll.items[0]['_watched_episodes'] as List<dynamic>;
+        expect(watched, hasLength(1));
+        expect((watched[0] as Map<String, dynamic>)['season'], 2);
+        expect((watched[0] as Map<String, dynamic>)['episode'], 21);
+      });
+
+      test('should not query watched episodes for anilist anime', () async {
+        when(() => mockItemMarkDao.getMarksForItems(any()))
+            .thenAnswer((_) async => <ItemMark>[]);
+
+        await sutMarks.createFullExport(
+          createTestCollection(),
+          <CollectionItem>[
+            createTestCollectionItem(
+              id: 1,
+              mediaType: MediaType.anime,
+              externalId: 600,
+              source: DataSource.anilist,
+              anime: createTestAnime(source: DataSource.anilist),
+            ),
+          ],
+          1,
+          includeUserData: true,
+        );
+
+        verifyNever(
+            () => mockTvShowDao.getWatchedEpisodes(any(), any(), any()));
+      });
+
       test('should not query watched episodes for non-tv items', () async {
         when(() => mockItemMarkDao.getMarksForItems(any()))
             .thenAnswer((_) async => <ItemMark>[]);

--- a/test/core/services/import_service_test.dart
+++ b/test/core/services/import_service_test.dart
@@ -2978,6 +2978,75 @@ void main() {
             any(), any(), any(), any(), any(), any()));
       });
 
+      test('should restore marks for kitsu anime', () async {
+        final MockAnimeDao animeDao = MockAnimeDao();
+        when(() => mockDb.animeDao).thenReturn(animeDao);
+        when(() => animeDao.upsertAnime(any())).thenAnswer((_) async {});
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 42);
+
+        final ImportResult result = await sutV2.importFromXcoll(
+          xcollWith(userData: true, items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 244,
+              'source': 'kitsu',
+              '_watched_episodes': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'season': 2,
+                  'episode': 21,
+                  'watched_at': 1700000000,
+                },
+              ],
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        expect(result.success, isTrue);
+        verify(() => mockTvShowDao.markEpisodeWatchedAt(
+            5, DataSource.kitsu, 244, 2, 21, 1700000000 * 1000)).called(1);
+      });
+
+      test('should ignore _watched_episodes on anilist anime', () async {
+        final MockAnimeDao animeDao = MockAnimeDao();
+        when(() => mockDb.animeDao).thenReturn(animeDao);
+        when(() => animeDao.upsertAnime(any())).thenAnswer((_) async {});
+        when(() => mockRepo.addItem(
+              collectionId: any(named: 'collectionId'),
+              mediaType: any(named: 'mediaType'),
+              externalId: any(named: 'externalId'),
+              platformId: any(named: 'platformId'),
+              source: any(named: 'source'),
+              authorComment: any(named: 'authorComment'),
+              status: any(named: 'status'),
+            )).thenAnswer((_) async => 42);
+
+        await sutV2.importFromXcoll(
+          xcollWith(userData: true, items: const <Map<String, dynamic>>[
+            <String, dynamic>{
+              'media_type': 'anime',
+              'external_id': 600,
+              'source': 'anilist',
+              '_watched_episodes': <Map<String, dynamic>>[
+                <String, dynamic>{'season': 1, 'episode': 1},
+              ],
+            },
+          ]),
+          collectionId: 5,
+        );
+
+        verifyNever(() => mockTvShowDao.markEpisodeWatchedAt(
+            any(), any(), any(), any(), any(), any()));
+      });
+
       test('should ignore _watched_episodes on a non-tv item', () async {
         when(() => mockApi.getGamesByIds(any()))
             .thenAnswer((_) async => const <Game>[Game(id: 100, name: 'G')]);

--- a/test/features/collections/providers/episode_tracker_provider_test.dart
+++ b/test/features/collections/providers/episode_tracker_provider_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/kitsu_api.dart';
 import 'package:tonkatsu_box/core/api/tmdb_api.dart';
 import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
 import 'package:tonkatsu_box/features/collections/providers/episode_tracker_provider.dart';
+import 'package:tonkatsu_box/shared/models/anime.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/item_status.dart';
@@ -1109,10 +1111,21 @@ void main() {
 
       ProviderContainer createTrackingContainer(
           List<CollectionItem> items) {
+        // Kitsu anime resolve their totals through the Kitsu source; without
+        // the override the resolver would build a real networked client.
+        final MockKitsuApi mockKitsuApi = MockKitsuApi();
+        when(() => mockKitsuApi.getAnimeById(any()))
+            .thenAnswer((_) async => null);
+        when(() => mockKitsuApi.getAnimeEpisodes(any()))
+            .thenAnswer((_) async => <TvEpisode>[]);
+        when(() => mockKitsuApi.getAnimeEpisodeCount(any()))
+            .thenAnswer((_) async => null);
+
         final ProviderContainer container = ProviderContainer(
           overrides: <Override>[
             databaseServiceProvider.overrideWithValue(mockDb),
             tmdbApiProvider.overrideWithValue(mockTmdbApi),
+            kitsuApiProvider.overrideWithValue(mockKitsuApi),
             collectionItemsNotifierProvider.overrideWith(
               () {
                 lastTracking = TrackingCollectionItemsNotifier(items);
@@ -1131,6 +1144,7 @@ void main() {
         MediaType mediaType = MediaType.tvShow,
         int totalEpisodes = 10,
         int? totalSeasons,
+        int? platformId,
       }) {
         return CollectionItem(
           id: id,
@@ -1139,6 +1153,7 @@ void main() {
           externalId: testShowId,
           status: status,
           addedAt: DateTime(2024),
+          platformId: platformId,
           tvShow: TvShow(
             tmdbId: testShowId,
             title: 'Test Show',
@@ -1193,6 +1208,79 @@ void main() {
 
         expect(lastTracking.updateStatusCalls, hasLength(1));
         expect(lastTracking.updateStatusCalls.first.$2, ItemStatus.inProgress);
+      });
+
+      // Kitsu anime run on the same tracker; their totals come from the anime
+      // record instead of a cached `tvShow` row.
+      CollectionItem createKitsuAnimeItem({
+        ItemStatus status = ItemStatus.notStarted,
+        int episodes = 10,
+      }) {
+        return CollectionItem(
+          id: 1,
+          collectionId: testCollectionId,
+          mediaType: MediaType.anime,
+          externalId: testShowId,
+          status: status,
+          addedAt: DateTime(2024),
+          anime: Anime(
+            id: testShowId,
+            source: DataSource.kitsu,
+            title: 'Test Anime',
+            episodes: episodes,
+          ),
+        );
+      }
+
+      const ({int collectionId, int showId, DataSource source}) kitsuArg = (
+        collectionId: testCollectionId,
+        showId: testShowId,
+        source: DataSource.kitsu,
+      );
+
+      test('kitsu-аниме: первый эпизод переводит в inProgress', () async {
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.kitsu, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{});
+        when(() => mockTvShowDao.markEpisodeWatched(
+                testCollectionId, DataSource.kitsu, testShowId, 1, 1))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createTrackingContainer(
+            <CollectionItem>[createKitsuAnimeItem()]);
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(kitsuArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+        await notifier.toggleEpisode(1, 1);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(lastTracking.updateStatusCalls, hasLength(1));
+        expect(lastTracking.updateStatusCalls.first.$2, ItemStatus.inProgress);
+        expect(lastTracking.updateStatusCalls.first.$3, MediaType.anime);
+      });
+
+      test('kitsu-аниме: последний эпизод переводит в completed', () async {
+        when(() => mockTvShowDao.getWatchedEpisodes(
+                testCollectionId, DataSource.kitsu, testShowId))
+            .thenAnswer((_) async => <(int, int), DateTime?>{
+                  (1, 1): DateTime(2024),
+                });
+        when(() => mockTvShowDao.markEpisodeWatched(
+                testCollectionId, DataSource.kitsu, testShowId, 1, 2))
+            .thenAnswer((_) async {});
+
+        final ProviderContainer container = createTrackingContainer(
+            <CollectionItem>[createKitsuAnimeItem(episodes: 2)]);
+        final EpisodeTrackerNotifier notifier =
+            container.read(episodeTrackerNotifierProvider(kitsuArg).notifier);
+
+        await Future<void>.delayed(Duration.zero);
+        await notifier.toggleEpisode(1, 2);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(lastTracking.updateStatusCalls, hasLength(1));
+        expect(lastTracking.updateStatusCalls.first.$2, ItemStatus.completed);
       });
 
       test('должен перевести в completed когда все эпизоды просмотрены',
@@ -1430,9 +1518,13 @@ void main() {
         expect(lastTracking.updateStatusCalls.first.$2, ItemStatus.inProgress);
       });
 
-      test('должен находить item по MediaType.animation', () async {
+      // Only the TV-show flavour of animation runs on the tracker; an
+      // animated movie has no episode grid to mark from.
+      test('должен находить анимационный сериал (MediaType.animation)',
+          () async {
         final CollectionItem item = createTvItem(
           mediaType: MediaType.animation,
+          platformId: AnimationSource.tvShow,
         );
         when(() => mockTvShowDao.getWatchedEpisodes(testCollectionId, DataSource.tmdb, testShowId))
             .thenAnswer((_) async => <(int, int), DateTime?>{});

--- a/test/features/collections/widgets/item_detail/item_detail_media_config_test.dart
+++ b/test/features/collections/widgets/item_detail/item_detail_media_config_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/collections/widgets/item_detail/item_detail_media_config.dart';
 import 'package:tonkatsu_box/shared/constants/media_type_theme.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 
 import '../../../../helpers/test_helpers.dart';
@@ -99,6 +100,39 @@ void main() {
       expect(c.hasAnimeProgress, isTrue);
       expect(c.hasMangaProgress, isFalse);
       expect(c.hasEpisodeTracker, isFalse);
+    });
+
+    testWidgets('anilist anime keeps the flat counter', (WidgetTester t) async {
+      final ItemDetailMediaConfig c = await buildConfig(
+        t,
+        createTestCollectionItem(
+          mediaType: MediaType.anime,
+          externalId: 6,
+          anime: createTestAnime(id: 6, episodes: 24),
+        ),
+      );
+
+      expect(c.hasAnimeProgress, isTrue);
+      expect(c.hasEpisodeTracker, isFalse);
+    });
+
+    testWidgets('kitsu anime swaps the counter for the episode tracker',
+        (WidgetTester t) async {
+      final ItemDetailMediaConfig c = await buildConfig(
+        t,
+        createTestCollectionItem(
+          mediaType: MediaType.anime,
+          externalId: 7442,
+          anime: createTestAnime(
+            id: 7442,
+            source: DataSource.kitsu,
+            episodes: 25,
+          ),
+        ),
+      );
+
+      expect(c.hasEpisodeTracker, isTrue);
+      expect(c.hasAnimeProgress, isFalse);
     });
   });
 }

--- a/test/helpers/fallbacks.dart
+++ b/test/helpers/fallbacks.dart
@@ -39,6 +39,7 @@ void registerAllFallbacks() {
   registerFallbackValue(const CustomMedia(id: 0, title: 'fallback'));
   registerFallbackValue(const Movie(tmdbId: 0, title: 'fallback'));
   registerFallbackValue(const TvShow(tmdbId: 0, title: 'fallback'));
+  registerFallbackValue(const Anime(id: 0, title: 'fallback'));
 
   registerFallbackValue(FakeCanvasItem());
   registerFallbackValue(FakeCanvasConnection());

--- a/test/shared/models/collection_item_test.dart
+++ b/test/shared/models/collection_item_test.dart
@@ -3223,6 +3223,85 @@ void main() {
           expect(game.customUnitGroupTotal, isNull);
         });
       });
+
+      group('usesEpisodeTracker', () {
+        CollectionItem itemOf({
+          required MediaType mediaType,
+          int? platformId,
+          Anime? anime,
+        }) =>
+            CollectionItem(
+              id: 1,
+              collectionId: 1,
+              mediaType: mediaType,
+              externalId: 1,
+              status: ItemStatus.notStarted,
+              addedAt: now,
+              platformId: platformId,
+              anime: anime,
+            );
+
+        test('true for TV shows', () {
+          expect(itemOf(mediaType: MediaType.tvShow).usesEpisodeTracker,
+              isTrue);
+        });
+
+        test('animation only when it is the TV-show source', () {
+          expect(
+            itemOf(
+              mediaType: MediaType.animation,
+              platformId: AnimationSource.tvShow,
+            ).usesEpisodeTracker,
+            isTrue,
+          );
+          expect(
+            itemOf(
+              mediaType: MediaType.animation,
+              platformId: AnimationSource.movie,
+            ).usesEpisodeTracker,
+            isFalse,
+          );
+        });
+
+        test('anime only from kitsu — anilist keeps the flat counter', () {
+          expect(
+            itemOf(
+              mediaType: MediaType.anime,
+              anime: const Anime(
+                id: 1,
+                source: DataSource.kitsu,
+                title: 'K',
+              ),
+            ).usesEpisodeTracker,
+            isTrue,
+          );
+          expect(
+            itemOf(
+              mediaType: MediaType.anime,
+              anime: const Anime(
+                id: 1,
+                source: DataSource.anilist,
+                title: 'A',
+              ),
+            ).usesEpisodeTracker,
+            isFalse,
+          );
+        });
+
+        test('false for every other type', () {
+          for (final MediaType type in <MediaType>[
+            MediaType.game,
+            MediaType.movie,
+            MediaType.visualNovel,
+            MediaType.manga,
+            MediaType.book,
+            MediaType.custom,
+          ]) {
+            expect(itemOf(mediaType: type).usesEpisodeTracker, isFalse,
+                reason: type.name);
+          }
+        });
+      });
     });
   });
 }

--- a/test/shared/models/tv_episode_kitsu_test.dart
+++ b/test/shared/models/tv_episode_kitsu_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
+import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+
+void main() {
+  Map<String, dynamic> resource(Map<String, dynamic> attributes) =>
+      <String, dynamic>{
+        'id': '104938',
+        'type': 'episodes',
+        'attributes': attributes,
+      };
+
+  group('TvEpisode.tryFromKitsu', () {
+    test('maps every field and stamps the kitsu source', () {
+      final TvEpisode? ep = TvEpisode.tryFromKitsu(
+        resource(<String, dynamic>{
+          'seasonNumber': 2,
+          'number': 3,
+          'canonicalTitle': 'To You Two Thousand Years Later',
+          'titles': <String, dynamic>{'en_jp': 'Ni Sen-Nen-Go no Kimi e'},
+          'synopsis': 'The Fall of Shiganshina.',
+          'airdate': '2013-04-06',
+          'length': 24,
+          'thumbnail': <String, dynamic>{
+            'original': 'https://media.kitsu.app/e/original.jpg',
+          },
+        }),
+        showId: 7442,
+      );
+
+      expect(ep, isNotNull);
+      expect(ep!.tmdbShowId, 7442);
+      expect(ep.seasonNumber, 2);
+      expect(ep.episodeNumber, 3);
+      expect(ep.name, 'To You Two Thousand Years Later');
+      expect(ep.overview, 'The Fall of Shiganshina.');
+      expect(ep.airDate, '2013-04-06');
+      expect(ep.runtime, 24);
+      expect(ep.stillUrl, 'https://media.kitsu.app/e/original.jpg');
+      expect(ep.source, DataSource.kitsu);
+    });
+
+    test('falls back through the title map when canonicalTitle is absent', () {
+      final TvEpisode? ep = TvEpisode.tryFromKitsu(
+        resource(<String, dynamic>{
+          'number': 1,
+          'titles': <String, dynamic>{'en_jp': 'Romaji', 'ja_jp': 'Native'},
+        }),
+        showId: 1,
+      );
+
+      expect(ep!.name, 'Romaji');
+    });
+
+    test('defaults a missing season number to the synthesized season 1', () {
+      final TvEpisode? ep = TvEpisode.tryFromKitsu(
+        resource(<String, dynamic>{'number': 5}),
+        showId: 1,
+      );
+
+      expect(ep!.seasonNumber, 1);
+      expect(ep.episodeNumber, 5);
+    });
+
+    test('returns null when the episode number is missing', () {
+      expect(
+        TvEpisode.tryFromKitsu(
+          resource(<String, dynamic>{'seasonNumber': 1}),
+          showId: 1,
+        ),
+        isNull,
+      );
+    });
+
+    test('empty strings and absent nested images read as null', () {
+      final TvEpisode? ep = TvEpisode.tryFromKitsu(
+        resource(<String, dynamic>{
+          'number': 2,
+          'canonicalTitle': '',
+          'synopsis': '',
+          'airdate': '',
+          'thumbnail': null,
+        }),
+        showId: 1,
+      );
+
+      expect(ep!.name, '');
+      expect(ep.overview, isNull);
+      expect(ep.airDate, isNull);
+      expect(ep.stillUrl, isNull);
+    });
+
+    test('attributes may be absent entirely', () {
+      expect(
+        TvEpisode.tryFromKitsu(
+          <String, dynamic>{'id': '1', 'type': 'episodes'},
+          showId: 1,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/shared/utils/item_card_progress_test.dart
+++ b/test/shared/utils/item_card_progress_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/shared/models/collection_item.dart';
 import 'package:tonkatsu_box/shared/models/custom_media.dart';
+import 'package:tonkatsu_box/shared/models/data_source.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/utils/item_card_progress.dart';
 
@@ -39,6 +40,15 @@ void main() {
       final ItemCardProgress? p = itemCardProgress(item);
       expect(p!.label, '12/24');
       expect(p.fraction, closeTo(0.5, 0.001));
+    });
+
+    test('null для kitsu-аниме: прогресс живёт в трекере эпизодов', () {
+      final CollectionItem item = createTestCollectionItem(
+        mediaType: MediaType.anime,
+        currentEpisode: 12,
+        anime: createTestAnime(source: DataSource.kitsu, episodes: 24),
+      );
+      expect(itemCardProgress(item), isNull);
     });
 
     test('аниме без известного тотала: только текущий, без доли', () {


### PR DESCRIPTION
Kitsu anime open the same season-and-episode grid TV series use: episode tiles with a preview frame, watched checkbox, likes and notes. Marking an episode moves the item to In progress, marking all of them completes it, and the card badge shows watched of total. Missing episode stills fall back to the season poster.

Seasons come from Kitsu's own episode data, so long titles keep their real structure (Bleach: 16 seasons, 366 episodes). AniList anime stay on the flat counter — only Kitsu ships per-episode metadata.

Also closes two silent data gaps the tv-only gate left: watched episodes of Kitsu anime now land in backups and survive a move between collections.