### PR TITLE
fix(collections): keep an explicit watched date and allow clearing dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **"No date" option for the started / completed dates**
+
+  An already-set date can now be erased from the date picker — for media
+  consumed long ago whose dates nobody remembers. Clearing a date never
+  touches the item's status (a film stays completed with an unknown watch
+  date), and the usual automation is intact: setting a date still syncs the
+  status, and status changes still fill the dates.
+
+  * lib/shared/widgets/dual_date_picker_dialog.dart (DualDateResult,
+    showDualDatePickerResult, DualDatePickerDialog.allowClear): New result
+    wrapper distinguishing "cleared" from "cancelled"; the "No date" action
+    shows only when the dialog is opened over an existing date. The original
+    showDualDatePicker contract is unchanged for its other callers.
+  * lib/shared/widgets/media_detail_view.dart (OnActivityDateChanged,
+    _MediaDetailViewState._pickActivityDate): The callback date is nullable —
+    null means "clear the field".
+  * lib/features/collections/screens/item_detail_screen.dart
+    (_ItemDetailScreenState._updateActivityDate): Routes a null date into the
+    clear flags.
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier.updateActivityDates),
+    lib/data/repositories/collection_repository.dart,
+    lib/core/database/database_service.dart,
+    packages/core/lib/database/dao/collection_dao.dart
+    (CollectionDao.updateItemActivityDates): New clearStartedAt /
+    clearCompletedAt flags — a plain null still means "leave unchanged";
+    clearing bypasses the date→status sync on purpose.
+  * lib/l10n/app_en.arb, app_es.arb, app_fr.arb, app_pt.arb, app_ru.arb,
+    app_zh.arb (dualDatePickerNoDate): New.
+  * test/shared/widgets/dual_date_picker_dialog_test.dart,
+    test/shared/widgets/media_detail_view_test.dart,
+    test/features/collections/providers/collections_provider_test.dart,
+    test/core/database/dao/collection_dao_test.dart,
+    packages/core/test/database/dao/collection_dao_status_dates_test.dart:
+    Clear-flow coverage — the button appears only over a set date, clearing
+    writes NULL and never calls updateItemStatus.
+
 - **Experimental web build (selfhost, phase 2)**
 
   The app now compiles and boots in the browser. Data lives in an in-browser
@@ -68,6 +105,26 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
     the flutter_launcher_icons config.
   * packages/core/test/utils/stable_id_test.dart: New. Golden vectors pin the
     id contract; io and web variants must agree.
+
+### Fixed
+
+- **Watched Date set in the past was overwritten with the current date**
+
+  Setting a Watched/Completed date on an item that was not yet completed
+  auto-promoted its status, and the completed transition stamped
+  `completed_at = now` over the just-saved user date. The UI kept showing the
+  chosen date until the list reloaded (e.g. after adding another film), which
+  made the overwrite look like it happened on add.
+
+  * lib/features/collections/providers/collections_provider.dart
+    (CollectionItemsNotifier.updateActivityDates): The status auto-update is
+    written strictly before the explicit dates, so the user's date always
+    lands last.
+  * test/features/collections/providers/collections_provider_test.dart:
+    Regression group pinning the repository write order.
+  * packages/core/test/database/dao/collection_dao_status_dates_test.dart:
+    New. Documents the DAO semantics (completed transition stamps now) that
+    make the ordering mandatory.
 
 ## [0.41.0] - 2026-08-04
 

--- a/lib/core/database/database_service.dart
+++ b/lib/core/database/database_service.dart
@@ -443,12 +443,16 @@ class DatabaseService {
     DateTime? startedAt,
     DateTime? completedAt,
     DateTime? lastActivityAt,
+    bool clearStartedAt = false,
+    bool clearCompletedAt = false,
   }) =>
       collectionDao.updateItemActivityDates(
         id,
         startedAt: startedAt,
         completedAt: completedAt,
         lastActivityAt: lastActivityAt,
+        clearStartedAt: clearStartedAt,
+        clearCompletedAt: clearCompletedAt,
       );
 
   Future<List<({int id, int? collectionId, int? platformId})>>

--- a/lib/data/repositories/collection_repository.dart
+++ b/lib/data/repositories/collection_repository.dart
@@ -288,12 +288,16 @@ class CollectionRepository {
     DateTime? startedAt,
     DateTime? completedAt,
     DateTime? lastActivityAt,
+    bool clearStartedAt = false,
+    bool clearCompletedAt = false,
   }) async {
     await _db.updateItemActivityDates(
       id,
       startedAt: startedAt,
       completedAt: completedAt,
       lastActivityAt: lastActivityAt,
+      clearStartedAt: clearStartedAt,
+      clearCompletedAt: clearCompletedAt,
     );
   }
 

--- a/lib/features/collections/providers/collections_provider.dart
+++ b/lib/features/collections/providers/collections_provider.dart
@@ -911,50 +911,56 @@ class CollectionItemsNotifier
     await _db.reorderItems(_collectionId, orderedIds);
   }
 
-  /// Auto-syncs status:
-  /// - setting [completedAt] forces `completed` from any state;
-  /// - setting [startedAt] promotes `notStarted`/`planned` to `inProgress`
-  ///   (others unchanged).
+  /// Setting a date auto-syncs status (completedAt forces `completed`,
+  /// startedAt promotes to `inProgress`); the `clear*` flags bypass that sync.
   Future<void> updateActivityDates(
     int id, {
     DateTime? startedAt,
     DateTime? completedAt,
     DateTime? lastActivityAt,
+    bool clearStartedAt = false,
+    bool clearCompletedAt = false,
   }) async {
+    final List<CollectionItem>? items = state.valueOrNull;
+    ItemStatus? newStatus;
+    MediaType? mediaType;
+
+    if (items != null && (completedAt != null || startedAt != null)) {
+      final CollectionItem? target =
+          items.where((CollectionItem i) => i.id == id).firstOrNull;
+      if (target != null) {
+        mediaType = target.mediaType;
+        newStatus = computeStatusForDates(
+          currentStatus: target.status,
+          newCompletedAt: completedAt,
+          newStartedAt: startedAt,
+        );
+      }
+    }
+
+    if (newStatus != null && mediaType != null) {
+      await _repository.updateItemStatus(id, newStatus, mediaType: mediaType);
+    }
+
+    // Strictly after the status write: the completed transition stamps
+    // completed_at = now, which must not clobber an explicit user date.
     await _repository.updateItemActivityDates(
       id,
       startedAt: startedAt,
       completedAt: completedAt,
       lastActivityAt: lastActivityAt,
+      clearStartedAt: clearStartedAt,
+      clearCompletedAt: clearCompletedAt,
     );
 
-    final List<CollectionItem>? items = state.valueOrNull;
     if (items != null) {
-      ItemStatus? newStatus;
-      MediaType? mediaType;
-
-      if (completedAt != null || startedAt != null) {
-        final CollectionItem? target =
-            items.where((CollectionItem i) => i.id == id).firstOrNull;
-        if (target != null) {
-          mediaType = target.mediaType;
-          newStatus = computeStatusForDates(
-            currentStatus: target.status,
-            newCompletedAt: completedAt,
-            newStartedAt: startedAt,
-          );
-        }
-      }
-
-      if (newStatus != null && mediaType != null) {
-        await _repository.updateItemStatus(id, newStatus, mediaType: mediaType);
-      }
-
       _patchItem(
         id,
         (CollectionItem i) => i.copyWith(
           startedAt: startedAt ?? i.startedAt,
           completedAt: completedAt ?? i.completedAt,
+          clearStartedAt: clearStartedAt,
+          clearCompletedAt: clearCompletedAt,
           lastActivityAt: lastActivityAt ?? i.lastActivityAt,
           status: newStatus ?? i.status,
           rewatchCount: computeRewatchCountForStatus(

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -679,7 +679,7 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
       lastActivityAt: item.lastActivityAt,
       completionTime: item.completionTime,
       onActivityDateChanged: widget.isEditable
-          ? (String type, DateTime date) =>
+          ? (String type, DateTime? date) =>
               _updateActivityDate(item.id, type, date)
           : null,
       tagWidget: widget.collectionId != null
@@ -1158,22 +1158,20 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
         .updateStatus(id, status, mediaType);
   }
 
-  Future<void> _updateActivityDate(int id, String type, DateTime date) async {
-    final CollectionItemsNotifier notifier =
-        ref.read(collectionItemsNotifierProvider(widget.collectionId).notifier);
-    if (type == 'started') {
-      await notifier.updateActivityDates(
-        id,
-        startedAt: date,
-        lastActivityAt: DateTime.now(),
-      );
-    } else {
-      await notifier.updateActivityDates(
-        id,
-        completedAt: date,
-        lastActivityAt: DateTime.now(),
-      );
-    }
+  /// A null [date] clears the field ("unknown date"); the status is left
+  /// untouched on purpose — only setting a date drives the status sync.
+  Future<void> _updateActivityDate(int id, String type, DateTime? date) async {
+    final bool started = type == 'started';
+    await ref
+        .read(collectionItemsNotifierProvider(widget.collectionId).notifier)
+        .updateActivityDates(
+          id,
+          startedAt: started ? date : null,
+          completedAt: started ? null : date,
+          clearStartedAt: started && date == null,
+          clearCompletedAt: !started && date == null,
+          lastActivityAt: DateTime.now(),
+        );
   }
 
   Future<void> _saveAuthorComment(int id, String? text) async {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1433,6 +1433,7 @@
   "settingsAnimeMangaTitleLanguageRomaji": "Romaji",
   "settingsAnimeMangaTitleLanguageEnglish": "English",
   "settingsAnimeMangaTitleLanguageNative": "Native",
+  "dualDatePickerNoDate": "No date",
   "dualDatePickerErrorEmpty": "Enter a date",
   "dualDatePickerErrorFormat": "Use format yyyy-MM-dd",
   "dualDatePickerErrorRange": "Date is out of range",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1413,6 +1413,7 @@
   "settingsAnimeMangaTitleLanguageRomaji": "Romaji",
   "settingsAnimeMangaTitleLanguageEnglish": "Inglés",
   "settingsAnimeMangaTitleLanguageNative": "Nativo",
+  "dualDatePickerNoDate": "Sin fecha",
   "dualDatePickerErrorEmpty": "Introduce una fecha",
   "dualDatePickerErrorFormat": "Usa el formato yyyy-MM-dd",
   "dualDatePickerErrorRange": "La fecha está fuera de rango",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1413,6 +1413,7 @@
   "settingsAnimeMangaTitleLanguageRomaji": "Romaji",
   "settingsAnimeMangaTitleLanguageEnglish": "Anglais",
   "settingsAnimeMangaTitleLanguageNative": "Original",
+  "dualDatePickerNoDate": "Sans date",
   "dualDatePickerErrorEmpty": "Entrez une date",
   "dualDatePickerErrorFormat": "Utilisez ce format : aaaa-MM-jj",
   "dualDatePickerErrorRange": "La date n'est pas valide",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5636,6 +5636,12 @@ abstract class S {
   /// **'Native'**
   String get settingsAnimeMangaTitleLanguageNative;
 
+  /// No description provided for @dualDatePickerNoDate.
+  ///
+  /// In en, this message translates to:
+  /// **'No date'**
+  String get dualDatePickerNoDate;
+
   /// No description provided for @dualDatePickerErrorEmpty.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3195,6 +3195,9 @@ class SEn extends S {
   String get settingsAnimeMangaTitleLanguageNative => 'Native';
 
   @override
+  String get dualDatePickerNoDate => 'No date';
+
+  @override
   String get dualDatePickerErrorEmpty => 'Enter a date';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3245,6 +3245,9 @@ class SEs extends S {
   String get settingsAnimeMangaTitleLanguageNative => 'Nativo';
 
   @override
+  String get dualDatePickerNoDate => 'Sin fecha';
+
+  @override
   String get dualDatePickerErrorEmpty => 'Introduce una fecha';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3251,6 +3251,9 @@ class SFr extends S {
   String get settingsAnimeMangaTitleLanguageNative => 'Original';
 
   @override
+  String get dualDatePickerNoDate => 'Sans date';
+
+  @override
   String get dualDatePickerErrorEmpty => 'Entrez une date';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3232,6 +3232,9 @@ class SPt extends S {
   String get settingsAnimeMangaTitleLanguageNative => 'Nativo';
 
   @override
+  String get dualDatePickerNoDate => 'Sem data';
+
+  @override
   String get dualDatePickerErrorEmpty => 'Digite uma data';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3261,6 +3261,9 @@ class SRu extends S {
   String get settingsAnimeMangaTitleLanguageNative => 'Native';
 
   @override
+  String get dualDatePickerNoDate => 'Без даты';
+
+  @override
   String get dualDatePickerErrorEmpty => 'Введите дату';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2994,6 +2994,9 @@ class SZh extends S {
   String get settingsAnimeMangaTitleLanguageNative => '原生语言';
 
   @override
+  String get dualDatePickerNoDate => '无日期';
+
+  @override
   String get dualDatePickerErrorEmpty => '请输入日期';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1663,6 +1663,7 @@
   "settingsAnimeMangaTitleLanguageRomaji": "Romaji",
   "settingsAnimeMangaTitleLanguageEnglish": "Inglês",
   "settingsAnimeMangaTitleLanguageNative": "Nativo",
+  "dualDatePickerNoDate": "Sem data",
   "dualDatePickerErrorEmpty": "Digite uma data",
   "dualDatePickerErrorFormat": "Use o formato yyyy-MM-dd",
   "dualDatePickerErrorRange": "Data fora do intervalo",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1137,6 +1137,7 @@
   "settingsAnimeMangaTitleLanguageRomaji": "Romaji",
   "settingsAnimeMangaTitleLanguageEnglish": "English",
   "settingsAnimeMangaTitleLanguageNative": "Native",
+  "dualDatePickerNoDate": "Без даты",
   "dualDatePickerErrorEmpty": "Введите дату",
   "dualDatePickerErrorFormat": "Формат: yyyy-MM-dd",
   "dualDatePickerErrorRange": "Дата вне диапазона",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1408,6 +1408,7 @@
   "settingsAnimeMangaTitleLanguageRomaji": "罗马字",
   "settingsAnimeMangaTitleLanguageEnglish": "英文",
   "settingsAnimeMangaTitleLanguageNative": "原生语言",
+  "dualDatePickerNoDate": "无日期",
   "dualDatePickerErrorEmpty": "请输入日期",
   "dualDatePickerErrorFormat": "请使用 yyyy-MM-dd 格式",
   "dualDatePickerErrorRange": "日期超出范围",

--- a/lib/shared/widgets/dual_date_picker_dialog.dart
+++ b/lib/shared/widgets/dual_date_picker_dialog.dart
@@ -7,20 +7,53 @@ import '../theme/app_spacing.dart';
 
 const String _isoPattern = 'yyyy-MM-dd';
 
+/// Distinguishes "clear the date" from a picked date; a dismissed dialog
+/// yields no result at all (null from the show function).
+class DualDateResult {
+  const DualDateResult.picked(DateTime this.date) : cleared = false;
+
+  const DualDateResult.cleared()
+      : date = null,
+        cleared = true;
+
+  final DateTime? date;
+  final bool cleared;
+}
+
 Future<DateTime?> showDualDatePicker({
   required BuildContext context,
   required DateTime initialDate,
   required DateTime firstDate,
   required DateTime lastDate,
   String? helpText,
+}) async {
+  final DualDateResult? result = await showDualDatePickerResult(
+    context: context,
+    initialDate: initialDate,
+    firstDate: firstDate,
+    lastDate: lastDate,
+    helpText: helpText,
+  );
+  return result?.date;
+}
+
+/// [allowClear] adds a "No date" action so an already-set date can be erased.
+Future<DualDateResult?> showDualDatePickerResult({
+  required BuildContext context,
+  required DateTime initialDate,
+  required DateTime firstDate,
+  required DateTime lastDate,
+  String? helpText,
+  bool allowClear = false,
 }) {
-  return showDialog<DateTime>(
+  return showDialog<DualDateResult>(
     context: context,
     builder: (BuildContext ctx) => DualDatePickerDialog(
       initialDate: initialDate,
       firstDate: firstDate,
       lastDate: lastDate,
       helpText: helpText,
+      allowClear: allowClear,
     ),
   );
 }
@@ -31,6 +64,7 @@ class DualDatePickerDialog extends StatefulWidget {
     required this.firstDate,
     required this.lastDate,
     this.helpText,
+    this.allowClear = false,
     super.key,
   });
 
@@ -38,6 +72,7 @@ class DualDatePickerDialog extends StatefulWidget {
   final DateTime firstDate;
   final DateTime lastDate;
   final String? helpText;
+  final bool allowClear;
 
   @override
   State<DualDatePickerDialog> createState() => _DualDatePickerDialogState();
@@ -200,8 +235,14 @@ class _DualDatePickerDialogState extends State<DualDatePickerDialog> {
               Expanded(child: body),
               const SizedBox(height: AppSpacing.sm),
               Row(
-                mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
+                  if (widget.allowClear)
+                    TextButton(
+                      onPressed: () => Navigator.of(context)
+                          .pop(const DualDateResult.cleared()),
+                      child: Text(l.dualDatePickerNoDate),
+                    ),
+                  const Spacer(),
                   TextButton(
                     onPressed: () => Navigator.of(context).pop(),
                     child: Text(l.cancel),
@@ -209,7 +250,8 @@ class _DualDatePickerDialogState extends State<DualDatePickerDialog> {
                   const SizedBox(width: AppSpacing.sm),
                   TextButton(
                     onPressed: _errorKey == null
-                        ? () => Navigator.of(context).pop(_selected)
+                        ? () => Navigator.of(context)
+                            .pop(DualDateResult.picked(_selected))
                         : null,
                     child: Text(l.confirm),
                   ),

--- a/lib/shared/widgets/media_detail_view.dart
+++ b/lib/shared/widgets/media_detail_view.dart
@@ -30,9 +30,10 @@ import 'media_detail/user_rating_section.dart';
 import 'mini_markdown_text.dart';
 export 'media_detail/media_detail_chip.dart' show MediaDetailChip;
 
-/// `type` is either 'started' or 'completed'.
+/// `type` is either 'started' or 'completed'; a null [date] clears the field
+/// ("unknown date") without touching the item's status.
 typedef OnActivityDateChanged =
-    Future<void> Function(String type, DateTime date);
+    Future<void> Function(String type, DateTime? date);
 
 /// Shared layout for game / movie / TV detail screens. Type-specific blocks
 /// are injected via [extraSections].
@@ -525,7 +526,7 @@ class _MediaDetailViewState extends ConsumerState<MediaDetailView> {
     final DateTime firstDate = DateTime(1980);
     final DateTime lastDate = DateTime.now().add(const Duration(days: 365));
 
-    final DateTime? picked = await showDualDatePicker(
+    final DualDateResult? picked = await showDualDatePickerResult(
       context: context,
       initialDate: initialDate,
       firstDate: firstDate,
@@ -533,10 +534,12 @@ class _MediaDetailViewState extends ConsumerState<MediaDetailView> {
       helpText: type == 'started'
           ? S.of(context).activityDatesSelectStart
           : S.of(context).activityDatesSelectCompletion,
+      // Nothing to clear while the field is still empty.
+      allowClear: current != null,
     );
 
     if (picked != null && context.mounted) {
-      await widget.onActivityDateChanged!(type, picked);
+      await widget.onActivityDateChanged!(type, picked.date);
     }
   }
 

--- a/packages/core/lib/database/dao/collection_dao.dart
+++ b/packages/core/lib/database/dao/collection_dao.dart
@@ -761,18 +761,26 @@ class CollectionDao {
     );
   }
 
+  /// The `clear*` flags erase a date: a plain `null` means "leave unchanged",
+  /// mirroring [CollectionItem.copyWith]. Status is deliberately not touched.
   Future<void> updateItemActivityDates(
     int id, {
     DateTime? startedAt,
     DateTime? completedAt,
     DateTime? lastActivityAt,
+    bool clearStartedAt = false,
+    bool clearCompletedAt = false,
   }) async {
     final Database db = await _getDatabase();
     final Map<String, dynamic> data = <String, dynamic>{};
-    if (startedAt != null) {
+    if (clearStartedAt) {
+      data['started_at'] = null;
+    } else if (startedAt != null) {
       data['started_at'] = startedAt.millisecondsSinceEpoch ~/ 1000;
     }
-    if (completedAt != null) {
+    if (clearCompletedAt) {
+      data['completed_at'] = null;
+    } else if (completedAt != null) {
       data['completed_at'] = completedAt.millisecondsSinceEpoch ~/ 1000;
     }
     if (lastActivityAt != null) {

--- a/packages/core/test/database/dao/collection_dao_status_dates_test.dart
+++ b/packages/core/test/database/dao/collection_dao_status_dates_test.dart
@@ -1,0 +1,165 @@
+import 'package:core/database/dao/anime_dao.dart';
+import 'package:core/database/dao/book_dao.dart';
+import 'package:core/database/dao/collection_dao.dart';
+import 'package:core/database/dao/custom_media_dao.dart';
+import 'package:core/database/dao/game_dao.dart';
+import 'package:core/database/dao/manga_dao.dart';
+import 'package:core/database/dao/movie_dao.dart';
+import 'package:core/database/dao/tv_show_dao.dart';
+import 'package:core/database/dao/visual_novel_dao.dart';
+import 'package:core/database/migrations/migration.dart';
+import 'package:core/database/migrations/migration_registry.dart';
+import 'package:core/models/item_status.dart';
+import 'package:core/models/media_type.dart';
+import 'package:test/test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late Database db;
+  late CollectionDao dao;
+
+  setUp(() async {
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(
+        version: MigrationRegistry.all.last.version,
+        onCreate: (Database d, int _) async {
+          for (final Migration m in MigrationRegistry.all) {
+            await m.migrate(d);
+          }
+        },
+        // Mirrors openAppDatabase — without it FK cascades silently no-op.
+        onConfigure: (Database d) => d.execute('PRAGMA foreign_keys = ON'),
+      ),
+    );
+    Future<Database> getDb() async => db;
+    dao = CollectionDao(
+      getDb,
+      gameDao: GameDao(getDb),
+      movieDao: MovieDao(getDb),
+      tvShowDao: TvShowDao(getDb),
+      visualNovelDao: VisualNovelDao(getDb),
+      animeDao: AnimeDao(getDb),
+      mangaDao: MangaDao(getDb),
+      bookDao: BookDao(getDb),
+      customMediaDao: CustomMediaDao(getDb),
+    );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<int> newItem({ItemStatus status = ItemStatus.notStarted}) async {
+    final int collectionId =
+        (await dao.createCollection(name: 'Films', author: 'me')).id;
+    final int? id = await dao.addItemToCollection(
+      collectionId: collectionId,
+      mediaType: MediaType.movie,
+      externalId: 100,
+      status: status,
+    );
+    return id!;
+  }
+
+  Future<Map<String, dynamic>> readItem(int id) async {
+    final List<Map<String, dynamic>> rows = await db.query(
+      'collection_items',
+      where: 'id = ?',
+      whereArgs: <Object?>[id],
+      limit: 1,
+    );
+    return rows.first;
+  }
+
+  int toDbSeconds(DateTime d) => d.millisecondsSinceEpoch ~/ 1000;
+
+  group('CollectionDao status/date writes', () {
+    group('updateItemStatus', () {
+      test('should stamp completed_at with now on the completed transition',
+          () async {
+        final int id = await newItem();
+        final int before = toDbSeconds(DateTime.now());
+
+        await dao.updateItemStatus(id, ItemStatus.completed,
+            mediaType: MediaType.movie);
+
+        final Map<String, dynamic> row = await readItem(id);
+        expect(row['completed_at'] as int, greaterThanOrEqualTo(before));
+        expect(row['started_at'], isNotNull);
+      });
+
+      test('should overwrite an existing completed_at with now', () async {
+        // The provider must therefore write explicit dates strictly after
+        // this call — the ordering the watched-date regression was about.
+        final int id = await newItem();
+        final DateTime past = DateTime(2023, 2, 14);
+        await dao.updateItemActivityDates(id, completedAt: past);
+
+        await dao.updateItemStatus(id, ItemStatus.completed,
+            mediaType: MediaType.movie);
+
+        final Map<String, dynamic> row = await readItem(id);
+        expect(row['completed_at'] as int, isNot(toDbSeconds(past)));
+      });
+    });
+
+    group('updateItemActivityDates after updateItemStatus', () {
+      test('should keep the explicit past watched date', () async {
+        final int id = await newItem();
+        final DateTime past = DateTime(2023, 2, 14);
+
+        await dao.updateItemStatus(id, ItemStatus.completed,
+            mediaType: MediaType.movie);
+        await dao.updateItemActivityDates(id, completedAt: past);
+
+        final Map<String, dynamic> row = await readItem(id);
+        expect(row['completed_at'] as int, toDbSeconds(past));
+        expect(ItemStatus.fromString(row['status'] as String),
+            ItemStatus.completed);
+      });
+    });
+
+    group('updateItemActivityDates clear flags', () {
+      test('should erase the date and leave the status untouched', () async {
+        final int id = await newItem();
+        await dao.updateItemStatus(id, ItemStatus.completed,
+            mediaType: MediaType.movie);
+
+        await dao.updateItemActivityDates(
+          id,
+          clearStartedAt: true,
+          clearCompletedAt: true,
+        );
+
+        final Map<String, dynamic> row = await readItem(id);
+        expect(row['started_at'], isNull);
+        expect(row['completed_at'], isNull);
+        expect(ItemStatus.fromString(row['status'] as String),
+            ItemStatus.completed);
+      });
+
+      test('should clear one date while updating the other', () async {
+        final int id = await newItem();
+        final DateTime past = DateTime(2023, 2, 14);
+        await dao.updateItemStatus(id, ItemStatus.completed,
+            mediaType: MediaType.movie);
+
+        await dao.updateItemActivityDates(
+          id,
+          completedAt: past,
+          clearStartedAt: true,
+        );
+
+        final Map<String, dynamic> row = await readItem(id);
+        expect(row['started_at'], isNull);
+        expect(row['completed_at'] as int, toDbSeconds(past));
+      });
+    });
+  });
+}

--- a/test/core/database/dao/collection_dao_test.dart
+++ b/test/core/database/dao/collection_dao_test.dart
@@ -1256,6 +1256,61 @@ void main() {
           ),
         );
       });
+
+      test('writes explicit NULLs when the clear flags are set', () async {
+        when(
+          () => mockDb.update(
+            'collection_items',
+            any(),
+            where: 'id = ?',
+            whereArgs: <Object?>[1],
+          ),
+        ).thenAnswer((_) async => 1);
+
+        await dao.updateItemActivityDates(
+          1,
+          clearStartedAt: true,
+          clearCompletedAt: true,
+        );
+
+        verify(
+          () => mockDb.update(
+            'collection_items',
+            <String, dynamic>{
+              'started_at': null,
+              'completed_at': null,
+            },
+            where: 'id = ?',
+            whereArgs: <Object?>[1],
+          ),
+        ).called(1);
+      });
+
+      test('clear flag wins over a supplied date for the same field', () async {
+        when(
+          () => mockDb.update(
+            'collection_items',
+            any(),
+            where: 'id = ?',
+            whereArgs: <Object?>[1],
+          ),
+        ).thenAnswer((_) async => 1);
+
+        await dao.updateItemActivityDates(
+          1,
+          completedAt: DateTime(2024, 6, 15),
+          clearCompletedAt: true,
+        );
+
+        verify(
+          () => mockDb.update(
+            'collection_items',
+            <String, dynamic>{'completed_at': null},
+            where: 'id = ?',
+            whereArgs: <Object?>[1],
+          ),
+        ).called(1);
+      });
     });
 
     group('updateItemProgress', () {

--- a/test/features/collections/providers/collections_provider_book_auto_status_test.dart
+++ b/test/features/collections/providers/collections_provider_book_auto_status_test.dart
@@ -61,6 +61,8 @@ void main() {
           startedAt: any(named: 'startedAt'),
           completedAt: any(named: 'completedAt'),
           lastActivityAt: any(named: 'lastActivityAt'),
+          clearStartedAt: any(named: 'clearStartedAt'),
+          clearCompletedAt: any(named: 'clearCompletedAt'),
         )).thenAnswer((_) async {});
   });
 

--- a/test/features/collections/providers/collections_provider_custom_auto_status_test.dart
+++ b/test/features/collections/providers/collections_provider_custom_auto_status_test.dart
@@ -72,6 +72,8 @@ void main() {
           startedAt: any(named: 'startedAt'),
           completedAt: any(named: 'completedAt'),
           lastActivityAt: any(named: 'lastActivityAt'),
+          clearStartedAt: any(named: 'clearStartedAt'),
+          clearCompletedAt: any(named: 'clearCompletedAt'),
         )).thenAnswer((_) async {});
   });
 

--- a/test/features/collections/providers/collections_provider_item_fields_test.dart
+++ b/test/features/collections/providers/collections_provider_item_fields_test.dart
@@ -39,6 +39,8 @@ void main() {
           startedAt: any(named: 'startedAt'),
           completedAt: any(named: 'completedAt'),
           lastActivityAt: any(named: 'lastActivityAt'),
+          clearStartedAt: any(named: 'clearStartedAt'),
+          clearCompletedAt: any(named: 'clearCompletedAt'),
         )).thenAnswer((_) async {});
     // setFavorite syncs the All Items notifier, which loads via this method.
     when(() => repo.getAllItemsWithData())

--- a/test/features/collections/providers/collections_provider_manga_auto_status_test.dart
+++ b/test/features/collections/providers/collections_provider_manga_auto_status_test.dart
@@ -67,6 +67,8 @@ void main() {
           startedAt: any(named: 'startedAt'),
           completedAt: any(named: 'completedAt'),
           lastActivityAt: any(named: 'lastActivityAt'),
+          clearStartedAt: any(named: 'clearStartedAt'),
+          clearCompletedAt: any(named: 'clearCompletedAt'),
         )).thenAnswer((_) async {});
   });
 

--- a/test/features/collections/providers/collections_provider_test.dart
+++ b/test/features/collections/providers/collections_provider_test.dart
@@ -78,6 +78,8 @@ void main() {
           startedAt: any(named: 'startedAt'),
           completedAt: any(named: 'completedAt'),
           lastActivityAt: any(named: 'lastActivityAt'),
+          clearStartedAt: any(named: 'clearStartedAt'),
+          clearCompletedAt: any(named: 'clearCompletedAt'),
         )).thenAnswer((_) async {});
 
     when(() => mockRepository.updateItemStatus(
@@ -312,6 +314,197 @@ void main() {
         expect(items, isNotNull);
         expect(items!.first.completedAt, completeDate);
         expect(items.first.status, ItemStatus.completed);
+      });
+    });
+
+    // Regression: the DAO stamps completed_at = now on the completed
+    // transition, so the explicit user date must be written strictly after it.
+    group('порядок записи в репозиторий', () {
+      test('should write the explicit watched date after the status auto-update', () async {
+        final CollectionItem item = _makeItem(
+          mediaType: MediaType.movie,
+          status: ItemStatus.notStarted,
+        );
+        final ProviderContainer container = createContainer(initialItems: <CollectionItem>[item]);
+        await waitForLoad(container, testCollectionId);
+
+        final CollectionItemsNotifier notifier =
+            container.read(collectionItemsNotifierProvider(testCollectionId).notifier);
+        final DateTime pastDate = DateTime(2023, 2, 14);
+
+        await notifier.updateActivityDates(1, completedAt: pastDate, lastActivityAt: DateTime.now());
+
+        verifyInOrder(<void Function()>[
+          () => mockRepository.updateItemStatus(
+                1,
+                ItemStatus.completed,
+                mediaType: MediaType.movie,
+              ),
+          () => mockRepository.updateItemActivityDates(
+                1,
+                startedAt: null,
+                completedAt: pastDate,
+                lastActivityAt: any(named: 'lastActivityAt'),
+              ),
+        ]);
+      });
+
+      test('should write the date without a status update when already completed', () async {
+        final CollectionItem item = _makeItem(
+          mediaType: MediaType.movie,
+          status: ItemStatus.completed,
+          startedAt: DateTime(2024, 1, 1),
+          completedAt: DateTime(2024, 5, 1),
+        );
+        final ProviderContainer container = createContainer(initialItems: <CollectionItem>[item]);
+        await waitForLoad(container, testCollectionId);
+
+        final CollectionItemsNotifier notifier =
+            container.read(collectionItemsNotifierProvider(testCollectionId).notifier);
+        final DateTime pastDate = DateTime(2023, 2, 14);
+
+        await notifier.updateActivityDates(1, completedAt: pastDate, lastActivityAt: DateTime.now());
+
+        verifyNever(() => mockRepository.updateItemStatus(
+              any(),
+              any(),
+              mediaType: any(named: 'mediaType'),
+            ));
+        verify(() => mockRepository.updateItemActivityDates(
+              1,
+              startedAt: null,
+              completedAt: pastDate,
+              lastActivityAt: any(named: 'lastActivityAt'),
+            )).called(1);
+      });
+
+      test('should write dates even when the items state is not loaded', () async {
+        when(() => mockRepository.getItemsWithData(testCollectionId))
+            .thenAnswer((_) async => <CollectionItem>[]);
+        final ProviderContainer container = ProviderContainer(
+          overrides: <Override>[
+            collectionRepositoryProvider.overrideWithValue(mockRepository),
+            sharedPreferencesProvider.overrideWithValue(sharedPrefs),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final CollectionItemsNotifier notifier =
+            container.read(collectionItemsNotifierProvider(testCollectionId).notifier);
+        final DateTime pastDate = DateTime(2023, 2, 14);
+
+        // No waitForLoad: state is still AsyncLoading at this point.
+        await notifier.updateActivityDates(1, completedAt: pastDate, lastActivityAt: DateTime.now());
+
+        verify(() => mockRepository.updateItemActivityDates(
+              1,
+              startedAt: null,
+              completedAt: pastDate,
+              lastActivityAt: any(named: 'lastActivityAt'),
+            )).called(1);
+        verifyNever(() => mockRepository.updateItemStatus(
+              any(),
+              any(),
+              mediaType: any(named: 'mediaType'),
+            ));
+      });
+    });
+
+    // Clearing a date ("unknown date") must bypass the status sync entirely:
+    // the status stays, only the date column goes to NULL.
+    group('очистка дат', () {
+      test('should clear completedAt without touching the status', () async {
+        final CollectionItem item = _makeItem(
+          mediaType: MediaType.movie,
+          status: ItemStatus.completed,
+          startedAt: DateTime(2024, 1, 1),
+          completedAt: DateTime(2024, 5, 1),
+        );
+        final ProviderContainer container = createContainer(initialItems: <CollectionItem>[item]);
+        await waitForLoad(container, testCollectionId);
+
+        final CollectionItemsNotifier notifier =
+            container.read(collectionItemsNotifierProvider(testCollectionId).notifier);
+
+        await notifier.updateActivityDates(
+          1,
+          clearCompletedAt: true,
+          lastActivityAt: DateTime.now(),
+        );
+
+        verifyNever(() => mockRepository.updateItemStatus(
+              any(),
+              any(),
+              mediaType: any(named: 'mediaType'),
+            ));
+        verify(() => mockRepository.updateItemActivityDates(
+              1,
+              startedAt: null,
+              completedAt: null,
+              lastActivityAt: any(named: 'lastActivityAt'),
+              clearStartedAt: false,
+              clearCompletedAt: true,
+            )).called(1);
+
+        final List<CollectionItem>? items =
+            container.read(collectionItemsNotifierProvider(testCollectionId)).valueOrNull;
+        expect(items, isNotNull);
+        expect(items!.first.completedAt, isNull);
+        expect(items.first.startedAt, DateTime(2024, 1, 1));
+        expect(items.first.status, ItemStatus.completed);
+      });
+
+      test('should clear startedAt without touching the status', () async {
+        final CollectionItem item = _makeItem(
+          status: ItemStatus.inProgress,
+          startedAt: DateTime(2024, 1, 1),
+        );
+        final ProviderContainer container = createContainer(initialItems: <CollectionItem>[item]);
+        await waitForLoad(container, testCollectionId);
+
+        final CollectionItemsNotifier notifier =
+            container.read(collectionItemsNotifierProvider(testCollectionId).notifier);
+
+        await notifier.updateActivityDates(
+          1,
+          clearStartedAt: true,
+          lastActivityAt: DateTime.now(),
+        );
+
+        verifyNever(() => mockRepository.updateItemStatus(
+              any(),
+              any(),
+              mediaType: any(named: 'mediaType'),
+            ));
+
+        final List<CollectionItem>? items =
+            container.read(collectionItemsNotifierProvider(testCollectionId)).valueOrNull;
+        expect(items, isNotNull);
+        expect(items!.first.startedAt, isNull);
+        expect(items.first.status, ItemStatus.inProgress);
+      });
+
+      test('should keep rewatchCount when a date is cleared', () async {
+        final CollectionItem item = _makeItem(
+          mediaType: MediaType.movie,
+          status: ItemStatus.completed,
+          completedAt: DateTime(2024, 5, 1),
+        ).copyWith(rewatchCount: 2);
+        final ProviderContainer container = createContainer(initialItems: <CollectionItem>[item]);
+        await waitForLoad(container, testCollectionId);
+
+        final CollectionItemsNotifier notifier =
+            container.read(collectionItemsNotifierProvider(testCollectionId).notifier);
+
+        await notifier.updateActivityDates(
+          1,
+          clearCompletedAt: true,
+          lastActivityAt: DateTime.now(),
+        );
+
+        final List<CollectionItem>? items =
+            container.read(collectionItemsNotifierProvider(testCollectionId)).valueOrNull;
+        expect(items!.first.rewatchCount, 2);
       });
     });
 

--- a/test/shared/widgets/dual_date_picker_dialog_test.dart
+++ b/test/shared/widgets/dual_date_picker_dialog_test.dart
@@ -95,6 +95,77 @@ void main() {
       await t.pump();
       expect(okEnabled(t), isTrue);
     });
+
+    group('allowClear', () {
+      Future<DualDateResult?> openResultAndGet(
+        WidgetTester tester, {
+        required bool allowClear,
+        required Future<void> Function(WidgetTester tester) interact,
+      }) async {
+        DualDateResult? result;
+        bool done = false;
+        await tester.pumpApp(
+          Builder(
+            builder: (BuildContext context) => ElevatedButton(
+              onPressed: () async {
+                result = await showDualDatePickerResult(
+                  context: context,
+                  initialDate: initial,
+                  firstDate: first,
+                  lastDate: last,
+                  allowClear: allowClear,
+                );
+                done = true;
+              },
+              child: const Text('open'),
+            ),
+          ),
+          wrapInScaffold: true,
+        );
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+        await interact(tester);
+        await tester.pumpAndSettle();
+        expect(done, isTrue, reason: 'dialog should have been dismissed');
+        return result;
+      }
+
+      testWidgets('hides the clear action by default', (WidgetTester t) async {
+        await _open(t, initial, first, last);
+        expect(find.text('No date'), findsNothing);
+      });
+
+      testWidgets('clear action returns a cleared result', (WidgetTester t) async {
+        final DualDateResult? r = await openResultAndGet(
+          t,
+          allowClear: true,
+          interact: (WidgetTester t) async => t.tap(find.text('No date')),
+        );
+        expect(r, isNotNull);
+        expect(r!.cleared, isTrue);
+        expect(r.date, isNull);
+      });
+
+      testWidgets('confirm still returns the picked date', (WidgetTester t) async {
+        final DualDateResult? r = await openResultAndGet(
+          t,
+          allowClear: true,
+          interact: (WidgetTester t) async => t.tap(find.text('OK')),
+        );
+        expect(r, isNotNull);
+        expect(r!.cleared, isFalse);
+        expect(r.date, DateTime(2024, 3, 15));
+      });
+
+      testWidgets('cancel returns null result', (WidgetTester t) async {
+        final DualDateResult? r = await openResultAndGet(
+          t,
+          allowClear: true,
+          interact: (WidgetTester t) async => t.tap(find.text('Cancel')),
+        );
+        expect(r, isNull);
+      });
+    });
   });
 }
 

--- a/test/shared/widgets/media_detail_view_test.dart
+++ b/test/shared/widgets/media_detail_view_test.dart
@@ -674,7 +674,7 @@ void main() {
           (WidgetTester tester) async {
         await tester.pumpWidget(buildTestWidget(
           addedAt: DateTime(2025, 1, 15),
-          onActivityDateChanged: (String type, DateTime date) async {},
+          onActivityDateChanged: (String type, DateTime? date) async {},
         ));
         await tester.pumpAndSettle();
 
@@ -695,12 +695,50 @@ void main() {
           (WidgetTester tester) async {
         await tester.pumpWidget(buildTestWidget(
           addedAt: DateTime(2025, 1, 15),
-          onActivityDateChanged: (String type, DateTime date) async {},
+          onActivityDateChanged: (String type, DateTime? date) async {},
         ));
         await tester.pumpAndSettle();
 
         final Finder inkWells = find.byType(InkWell);
         expect(inkWells, findsAtLeast(2));
+      });
+
+      testWidgets(
+          'should pass null to the callback when the set date is cleared',
+          (WidgetTester tester) async {
+        String? clearedType;
+        DateTime? clearedDate = DateTime(2099);
+        await tester.pumpWidget(buildTestWidget(
+          addedAt: DateTime(2025, 1, 15),
+          completedAt: DateTime(2025, 2, 1),
+          onActivityDateChanged: (String type, DateTime? date) async {
+            clearedType = type;
+            clearedDate = date;
+          },
+        ));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Completed'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('No date'));
+        await tester.pumpAndSettle();
+
+        expect(clearedType, 'completed');
+        expect(clearedDate, isNull);
+      });
+
+      testWidgets('should not offer clearing while the date is unset',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(buildTestWidget(
+          addedAt: DateTime(2025, 1, 15),
+          onActivityDateChanged: (String type, DateTime? date) async {},
+        ));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Completed'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('No date'), findsNothing);
       });
 
       testWidgets('should display completion time when set',


### PR DESCRIPTION
Two changes to the started/completed dates on the item detail screen:

- Setting a past watched date on a not-yet-completed item no longer gets overwritten by the auto-status transition: the status write now lands strictly before the explicit dates.
- The date picker gains a "No date" action for an already-set date. Clearing goes through new clearStartedAt/clearCompletedAt flags down to the DAO and deliberately bypasses the date-to-status sync: the status, the other date and the rewatch count stay untouched.