### PR TITLE
refactor(core): extract database opening into the core package

### DIFF
--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -23,8 +23,8 @@ import 'package:core/database/dao/tracker_dao.dart';
 import 'package:core/database/dao/tv_show_dao.dart';
 import 'package:core/database/dao/visual_novel_dao.dart';
 import 'package:core/database/dao/wishlist_dao.dart';
+import 'package:core/database/database_opener.dart';
 import 'package:core/database/migrations/migration.dart';
-import 'package:core/database/migrations/migration_registry.dart';
 import 'package:core/database/migrations/migration_runner.dart';
 import 'package:core/models/collected_item_info.dart';
 import 'package:core/models/collection.dart';
@@ -261,52 +261,16 @@ class DatabaseService {
       'Database path: $dbPath (${kReleaseMode ? 'release' : 'debug'} mode)',
     );
 
-    return databaseFactory.openDatabase(
-      dbPath,
-      options: OpenDatabaseOptions(
-        version: 60,
-        onCreate: _onCreate,
-        onUpgrade: _onUpgrade,
-        onConfigure: (Database db) async {
-          await db.execute('PRAGMA foreign_keys = ON');
-          // WAL + NORMAL batches commits into one fsync per checkpoint;
-          // `journal_mode` returns a row, so Android needs rawQuery.
-          await db.rawQuery('PRAGMA journal_mode = WAL');
-          await db.execute('PRAGMA synchronous = NORMAL');
-        },
-      ),
-    );
-  }
-
-  Future<void> _onCreate(Database db, int version) async {
-    _log.info('Creating database schema v$version');
-    // Single source of truth: a fresh DB is built by running the whole
-    // migration chain (v1..N) in order, exactly like an upgrade from zero.
-    await MigrationRunner.run(
-      db,
-      MigrationRegistry.all,
-      fromVersion: 0,
-      toVersion: version,
-      onFailure: _logMigrationFailure,
-    );
-  }
-
-  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
-    _log.info('Upgrading database from v$oldVersion to v$newVersion');
-    await MigrationRunner.run(
-      db,
-      MigrationRegistry.pending(oldVersion),
-      fromVersion: oldVersion,
-      toVersion: newVersion,
-      onStart: (Migration m) =>
+    return openAppDatabase(
+      factory: databaseFactory,
+      path: dbPath,
+      onInfo: _log.info,
+      onMigrationStart: (Migration m) =>
           _log.fine('Running migration v${m.version}: ${m.description}'),
-      onFailure: _logMigrationFailure,
+      onMigrationFailure: (MigrationFailure failure, StackTrace stack) =>
+          _log.severe('Migration v${failure.version} failed', failure, stack),
     );
-    _log.info('Database upgrade complete');
   }
-
-  void _logMigrationFailure(MigrationFailure failure, StackTrace stack) =>
-      _log.severe('Migration v${failure.version} failed', failure, stack);
 
   Future<List<Collection>> getAllCollections() =>
       collectionDao.getAllCollections();

--- a/packages/core/lib/database/database_opener.dart
+++ b/packages/core/lib/database/database_opener.dart
@@ -1,0 +1,61 @@
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'migrations/migration.dart';
+import 'migrations/migration_registry.dart';
+import 'migrations/migration_runner.dart';
+
+/// Opens the app database at [path] and brings its schema up to date.
+///
+/// Deciding *where* the file lives is the caller's job — the app resolves a
+/// per-profile directory, the selfhost server a container volume — so this takes
+/// a ready [path] and stays free of `dart:io`.
+///
+/// The target version comes from [MigrationRegistry.latestVersion], so adding a
+/// migration cannot drift from a hand-maintained number.
+Future<Database> openAppDatabase({
+  required DatabaseFactory factory,
+  required String path,
+  void Function(String message)? onInfo,
+  void Function(Migration migration)? onMigrationStart,
+  void Function(MigrationFailure failure, StackTrace stack)? onMigrationFailure,
+}) {
+  final int target = MigrationRegistry.latestVersion;
+  return factory.openDatabase(
+    path,
+    options: OpenDatabaseOptions(
+      version: target,
+      onCreate: (Database db, int version) async {
+        onInfo?.call('Creating database schema v$version');
+        // Single source of truth: a fresh DB runs the whole chain (v1..N) in
+        // order, exactly like an upgrade from zero.
+        await MigrationRunner.run(
+          db,
+          MigrationRegistry.all,
+          fromVersion: 0,
+          toVersion: version,
+          onStart: onMigrationStart,
+          onFailure: onMigrationFailure,
+        );
+      },
+      onUpgrade: (Database db, int oldVersion, int newVersion) async {
+        onInfo?.call('Upgrading database from v$oldVersion to v$newVersion');
+        await MigrationRunner.run(
+          db,
+          MigrationRegistry.pending(oldVersion),
+          fromVersion: oldVersion,
+          toVersion: newVersion,
+          onStart: onMigrationStart,
+          onFailure: onMigrationFailure,
+        );
+        onInfo?.call('Database upgrade complete');
+      },
+      onConfigure: (Database db) async {
+        await db.execute('PRAGMA foreign_keys = ON');
+        // WAL + NORMAL batches commits into one fsync per checkpoint;
+        // `journal_mode` returns a row, so Android needs rawQuery.
+        await db.rawQuery('PRAGMA journal_mode = WAL');
+        await db.execute('PRAGMA synchronous = NORMAL');
+      },
+    ),
+  );
+}

--- a/packages/core/test/database/database_opener_test.dart
+++ b/packages/core/test/database/database_opener_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:core/database/database_opener.dart';
+import 'package:core/database/migrations/migration.dart';
+import 'package:core/database/migrations/migration_registry.dart';
+import 'package:core/database/migrations/migration_runner.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUpAll(sqfliteFfiInit);
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('opener_test');
+    dbPath = '${tempDir.path}/test.db';
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  Future<Database> open({
+    void Function(Migration)? onMigrationStart,
+  }) =>
+      openAppDatabase(
+        factory: databaseFactoryFfi,
+        path: dbPath,
+        onMigrationStart: onMigrationStart,
+      );
+
+  group('openAppDatabase', () {
+    test('should enable foreign keys and WAL on the opened connection',
+        () async {
+      final Database db = await open();
+      addTearDown(db.close);
+
+      final List<Map<String, Object?>> fk =
+          await db.rawQuery('PRAGMA foreign_keys');
+      final List<Map<String, Object?>> journal =
+          await db.rawQuery('PRAGMA journal_mode');
+
+      expect(fk.first.values.first, 1);
+      expect((journal.first.values.first as String).toLowerCase(), 'wal');
+    });
+
+    test('should cascade a delete, proving foreign keys are enforced',
+        () async {
+      final Database db = await open();
+      addTearDown(db.close);
+
+      final int collectionId = await db.insert('collections', <String, Object?>{
+        'name': 'c',
+        'author': 'a',
+        'created_at': 1,
+      });
+      await db.insert('collection_items', <String, Object?>{
+        'collection_id': collectionId,
+        'external_id': 1,
+        'added_at': 1,
+      });
+
+      await db.delete('collections', where: 'id = ?', whereArgs: <Object?>[
+        collectionId,
+      ]);
+
+      expect(await db.query('collection_items'), isEmpty);
+    });
+
+    test('should land a fresh database on the registry latest version',
+        () async {
+      final Database db = await open();
+      addTearDown(db.close);
+
+      expect(await db.getVersion(), MigrationRegistry.latestVersion);
+    });
+
+    test('should run only pending migrations when upgrading', () async {
+      const int from = 58;
+      final Database seeded = await databaseFactoryFfi.openDatabase(
+        dbPath,
+        options: OpenDatabaseOptions(
+          version: from,
+          onCreate: (Database db, int version) => MigrationRunner.run(
+            db,
+            MigrationRegistry.pending(0).where((Migration m) => m.version <= from),
+            fromVersion: 0,
+            toVersion: from,
+          ),
+        ),
+      );
+      await seeded.close();
+
+      final List<int> ran = <int>[];
+      final Database db = await open(
+        onMigrationStart: (Migration m) => ran.add(m.version),
+      );
+      addTearDown(db.close);
+
+      expect(ran, <int>[59, 60]);
+      expect(await db.getVersion(), MigrationRegistry.latestVersion);
+    });
+  });
+}


### PR DESCRIPTION
Last piece of selfhost-web phase 1. `openAppDatabase` in packages/core owns onCreate / onUpgrade / onConfigure; the app keeps only the part that decides *where* the file lives (profile directory, dart:io), so the selfhost server can point the same opener at a container volume. The hardcoded `version: 60` is gone — the target now comes from MigrationRegistry.latestVersion, so adding a migration cannot drift from a hand-maintained number.

The DAO providers and the delegating facade stay in database_service.dart: they are the app's surface, and gameDaoProvider is the seam a web build swaps for an RPC stub.

Adds packages/core/test/database/database_opener_test.dart, which also makes the pure-Dart suite real — `dart test` inside packages/core now runs without a Flutter SDK, the phase-1 acceptance criterion that had no test behind it.

Those tests exist because mutation-testing the old gate found it blind: deleting `PRAGMA foreign_keys = ON` or swapping `pending(oldVersion)` for `all` both kept 6666 tests green while silently breaking cascade deletes and re-running applied migrations. Both mutations now fail, as does dropping WAL.

Verified against real data as well as fixtures: a live v53 profile database (3 collections, 154 items) upgraded to v60 running exactly migrations [54..60], with per-collection counts identical to the original and integrity_check / foreign_key_check clean.