### PR TITLE
docs(readme,site): actualize for 0.41 and lead with the source logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml"><img src="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml/badge.svg" alt="Tests"></a>
   <a href="https://github.com/hacan359/tonkatsu_box/actions/workflows/test.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/hacan359/7ed48e87a6bd59afeb08eaf656fd2adb/raw/tonkatsu-box-coverage.json" alt="Coverage"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://flutter.dev"><img src="https://img.shields.io/badge/Flutter-3.44+-02569B?logo=flutter&logoColor=white" alt="Flutter 3.44+"></a>
+  <a href="https://flutter.dev"><img src="https://img.shields.io/badge/Flutter-3.38+-02569B?logo=flutter&logoColor=white" alt="Flutter 3.38+"></a>
   <a href="https://discord.gg/JZVNPF7cS2"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
@@ -35,11 +35,29 @@
 
 ---
 
-Tonkatsu Box is a free, open-source app to organize your media collections. Search millions of titles from IGDB, TMDB, TVmaze, VNDB, AniList, MangaBaka, MangaDex, Kitsu, OpenLibrary, Fantlab, ComicVine, Google Books, and Hardcover. Track your progress, rate everything, create visual boards and mood grids, and import your library from Steam, IGDB lists, Trakt.tv, Kinorium, RetroAchievements, MyAnimeList, AniList, or Hardcover.
+Tonkatsu Box is a free, open-source app to organize your media collections. Search millions of titles across thirteen catalogs, track your progress episode by episode, rate everything, see your library in numbers, build visual boards, tier lists and mood grids, and bring in what you already track elsewhere.
+
+### Search thirteen catalogs
+
+| | | | | | | |
+|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| <img src="assets/images/icon_igdb_color.png" width="34" alt="IGDB"><br>IGDB | <img src="assets/images/icon_tmdb_color.png" width="34" alt="TMDB"><br>TMDB | <img src="assets/images/icon_twm_color.png" width="34" alt="TVmaze"><br>TVmaze | <img src="assets/images/icon_vndb_color.png" width="34" alt="VNDB"><br>VNDB | <img src="assets/images/icon_anilist_color.png" width="34" alt="AniList"><br>AniList | <img src="assets/images/icon_kitsu_color.png" width="34" alt="Kitsu"><br>Kitsu | <img src="assets/images/icon_mangabaka_color.png" width="34" alt="MangaBaka"><br>MangaBaka |
+| <img src="assets/images/icon_mangadex_color.png" width="34" alt="MangaDex"><br>MangaDex | <img src="assets/images/open_library_color.png" width="34" alt="OpenLibrary"><br>OpenLibrary | <img src="assets/images/icon_fantlab_color.png" width="34" alt="Fantlab"><br>Fantlab | <img src="assets/images/icon_google_book_color.png" width="34" alt="Google Books"><br>Google&nbsp;Books | <img src="assets/images/icon_hardcover_color.png" width="34" alt="Hardcover"><br>Hardcover | <img src="assets/images/comic_vine_color.png" width="34" alt="ComicVine"><br>ComicVine | |
+
+### Bring your library from
+
+| | | | | | |
+|:-:|:-:|:-:|:-:|:-:|:-:|
+| <img src="assets/images/icon_steam_color.png" width="34" alt="Steam"><br>Steam | <img src="assets/images/icon_igdb_color.png" width="34" alt="IGDB"><br>IGDB&nbsp;list | <img src="assets/images/icon_trakt_color.png" width="34" alt="Trakt.tv"><br>Trakt.tv | <img src="assets/images/icon_simkl_color.png" width="34" alt="Simkl"><br>Simkl | <img src="assets/images/icon_kinorium_color.png" width="34" alt="Kinorium"><br>Kinorium | <img src="assets/images/ra_logo.png" width="34" alt="RetroAchievements"><br>RetroAch. |
+| <img src="assets/images/icon_myanimelist_color.png" width="34" alt="MyAnimeList"><br>MyAnimeList | <img src="assets/images/icon_anilist_color.png" width="34" alt="AniList"><br>AniList | <img src="assets/images/icon_hardcover_color.png" width="34" alt="Hardcover"><br>Hardcover | 📁<br>JSON&nbsp;/&nbsp;CSV | 📦<br>.xcollx | |
 
 <p align="center">
   <img src="docs/screenshots/mockup_main_all.jpg" width="800" alt="Main screen">
 </p>
+
+## Contents
+
+[Languages](#languages) · [Screenshots](#screenshots) · [Features](#features) · [Download](#download) · [Quick Start](#quick-start) · [Ready-made Collections](#ready-made-collections) · [Import Your Data](#import-your-data) · [Sync & Backup](#sync--backup) · [Data Sources](#data-sources) · [Platform Support](#platform-support) · [Building from Source](#building-from-source) · [Contributing](#contributing)
 
 ## Languages
 
@@ -78,19 +96,26 @@ The whole interface is localized with runtime switching. Pick your language in *
 
 ## Features
 
-| | |
-|---|---|
-| **Collections** | Organize by platform, genre, or any way you like. Grid, list, and table views |
-| **Wishlist** | Dedicated top-level list for what you want to play, watch, or read next |
-| **Search** | IGDB (games), TMDB (movies/TV), TVmaze (TV), AniList (anime & manga), MangaBaka, MangaDex & Kitsu (manga), VNDB (visual novels), OpenLibrary, Fantlab, Google Books & Hardcover (books), ComicVine (comics) |
-| **Progress Tracking** | Status, ratings 1-10, episode tracking for TV shows and anime |
-| **Discord Rich Presence** | Show what you're playing/watching/reading in Discord (desktop) |
-| **Visual Boards** | Drag-and-drop canvas with posters, notes, and connections |
-| **Tier Lists & Mood Grids** | Rank items into S/A/B/C tiers, or arrange them on a visual N×M board with labels — export either as PNG |
-| **Import** | Steam library, IGDB list CSV, Trakt.tv history, Kinorium CSV, RetroAchievements progress, MyAnimeList XML, AniList and Hardcover by username |
-| **Kodi Sync** | Pull watched status and ratings for your movies from a Kodi media server over JSON-RPC |
-| **Export & Share** | .xcoll / .xcollx files with full offline support |
-| **Gamepad** | Navigate with Xbox controller (desktop and Android handhelds) |
+| | | |
+|:-:|---|---|
+| 📦 | **Collections** | Organize by platform, genre, or any way you like. Grid, list, table and board views, manual drag-and-drop order, bulk actions over a selection |
+| 🔍 | **Search** | Thirteen catalogs behind one search field, each with its own filters and an empty-query browse mode. Add a result to several collections at once |
+| ✅ | **Progress tracking** | Status, ratings 1-10, start and finish dates, replays, time spent. Reading progress by page for books, chapters for manga |
+| 📺 | **Episode tracker** | Season accordion with posters, episode stills, air dates and synopses. Mark an episode, a whole season, or the next unwatched one in a tap. TMDB, TVmaze and Kitsu titles |
+| ❤️ | **Likes & notes** | Like and annotate a single episode, season, chapter, volume or page, and filter the list down to what you starred |
+| 🏷️ | **Tags** | Global tags with their own manager, grouping and filtering — add or remove them across a whole selection |
+| 📊 | **Statistics** | Your library in numbers, for all time or one year: counters, per-type breakdowns, a month-by-month ribbon, platforms, formats, tags, best vs worst, and a shareable summary card |
+| ☁️ | **Personalization** | A genre / platform / decade cloud built from your library, and recommendations from what you completed and rated |
+| 🔔 | **Releases & calendar** | Follow a show and its upcoming episodes land on a month / week / day calendar, together with any date you add yourself |
+| 📝 | **Wishlist** | Dedicated top-level list for what you want to play, watch, or read next — importers park anything they could not match here |
+| 🎨 | **Visual boards** | Drag-and-drop canvas with posters, notes, and connections |
+| 🏆 | **Tier lists & mood grids** | Rank items into S/A/B/C tiers, or arrange them on a visual N×M board with labels — export either as PNG |
+| 📥 | **Import** | Simkl, Steam, IGDB list CSV, Trakt.tv, Kinorium CSV, RetroAchievements, MyAnimeList XML, AniList and Hardcover by username, plus your own cards from JSON / CSV |
+| 🎬 | **Kodi sync** | Pull watched status and ratings for your movies from a Kodi media server over JSON-RPC |
+| 🎧 | **Discord Rich Presence** | Show what you're playing/watching/reading in Discord (desktop) |
+| 👤 | **Profiles** | Several people on one install — separate collections, boards and covers per profile, with the API keys and app language shared |
+| 💾 | **Export & share** | .xcoll / .xcollx files with full offline support, device-to-device sync, one-click backups |
+| 🎮 | **Gamepad** | Navigate with Xbox controller (desktop and Android handhelds) |
 
 ## Download
 
@@ -143,16 +168,32 @@ Already tracking elsewhere? Bring your data:
 | <img src="assets/images/icon_steam_color.png" width="28" alt="Steam"> | **Steam** | Owned games, playtime, last played date |
 | <img src="assets/images/icon_igdb_color.png" width="28" alt="IGDB"> | **IGDB** | A game list exported as CSV — matched by IGDB id, with a status you pick for the list |
 | <img src="assets/images/icon_trakt_color.png" width="28" alt="Trakt.tv"> | **Trakt.tv** | Watch history, ratings, watchlist, episode progress |
+| <img src="assets/images/icon_simkl_color.png" width="28" alt="Simkl"> | **Simkl** | Movies, TV shows and anime from one account, signed in with a short code — statuses, ratings, notes and the episode watch history with its original dates |
 | <img src="assets/images/icon_kinorium_color.png" width="28" alt="Kinorium"> | **Kinorium** | Movies, TV & animation from a CSV export — ratings and watch dates |
 | <img src="assets/images/ra_logo.png" width="28" alt="RetroAchievements"> | **RetroAchievements** | Retro game library, achievement progress, awards |
 | <img src="assets/images/icon_myanimelist_color.png" width="28" alt="MyAnimeList"> | **MyAnimeList** | Anime and manga lists with scores, status and progress from an XML export |
 | <img src="assets/images/icon_anilist_color.png" width="28" alt="AniList"> | **AniList** | Anime and manga directly by a public username — no API key required |
 | <img src="assets/images/icon_hardcover_color.png" width="28" alt="Hardcover"> | **Hardcover** | Book library by username — statuses, ratings, dates and re-reads |
+| 📁 | **Your own cards** | A JSON or CSV file of custom entries — titles, types, covers, notes, tags and personal fields |
 | 📦 | **.xcollx files** | Collections shared by others |
 
 > [Import guides on Wiki](https://github.com/hacan359/tonkatsu_box/wiki)
 
-## Device-to-Device Sync
+## Sync & Backup
+
+Everything lives on your device. Nothing here needs an account or a cloud.
+
+| | What | Where |
+|:-:|---|---|
+| 🔄 | **Device-to-device sync** — copy the whole database to another device over your home network | Settings → Database → Device-to-device sync |
+| 💾 | **Backup & restore** — one archive with collections, tags, boards, tier lists, mood grids, wishlist, watch progress, calendar and settings | Settings → Backup |
+| 📁 | **Custom data folder** — keep the database on an SD card or any folder you pick | Settings → Database → Storage location |
+| <img src="assets/images/icon_kodi_color.png" width="24" alt="Kodi"> | **Kodi sync** — pull watched status and ratings for your movies from a Kodi media server | Settings → Kodi |
+| <img src="assets/images/icon_discord_color.png" width="24" alt="Discord"> | **Discord Rich Presence** — show what you're playing, watching or reading | Settings → Discord |
+
+> [Details on the Wiki](https://github.com/hacan359/tonkatsu_box/wiki/Data-Sync-Backup)
+
+### Device-to-Device Sync
 
 Move your whole collection from one device to another over your home network. No cloud, no account: the two devices talk to each other directly.
 
@@ -196,7 +237,7 @@ When you pick an empty folder, the app copies your current data there. When you 
 | <img src="assets/images/icon_anilist_color.png" width="28" alt="AniList"> | Anime & Manga | [AniList](https://anilist.co/) | Not required |
 | <img src="assets/images/icon_mangabaka_color.png" width="28" alt="MangaBaka"> | Manga | [MangaBaka](https://mangabaka.org/) | Not required |
 | <img src="assets/images/icon_mangadex_color.png" width="28" alt="MangaDex"> | Manga | [MangaDex](https://mangadex.org/) | Not required |
-| <img src="assets/images/icon_kitsu_color.png" width="28" alt="Kitsu"> | Manga | [Kitsu](https://kitsu.io/) | Not required |
+| <img src="assets/images/icon_kitsu_color.png" width="28" alt="Kitsu"> | Anime & Manga | [Kitsu](https://kitsu.io/) | Not required |
 | <img src="assets/images/open_library_color.png" width="28" alt="OpenLibrary"> | Books | [OpenLibrary](https://openlibrary.org/) | Not required |
 | <img src="assets/images/icon_fantlab_color.png" width="28" alt="Fantlab"> | Books | [Fantlab](https://fantlab.ru/) | Not required |
 | <img src="assets/images/icon_google_book_color.png" width="28" alt="Google Books"> | Books | [Google Books](https://books.google.com/) | Optional (free key) |
@@ -213,10 +254,12 @@ When you pick an empty folder, the app copies your current data there. When you 
 | Feature | Windows | Linux | macOS | Android |
 |---------|:-------:|:-----:|:-----:|:-------:|
 | Collections & search | ✅ | ✅ | ✅ | ✅ |
-| Progress tracking | ✅ | ✅ | ✅ | ✅ |
+| Progress & episode tracker | ✅ | ✅ | ✅ | ✅ |
+| Statistics & personalization | ✅ | ✅ | ✅ | ✅ |
 | Visual boards | ✅ | ✅ | ✅ | ✅ |
-| Tier lists | ✅ | ✅ | ✅ | ✅ |
-| Import (Steam/Trakt/RA) | ✅ | ✅ | ✅ | ✅ |
+| Tier lists & mood grids | ✅ | ✅ | ✅ | ✅ |
+| Imports (Simkl / Steam / Trakt / RA / …) | ✅ | ✅ | ✅ | ✅ |
+| Device-to-device sync & backups | ✅ | ✅ | ✅ | ✅ |
 | Kodi sync | ✅ | ✅ | ✅ | ✅ |
 | VGMaps browser | ✅ | — | — | — |
 | Gamepad | ✅ | ✅ | ✅ | ✅ |
@@ -236,7 +279,7 @@ flutter pub get
 flutter run -d windows  # or linux / macos / android
 ```
 
-Requires Flutter 3.44+. See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
+Requires Flutter 3.38+ / Dart 3.10+. See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
 
 ## Community
 
@@ -249,7 +292,9 @@ Contributions welcome! See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for build ins
 
 ## Credits
 
-Data: [IGDB](https://www.igdb.com/) · [TMDB](https://www.themoviedb.org/) · [TVmaze](https://www.tvmaze.com/) · [VNDB](https://vndb.org/) · [AniList](https://anilist.co/) · [MangaBaka](https://mangabaka.org/) · [MangaDex](https://mangadex.org/) · [Kitsu](https://kitsu.io/) · [OpenLibrary](https://openlibrary.org/) · [Fantlab](https://fantlab.ru/) · [Google Books](https://books.google.com/) · [Hardcover](https://hardcover.app/) · [ComicVine](https://comicvine.gamespot.com/) · [MyAnimeList](https://myanimelist.net/) · [RetroAchievements](https://retroachievements.org/) · [SteamGridDB](https://www.steamgriddb.com/) · [ScreenScraper](https://www.screenscraper.fr/)
+Catalogs: [IGDB](https://www.igdb.com/) · [TMDB](https://www.themoviedb.org/) · [TVmaze](https://www.tvmaze.com/) · [VNDB](https://vndb.org/) · [AniList](https://anilist.co/) · [MangaBaka](https://mangabaka.org/) · [MangaDex](https://mangadex.org/) · [Kitsu](https://kitsu.io/) · [OpenLibrary](https://openlibrary.org/) · [Fantlab](https://fantlab.ru/) · [Google Books](https://books.google.com/) · [Hardcover](https://hardcover.app/) · [ComicVine](https://comicvine.gamespot.com/)
+
+Imports and extras: [Simkl](https://simkl.com/) · [Trakt.tv](https://trakt.tv/) · [Steam](https://store.steampowered.com/) · [Kinorium](https://kinorium.com/) · [MyAnimeList](https://myanimelist.net/) · [RetroAchievements](https://retroachievements.org/) · [SteamGridDB](https://www.steamgriddb.com/) · [ScreenScraper](https://www.screenscraper.fr/) · [Kodi](https://kodi.tv/)
 
 *This product uses the TMDB API but is not endorsed or certified by TMDB.*
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <!-- SEO Meta Tags -->
   <title>Tonkatsu Box — Organize Games, Movies, TV Shows, Anime, Manga, Visual Novels & Books</title>
   <meta name="description" content="Free open-source app to build and manage collections of retro games, movies, TV shows, anime, manga, visual novels, and books. Track progress, rate favorites, create tier lists, visual boards, and share with friends. Windows, Linux, macOS & Android.">
-  <meta name="keywords" content="game collection manager, retro game organizer, movie tracker, TV show tracker, anime tracker, manga tracker, visual novel tracker, book tracker, tier list maker, tier list generator, mood grid, IGDB, TMDB, TVmaze, VNDB, AniList, MangaBaka, MangaDex, Kitsu, OpenLibrary, Fantlab, ComicVine, Google Books, Hardcover, Trakt import, Steam import, Kinorium import, RetroAchievements import, MyAnimeList import, AniList import, ScreenScraper, collection app, backlog tracker, game library, Flutter app, open source">
+  <meta name="keywords" content="game collection manager, retro game organizer, movie tracker, TV show tracker, anime tracker, manga tracker, visual novel tracker, book tracker, tier list maker, tier list generator, mood grid, IGDB, TMDB, TVmaze, VNDB, AniList, MangaBaka, MangaDex, Kitsu, OpenLibrary, Fantlab, ComicVine, Google Books, Hardcover, Trakt import, Simkl import, Steam import, Kinorium import, RetroAchievements import, MyAnimeList import, AniList import, Hardcover import, ScreenScraper, library statistics, collection app, backlog tracker, game library, Flutter app, open source">
   <meta name="author" content="hacan359">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://hacan359.github.io/tonkatsu_box/">
@@ -539,6 +539,7 @@
     .feature-card--board  { --accent: var(--custom); }
     .feature-card--tier   { --accent: var(--status-planned); }
     .feature-card--lang   { --accent: var(--status-progress); }
+    .feature-card--stats  { --accent: var(--anime); }
 
     .feature-card__icon {
       width: 48px;
@@ -1192,6 +1193,14 @@
           </div>
         </div>
 
+        <div class="feature-card feature-card--stats reveal">
+          <div class="feature-card__icon">📈</div>
+          <h3 class="feature-card__title" data-i18n="feat_stats_title">Your Library in Numbers</h3>
+          <p class="feature-card__desc" data-i18n="feat_stats_desc">
+            Episodes, chapters, pages and hours you got through, a status breakdown per media type, a month-by-month ribbon, platforms, formats, tags, best against worst — for all time or a single year, with a share card to export.
+          </p>
+        </div>
+
         <div class="feature-card feature-card--book reveal">
           <div class="feature-card__icon">📚</div>
           <h3 class="feature-card__title" data-i18n="feat_books_title">Books & Reading</h3>
@@ -1212,7 +1221,7 @@
           <div class="feature-card__icon">📤</div>
           <h3 class="feature-card__title" data-i18n="feat_share_title">Import & Share</h3>
           <p class="feature-card__desc" data-i18n="feat_share_desc">
-            Import from Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, or Kinorium. Share collections as <code>.xcoll</code> or <code>.xcollx</code> files. Friends can import and fork your lists.
+            Import from Simkl, Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, Hardcover, an IGDB list or Kinorium. Share collections as <code>.xcoll</code> or <code>.xcollx</code> files. Friends can import and fork your lists.
           </p>
         </div>
 
@@ -1322,11 +1331,32 @@
         <div class="section-label" data-i18n="sharing_label">Import & Share</div>
         <h2 class="section-title" data-i18n="sharing_title">Import &amp; share your taste</h2>
         <p class="section-subtitle" data-i18n="sharing_subtitle">
-          Import from Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, or Kinorium, export your collections, and share with friends.
+          Import from Simkl, Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, Hardcover or Kinorium, export your collections, and share with friends.
         </p>
       </div>
 
       <div class="formats reveal">
+        <div class="format-card">
+          <div class="format-card__ext">Simkl</div>
+          <div class="format-card__name" data-i18n="format_simkl_name">Simkl Import</div>
+          <p class="format-card__desc" data-i18n="format_simkl_desc">
+            Sign in with a short code and bring movies, TV shows and anime from one Simkl account, together with the episode watch history and its original dates.
+          </p>
+        </div>
+        <div class="format-card">
+          <div class="format-card__ext">Steam</div>
+          <div class="format-card__name" data-i18n="format_steam_name">Steam Import</div>
+          <p class="format-card__desc" data-i18n="format_steam_desc">
+            Import your owned games with playtime and the last played date, matched against IGDB.
+          </p>
+        </div>
+        <div class="format-card">
+          <div class="format-card__ext">Hardcover</div>
+          <div class="format-card__name" data-i18n="format_hardcover_name">Hardcover Import</div>
+          <p class="format-card__desc" data-i18n="format_hardcover_desc">
+            Import a book library by username — statuses, ratings, dates and re-reads, graphic novels included.
+          </p>
+        </div>
         <div class="format-card">
           <div class="format-card__ext">Trakt.tv</div>
           <div class="format-card__name" data-i18n="format_trakt_name">Trakt Import</div>
@@ -1613,12 +1643,14 @@
         status_completed: 'Completed',
         status_planned: 'Planned',
         status_dropped: 'Dropped',
+        feat_stats_title: 'Your Library in Numbers',
+        feat_stats_desc: 'Episodes, chapters, pages and hours you got through, a status breakdown per media type, a month-by-month ribbon, platforms, formats, tags, best against worst — for all time or a single year, with a share card to export.',
         feat_books_title: 'Books & Reading',
         feat_books_desc: 'Search books on OpenLibrary, Fantlab, Google Books, and Hardcover, and comics on ComicVine — track your reading and organize novels and series alongside the rest of your collection.',
         feat_boards_title: 'Visual Boards',
         feat_boards_desc: 'Arrange posters on a free-form canvas. Add text notes, images, and links. Draw connections between items. Browse artwork from SteamGridDB.',
         feat_share_title: 'Import & Share',
-        feat_share_desc: 'Import from Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, or Kinorium. Share collections as <code>.xcoll</code> or <code>.xcollx</code> files. Friends can import and fork your lists.',
+        feat_share_desc: 'Import from Simkl, Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, Hardcover, an IGDB list or Kinorium. Share collections as <code>.xcoll</code> or <code>.xcollx</code> files. Friends can import and fork your lists.',
         feat_rate_title: 'Rate & Review',
         feat_rate_desc: 'Rate every title from 1–10 stars. Write personal notes and author reviews visible on export. Track when you started and finished each item.',
         feat_tier_title: 'Tier Lists',
@@ -1636,7 +1668,13 @@
         step3_desc: 'Want to use your own API keys? Register for free at <strong>IGDB</strong>, <strong>TMDB</strong>, or <strong>SteamGridDB</strong> and enter them in Settings. Completely optional — everything works without them.',
         sharing_label: 'Import & Share',
         sharing_title: 'Import &amp; share your taste',
-        sharing_subtitle: 'Import from Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, or Kinorium, export your collections, and share with friends.',
+        sharing_subtitle: 'Import from Simkl, Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, Hardcover or Kinorium, export your collections, and share with friends.',
+        format_simkl_name: 'Simkl Import',
+        format_simkl_desc: 'Sign in with a short code and bring movies, TV shows and anime from one Simkl account, together with the episode watch history and its original dates.',
+        format_steam_name: 'Steam Import',
+        format_steam_desc: 'Import your owned games with playtime and the last played date, matched against IGDB.',
+        format_hardcover_name: 'Hardcover Import',
+        format_hardcover_desc: 'Import a book library by username — statuses, ratings, dates and re-reads, graphic novels included.',
         format_trakt_name: 'Trakt Import',
         format_trakt_desc: 'Import watched movies, shows, ratings, and watchlist from your Trakt.tv ZIP data export.',
         format_ra_name: 'RA Import',
@@ -1719,12 +1757,14 @@
         status_completed: 'Пройдено',
         status_planned: 'Отложено',
         status_dropped: 'Брошено',
+        feat_stats_title: 'Библиотека в цифрах',
+        feat_stats_desc: 'Серии, главы, страницы и часы, разбивка по статусам для каждого типа медиа, лента по месяцам, платформы, форматы, теги, лучшее против худшего — за всё время или за один год, с карточкой итогов на экспорт.',
         feat_books_title: 'Книги',
         feat_books_desc: 'Ищите книги в OpenLibrary, Fantlab, Google Books и Hardcover, а комиксы — в ComicVine, отслеживайте чтение и организуйте романы и циклы вместе с остальной коллекцией.',
         feat_boards_title: 'Визуальные доски',
         feat_boards_desc: 'Расставляйте постеры на свободном холсте. Добавляйте заметки, изображения и ссылки. Рисуйте связи между элементами. Арты из SteamGridDB.',
         feat_share_title: 'Импорт и шаринг',
-        feat_share_desc: 'Импорт из Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList или Kinorium. Делитесь коллекциями через <code>.xcoll</code> и <code>.xcollx</code>. Друзья могут импортировать и форкнуть.',
+        feat_share_desc: 'Импорт из Simkl, Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, Hardcover, списка IGDB или Kinorium. Делитесь коллекциями через <code>.xcoll</code> и <code>.xcollx</code>. Друзья могут импортировать и форкнуть.',
         feat_rate_title: 'Оценки и отзывы',
         feat_rate_desc: 'Оценивайте от 1 до 10 звёзд. Пишите личные заметки и рецензии, видимые при экспорте. Отслеживайте даты начала и окончания.',
         feat_tier_title: 'Тир-листы',
@@ -1742,7 +1782,13 @@
         step3_desc: 'Хотите использовать свои ключи? Зарегистрируйтесь бесплатно на <strong>IGDB</strong>, <strong>TMDB</strong> или <strong>SteamGridDB</strong> и введите их в Настройках. Полностью опционально — всё работает и без них.',
         sharing_label: 'Импорт и шаринг',
         sharing_title: 'Импорт и обмен',
-        sharing_subtitle: 'Импорт из Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList или Kinorium, экспорт коллекций и обмен с друзьями.',
+        sharing_subtitle: 'Импорт из Simkl, Steam, Trakt.tv, RetroAchievements, MyAnimeList, AniList, Hardcover или Kinorium, экспорт коллекций и обмен с друзьями.',
+        format_simkl_name: 'Импорт Simkl',
+        format_simkl_desc: 'Войдите по короткому коду и заберите фильмы, сериалы и аниме из одного аккаунта Simkl вместе с историей просмотра серий и её датами.',
+        format_steam_name: 'Импорт Steam',
+        format_steam_desc: 'Импортируйте купленные игры с наигранным временем и датой последнего запуска, сопоставленные с IGDB.',
+        format_hardcover_name: 'Импорт Hardcover',
+        format_hardcover_desc: 'Импортируйте книжную библиотеку по нику — статусы, оценки, даты и перечитывания, включая графические романы.',
         format_trakt_name: 'Импорт Trakt',
         format_trakt_desc: 'Импортируйте просмотренные фильмы, сериалы, оценки и вишлист из ZIP-выгрузки Trakt.tv.',
         format_ra_name: 'Импорт RA',


### PR DESCRIPTION
README opens with two labelled logo grids — the thirteen searchable catalogs and the eleven places a library can come from, Simkl included — followed by a one-line table of contents.

Features became an icon grid and gained everything that was missing: the episode tracker, likes and notes, tags, statistics, personalization, releases and calendar, profiles, custom-card import and Simkl. Sync-related settings now share one "Sync & Backup" summary table (device-to-device, backups, custom data folder, Kodi, Discord) above the existing detailed sections.

Kitsu is Anime & Manga, not manga only; the platform matrix lists statistics, sync and backups; credits are split into catalogs and imports. The Flutter badge said 3.44+ while pubspec asks for Dart ^3.10.8 and CONTRIBUTING says 3.38+ — aligned on 3.38+ / Dart 3.10+.

Site: a "Your Library in Numbers" feature card, Simkl / Steam / Hardcover import cards, Simkl and statistics in the keywords, and every new string translated in both the en and ru dictionaries.