### PR TITLE
fix(search,api,db,stats): harden the 0.41 release after the finish review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,19 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Fixed
 
+- **Episode watch marks no longer stay behind for a look-alike sibling**
+
+  Moving a series between collections deletes its old watch marks unless
+  another item can still use them. The sibling check now counts only items
+  that actually carry marks — an animated movie sharing the same TMDB id
+  (movie and TV ids overlap numerically) no longer keeps orphaned rows alive.
+
+  * packages/core/lib/database/dao/collection_dao.dart (CollectionDao._hasTvSibling):
+    Mirror CollectionItem.usesEpisodeTrackerFor — require platform_id for
+    animation and source kitsu for anime instead of any media-type match.
+  * packages/core/test/database/dao/collection_dao_watched_transfer_test.dart:
+    Regression test with an animated-movie and an AniList-anime sibling.
+
 - **Backup restore keeps collection creation and item added dates**
 
   Restoring a full backup used to stamp every collection and item with the

--- a/lib/core/api/episode_source/kitsu_episode_source.dart
+++ b/lib/core/api/episode_source/kitsu_episode_source.dart
@@ -3,20 +3,17 @@ import 'package:core/models/data_source.dart';
 import 'package:core/models/tv_episode.dart';
 import 'package:core/models/tv_season.dart';
 import 'package:core/models/tv_show.dart';
+import 'package:logging/logging.dart';
 
 import '../kitsu_api.dart';
 import 'tv_episode_source.dart';
 
-/// [TvEpisodeSource] backed by Kitsu anime episodes.
-///
-/// Kitsu has no seasons endpoint and no per-season episode filter, so seasons
-/// are synthesized and [getSeasonEpisodes] fetches the full list once per anime
-/// and filters in memory (the shape [TvMazeEpisodeSource] already uses). Both
-/// the anime record and the episode list are memoized per show id so opening a
-/// card does not repeat requests; a failed fetch is dropped so the next call
-/// retries.
+/// [TvEpisodeSource] backed by Kitsu: seasons are synthesized from the full
+/// episode list, memoized per show id; a failed fetch is dropped so calls retry.
 class KitsuEpisodeSource implements TvEpisodeSource {
   KitsuEpisodeSource(this._api);
+
+  static final Logger _log = Logger('KitsuEpisodeSource');
 
   /// Kitsu splits long-running titles into separate anime records, so a record
   /// nearly always carries a single season.
@@ -36,14 +33,8 @@ class KitsuEpisodeSource implements TvEpisodeSource {
     return anime == null ? null : _asTvShow(anime);
   }
 
-  /// Seasons come from the episodes themselves — Kitsu has no seasons endpoint,
-  /// and long-running records really do carry several seasons (Bleach: 16, with
-  /// `number` counting absolutely across all of them). That costs the full
-  /// episode list here, but the caller persists the result and the list is
-  /// memoized, so expanding a season afterwards needs no further requests.
-  ///
-  /// Falls back to one synthesized season when the list is unavailable, so an
-  /// API failure still renders a tracker instead of nothing.
+  /// Seasons come from the episodes — Kitsu has no seasons endpoint and
+  /// `number` counts absolutely across a record's seasons (Bleach: 16).
   @override
   Future<List<TvSeason>> getSeasons(int showId) async {
     final Anime? anime = await _animeRecord(showId);
@@ -51,7 +42,10 @@ class KitsuEpisodeSource implements TvEpisodeSource {
     List<TvEpisode> episodes;
     try {
       episodes = await _allEpisodes(showId);
-    } on Object {
+    } on Object catch (e) {
+      // Fall back to one synthesized season so an API failure still renders
+      // a tracker instead of nothing.
+      _log.warning('Episode list for anime $showId failed: $e');
       episodes = const <TvEpisode>[];
     }
 

--- a/lib/core/api/kitsu/kitsu_episode_api.dart
+++ b/lib/core/api/kitsu/kitsu_episode_api.dart
@@ -5,12 +5,8 @@ import 'package:dio/dio.dart';
 
 import 'kitsu_http_client.dart';
 
-/// Anime episodes on Kitsu (`/anime/{id}/episodes`, JSON:API).
-///
-/// The endpoint caps a page at 20 items and has no season filter, so a full
-/// list is the only way to get one season. Page one carries `meta.count`, the
-/// remaining pages go out in parallel batches — that keeps even the outliers
-/// (One Piece, ~70 pages) down to seconds instead of a serial crawl.
+/// Anime episodes on Kitsu (`/anime/{id}/episodes`, JSON:API). Pages cap at 20;
+/// `meta.count` from page one lets the remaining pages go out in parallel batches.
 class KitsuEpisodeApi {
   KitsuEpisodeApi(this._client);
 
@@ -39,23 +35,36 @@ class KitsuEpisodeApi {
     try {
       final Map<String, dynamic> firstPage = await _page(animeId, 0);
       final List<TvEpisode> episodes = _parse(firstPage, animeId);
-      final int total = _client.totalCount(firstPage) ?? episodes.length;
+      final int? total = _client.totalCount(firstPage);
 
-      final List<int> offsets = <int>[
-        for (int offset = _pageLimit; offset < total; offset += _pageLimit)
-          offset,
-      ];
+      if (total == null) {
+        // No meta.count — crawl serially until links.next disappears.
+        bool more = _client.hasNext(firstPage) ?? episodes.length == _pageLimit;
+        int offset = _pageLimit;
+        while (more) {
+          final Map<String, dynamic> page = await _page(animeId, offset);
+          final List<TvEpisode> parsed = _parse(page, animeId);
+          episodes.addAll(parsed);
+          offset += _pageLimit;
+          more = _client.hasNext(page) ?? parsed.length == _pageLimit;
+        }
+      } else {
+        final List<int> offsets = <int>[
+          for (int offset = _pageLimit; offset < total; offset += _pageLimit)
+            offset,
+        ];
 
-      for (int i = 0; i < offsets.length; i += _maxConcurrentPages) {
-        final List<int> batch = offsets.sublist(
-          i,
-          math.min(i + _maxConcurrentPages, offsets.length),
-        );
-        final List<Map<String, dynamic>> pages = await Future.wait(
-          batch.map((int offset) => _page(animeId, offset)),
-        );
-        for (final Map<String, dynamic> page in pages) {
-          episodes.addAll(_parse(page, animeId));
+        for (int i = 0; i < offsets.length; i += _maxConcurrentPages) {
+          final List<int> batch = offsets.sublist(
+            i,
+            math.min(i + _maxConcurrentPages, offsets.length),
+          );
+          final List<Map<String, dynamic>> pages = await Future.wait(
+            batch.map((int offset) => _page(animeId, offset)),
+          );
+          for (final Map<String, dynamic> page in pages) {
+            episodes.addAll(_parse(page, animeId));
+          }
         }
       }
 

--- a/lib/core/api/kitsu/kitsu_mapping_api.dart
+++ b/lib/core/api/kitsu/kitsu_mapping_api.dart
@@ -5,12 +5,8 @@ import 'package:dio/dio.dart';
 
 import 'kitsu_http_client.dart';
 
-/// External-id lookup on Kitsu (`/mappings`, JSON:API).
-///
-/// Resolves ids of other catalogs (MyAnimeList, AniDB) to Kitsu anime.
-/// `filter[externalId]` accepts a comma list and `include=item` returns the
-/// anime records in the same response, so one request covers both the id
-/// match and the card — no follow-up fetch per title.
+/// External-id lookup on Kitsu (`/mappings`, JSON:API): `filter[externalId]`
+/// takes a comma list and `include=item` inlines the anime records.
 class KitsuMappingApi {
   KitsuMappingApi(this._client);
 
@@ -25,10 +21,8 @@ class KitsuMappingApi {
 
   final KitsuHttpClient _client;
 
-  /// Maps each resolvable external id to its Kitsu anime.
-  ///
-  /// Ids without a mapping — or with a mapping whose `item` is missing from
-  /// the response (stale records) — are simply absent from the result.
+  /// Maps each resolvable external id to its Kitsu anime. Ids without a
+  /// mapping or with a stale `item` are simply absent from the result.
   Future<Map<int, Anime>> resolveAnime({
     required String externalSite,
     required List<int> externalIds,
@@ -49,56 +43,68 @@ class KitsuMappingApi {
     List<int> batch,
   ) async {
     try {
-      final Response<dynamic> resp = await _client.get(
-        'mappings',
-        queryParameters: <String, dynamic>{
-          'filter[externalSite]': externalSite,
-          'filter[externalId]': batch.join(','),
-          'include': 'item',
-          'page[limit]': _batchLimit,
-        },
-      );
-      final Map<String, dynamic> data =
-          (resp.data as Map<String, dynamic>?) ?? <String, dynamic>{};
-
-      // Included anime records by Kitsu id.
-      final Map<String, Anime> included = <String, Anime>{};
-      for (final Map<String, dynamic> resource
-          in ((data['included'] as List<dynamic>?) ?? <dynamic>[])
-              .whereType<Map<String, dynamic>>()) {
-        if (resource['type'] != 'anime') continue;
-        final Anime? anime = _tryParse(resource);
-        final Object? id = resource['id'];
-        if (anime != null && id is String) included[id] = anime;
-      }
-
       final Map<int, Anime> out = <int, Anime>{};
-      for (final Map<String, dynamic> mapping
-          in ((data['data'] as List<dynamic>?) ?? <dynamic>[])
-              .whereType<Map<String, dynamic>>()) {
-        final Map<String, dynamic>? attrs =
-            mapping['attributes'] as Map<String, dynamic>?;
-        final int? externalId =
-            int.tryParse((attrs?['externalId'] as String?) ?? '');
-        if (externalId == null) continue;
-
-        final Object? relationships = mapping['relationships'];
-        final Object? item = relationships is Map<String, dynamic>
-            ? relationships['item']
-            : null;
-        final Object? itemData =
-            item is Map<String, dynamic> ? item['data'] : null;
-        final String? kitsuId = itemData is Map<String, dynamic>
-            ? itemData['id'] as String?
-            : null;
-
-        final Anime? anime = kitsuId != null ? included[kitsuId] : null;
-        if (anime != null) out[externalId] = anime;
+      int offset = 0;
+      // Duplicate mapping rows can push a 20-id batch past one page.
+      while (true) {
+        final Response<dynamic> resp = await _client.get(
+          'mappings',
+          queryParameters: <String, dynamic>{
+            'filter[externalSite]': externalSite,
+            'filter[externalId]': batch.join(','),
+            'include': 'item',
+            'page[limit]': _batchLimit,
+            'page[offset]': offset,
+          },
+        );
+        final Map<String, dynamic> data =
+            (resp.data as Map<String, dynamic>?) ?? <String, dynamic>{};
+        out.addAll(_parsePage(data));
+        if (!(_client.hasNext(data) ?? false)) break;
+        offset += _batchLimit;
       }
       return out;
     } on DioException catch (e) {
       throw _client.handleDioException(e, 'Failed to resolve Kitsu mappings');
     }
+  }
+
+  static Map<int, Anime> _parsePage(Map<String, dynamic> data) {
+    // Included anime records by Kitsu id.
+    final Map<String, Anime> included = <String, Anime>{};
+    for (final Map<String, dynamic> resource
+        in ((data['included'] as List<dynamic>?) ?? <dynamic>[])
+            .whereType<Map<String, dynamic>>()) {
+      if (resource['type'] != 'anime') continue;
+      final Anime? anime = _tryParse(resource);
+      final Object? id = resource['id'];
+      if (anime != null && id is String) included[id] = anime;
+    }
+
+    final Map<int, Anime> out = <int, Anime>{};
+    for (final Map<String, dynamic> mapping
+        in ((data['data'] as List<dynamic>?) ?? <dynamic>[])
+            .whereType<Map<String, dynamic>>()) {
+      final Map<String, dynamic>? attrs =
+          mapping['attributes'] as Map<String, dynamic>?;
+      final int? externalId =
+          int.tryParse((attrs?['externalId'] as String?) ?? '');
+      if (externalId == null) continue;
+
+      final Object? relationships = mapping['relationships'];
+      final Object? item = relationships is Map<String, dynamic>
+          ? relationships['item']
+          : null;
+      final Object? itemData =
+          item is Map<String, dynamic> ? item['data'] : null;
+      final String? kitsuId = itemData is Map<String, dynamic>
+          ? itemData['id'] as String?
+          : null;
+
+      final Anime? anime = kitsuId != null ? included[kitsuId] : null;
+      if (anime != null) out[externalId] = anime;
+    }
+    return out;
   }
 
   static Anime? _tryParse(Map<String, dynamic> json) {

--- a/lib/core/api/simkl/simkl_http_client.dart
+++ b/lib/core/api/simkl/simkl_http_client.dart
@@ -4,12 +4,8 @@ import '../api_dio.dart';
 import '../api_error_detail.dart';
 import 'simkl_types.dart';
 
-/// Simkl transport (`https://api.simkl.com`).
-///
-/// Every request carries the app's `simkl-api-key` (the OAuth client id);
-/// account requests additionally send the user's Bearer token obtained via
-/// the PIN flow. The token may live only in memory — persisting it is the
-/// user's opt-in choice on the import screen.
+/// Simkl transport: every request carries the `simkl-api-key` client id;
+/// account requests add the user's PIN-flow Bearer token (persisting is opt-in).
 class SimklHttpClient {
   SimklHttpClient({required String clientId, Dio? dio})
       : _clientId = clientId,
@@ -45,10 +41,8 @@ class SimklHttpClient {
 
   void clearAccessToken() => _accessToken = null;
 
-  /// GET returning a decoded JSON map.
-  ///
-  /// [authorized] adds the Bearer token; [tokenOverride] sends a specific
-  /// token instead (used while the poll loop validates a fresh one).
+  /// GET returning a decoded JSON map. [authorized] adds the Bearer token;
+  /// [tokenOverride] sends a specific one (the poll loop validating a fresh one).
   Future<Map<String, dynamic>> get(
     String path, {
     Map<String, dynamic>? queryParameters,

--- a/lib/core/api/simkl_api.dart
+++ b/lib/core/api/simkl_api.dart
@@ -7,12 +7,8 @@ import 'simkl/simkl_types.dart';
 
 export 'simkl/simkl_types.dart';
 
-/// Simkl (`api.simkl.com`) facade backing the library import.
-///
-/// Auth is the PIN flow — the only OAuth variant that works identically on
-/// Windows and Android without a redirect URI, a deep link, or a client
-/// secret in the build: [requestPin] issues a short code the user enters at
-/// simkl.com/pin while [pollPin] waits for the token.
+/// Simkl facade backing the library import. Auth is the PIN flow — the one
+/// OAuth variant needing no redirect URI, deep link, or client secret.
 class SimklApi {
   SimklApi({String? clientId, Dio? dio})
       : _client = SimklHttpClient(
@@ -48,9 +44,8 @@ class SimklApi {
     return pin;
   }
 
-  /// One poll tick (`GET /oauth/pin/{code}`). Returns the access token once
-  /// the user has confirmed the code, null while authorization is pending
-  /// (Simkl answers `result: "KO"` — and 4xx on some edges — until then).
+  /// One poll tick: the access token once the user confirmed the code, null
+  /// while pending (Simkl answers `result: "KO"`, and 4xx on some edges).
   Future<String?> pollPin(String userCode) async {
     try {
       final Map<String, dynamic> json =

--- a/lib/core/import/import_progress.dart
+++ b/lib/core/import/import_progress.dart
@@ -1,9 +1,8 @@
 /// Receives [ImportProgress] updates while an import runs.
 typedef ImportProgressCallback = void Function(ImportProgress progress);
 
-/// A snapshot of an import in flight: the current [stage], how far it has
-/// got, running tallies, and rate-limit back-off info when a source is
-/// waiting out a 429 window.
+/// A snapshot of an import in flight: [stage], progress, running tallies,
+/// and rate-limit back-off info when a source is waiting out a 429 window.
 class ImportProgress {
   const ImportProgress({
     required this.stage,

--- a/lib/core/import/import_writer.dart
+++ b/lib/core/import/import_writer.dart
@@ -6,12 +6,8 @@ import 'package:core/models/wishlist_item.dart';
 import '../../data/repositories/collection_repository.dart';
 import '../../data/repositories/wishlist_repository.dart';
 
-/// One item an adapter wants written to the target collection.
-///
-/// [insertRow] is the full column map for a fresh insert. [changedFields]
-/// returns the columns to update when the item is already present (an empty map
-/// means "leave untouched"), so each source keeps its own re-sync merge policy
-/// while the batch plumbing stays shared.
+/// One item an adapter wants written: [insertRow] for a fresh insert,
+/// [changedFields] for an existing item (empty map = leave untouched).
 class ImportCandidate {
   const ImportCandidate({
     required this.mediaType,
@@ -55,9 +51,8 @@ class WishlistCandidate {
   final String? note;
 }
 
-/// Per-type tallies for one collection write, plus the row ids the write
-/// resolved to — so an adapter can act on the written items (tags, tracker
-/// side-tables) without re-reading the whole collection.
+/// Per-type tallies for one collection write, plus the resolved row ids so an
+/// adapter can act on written items without re-reading the whole collection.
 class ImportWriteResult {
   const ImportWriteResult({
     required this.importedByType,
@@ -72,9 +67,8 @@ class ImportWriteResult {
   /// Items dropped as in-batch duplicates or as unchanged existing items.
   final int skipped;
 
-  /// `collection_items.id` for every candidate that ended up in the
-  /// collection — freshly inserted and already-present alike — keyed by
-  /// [ImportWriter.itemKey].
+  /// `collection_items.id` for every candidate that ended up in the collection,
+  /// inserted and already-present alike, keyed by [ImportWriter.itemKey].
   final Map<String, int> itemIdsByKey;
 
   /// The row id for one written item, or `null` when it was not written
@@ -90,14 +84,9 @@ class ImportWriteResult {
       ];
 }
 
-/// Shared write-side for importers: resolves the target collection,
-/// batch-writes items (new inserts plus selective updates of existing ones,
-/// de-duplicated within the batch), and batch-writes wishlist fallbacks.
-///
-/// Goes through the repositories, never the DAOs directly, so the data-access
-/// boundary stays in one place (per the app's repository-as-source-of-truth
-/// rule). Media-cache upsert is intentionally left to the adapter — it is
-/// media-type specific (movie / tv / game / anime / manga DAOs).
+/// Shared write-side for importers: target collection, batched item writes and
+/// wishlist fallbacks. Goes through repositories; media-cache upsert stays
+/// with the adapter (media-type specific).
 class ImportWriter {
   const ImportWriter({
     required CollectionRepository collections,
@@ -126,13 +115,8 @@ class ImportWriter {
     return _collections.create(name: newCollectionName, author: author);
   }
 
-  /// Writes [candidates] to [collectionId]: new items are batch-inserted,
-  /// already-present items get the fields their [ImportCandidate.changedFields]
-  /// reports (skipped when empty), and in-batch duplicates are dropped.
-  ///
-  /// The result carries the resulting row ids
-  /// ([ImportWriteResult.itemIdsByKey]) for both inserted and pre-existing
-  /// items.
+  /// Writes [candidates] to [collectionId]: inserts, [ImportCandidate.changedFields]
+  /// updates for already-present items, in-batch duplicates dropped.
   Future<ImportWriteResult> writeItems({
     required int collectionId,
     required List<ImportCandidate> candidates,

--- a/lib/core/import/sources/kinorium/kinorium_import_service.dart
+++ b/lib/core/import/sources/kinorium/kinorium_import_service.dart
@@ -139,9 +139,8 @@ class KinoriumImportService implements ImportSource {
         );
       }
 
-      // Read + parse off the UI isolate: a big CSV decoded synchronously
-      // would freeze the progress dialog. Local copies keep the closure from
-      // capturing `this` (non-sendable API/DB handles).
+      // Parse off the UI isolate (a big CSV would freeze the dialog); local
+      // copies keep the closure from capturing non-sendable `this`.
       final KinoriumCsvParser parser = _parser;
       final String filePath = options.filePath;
       final List<KinoriumEntry> entries = await Isolate.run(

--- a/lib/core/import/sources/simkl/simkl_import_service.dart
+++ b/lib/core/import/sources/simkl/simkl_import_service.dart
@@ -60,15 +60,8 @@ class SimklImportOptions extends ImportOptions {
   final String newCollectionName;
 }
 
-/// Simkl import on the shared import layer.
-///
-/// One `all-items` call brings the whole account. Movies and shows are
-/// enriched from TMDB by the `tmdb` id (the Trakt path); anime goes to Kitsu
-/// — primarily by the `kitsu` id Simkl sends in the list, with `/mappings`
-/// lookups by MAL/AniDB ids as fallback — so anime lands as a
-/// `DataSource.kitsu` item, the one source whose episode tracker supports
-/// per-episode marks. Everything that cannot be resolved goes to the text
-/// wishlist under the import tag; nothing is dropped silently.
+/// Simkl import: movies and shows enrich from TMDB, anime resolves to Kitsu
+/// (per-episode marks); anything unresolved goes to the text wishlist.
 class SimklImportService implements ImportSource {
   SimklImportService({
     required SimklApi simklApi,
@@ -333,12 +326,8 @@ class SimklImportService implements ImportSource {
   }
 
 
-  /// Fetches and caches the TMDB card for every distinct `ids.tmdb` in
-  /// [entries], recording whether it is animation. A failed title is only
-  /// missing from the result — the caller routes it to the wishlist.
-  ///
-  /// [alreadyFetched] offsets the reported progress so movies and shows share
-  /// one bar over [grandTotal].
+  /// Fetches the TMDB card per distinct `ids.tmdb`; a failed title is simply
+  /// absent and routes to the wishlist. [alreadyFetched] offsets progress.
   Future<_TmdbFetch> _fetchTmdbCards<T>({
     required List<SimklEntry> entries,
     required ImportStage stage,
@@ -388,11 +377,8 @@ class SimklImportService implements ImportSource {
     return result;
   }
 
-
-  /// Maps each anime entry index to its Kitsu card. Order of attempts:
-  /// direct `kitsu` ids from the Simkl list (batched `filter[id]`), then
-  /// `/mappings` by MAL id, then by AniDB id. Failures of any lane only
-  /// shrink the result — callers route unresolved entries to the wishlist.
+  /// Maps each anime entry index to its Kitsu card: direct `kitsu` ids, then
+  /// `/mappings` by MAL, then AniDB. Unresolved entries route to the wishlist.
   Future<Map<int, Anime>> _resolveAnime(List<SimklEntry> entries) async {
     final Map<int, Anime> resolved = <int, Anime>{};
 
@@ -668,13 +654,8 @@ class SimklImportService implements ImportSource {
     }
   }
 
-  /// TMDB shows: Simkl season/episode numbers match TMDB numbering directly.
-  ///
-  /// A `completed` entry arrives with NO `seasons` block (Simkl drops the
-  /// per-episode detail once a title is completed) — [_EpisodeMarks.fillAll]
-  /// then expands the title into marks for every episode from the TMDB
-  /// metadata, dated by the entry's `last_watched_at`. Episodes that already
-  /// carry a mark keep their own date (inserts use `ConflictAlgorithm.ignore`).
+  /// TMDB shows: Simkl numbering matches TMDB directly. `completed` entries
+  /// come without `seasons`, so [_EpisodeMarks.fillAll] marks every episode.
   Future<void> _markShowEpisodes(int collectionId, _EpisodeMarks mark) async {
     final int fallbackMs =
         mark.entry.lastWatchedAt?.millisecondsSinceEpoch ??
@@ -718,14 +699,8 @@ class SimklImportService implements ImportSource {
     );
   }
 
-  /// Kitsu anime: Simkl sends one season with absolute episode numbers, and
-  /// our synthesized Kitsu seasons keep the same absolute numbers inside —
-  /// so the only work is mapping "absolute number → synthesized season" via
-  /// the full Kitsu episode list. The Simkl season number is ignored.
-  ///
-  /// [_EpisodeMarks.fillAll] (a `completed` entry, which Simkl sends without
-  /// the `seasons` block) marks every episode of the Kitsu list, dated by the
-  /// entry's `last_watched_at`; existing marks keep their own dates.
+  /// Kitsu anime: Simkl episode numbers are absolute and map onto synthesized
+  /// Kitsu seasons via the full episode list; the Simkl season number is ignored.
   Future<void> _markAnimeEpisodes(int collectionId, _EpisodeMarks mark) async {
     final List<TvEpisode> episodes = await _retry.run(
       () => _kitsu.getAnimeEpisodes(mark.showId),

--- a/lib/features/genre_cloud/genre_cloud_layout.dart
+++ b/lib/features/genre_cloud/genre_cloud_layout.dart
@@ -1,15 +1,5 @@
-// Pure word-cloud layout: places facet words on a canvas with no overlaps.
-//
-// Kept free of Flutter widget code so it can be unit-tested with an injected
-// text measurement function. Words are placed largest-first along an
-// Archimedean spiral; if not everything fits, the size scale is shrunk and the
-// layout is retried (auto-fit). Whatever still cannot be placed is reported via
-// [hidden].
-//
-// Two entry points share the same placement code: [layoutGenreCloud] runs
-// synchronously (export views, tests) and [layoutGenreCloudAsync] yields to the
-// event loop between words so the UI thread keeps pumping frames (the loading
-// indicator keeps animating) while a large cloud is being placed.
+// Pure word-cloud layout, free of Flutter widget code so it unit-tests with an
+// injected text measurer; layoutGenreCloudAsync yields between words.
 
 import 'dart:math' as math;
 import 'dart:ui' show Offset, Rect, Size;

--- a/lib/features/search/providers/browse_provider.dart
+++ b/lib/features/search/providers/browse_provider.dart
@@ -371,6 +371,7 @@ class BrowseNotifier extends Notifier<BrowseState> {
       // The generation bump discards whatever is in flight, so its loading
       // marks have to go with it or a source shimmers forever.
       loadingSourceIds: const <String>{},
+      isLoadingMore: false,
       clearSortBy: true,
     );
 
@@ -397,6 +398,7 @@ class BrowseNotifier extends Notifier<BrowseState> {
     state = state.copyWith(
       searchQuery: '',
       loadingSourceIds: const <String>{},
+      isLoadingMore: false,
     );
 
     // Remaining filters still warrant a reload with filters only.
@@ -477,6 +479,9 @@ class BrowseNotifier extends Notifier<BrowseState> {
       loadingSourceIds: <String>{
         for (final SearchSource source in stale.keys) source.id,
       },
+      // The generation bump discards an in-flight loadMore, which can no
+      // longer reset its own flag.
+      isLoadingMore: false,
       itemsBySource: items,
       pages: pages,
       moreBySource: more,
@@ -563,11 +568,15 @@ class BrowseNotifier extends Notifier<BrowseState> {
             : (Map<String, String>.from(state.loadedSignatures)
               ..[source.id] = signature),
       );
-    } on Exception catch (e) {
+    } on Object catch (e) {
+      // A non-Exception throw (e.g. a TypeError in a source's mapping) must
+      // not escape Future.wait and leave the source shimmering forever.
       if (_generation != gen) return;
+      final ApiError error = e is Exception
+          ? extractApiError(e)
+          : (message: 'Unexpected error', detail: e.toString());
       state = state.copyWith(
-        errors: Map<String, ApiError>.from(state.errors)
-          ..[source.id] = extractApiError(e),
+        errors: Map<String, ApiError>.from(state.errors)..[source.id] = error,
         loadingSourceIds: _doneLoading(source.id),
         moreBySource: Map<String, bool>.from(state.moreBySource)
           ..[source.id] = false,

--- a/lib/features/search/widgets/discover_customize_sheet.dart
+++ b/lib/features/search/widgets/discover_customize_sheet.dart
@@ -13,7 +13,6 @@ import '../providers/discover_provider.dart';
 class DiscoverCustomizeSheet extends ConsumerWidget {
   const DiscoverCustomizeSheet({required this.mediaType, super.key});
 
-  /// Current source id: movies, tv, or anime.
   final MediaType mediaType;
 
   @override

--- a/lib/features/search/widgets/filter_sheet.dart
+++ b/lib/features/search/widgets/filter_sheet.dart
@@ -341,7 +341,7 @@ class _FilterRowState extends ConsumerState<_FilterRow>
     if (widget.filter.multiSelect && widget.value is List<Object>) {
       final List<Object> sel = widget.value! as List<Object>;
       if (sel.isEmpty) return l.all;
-      return l.platformFilterApply(sel.length);
+      return l.selectedCount(sel.length);
     }
     final List<FilterOption>? loaded = options;
     if (loaded == null) return '…';

--- a/lib/features/search/widgets/media_type_chevron.dart
+++ b/lib/features/search/widgets/media_type_chevron.dart
@@ -29,7 +29,7 @@ class MediaTypeChevron extends StatelessWidget {
   Widget build(BuildContext context) {
     final S l = S.of(context);
 
-    return DropdownChevronSegment<Object>(
+    return DropdownChevronSegment<MediaType>(
       label: mediaType.localizedPluralLabel(l),
       subtitle: l.searchWhatToFind,
       icon: Icons.category_outlined,
@@ -37,10 +37,10 @@ class MediaTypeChevron extends StatelessWidget {
       accentColor: accentColor,
       isFirst: true,
       isLast: isLast,
-      menuBuilder: (BuildContext _) => <PopupMenuEntry<Object>>[
+      menuBuilder: (BuildContext _) => <PopupMenuEntry<MediaType>>[
         for (final MediaType type in searchableMediaTypes)
-          PopupMenuItem<Object>(
-            value: type.name,
+          PopupMenuItem<MediaType>(
+            value: type,
             height: 36,
             child: Row(
               children: <Widget>[
@@ -66,14 +66,8 @@ class MediaTypeChevron extends StatelessWidget {
             ),
           ),
       ],
-      onSelected: (Object? value) {
-        if (value is! String) return;
-        for (final MediaType type in searchableMediaTypes) {
-          if (type.name == value) {
-            onChanged(type);
-            return;
-          }
-        }
+      onSelected: (MediaType? value) {
+        if (value != null) onChanged(value);
       },
     );
   }

--- a/lib/features/statistics/widgets/stats_month_detail_dialog.dart
+++ b/lib/features/statistics/widgets/stats_month_detail_dialog.dart
@@ -146,26 +146,32 @@ class _WeekBars extends StatelessWidget {
     }
     if (maxTotal == 0) return const SizedBox.shrink();
 
+    // Expanded slots: fixed bar widths overflow the dialog once the phone
+    // keyboard-squeezed width drops under 5 * (bar + gap).
     return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: <Widget>[
         for (final (int index, Map<MediaType, int> week) in weeks.indexed)
-          Padding(
-            padding: const EdgeInsets.only(right: AppSpacing.md),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                _WeekBar(
-                  week: week,
-                  maxTotal: maxTotal,
-                ),
-                const SizedBox(height: AppSpacing.xs),
-                Text(
-                  _labels[index],
-                  style: AppTypography.caption
-                      .copyWith(color: AppColors.textTertiary, fontSize: 10),
-                ),
-              ],
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.only(
+                right: index == weeks.length - 1 ? 0 : AppSpacing.md,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  _WeekBar(
+                    week: week,
+                    maxTotal: maxTotal,
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    _labels[index],
+                    style: AppTypography.caption
+                        .copyWith(color: AppColors.textTertiary, fontSize: 10),
+                  ),
+                ],
+              ),
             ),
           ),
       ],
@@ -183,35 +189,40 @@ class _WeekBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final int total = week.values.fold(0, (int sum, int c) => sum + c);
-    return SizedBox(
-      height: _WeekBars._barHeight,
-      width: 32,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: <Widget>[
-          if (total == 0)
-            Container(height: 2, color: AppColors.surfaceLight)
-          else
-            SizedBox(
-              height: total / maxTotal * _WeekBars._barHeight,
-              child: Column(
-                children: <Widget>[
-                  for (final MediaType type in MediaType.values)
-                    if ((week[type] ?? 0) > 0)
-                      Expanded(
-                        flex: week[type]!,
-                        child: Container(
-                          margin: const EdgeInsets.only(bottom: 1),
-                          decoration: BoxDecoration(
-                            color: MediaTypeTheme.colorFor(type),
-                            borderRadius: BorderRadius.circular(2),
+    // Fills its Expanded slot up to the design width, shrinking on narrow
+    // dialogs instead of overflowing.
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 32),
+      child: SizedBox(
+        height: _WeekBars._barHeight,
+        width: double.infinity,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: <Widget>[
+            if (total == 0)
+              Container(height: 2, color: AppColors.surfaceLight)
+            else
+              SizedBox(
+                height: total / maxTotal * _WeekBars._barHeight,
+                child: Column(
+                  children: <Widget>[
+                    for (final MediaType type in MediaType.values)
+                      if ((week[type] ?? 0) > 0)
+                        Expanded(
+                          flex: week[type]!,
+                          child: Container(
+                            margin: const EdgeInsets.only(bottom: 1),
+                            decoration: BoxDecoration(
+                              color: MediaTypeTheme.colorFor(type),
+                              borderRadius: BorderRadius.circular(2),
+                            ),
                           ),
                         ),
-                      ),
-                ],
+                  ],
+                ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,9 +38,8 @@ Future<void> main() async {
         databaseFactory = databaseFactoryFfi;
       }
 
-      // SharedPreferences.setPrefix должен вызываться строго до первого
-      // getInstance() и ровно один раз за процесс, иначе StateError при
-      // рестарте через AppRestartScope.
+      // setPrefix must run before the first getInstance() and exactly once
+      // per process — otherwise a restart via AppRestartScope hits StateError.
       if (!kReleaseMode) {
         SharedPreferences.setPrefix('flutter_dev.');
       }
@@ -77,17 +76,14 @@ Future<void> _loadAppState() async {
   _heroDir = await CollectionHeroService.resolveRoot();
 }
 
-/// Обёртка для перезапуска приложения на мобильных платформах.
-///
-/// Меняет [Key] у [ProviderScope], что пересоздаёт все провайдеры с нуля.
-/// На десктопе перезапуск происходит через `Process.start + exit(0)`.
+/// In-process restart for mobile: swaps the [ProviderScope]'s [Key] to rebuild
+/// every provider from scratch. Desktop restarts via `Process.start + exit(0)`.
 class AppRestartScope extends StatefulWidget {
   const AppRestartScope({required this.child, super.key});
 
-  /// Дочерний виджет (обычно [TonkatsuBoxApp]).
   final Widget child;
 
-  /// Перезапускает приложение: перечитывает профили и пересоздаёт ProviderScope.
+  /// Reloads profiles and recreates the ProviderScope.
   static Future<void> restart(BuildContext context) async {
     final _AppRestartScopeState? state =
         context.findAncestorStateOfType<_AppRestartScopeState>();

--- a/lib/shared/theme/app_colors.dart
+++ b/lib/shared/theme/app_colors.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 ///
 /// All colors are static constants for consistency across widgets.
 abstract final class AppColors {
-
   /// Main app background.
   static const Color background = Color(0xFF0A0A0A);
 

--- a/lib/shared/theme/app_spacing.dart
+++ b/lib/shared/theme/app_spacing.dart
@@ -9,7 +9,6 @@ import 'app_typography.dart';
 /// One spacing system for a consistent UI.
 /// Base step is 4px; the main values are multiples of it.
 abstract final class AppSpacing {
-
   /// 4px — minimal padding.
   static const double xs = 4;
 

--- a/lib/shared/widgets/logo_loader.dart
+++ b/lib/shared/widgets/logo_loader.dart
@@ -1,7 +1,5 @@
-// Branded loading indicator. Like any Flutter animation it is driven by the
-// UI thread — it only animates while heavy work stays off the main isolate
-// (layoutGenreCloudAsync, Isolate.run in imports). Pure widget code, so the
-// selfhost web target (dev/backlog/selfhost-web) renders it unchanged.
+// UI-thread animation: it only animates while heavy work stays off the main
+// isolate (layoutGenreCloudAsync, Isolate.run in imports).
 
 import 'dart:math' as math;
 

--- a/packages/core/lib/database/dao/collection_dao.dart
+++ b/packages/core/lib/database/dao/collection_dao.dart
@@ -1,4 +1,5 @@
-import '../query_chunk.dart';
+import 'package:sqflite_common/sqlite_api.dart';
+
 import '../../models/anime.dart';
 import '../../models/book.dart';
 import '../../models/collected_item_info.dart';
@@ -16,8 +17,7 @@ import '../../models/movie.dart';
 import '../../models/platform.dart';
 import '../../models/tv_show.dart';
 import '../../models/visual_novel.dart';
-import 'package:sqflite_common/sqlite_api.dart';
-
+import '../query_chunk.dart';
 import 'anime_dao.dart';
 import 'book_dao.dart';
 import 'custom_media_dao.dart';
@@ -603,16 +603,21 @@ class CollectionDao {
     int externalId,
     String source,
   ) async {
+    // Mirrors CollectionItem.usesEpisodeTrackerFor: only rows that can carry
+    // watch marks count (not animated movies, not non-Kitsu anime).
     final List<Map<String, dynamic>> siblings = await db.query(
       'collection_items',
       columns: <String>['id'],
       where: 'collection_id = ? AND external_id = ? '
-          "AND media_type IN ('tv_show', 'animation', 'anime') "
-          "AND COALESCE(source, 'tmdb') = ?",
+          "AND COALESCE(source, 'tmdb') = ? "
+          "AND (media_type = 'tv_show' "
+          "OR (media_type = 'animation' AND platform_id = ?) "
+          "OR (media_type = 'anime' AND source = 'kitsu'))",
       whereArgs: <Object?>[
         collectionId,
         externalId,
         source,
+        AnimationSource.tvShow,
       ],
       limit: 1,
     );

--- a/packages/core/lib/database/dao/stats_dao.dart
+++ b/packages/core/lib/database/dao/stats_dao.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
 
+import 'package:sqflite_common/sqlite_api.dart';
+
 import '../../models/item_status.dart';
 import '../../models/media_type.dart';
-import 'package:sqflite_common/sqlite_api.dart';
 
 /// SQL aggregates for the statistics page. Schema date units: `added_at` is
 /// unix seconds, `watched_at`/`liked_at` milliseconds; bucketing is local time.

--- a/packages/core/lib/database/dao/tv_show_dao.dart
+++ b/packages/core/lib/database/dao/tv_show_dao.dart
@@ -1,10 +1,11 @@
-import '../query_chunk.dart';
-import '../sparse_upsert.dart';
+import 'package:sqflite_common/sqlite_api.dart';
+
 import '../../models/data_source.dart';
 import '../../models/tv_episode.dart';
 import '../../models/tv_season.dart';
 import '../../models/tv_show.dart';
-import 'package:sqflite_common/sqlite_api.dart';
+import '../query_chunk.dart';
+import '../sparse_upsert.dart';
 
 /// Season, episode and watched rows are keyed by `(source, show id)`.
 class TvShowDao {

--- a/packages/core/lib/models/book.dart
+++ b/packages/core/lib/models/book.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 
-export 'package:core/utils/stable_id.dart' show fnv1a64;
-import 'data_source.dart';
 import '../utils/bbcode.dart';
 import '../utils/stable_id.dart';
-
 import 'book_kind.dart';
+import 'data_source.dart';
+
+export '../utils/stable_id.dart' show fnv1a64;
 
 /// Identity mirrors [Manga]: cache key is `(id, source)`. [id] holds the
 /// provider's numeric id; its native form (`OL27448W`) stays in [nativeId].

--- a/packages/core/test/database/dao/collection_dao_watched_transfer_test.dart
+++ b/packages/core/test/database/dao/collection_dao_watched_transfer_test.dart
@@ -198,6 +198,33 @@ void main() {
       expect(await watchedCount(2, 500), 1);
     });
 
+    test('should not count a sibling that cannot carry marks', () async {
+      await insertItem(
+          id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);
+      // Same external id, but an animated movie (TMDB movie namespace) and an
+      // AniList anime never use the shared tracker rows.
+      await insertItem(
+        id: 11,
+        collectionId: 1,
+        mediaType: 'animation',
+        externalId: 500,
+        platformId: AnimationSource.movie,
+      );
+      await insertItem(
+        id: 12,
+        collectionId: 1,
+        mediaType: 'anime',
+        externalId: 500,
+        source: 'anilist',
+      );
+      await insertWatched(collectionId: 1, showId: 500);
+
+      await dao.updateItemCollectionId(10, 2);
+
+      expect(await watchedCount(1, 500), 0);
+      expect(await watchedCount(2, 500), 1);
+    });
+
     test('should overwrite stale orphan marks in the target', () async {
       await insertItem(
           id: 10, collectionId: 1, mediaType: 'tv_show', externalId: 500);

--- a/test/core/api/kitsu/kitsu_episode_api_test.dart
+++ b/test/core/api/kitsu/kitsu_episode_api_test.dart
@@ -137,6 +137,40 @@ void main() {
       expect(await api.getAnimeEpisodes(1), hasLength(1));
     });
 
+    test('crawls by links.next when meta.count is absent', () async {
+      Response<dynamic> linkedPage(
+        List<Map<String, dynamic>> rows, {
+        required bool hasNext,
+      }) =>
+          Response<dynamic>(
+            data: <String, dynamic>{
+              'data': rows,
+              'links': <String, dynamic>{
+                if (hasNext) 'next': 'https://kitsu.io/api/edge/next',
+              },
+            },
+            statusCode: 200,
+            requestOptions: RequestOptions(path: ''),
+          );
+
+      stubPages(<int, Response<dynamic>>{
+        0: linkedPage(<Map<String, dynamic>>[
+          for (int i = 1; i <= 20; i++) episode(i),
+        ], hasNext: true),
+        20: linkedPage(<Map<String, dynamic>>[
+          for (int i = 21; i <= 25; i++) episode(i),
+        ], hasNext: false),
+      });
+
+      final List<TvEpisode> episodes = await api.getAnimeEpisodes(1);
+
+      expect(episodes, hasLength(25));
+      expect(
+        episodes.map((TvEpisode e) => e.episodeNumber),
+        List<int>.generate(25, (int i) => i + 1),
+      );
+    });
+
     test('wraps transport failures in KitsuApiException', () async {
       when(() => mockDio.get<dynamic>(
             any(),

--- a/test/core/api/kitsu/kitsu_mapping_api_test.dart
+++ b/test/core/api/kitsu/kitsu_mapping_api_test.dart
@@ -130,6 +130,31 @@ void main() {
           ));
     });
 
+    test('follows links.next when duplicate rows overflow one page', () async {
+      stubGet(<Response<dynamic>>[
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[mapping('11061', '6448')],
+          'included': <Map<String, dynamic>>[animeResource('6448')],
+          'links': <String, dynamic>{
+            'next': 'https://kitsu.io/api/edge/next',
+          },
+        }),
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[mapping('999', '500')],
+          'included': <Map<String, dynamic>>[animeResource('500')],
+        }),
+      ]);
+
+      final Map<int, Anime> result =
+          await api.getAnimeByMalIds(<int>[11061, 999]);
+
+      expect(result.keys, containsAll(<int>[11061, 999]));
+      final List<Map<String, dynamic>> queries = capturedQueries();
+      expect(queries, hasLength(2));
+      expect(queries[0]['page[offset]'], 0);
+      expect(queries[1]['page[offset]'], 20);
+    });
+
     test('surfaces transport failures as KitsuApiException', () async {
       when(() => mockDio.get<dynamic>(
             any(),

--- a/test/features/search/providers/browse_provider_test.dart
+++ b/test/features/search/providers/browse_provider_test.dart
@@ -493,6 +493,35 @@ void main() {
       expect(container.read(browseProvider).isLoading, isFalse);
     });
 
+    test('clearing filters resets a load-more left in flight', () async {
+      final ProviderContainer container = await containerWith(
+        <String, Object>{BrowseSettingsKeys.mediaType: 'manga'},
+      );
+      final BrowseNotifier notifier = container.read(browseProvider.notifier);
+
+      // Stand in for a page-2 request whose completion the generation bump
+      // will discard — the flag must not stay up or loadMore is blocked.
+      notifier.state = notifier.state.copyWith(isLoadingMore: true);
+      notifier.clearFilters();
+
+      expect(container.read(browseProvider).isLoadingMore, isFalse);
+    });
+
+    test('clearing the search resets a load-more left in flight', () async {
+      final ProviderContainer container = await containerWith(
+        <String, Object>{BrowseSettingsKeys.mediaType: 'manga'},
+      );
+      final BrowseNotifier notifier = container.read(browseProvider.notifier);
+
+      notifier.state = notifier.state.copyWith(
+        searchQuery: 'berserk',
+        isLoadingMore: true,
+      );
+      notifier.clearSearch();
+
+      expect(container.read(browseProvider).isLoadingMore, isFalse);
+    });
+
     test('setSort is refused when the source ignores sort on search', () async {
       final ProviderContainer container = await containerWith(
         <String, Object>{BrowseSettingsKeys.mediaType: 'movie'},

--- a/test/features/search/providers/discover_provider_test.dart
+++ b/test/features/search/providers/discover_provider_test.dart
@@ -158,7 +158,7 @@ void main() {
         expect(
           discoverSectionsPerMediaType[type],
           contains(DiscoverSectionId.trending),
-          reason: '\$type should contain trending',
+          reason: '$type should contain trending',
         );
       }
     });

--- a/test/features/statistics/widgets/stats_month_detail_dialog_test.dart
+++ b/test/features/statistics/widgets/stats_month_detail_dialog_test.dart
@@ -1,0 +1,66 @@
+import 'package:core/models/media_type.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/statistics/models/library_stats.dart';
+import 'package:tonkatsu_box/features/statistics/providers/statistics_provider.dart';
+import 'package:tonkatsu_box/features/statistics/widgets/stats_month_detail_dialog.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  const MonthDetail detail = MonthDetail(
+    year: 2026,
+    month: 7,
+    weeks: <Map<MediaType, int>>[
+      <MediaType, int>{MediaType.game: 3, MediaType.movie: 2},
+      <MediaType, int>{MediaType.tvShow: 5},
+      <MediaType, int>{MediaType.anime: 1, MediaType.manga: 4},
+      <MediaType, int>{MediaType.book: 2},
+      <MediaType, int>{MediaType.game: 1},
+    ],
+    totalAdded: 18,
+  );
+
+  Widget dialog() => const StatsMonthDetailDialog(
+        year: 2026,
+        month: 7,
+        episodesWatched: 12,
+      );
+
+  group('StatsMonthDetailDialog', () {
+    testWidgets('should render all five week bars without exceptions',
+        (WidgetTester tester) async {
+      await tester.pumpApp(
+        dialog(),
+        overrides: <Override>[
+          monthDetailProvider.overrideWith(
+            (Ref ref, (int, int) key) async => detail,
+          ),
+        ],
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('1–7'), findsOneWidget);
+      expect(find.text('29+'), findsOneWidget);
+    });
+
+    testWidgets('should not overflow on a phone-sized screen',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpApp(
+        dialog(),
+        overrides: <Override>[
+          monthDetailProvider.overrideWith(
+            (Ref ref, (int, int) key) async => detail,
+          ),
+        ],
+      );
+
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/tool/merge_lcov.py
+++ b/tool/merge_lcov.py
@@ -10,6 +10,7 @@ Usage: merge_lcov.py OUT IN [IN ...]
 """
 
 import collections
+import posixpath
 import sys
 
 
@@ -21,7 +22,12 @@ def read(path, hits):
             if line.startswith('SF:'):
                 # Normalize separators so a Windows-produced report merges with
                 # a Linux-produced one.
-                current = line[3:].replace('\\', '/')
+                current = posixpath.normpath(line[3:].replace('\\', '/'))
+                if (posixpath.isabs(current) or ':' in current[:3]
+                        or current.startswith('..')):
+                    # A path outside the repo root would silently split one
+                    # file into two records — fail loudly instead.
+                    raise SystemExit(f'{path}: non-repo-relative SF: {current}')
                 hits.setdefault(current, collections.Counter())
             elif line.startswith('DA:') and current is not None:
                 number, _, count = line[3:].partition(',')


### PR DESCRIPTION
Kitsu episode list no longer truncates to 20 when meta.count is absent (serial links.next crawl); mapping batches follow links.next so duplicate rows cannot drop ids. Browse recovers isLoadingMore when a new query supersedes an in-flight page and isolates non-Exception source failures. Watched-mark sibling check now mirrors usesEpisodeTrackerFor, so an animated movie sharing a TMDB id no longer keeps orphaned rows alive. Month drill-down week bars flex instead of overflowing narrow dialogs. Also: multi-select filter value label, typed MediaType dropdown, lcov path guard, comment-policy cleanups.