### PR TITLE
feat(shared,genre_cloud,import): pulsing logo loader, unfreeze heavy loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,30 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * test/helpers/fallbacks.dart (registerAllFallbacks): Register an `Anime`
     fallback for mocktail.
 
+- **Branded loading indicator: the app logo pulses and rotates instead of the
+  Material spinner**
+
+  Long operations now show the Tonkatsu Box logo breathing (85%→105% scale)
+  and turning a quarter revolution per pulse: the blocking overlay, import
+  progress dialogs (Trakt, Kinorium, collections), Trakt archive validation,
+  the genre cloud and recommendations loading states, and the All Items
+  reload. Small inline spinners (collection pickers, image placeholders) keep
+  the stock indicator.
+
+  * lib/shared/widgets/logo_loader.dart (LogoLoader): New. Pure widget code —
+    no dart:io or isolates — so the planned selfhost web target renders it
+    unchanged.
+  * lib/shared/widgets/loading_overlay.dart (withBlockingSpinner),
+    lib/features/collections/widgets/import_progress_dialog.dart
+    (ImportProgressDialog), lib/features/settings/content/trakt_import_content.dart,
+    lib/features/settings/content/kinorium_import_content.dart,
+    lib/features/genre_cloud/screens/genre_cloud_screen.dart,
+    lib/features/genre_cloud/widgets/genre_cloud_view.dart,
+    lib/features/recommendations/screens/recommendations_screen.dart,
+    lib/features/home/screens/all_items_screen.dart: Replace the centred
+    CircularProgressIndicator with LogoLoader.
+  * test/shared/widgets/logo_loader_test.dart: New.
+
 ### Changed
 
 - **Move DAO query infrastructure and pure-Dart utils into the `core` package**
@@ -95,6 +119,49 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     packages/core/lib/utils/tvmaze_json.dart: Moved from lib/shared/utils/.
   * lib/, test/: Import paths rewritten to `package:core/...` across the DAOs,
     models, services and tests that consume the moved files.
+
+- **Loading indicators no longer freeze during heavy operations**
+
+  The spinner used to stand still because heavy work ran synchronously on the
+  UI thread. The genre cloud layout now computes cooperatively (yielding to
+  the event loop on a time budget, so it also works on the future web target),
+  and the Trakt / Kinorium imports unzip and parse their exports on a
+  background isolate. Animations keep running through personalization loads
+  and import parsing.
+
+  * lib/features/genre_cloud/genre_cloud_layout.dart (layoutGenreCloudAsync,
+    _placeAllChunked, _placeWord): New chunked layout entry point producing
+    results identical to the synchronous layoutGenreCloud (kept for export
+    views).
+  * lib/features/genre_cloud/widgets/genre_cloud_view.dart
+    (_GenreCloudViewState._runLayout, _GenreCloudViewState._memoizedMeasure,
+    measureGenreWord): Drive the deferred layout through the async entry
+    point; memoize word measurements across auto-fit and growth passes and
+    dispose TextPainters after measuring.
+  * lib/core/import/sources/trakt/trakt_import_service.dart
+    (TraktImportService.validateZip, TraktImportService._readAndParseArchive,
+    _TraktParsedArchive): Read, unzip and JSON-parse the export via
+    Isolate.run; parse helpers became static so the isolate closure carries no
+    API/DB handles.
+  * lib/core/import/sources/kinorium/kinorium_import_service.dart
+    (KinoriumImportService.import): Read and parse the CSV via Isolate.run.
+  * test/features/genre_cloud/genre_cloud_layout_test.dart: Async layout
+    equivalence tests.
+
+### Fixed
+
+- **Tier list card labels no longer overflow under Android font scaling**
+
+  The compact card label reserves exactly two lines of caption text; with a
+  system font scale above 1.0 the text grew past that and threw a RenderFlex
+  overflow. The tiny caption now opts out of system text scaling — the full
+  name stays available in the tooltip.
+
+  * lib/features/tier_lists/widgets/tier_item_card.dart (TierItemCard._buildCard):
+    Pin the label to TextScaler.noScaling and drop the single-child Column
+    that produced the overflowing RenderFlex.
+  * test/features/tier_lists/widgets/tier_item_card_test.dart: Regression test
+    at text scale 1.3.
 
 ## [0.40.0] - 2026-07-26
 

--- a/lib/core/import/sources/kinorium/kinorium_import_service.dart
+++ b/lib/core/import/sources/kinorium/kinorium_import_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
@@ -138,8 +139,14 @@ class KinoriumImportService implements ImportSource {
         );
       }
 
-      final List<KinoriumEntry> entries =
-          _parser.parseBytes(await file.readAsBytes());
+      // Read + parse off the UI isolate: a big CSV decoded synchronously
+      // would freeze the progress dialog. Local copies keep the closure from
+      // capturing `this` (non-sendable API/DB handles).
+      final KinoriumCsvParser parser = _parser;
+      final String filePath = options.filePath;
+      final List<KinoriumEntry> entries = await Isolate.run(
+        () => parser.parseBytes(File(filePath).readAsBytesSync()),
+      );
       if (entries.isEmpty) {
         return const UniversalImportResult.failure(
           sourceName: 'Kinorium',

--- a/lib/core/import/sources/trakt/trakt_import_service.dart
+++ b/lib/core/import/sources/trakt/trakt_import_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:archive/archive.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -154,6 +155,31 @@ class _TraktWatchlistEntry {
   final String type; // 'movie' | 'show'
 }
 
+/// Everything parsed out of the export archive in one background-isolate
+/// pass; only plain data, so it is sendable back to the main isolate.
+class _TraktParsedArchive {
+  const _TraktParsedArchive({
+    required this.username,
+    required this.hasNoJsonFiles,
+    required this.watchedMovies,
+    required this.watchedShows,
+    required this.movieRatings,
+    required this.showRatings,
+    required this.watchlistEntries,
+  });
+
+  final String username;
+
+  /// True when the archive contained no JSON files at all.
+  final bool hasNoJsonFiles;
+
+  final List<_TraktMovie> watchedMovies;
+  final List<_TraktShow> watchedShows;
+  final List<_TraktRating> movieRatings;
+  final List<_TraktRating> showRatings;
+  final List<_TraktWatchlistEntry> watchlistEntries;
+}
+
 final Provider<TraktImportService> traktImportServiceProvider =
     Provider<TraktImportService>((Ref ref) {
   return TraktImportService(
@@ -193,10 +219,16 @@ class TraktImportService implements ImportSource {
   @override
   String get displayName => 'Trakt';
 
-  Future<TraktZipInfo> validateZip(String zipPath) async {
+  Future<TraktZipInfo> validateZip(String zipPath) {
+    // Unzip + JSON decode of a large export blocks for seconds — run it on a
+    // background isolate so the UI (and its loader animation) keeps running.
+    return Isolate.run(() => _validateZipSync(zipPath));
+  }
+
+  static TraktZipInfo _validateZipSync(String zipPath) {
     try {
       final ({Map<String, String> files, String username}) archive =
-          _readArchive(zipPath);
+          _readArchiveSync(zipPath);
       if (archive.files.isEmpty) {
         return const TraktZipInfo.invalid('No JSON files found in archive');
       }
@@ -289,47 +321,30 @@ class TraktImportService implements ImportSource {
         message: 'Reading ZIP archive...',
       ));
 
-      final ({Map<String, String> files, String username}) archive =
-          _readArchive(options.zipPath);
-      if (archive.files.isEmpty) {
+      // Unzip + JSON parse of the whole export runs on a background isolate:
+      // done synchronously it freezes the progress dialog for seconds.
+      final _TraktParsedArchive parsed = await Isolate.run(
+        () => _readAndParseArchive(
+          zipPath: options.zipPath,
+          importWatched: options.importWatched,
+          importRatings: options.importRatings,
+          importWatchlist: options.importWatchlist,
+        ),
+      );
+      if (parsed.hasNoJsonFiles) {
         return const UniversalImportResult.failure(
           sourceName: 'Trakt',
           error: 'No data found in archive',
         );
       }
 
-      final Map<String, String> files = archive.files;
-      final String username = archive.username;
-
-      final List<_TraktMovie> watchedMovies = options.importWatched
-          ? _parseWatchedMovies(_getFile(
-              files, 'watched/watched-movies.json', 'watched-movies.json'))
-          : <_TraktMovie>[];
-
-      final List<_TraktShow> watchedShows = options.importWatched
-          ? _parseWatchedShows(_getFile(
-              files, 'watched/watched-shows.json', 'watched-shows.json'))
-          : <_TraktShow>[];
-
-      final List<_TraktRating> movieRatings = options.importRatings
-          ? _parseRatings(
-              _getFile(
-                  files, 'ratings/ratings-movies.json', 'ratings-movies.json'),
-              'movie')
-          : <_TraktRating>[];
-
-      final List<_TraktRating> showRatings = options.importRatings
-          ? _parseRatings(
-              _getFile(
-                  files, 'ratings/ratings-shows.json', 'ratings-shows.json'),
-              'show')
-          : <_TraktRating>[];
-
+      final String username = parsed.username;
+      final List<_TraktMovie> watchedMovies = parsed.watchedMovies;
+      final List<_TraktShow> watchedShows = parsed.watchedShows;
+      final List<_TraktRating> movieRatings = parsed.movieRatings;
+      final List<_TraktRating> showRatings = parsed.showRatings;
       final List<_TraktWatchlistEntry> watchlistEntries =
-          options.importWatchlist
-              ? _parseWatchlist(_getFile(
-                  files, 'lists/watchlist.json', 'lists-watchlist.json'))
-              : <_TraktWatchlistEntry>[];
+          parsed.watchlistEntries;
 
       // Dedup TMDB IDs across all sections to fetch each from TMDB once.
       final Set<int> movieTmdbIds = <int>{};
@@ -720,8 +735,51 @@ class TraktImportService implements ImportSource {
     );
   }
 
+  /// Reads and parses the export archive in one go. Static and pure so it can
+  /// run on a background isolate via [Isolate.run] without capturing `this`
+  /// (the service holds non-sendable handles: API client, database).
+  static _TraktParsedArchive _readAndParseArchive({
+    required String zipPath,
+    required bool importWatched,
+    required bool importRatings,
+    required bool importWatchlist,
+  }) {
+    final ({Map<String, String> files, String username}) archive =
+        _readArchiveSync(zipPath);
+    final Map<String, String> files = archive.files;
+    return _TraktParsedArchive(
+      username: archive.username,
+      hasNoJsonFiles: files.isEmpty,
+      watchedMovies: importWatched
+          ? _parseWatchedMovies(_getFile(
+              files, 'watched/watched-movies.json', 'watched-movies.json'))
+          : <_TraktMovie>[],
+      watchedShows: importWatched
+          ? _parseWatchedShows(_getFile(
+              files, 'watched/watched-shows.json', 'watched-shows.json'))
+          : <_TraktShow>[],
+      movieRatings: importRatings
+          ? _parseRatings(
+              _getFile(
+                  files, 'ratings/ratings-movies.json', 'ratings-movies.json'),
+              'movie')
+          : <_TraktRating>[],
+      showRatings: importRatings
+          ? _parseRatings(
+              _getFile(
+                  files, 'ratings/ratings-shows.json', 'ratings-shows.json'),
+              'show')
+          : <_TraktRating>[],
+      watchlistEntries: importWatchlist
+          ? _parseWatchlist(_getFile(
+              files, 'lists/watchlist.json', 'lists-watchlist.json'))
+          : <_TraktWatchlistEntry>[],
+    );
+  }
+
   /// Reads JSON files and username in a single pass.
-  ({Map<String, String> files, String username}) _readArchive(String zipPath) {
+  static ({Map<String, String> files, String username}) _readArchiveSync(
+      String zipPath) {
     final List<int> bytes = File(zipPath).readAsBytesSync();
     final Archive archive = ZipDecoder().decodeBytes(bytes);
     final Map<String, String> files = <String, String>{};
@@ -768,11 +826,11 @@ class TraktImportService implements ImportSource {
   }
 
   /// Tries both old (nested) and new (flat) key layouts.
-  String? _getFile(Map<String, String> files, String oldKey, String newKey) {
+  static String? _getFile(Map<String, String> files, String oldKey, String newKey) {
     return files[oldKey] ?? files[newKey];
   }
 
-  List<_TraktMovie> _parseWatchedMovies(String? json) {
+  static List<_TraktMovie> _parseWatchedMovies(String? json) {
     if (json == null || json.isEmpty) return <_TraktMovie>[];
 
     final List<dynamic> list = jsonDecode(json) as List<dynamic>;
@@ -805,7 +863,7 @@ class TraktImportService implements ImportSource {
     return result;
   }
 
-  List<_TraktShow> _parseWatchedShows(String? json) {
+  static List<_TraktShow> _parseWatchedShows(String? json) {
     if (json == null || json.isEmpty) return <_TraktShow>[];
 
     final List<dynamic> list = jsonDecode(json) as List<dynamic>;
@@ -876,7 +934,7 @@ class TraktImportService implements ImportSource {
     return result;
   }
 
-  List<_TraktRating> _parseRatings(String? json, String type) {
+  static List<_TraktRating> _parseRatings(String? json, String type) {
     if (json == null || json.isEmpty) return <_TraktRating>[];
 
     final List<dynamic> list = jsonDecode(json) as List<dynamic>;
@@ -906,7 +964,7 @@ class TraktImportService implements ImportSource {
     return result;
   }
 
-  List<_TraktWatchlistEntry> _parseWatchlist(String? json) {
+  static List<_TraktWatchlistEntry> _parseWatchlist(String? json) {
     if (json == null || json.isEmpty) return <_TraktWatchlistEntry>[];
 
     final List<dynamic> list = jsonDecode(json) as List<dynamic>;

--- a/lib/features/collections/widgets/import_progress_dialog.dart
+++ b/lib/features/collections/widgets/import_progress_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../core/services/import_service.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/logo_loader.dart';
 
 /// Can only be dismissed via the "Done" button, which appears once the
 /// import future completes.
@@ -28,7 +29,7 @@ class ImportProgressDialog extends StatelessWidget {
           if (progress == null) {
             return const SizedBox(
               height: 100,
-              child: Center(child: CircularProgressIndicator()),
+              child: Center(child: LogoLoader()),
             );
           }
 

--- a/lib/features/genre_cloud/genre_cloud_layout.dart
+++ b/lib/features/genre_cloud/genre_cloud_layout.dart
@@ -5,6 +5,11 @@
 // Archimedean spiral; if not everything fits, the size scale is shrunk and the
 // layout is retried (auto-fit). Whatever still cannot be placed is reported via
 // [hidden].
+//
+// Two entry points share the same placement code: [layoutGenreCloud] runs
+// synchronously (export views, tests) and [layoutGenreCloudAsync] yields to the
+// event loop between words so the UI thread keeps pumping frames (the loading
+// indicator keeps animating) while a large cloud is being placed.
 
 import 'dart:math' as math;
 import 'dart:ui' show Offset, Rect, Size;
@@ -73,6 +78,12 @@ const double _defaultMinFontSize = 13;
 /// step between tiers stays clearly visible instead of collapsing.
 const int _defaultMaxTiers = 10;
 
+/// Time budget a chunked (async) pass may spend before yielding to the event
+/// loop. Word costs vary wildly (spiral search), so the yield is elapsed-time
+/// gated rather than per-N-words — this also keeps the pass fast on web,
+/// where a zero-delay timer still costs ~4ms.
+const int _yieldBudgetMs = 8;
+
 /// Decides whether the word at [index] (descending frequency) is rotated.
 ///
 /// The most frequent word (index 0) always stays horizontal for readability;
@@ -89,12 +100,81 @@ GenreCloudLayout layoutGenreCloud({
   double maxFontSize = _defaultMaxFontSize,
   int maxTiers = _defaultMaxTiers,
 }) {
-  if (words.isEmpty || canvasSize.width <= 0 || canvasSize.height <= 0) {
-    return GenreCloudLayout(
+  final _Prepared? prep = _prepare(words, canvasSize);
+  if (prep == null) return _emptyLayout(canvasSize);
+
+  double scaleMax = maxFontSize;
+  _Attempt attempt = _placeAll(
+    prep, canvasSize, measure, minFontSize, scaleMax, maxTiers,
+  );
+  // Auto-fit: shrink the top of the scale until everything fits or we hit the
+  // floor (then [hidden] carries whatever still does not fit).
+  while (attempt.hidden > 0 && scaleMax > minFontSize + 1) {
+    scaleMax = math.max(minFontSize, scaleMax * 0.85);
+    attempt = _placeAll(
+      prep, canvasSize, measure, minFontSize, scaleMax, maxTiers,
+    );
+  }
+
+  return GenreCloudLayout(
+    placed: attempt.placed,
+    hidden: attempt.hidden,
+    size: canvasSize,
+  );
+}
+
+/// Same layout as [layoutGenreCloud], but yields to the event loop every few
+/// words so long computations don't freeze the UI thread. The result is
+/// identical to the synchronous version (placement is deterministic).
+Future<GenreCloudLayout> layoutGenreCloudAsync({
+  required List<FacetValue> words,
+  required Size canvasSize,
+  required MeasureWord measure,
+  double minFontSize = _defaultMinFontSize,
+  double maxFontSize = _defaultMaxFontSize,
+  int maxTiers = _defaultMaxTiers,
+}) async {
+  final _Prepared? prep = _prepare(words, canvasSize);
+  if (prep == null) return _emptyLayout(canvasSize);
+
+  double scaleMax = maxFontSize;
+  _Attempt attempt = await _placeAllChunked(
+    prep, canvasSize, measure, minFontSize, scaleMax, maxTiers,
+  );
+  while (attempt.hidden > 0 && scaleMax > minFontSize + 1) {
+    scaleMax = math.max(minFontSize, scaleMax * 0.85);
+    attempt = await _placeAllChunked(
+      prep, canvasSize, measure, minFontSize, scaleMax, maxTiers,
+    );
+  }
+
+  return GenreCloudLayout(
+    placed: attempt.placed,
+    hidden: attempt.hidden,
+    size: canvasSize,
+  );
+}
+
+GenreCloudLayout _emptyLayout(Size canvasSize) => GenreCloudLayout(
       placed: const <PlacedWord>[],
       hidden: 0,
       size: canvasSize,
     );
+
+/// Sorted words plus count-rank data shared by every placement pass, or `null`
+/// when there is nothing to lay out.
+class _Prepared {
+  const _Prepared(this.sorted, this.rankByCount);
+
+  final List<FacetValue> sorted;
+  final Map<int, int> rankByCount;
+
+  int get distinct => rankByCount.length;
+}
+
+_Prepared? _prepare(List<FacetValue> words, Size canvasSize) {
+  if (words.isEmpty || canvasSize.width <= 0 || canvasSize.height <= 0) {
+    return null;
   }
 
   final List<FacetValue> sorted = List<FacetValue>.of(words)
@@ -113,117 +193,127 @@ GenreCloudLayout layoutGenreCloud({
   final Map<int, int> rankByCount = <int, int>{
     for (int i = 0; i < distinctCounts.length; i++) distinctCounts[i]: i,
   };
-  final int distinct = distinctCounts.length;
-
-  double scaleMax = maxFontSize;
-  _Attempt attempt = _placeAll(
-    sorted, canvasSize, measure, minFontSize, scaleMax,
-    rankByCount, distinct, maxTiers,
-  );
-  // Auto-fit: shrink the top of the scale until everything fits or we hit the
-  // floor (then [hidden] carries whatever still does not fit).
-  while (attempt.hidden > 0 && scaleMax > minFontSize + 1) {
-    scaleMax = math.max(minFontSize, scaleMax * 0.85);
-    attempt = _placeAll(
-      sorted, canvasSize, measure, minFontSize, scaleMax,
-      rankByCount, distinct, maxTiers,
-    );
-  }
-
-  return GenreCloudLayout(
-    placed: attempt.placed,
-    hidden: attempt.hidden,
-    size: canvasSize,
-  );
+  return _Prepared(sorted, rankByCount);
 }
 
 /// One placement pass at a given [scaleMax].
 _Attempt _placeAll(
-  List<FacetValue> sorted,
+  _Prepared prep,
   Size size,
   MeasureWord measure,
   double minFont,
   double scaleMax,
-  Map<int, int> rankByCount,
-  int distinct,
   int maxTiers,
 ) {
-  final List<PlacedWord> placed = <PlacedWord>[];
-  final List<Rect> occupied = <Rect>[];
-  int hidden = 0;
+  final _Attempt attempt = _Attempt();
+  for (int i = 0; i < prep.sorted.length; i++) {
+    _placeWord(attempt, prep, i, size, measure, minFont, scaleMax, maxTiers);
+  }
+  return attempt;
+}
 
-  final double cx = size.width / 2;
-  final double cy = size.height / 2;
+/// One placement pass at a given [scaleMax], yielding to the event loop (so
+/// animation frames can run) whenever [_yieldBudgetMs] of work accumulates.
+Future<_Attempt> _placeAllChunked(
+  _Prepared prep,
+  Size size,
+  MeasureWord measure,
+  double minFont,
+  double scaleMax,
+  int maxTiers,
+) async {
+  final _Attempt attempt = _Attempt();
+  final Stopwatch sinceYield = Stopwatch()..start();
+  for (int i = 0; i < prep.sorted.length; i++) {
+    _placeWord(attempt, prep, i, size, measure, minFont, scaleMax, maxTiers);
+    if (sinceYield.elapsedMilliseconds >= _yieldBudgetMs) {
+      await Future<void>.delayed(Duration.zero);
+      sinceYield.reset();
+    }
+  }
+  return attempt;
+}
+
+/// Places the word at [index] into [attempt] (or counts it as hidden).
+void _placeWord(
+  _Attempt attempt,
+  _Prepared prep,
+  int index,
+  Size size,
+  MeasureWord measure,
+  double minFont,
+  double scaleMax,
+  int maxTiers,
+) {
   const double pad = 4;
   const double margin = 6;
   const double aspect = 1.7; // spread wider than tall, like a real cloud
+  final double cx = size.width / 2;
+  final double cy = size.height / 2;
 
-  for (int i = 0; i < sorted.length; i++) {
-    final FacetValue word = sorted[i];
-    final double fontSize = _fontForRank(
-      rankByCount[word.count] ?? 0, distinct, maxTiers, minFont, scaleMax,
+  final FacetValue word = prep.sorted[index];
+  final double fontSize = _fontForRank(
+    prep.rankByCount[word.count] ?? 0, prep.distinct, maxTiers, minFont,
+    scaleMax,
+  );
+  final Size raw = measure(word, fontSize);
+  final bool rotated = rotatedAtIndex(index);
+  final double w = rotated ? raw.height : raw.width;
+  final double h = rotated ? raw.width : raw.height;
+
+  // Word too large for the canvas at this scale -> defer to a smaller scale.
+  if (w > size.width - margin * 2 || h > size.height - margin * 2) {
+    attempt.hidden++;
+    return;
+  }
+
+  Offset? center;
+  double t = 0;
+  for (int step = 0; step < 6000; step++) {
+    final double r = 3.0 * t;
+    final double x = cx + r * math.cos(t) * aspect;
+    final double y = cy + r * math.sin(t);
+    t += 0.2;
+
+    final Rect rect = Rect.fromCenter(
+      center: Offset(x, y),
+      width: w + pad,
+      height: h + pad,
     );
-    final Size raw = measure(word, fontSize);
-    final bool rotated = rotatedAtIndex(i);
-    final double w = rotated ? raw.height : raw.width;
-    final double h = rotated ? raw.width : raw.height;
-
-    // Word too large for the canvas at this scale -> defer to a smaller scale.
-    if (w > size.width - margin * 2 || h > size.height - margin * 2) {
-      hidden++;
+    if (rect.left < margin ||
+        rect.top < margin ||
+        rect.right > size.width - margin ||
+        rect.bottom > size.height - margin) {
+      if (r > size.width + size.height) break; // spiral left the canvas
       continue;
     }
 
-    Offset? center;
-    double t = 0;
-    for (int step = 0; step < 6000; step++) {
-      final double r = 3.0 * t;
-      final double x = cx + r * math.cos(t) * aspect;
-      final double y = cy + r * math.sin(t);
-      t += 0.2;
-
-      final Rect rect = Rect.fromCenter(
-        center: Offset(x, y),
-        width: w + pad,
-        height: h + pad,
-      );
-      if (rect.left < margin ||
-          rect.top < margin ||
-          rect.right > size.width - margin ||
-          rect.bottom > size.height - margin) {
-        if (r > size.width + size.height) break; // spiral left the canvas
-        continue;
-      }
-
-      bool collides = false;
-      for (final Rect other in occupied) {
-        if (other.overlaps(rect)) {
-          collides = true;
-          break;
-        }
-      }
-      if (!collides) {
-        center = Offset(x, y);
-        occupied.add(rect);
+    bool collides = false;
+    for (final Rect other in attempt.occupied) {
+      if (other.overlaps(rect)) {
+        collides = true;
         break;
       }
     }
-
-    if (center == null) {
-      hidden++;
-      continue;
+    if (!collides) {
+      center = Offset(x, y);
+      attempt.occupied.add(rect);
+      break;
     }
-    placed.add(
-      PlacedWord(
-        word: word,
-        fontSize: fontSize,
-        center: center,
-        rotated: rotated,
-      ),
-    );
   }
 
-  return _Attempt(placed, hidden);
+  if (center == null) {
+    attempt.hidden++;
+    return;
+  }
+  attempt.placed.add(
+    PlacedWord(
+      word: word,
+      fontSize: fontSize,
+      center: center,
+      rotated: rotated,
+    ),
+  );
 }
 
 /// Maps a count [rank] (0 = most frequent) to a font size along a geometric
@@ -242,10 +332,11 @@ double _fontForRank(
   return scaleMax * math.pow(minFont / scaleMax, tNorm).toDouble();
 }
 
-/// Outcome of a single [_placeAll] pass.
+/// Accumulating state of a single placement pass.
 class _Attempt {
-  const _Attempt(this.placed, this.hidden);
+  _Attempt();
 
-  final List<PlacedWord> placed;
-  final int hidden;
+  final List<PlacedWord> placed = <PlacedWord>[];
+  final List<Rect> occupied = <Rect>[];
+  int hidden = 0;
 }

--- a/lib/features/genre_cloud/screens/genre_cloud_screen.dart
+++ b/lib/features/genre_cloud/screens/genre_cloud_screen.dart
@@ -14,6 +14,7 @@ import '../../../shared/services/png_export_service.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/logo_loader.dart';
 import '../../../shared/widgets/draggable_fab.dart';
 import '../facet.dart';
 import '../facet_value.dart';
@@ -177,7 +178,7 @@ class _GenreCloudScreenState extends ConsumerState<GenreCloudScreen> {
     List<FacetValue> words,
   ) {
     return itemsAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: LogoLoader()),
       error: (Object error, StackTrace stack) => Center(
         child: Text(
           '${l.settingsError}: $error',

--- a/lib/features/genre_cloud/widgets/genre_cloud_view.dart
+++ b/lib/features/genre_cloud/widgets/genre_cloud_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/constants/media_type_theme.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/logo_loader.dart';
 import '../facet_value.dart';
 import '../genre_cloud_layout.dart';
 
@@ -62,7 +63,10 @@ Size measureGenreWord(
     textDirection: TextDirection.ltr,
     maxLines: 1,
   )..layout();
-  return Size(painter.width, painter.height);
+  final Size size = Size(painter.width, painter.height);
+  // Free the native paragraph now; layout passes measure thousands of words.
+  painter.dispose();
+  return size;
 }
 
 /// Paints a preference cloud. Word size scales with frequency rank; colour
@@ -127,7 +131,6 @@ class _GenreCloudViewState extends State<GenreCloudView> {
 
   // Deferred (post-frame) layout bookkeeping; see _scheduleLayout.
   bool _layoutPending = false;
-  Size? _pendingViewport;
 
   // Canvas the view is currently centred for; re-centre only when it changes so
   // the user's own panning survives rebuilds.
@@ -150,11 +153,34 @@ class _GenreCloudViewState extends State<GenreCloudView> {
     if (home != null) _controller.value = home;
   }
 
+  /// Measurement memo shared by every pass of one layout run: auto-fit and
+  /// growth passes re-ask for the same (word, fontSize) pairs many times over.
+  MeasureWord _memoizedMeasure() {
+    final Map<String, Size> cache = <String, Size>{};
+    final bool showCount = widget.showCount;
+    return (FacetValue word, double fontSize) => cache.putIfAbsent(
+          '${word.label}|${word.count}|$fontSize',
+          () => measureGenreWord(word, fontSize, showCount: showCount),
+        );
+  }
+
   GenreCloudLayout _compute(Size canvas) => layoutGenreCloud(
         words: widget.words,
         canvasSize: canvas,
-        measure: (FacetValue word, double fontSize) =>
-            measureGenreWord(word, fontSize, showCount: widget.showCount),
+        measure: _memoizedMeasure(),
+        minFontSize: widget.minFontSize,
+        maxFontSize: widget.maxFontSize,
+      );
+
+  Future<GenreCloudLayout> _computeAsync(
+    Size canvas,
+    List<FacetValue> words,
+    MeasureWord measure,
+  ) =>
+      layoutGenreCloudAsync(
+        words: words,
+        canvasSize: canvas,
+        measure: measure,
         minFontSize: widget.minFontSize,
         maxFontSize: widget.maxFontSize,
       );
@@ -170,44 +196,52 @@ class _GenreCloudViewState extends State<GenreCloudView> {
     return null;
   }
 
-  GenreCloudLayout _computeWithGrowth(Size viewport) {
+  Future<GenreCloudLayout> _computeWithGrowth(
+    Size viewport,
+    List<FacetValue> words,
+  ) async {
     Size canvas = viewport;
-    GenreCloudLayout layout = _compute(canvas);
+    final MeasureWord measure = _memoizedMeasure();
+    GenreCloudLayout layout = await _computeAsync(canvas, words, measure);
     // Grow the canvas (keeping fonts readable) until everything fits, so the
     // pan/zoom can reach every word.
     int pass = 0;
     while (layout.hidden > 0 && pass < _maxGrowthPasses) {
       canvas = Size(canvas.width * 1.4, canvas.height * 1.4);
-      layout = _compute(canvas);
+      layout = await _computeAsync(canvas, words, measure);
       pass++;
     }
     return layout;
   }
 
-  /// Defers the expensive placement past the current frame so the screen
-  /// paints (with a progress indicator) before the layout blocks the UI
-  /// thread, instead of freezing navigation for the whole computation.
-  void _scheduleLayout() {
+  /// Defers the expensive placement past the current frame, then runs it
+  /// cooperatively (the async layout yields between words), so the loading
+  /// indicator keeps animating instead of freezing on its first frame.
+  void _scheduleLayout(Size viewport) {
     if (_layoutPending) return;
     _layoutPending = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
-        _layoutPending = false;
-        return;
-      }
-      final Size? viewport = _pendingViewport;
-      if (viewport == null) {
-        _layoutPending = false;
-        return;
-      }
-      final GenreCloudLayout layout = _computeWithGrowth(viewport);
+      _runLayout(viewport);
+    });
+  }
+
+  Future<void> _runLayout(Size viewport) async {
+    try {
+      if (!mounted) return;
+      // Snapshot the inputs: if words change mid-computation the result is
+      // stored against this snapshot, the next build's cache check misses and
+      // a fresh pass is scheduled.
+      final List<FacetValue> words = List<FacetValue>.of(widget.words);
+      final GenreCloudLayout layout = await _computeWithGrowth(viewport, words);
+      if (!mounted) return;
       setState(() {
         _layout = layout;
-        _laidOutWords = List<FacetValue>.of(widget.words);
+        _laidOutWords = words;
         _laidOutViewport = viewport;
-        _layoutPending = false;
       });
-    });
+    } finally {
+      _layoutPending = false;
+    }
   }
 
   void _maybeRecenter(Size viewport, Size canvas) {
@@ -236,9 +270,8 @@ class _GenreCloudViewState extends State<GenreCloudView> {
           // instantly with a spinner instead of a frozen frame.
           final GenreCloudLayout? cached = _cachedLayout(viewport);
           if (cached == null) {
-            _pendingViewport = viewport;
-            _scheduleLayout();
-            return const Center(child: CircularProgressIndicator());
+            _scheduleLayout(viewport);
+            return const Center(child: LogoLoader());
           }
           layout = cached;
         } else {

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -20,6 +20,7 @@ import '../../../shared/utils/item_card_progress.dart';
 import '../../../shared/utils/media_format.dart';
 import '../../../shared/widgets/chevron_filter_bar.dart';
 import '../../../shared/widgets/filter_subfilter_bar.dart';
+import '../../../shared/widgets/logo_loader.dart';
 import '../../../shared/widgets/media_poster_card.dart';
 import '../../../shared/widgets/uncategorized_deprecation_banner.dart';
 import '../../collections/helpers/collection_actions.dart';
@@ -104,7 +105,7 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
               return _buildGridView(
                   visibleItems, collectionNames, tagsMap, itemTags);
             },
-            loading: () => const Center(child: CircularProgressIndicator()),
+            loading: () => const Center(child: LogoLoader()),
             error: (Object error, StackTrace stack) =>
                 _buildErrorState(error),
           ),

--- a/lib/features/recommendations/screens/recommendations_screen.dart
+++ b/lib/features/recommendations/screens/recommendations_screen.dart
@@ -13,6 +13,7 @@ import '../../../shared/models/platform.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
+import '../../../shared/widgets/logo_loader.dart';
 import '../../search/handlers/media_handlers.dart';
 import '../../search/widgets/collection_chips_row.dart';
 import '../providers/recommendations_provider.dart';
@@ -134,7 +135,7 @@ class _RecommendationsScreenState extends ConsumerState<RecommendationsScreen> {
     AsyncValue<RecommendationResult> async,
   ) {
     return async.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: LogoLoader()),
       error: (Object error, StackTrace _) => Center(
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.xl),

--- a/lib/features/settings/content/kinorium_import_content.dart
+++ b/lib/features/settings/content/kinorium_import_content.dart
@@ -14,6 +14,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/collection_picker_field.dart';
+import '../../../shared/widgets/logo_loader.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../home/providers/all_items_provider.dart';
@@ -383,7 +384,7 @@ class _KinoriumImportProgressDialog extends StatelessWidget {
           if (progress == null) {
             return const SizedBox(
               height: 100,
-              child: Center(child: CircularProgressIndicator()),
+              child: Center(child: LogoLoader()),
             );
           }
 

--- a/lib/features/settings/content/trakt_import_content.dart
+++ b/lib/features/settings/content/trakt_import_content.dart
@@ -14,6 +14,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
 import '../../../shared/theme/app_typography.dart';
 import '../../../shared/widgets/collection_picker_field.dart';
+import '../../../shared/widgets/logo_loader.dart';
 import '../../collections/providers/canvas_provider.dart';
 import '../../collections/providers/collection_covers_provider.dart';
 import '../../collections/providers/collections_provider.dart';
@@ -115,7 +116,7 @@ class _TraktImportContentState extends ConsumerState<TraktImportContent> {
         if (_isValidating)
           const Padding(
             padding: EdgeInsets.all(AppSpacing.md),
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: LogoLoader()),
           )
         else if (_zipPath != null && _zipInfo != null && _zipInfo!.isValid)
           Padding(
@@ -516,7 +517,7 @@ class _TraktImportProgressDialog extends StatelessWidget {
           if (progress == null) {
             return const SizedBox(
               height: 100,
-              child: Center(child: CircularProgressIndicator()),
+              child: Center(child: LogoLoader()),
             );
           }
 

--- a/lib/features/tier_lists/widgets/tier_item_card.dart
+++ b/lib/features/tier_lists/widgets/tier_item_card.dart
@@ -161,21 +161,21 @@ class TierItemCard extends StatelessWidget {
                   vertical: 2,
                 ),
                 alignment: Alignment.center,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Text(
-                      displayName,
-                      textAlign: TextAlign.center,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 10,
-                        height: 1.2,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
+                child: Text(
+                  displayName,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  // The label box is metrics-sized to exactly 2 lines of
+                  // 10pt × 1.2 (cardLabelMinHeight); system font scaling
+                  // pushes past that and overflows on Android, so this tiny
+                  // caption opts out — the full name is in the tooltip.
+                  textScaler: TextScaler.noScaling,
+                  style: const TextStyle(
+                    fontSize: 10,
+                    height: 1.2,
+                    color: Colors.white,
+                  ),
                 ),
               ),
           ],

--- a/lib/shared/widgets/loading_overlay.dart
+++ b/lib/shared/widgets/loading_overlay.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
-/// Runs [action] behind a modal, non-dismissible spinner so the user sees that
+import 'logo_loader.dart';
+
+/// Runs [action] behind a modal, non-dismissible loader so the user sees that
 /// something is happening during a slow step (a network fetch, a heavy save).
 ///
 /// The overlay is always torn down, even if [action] throws. Reusable for any
@@ -17,7 +19,7 @@ Future<T> withBlockingSpinner<T>(
       barrierColor: Colors.black54,
       builder: (BuildContext _) => const PopScope<Object?>(
         canPop: false,
-        child: Center(child: CircularProgressIndicator()),
+        child: Center(child: LogoLoader(size: 96)),
       ),
     ),
   );

--- a/lib/shared/widgets/logo_loader.dart
+++ b/lib/shared/widgets/logo_loader.dart
@@ -1,0 +1,85 @@
+// Branded loading indicator. Like any Flutter animation it is driven by the
+// UI thread — it only animates while heavy work stays off the main isolate
+// (layoutGenreCloudAsync, Isolate.run in imports). Pure widget code, so the
+// selfhost web target (dev/backlog/selfhost-web) renders it unchanged.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_assets.dart';
+
+/// Animated app-logo loader: each pulse the logo breathes (grows and shrinks
+/// back) while rotating a quarter turn, looping until removed.
+class LogoLoader extends StatefulWidget {
+  /// Creates a [LogoLoader].
+  const LogoLoader({this.size = 64, super.key});
+
+  /// Width and height of the loader.
+  final double size;
+
+  @override
+  State<LogoLoader> createState() => _LogoLoaderState();
+}
+
+class _LogoLoaderState extends State<LogoLoader>
+    with SingleTickerProviderStateMixin {
+  /// One pulse: grow to [_scaleMax], shrink back, and complete a quarter
+  /// turn. The controller spans four pulses (a full revolution) so a plain
+  /// `repeat()` wraps at an identical pose — no restart bookkeeping.
+  static const Duration _pulse = Duration(milliseconds: 1200);
+
+  /// Scale bounds of the pulse.
+  static const double _scaleMin = 0.85;
+  static const double _scaleMax = 1.05;
+
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: _pulse * 4)
+      ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Pulse scale at in-pulse time [t]: min at the edges, max mid-pulse, so
+  /// consecutive pulses chain into a continuous breath.
+  static double _scaleAt(double t) =>
+      _scaleMin + (_scaleMax - _scaleMin) * math.sin(math.pi * t);
+
+  /// Rotation for pulse [quarter] at in-pulse time [t]: eased quarter turn on
+  /// top of the turns already completed.
+  static double _angleAt(int quarter, double t) =>
+      (quarter + Curves.easeInOut.transform(t)) * math.pi / 2;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: SizedBox(
+        width: widget.size,
+        height: widget.size,
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (BuildContext context, Widget? child) {
+            final double cycles = _controller.value * 4;
+            final int quarter = cycles.floor().clamp(0, 3);
+            final double t = cycles - quarter;
+            return Transform(
+              alignment: Alignment.center,
+              transform: Matrix4.rotationZ(_angleAt(quarter, t))
+                ..scaleByDouble(_scaleAt(t), _scaleAt(t), 1, 1),
+              child: child,
+            );
+          },
+          child: Image.asset(AppAssets.logo, fit: BoxFit.contain),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/genre_cloud/genre_cloud_layout_test.dart
+++ b/test/features/genre_cloud/genre_cloud_layout_test.dart
@@ -163,4 +163,45 @@ void main() {
       expect(layout.hidden, 1);
     });
   });
+
+  group('layoutGenreCloudAsync', () {
+    test('returns empty layout for no words', () async {
+      final GenreCloudLayout layout = await layoutGenreCloudAsync(
+        words: const <FacetValue>[],
+        canvasSize: const Size(500, 500),
+        measure: _fakeMeasure,
+      );
+      expect(layout.isEmpty, isTrue);
+      expect(layout.hidden, 0);
+    });
+
+    test('produces exactly the same layout as the sync version', () async {
+      // Enough words to force yields (>4) and the auto-fit shrink loop.
+      final List<FacetValue> words = <FacetValue>[
+        for (int i = 0; i < 40; i++) _w('Genre$i', 40 - i),
+      ];
+      const Size canvas = Size(800, 600);
+
+      final GenreCloudLayout sync = layoutGenreCloud(
+        words: words,
+        canvasSize: canvas,
+        measure: _fakeMeasure,
+      );
+      final GenreCloudLayout chunked = await layoutGenreCloudAsync(
+        words: words,
+        canvasSize: canvas,
+        measure: _fakeMeasure,
+      );
+
+      expect(chunked.hidden, sync.hidden);
+      expect(chunked.size, sync.size);
+      expect(chunked.placed.length, sync.placed.length);
+      for (int i = 0; i < sync.placed.length; i++) {
+        expect(chunked.placed[i].word.label, sync.placed[i].word.label);
+        expect(chunked.placed[i].fontSize, sync.placed[i].fontSize);
+        expect(chunked.placed[i].center, sync.placed[i].center);
+        expect(chunked.placed[i].rotated, sync.placed[i].rotated);
+      }
+    });
+  });
 }

--- a/test/features/genre_cloud/genre_cloud_view_test.dart
+++ b/test/features/genre_cloud/genre_cloud_view_test.dart
@@ -4,6 +4,7 @@ import 'package:tonkatsu_box/features/genre_cloud/facet.dart';
 import 'package:tonkatsu_box/features/genre_cloud/facet_value.dart';
 import 'package:tonkatsu_box/features/genre_cloud/widgets/genre_cloud_view.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
+import 'package:tonkatsu_box/shared/widgets/logo_loader.dart';
 
 import '../../helpers/test_helpers.dart';
 
@@ -83,12 +84,12 @@ void main() {
       );
 
       // First frame: the expensive placement is deferred past it.
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(LogoLoader), findsOneWidget);
       expect(find.byType(InteractiveViewer), findsNothing);
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(LogoLoader), findsNothing);
       expect(find.byType(InteractiveViewer), findsOneWidget);
     });
 

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:tonkatsu_box/shared/models/item_status.dart';
 import 'package:tonkatsu_box/shared/models/media_type.dart';
 import 'package:tonkatsu_box/shared/models/platform.dart' as model;
 import 'package:tonkatsu_box/shared/models/tv_episode.dart';
+import 'package:tonkatsu_box/shared/widgets/logo_loader.dart';
 import 'package:tonkatsu_box/shared/models/tv_season.dart';
 import 'package:tonkatsu_box/shared/models/visual_novel.dart';
 import 'package:tonkatsu_box/shared/navigation/search_providers.dart';
@@ -291,7 +292,7 @@ void main() {
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(LogoLoader), findsOneWidget);
 
       // Complete the future to avoid leaving a pending timer.
       completer.complete(testItems);

--- a/test/features/tier_lists/widgets/tier_item_card_test.dart
+++ b/test/features/tier_lists/widgets/tier_item_card_test.dart
@@ -204,6 +204,38 @@ void main() {
       expect(find.text('Unknown Platform'), findsNothing);
     });
 
+    testWidgets(
+        'label fits the compact metrics box under system font scaling',
+        (WidgetTester tester) async {
+      // Compact metrics reserve exactly 2 lines of 10pt × 1.2 + 4px padding
+      // for the label; with system font scaling the caption must not grow
+      // past that (it opts out of scaling) — previously this overflowed on
+      // Android and threw a RenderFlex overflow.
+      const String longName = 'Very Long Game Name That Wraps Twice';
+      await tester.pumpApp(
+        Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context)
+                .copyWith(textScaler: const TextScaler.linear(1.3)),
+            child: TierItemCard(
+              item: itemNoThumb,
+              displayName: longName,
+              width: 64,
+              height: 86,
+              labelHeight: 28,
+            ),
+          ),
+        ),
+        settle: false,
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      // 28px label minus 4px vertical padding.
+      expect(tester.getSize(find.text(longName)).height,
+          lessThanOrEqualTo(24.0));
+    });
+
     testWidgets('should not show platform when platform is null',
         (WidgetTester tester) async {
       final CollectionItem gameNoPlatform = createTestCollectionItem(

--- a/test/shared/widgets/logo_loader_test.dart
+++ b/test/shared/widgets/logo_loader_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/shared/widgets/logo_loader.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('LogoLoader', () {
+    testWidgets('renders and keeps animating without errors',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        const Center(child: LogoLoader()),
+        wrapInScaffold: true,
+        settle: false, // the loader animates forever; pumpAndSettle would hang
+      );
+      expect(find.byType(LogoLoader), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      // Advance through several full pulse cycles: the looping animation
+      // must keep building without throwing.
+      for (int i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(tester.takeException(), isNull);
+      }
+    });
+
+    testWidgets('honours the size parameter', (WidgetTester tester) async {
+      await tester.pumpApp(
+        const Center(child: LogoLoader(size: 96)),
+        wrapInScaffold: true,
+        settle: false,
+      );
+      expect(tester.getSize(find.byType(LogoLoader)), const Size(96, 96));
+    });
+
+    testWidgets('disposes cleanly mid-animation', (WidgetTester tester) async {
+      await tester.pumpApp(
+        const Center(child: LogoLoader()),
+        wrapInScaffold: true,
+        settle: false,
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpApp(const SizedBox.shrink(), settle: false);
+      expect(find.byType(LogoLoader), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Replace the Material spinner with a branded LogoLoader (the app logo breathes 85%-105% and turns a quarter revolution per pulse) in blocking and long-running spots: the modal overlay, import progress dialogs, Trakt archive validation, personalization (genre cloud and recommendations) and the All Items reload.

Fix the indicators standing frozen: the genre cloud layout now computes cooperatively (time-budgeted yields, results identical to the sync path, word measurements memoized across passes), and Trakt/Kinorium imports unzip and parse their exports on a background isolate.

Also fix the tier list card label overflowing under Android system font scaling by pinning the caption to TextScaler.noScaling.