### PR TITLE
feat(recommendations): anime and manga similars + personalization domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,75 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Added
 
+- **Anime and manga recommendations — in the item card and on the Personalization tab**
+
+  An anime's detail page now shows a "Similar" carousel: AniList's community
+  recommendations rendered as Kitsu titles, so an added pick keeps seasons and
+  the episode tracker. The manga "Similar" carousel, previously limited to
+  MangaBaka and MangaDex entries, now also works for manga added from AniList
+  and Kitsu. The Personalization → Recommendations tab learns two new taste
+  domains next to movies/TV: anime (from completed AniList titles) and manga
+  (per source — MangaBaka, MangaDex, AniList), each with its own "because you
+  liked" rows. All new sources are keyless — no API key required.
+
+  * lib/core/api/anilist/anilist_queries.dart
+    (AniListQueries.recommendationsBatch, AniListQueries.recommendationAlias):
+    New Media.recommendations query, rating-sorted, capped at AniList's nested
+    perPage of 25; one aliased block per seed so a whole seed set costs a
+    single request against the 30/min rate limit.
+  * lib/core/api/anilist/anilist_media_parser.dart
+    (AniListMediaParser.recommendedAnimeBatch,
+    AniListMediaParser.recommendedMangaBatch): Map recommendation nodes per
+    seed, dropping deleted media and cross-type entries.
+  * lib/core/api/anilist/anilist_media_api.dart, lib/core/api/anilist_api.dart
+    (AniListApi.getAnimeRecommendations, AniListApi.getMangaRecommendations,
+    AniListApi.getAnimeRecommendationsBatch,
+    AniListApi.getMangaRecommendationsBatch): New; retried on a 429.
+  * lib/core/api/kitsu/kitsu_mapping_api.dart (KitsuMappingApi.getAniListId,
+    KitsuMappingApi.siteAniListAnime, KitsuMappingApi.siteAniListManga),
+    lib/core/api/kitsu_api.dart (KitsuApi.getAniListAnimeId,
+    KitsuApi.getAniListMangaId, KitsuApi.getAnimeByAniListIds): Kitsu↔AniList
+    id bridges over the mappings endpoints, both directions.
+  * lib/features/collections/widgets/anime_similars_section.dart
+    (AnimeSimilarsSection): New. AniList seed queried directly, Kitsu seed
+    bridged first; candidates resolved back to Kitsu entities, unmapped ones
+    dropped.
+  * lib/features/collections/widgets/manga_similars_section.dart
+    (mangaSimilarsSources, MangaSimilarsSection): AniList and Kitsu seed
+    routing; owned badge matches the candidates' source.
+  * lib/features/collections/widgets/similars_poster_row.dart
+    (SimilarsPosterRow, SimilarsPosterRowShimmer, SimilarCardData): New shared
+    carousel replacing the per-section row/shimmer copies.
+  * lib/features/collections/screens/item_detail_screen.dart
+    (_ItemDetailScreenState._addAnimeFromSimilars): New add-to-collection
+    handler; anime/manga similars gating.
+  * lib/features/recommendations/anime_taste_input.dart (animeTasteId,
+    tasteTitleFromAnimeItem, tasteTitleFromAnime, ownedAnimeTasteIds),
+    lib/features/recommendations/manga_taste_input.dart (mangaTasteId,
+    mangaTasteSources, tasteTitleFromMangaItem, tasteTitleFromManga,
+    ownedMangaTasteIds), lib/features/recommendations/taste_features.dart
+    (buildNameFeatureTitle): New engine adapters; genres+tags matched by
+    source-native names, vocabularies never mixed across sources.
+  * lib/features/recommendations/providers/recommendations_provider.dart
+    (recommendationsProvider, RecommendedItem, RecommendationStatus,
+    collectedRecommendationIdsProvider): Split into independent concurrent
+    domains (movie/TV, anime, manga); a domain with nothing to say contributes
+    no rows; the TMDB key gates only the movie/TV domain. RecommendedItem
+    carries source + externalId instead of a TMDB-only id.
+  * lib/features/recommendations/widgets/recommendation_row.dart
+    (RecommendationRowWidget): Poster cache type/id, placeholder icon and
+    source badge follow the item's media type and source.
+  * test/core/api/anilist/anilist_media_parser_test.dart,
+    test/core/api/anilist_api_test.dart,
+    test/core/api/kitsu/kitsu_mapping_api_test.dart,
+    test/features/collections/widgets/anime_similars_section_test.dart,
+    test/features/collections/widgets/manga_similars_section_test.dart,
+    test/features/recommendations/anime_taste_input_test.dart,
+    test/features/recommendations/manga_taste_input_test.dart,
+    test/features/recommendations/providers/recommendations_provider_test.dart:
+    New coverage — batch parser mapping, bridges, per-source routing, owned
+    matching, adapters, multi-domain partial results and status precedence.
+
 - **"No date" option for the started / completed dates**
 
   An already-set date can now be erased from the date picker — for media

--- a/lib/core/api/anilist/anilist_media_api.dart
+++ b/lib/core/api/anilist/anilist_media_api.dart
@@ -120,6 +120,63 @@ class AniListMediaApi {
     return Anime.fromJson(media);
   }
 
+  // AniList caps a nested connection's perPage at 25 (50 elsewhere).
+  static const int _recommendationsPerPage = 25;
+
+  Future<List<Anime>> getAnimeRecommendations(int id) async =>
+      (await getAnimeRecommendationsBatch(<int>[id]))[id] ?? const <Anime>[];
+
+  Future<List<Manga>> getMangaRecommendations(int id) async =>
+      (await getMangaRecommendationsBatch(<int>[id]))[id] ?? const <Manga>[];
+
+  /// Recommendations for every seed in one aliased request (see
+  /// [AniListQueries.recommendationsBatch]), retried on a 429.
+  Future<Map<int, List<Anime>>> getAnimeRecommendationsBatch(
+    List<int> ids,
+  ) async {
+    if (ids.isEmpty) return const <int, List<Anime>>{};
+    final Map<String, dynamic>? data = await _postRecommendationsBatch(
+      ids: ids,
+      anime: true,
+      errorContext: 'Failed to fetch anime recommendations',
+    );
+    return AniListMediaParser.recommendedAnimeBatch(data, ids);
+  }
+
+  Future<Map<int, List<Manga>>> getMangaRecommendationsBatch(
+    List<int> ids,
+  ) async {
+    if (ids.isEmpty) return const <int, List<Manga>>{};
+    final Map<String, dynamic>? data = await _postRecommendationsBatch(
+      ids: ids,
+      anime: false,
+      errorContext: 'Failed to fetch manga recommendations',
+    );
+    return AniListMediaParser.recommendedMangaBatch(data, ids);
+  }
+
+  Future<Map<String, dynamic>?> _postRecommendationsBatch({
+    required List<int> ids,
+    required bool anime,
+    required String errorContext,
+  }) async {
+    final String query =
+        AniListQueries.recommendationsBatch(ids: ids, anime: anime);
+    for (int attempt = 1; ; attempt++) {
+      try {
+        final Map<String, dynamic> body = await _client.post(
+          query: query,
+          variables: <String, dynamic>{'perPage': _recommendationsPerPage},
+          errorContext: errorContext,
+        );
+        return _client.unwrapData(body);
+      } on AniListRateLimitException catch (e) {
+        if (attempt >= _maxRateLimitRetries) rethrow;
+        await Future<void>.delayed(e.retryAfter);
+      }
+    }
+  }
+
   /// Maximum retries per batch on a 429 before that batch is skipped.
   static const int _maxRateLimitRetries = 3;
 
@@ -135,10 +192,8 @@ class AniListMediaApi {
   }) =>
       _fetchByIdsResilient<Anime>(ids, _fetchAnimeBatch, onRateLimit);
 
-  /// Fetches in batches, retrying each batch on a 429 and tolerating failures:
-  /// a batch that keeps rate-limiting or hard-errors is skipped, keeping the
-  /// partial result instead of discarding everything. This is what lets a
-  /// large import cache as much as it can (mirrors the tolerant MAL lookup).
+  /// Batched fetch that retries a batch on a 429 and skips it on repeated
+  /// failure — a large import keeps its partial result instead of nothing.
   Future<List<T>> _fetchByIdsResilient<T>(
     List<int> ids,
     Future<List<T>> Function(List<int>) fetchBatch,

--- a/lib/core/api/anilist/anilist_media_parser.dart
+++ b/lib/core/api/anilist/anilist_media_parser.dart
@@ -1,6 +1,8 @@
 import 'package:core/models/anime.dart';
 import 'package:core/models/manga.dart';
 
+import 'anilist_queries.dart';
+
 class AniListMediaParser {
   const AniListMediaParser._();
 
@@ -32,6 +34,69 @@ class AniListMediaParser {
         .map((Map<String, dynamic> json) => Manga.fromJson(json))
         .toList();
     return (items, info.$1, info.$2);
+  }
+
+  // AniList's own GraphQL MediaType tokens as returned in `type` — not our
+  // MediaType enum (external-API namespace, translation boundary).
+  static const String _aniListTypeAnime = 'ANIME';
+  static const String _aniListTypeManga = 'MANGA';
+
+  /// Recommendations per seed from an aliased batch response; a seed whose
+  /// `Media` came back null (deleted) maps to an empty list.
+  static Map<int, List<Anime>> recommendedAnimeBatch(
+    Map<String, dynamic>? data,
+    List<int> seedIds,
+  ) =>
+      _recommendationBatch(
+        data,
+        seedIds,
+        _aniListTypeAnime,
+        (Map<String, dynamic> json) => Anime.fromJson(json),
+      );
+
+  static Map<int, List<Manga>> recommendedMangaBatch(
+    Map<String, dynamic>? data,
+    List<int> seedIds,
+  ) =>
+      _recommendationBatch(
+        data,
+        seedIds,
+        _aniListTypeManga,
+        (Map<String, dynamic> json) => Manga.fromJson(json),
+      );
+
+  static Map<int, List<T>> _recommendationBatch<T>(
+    Map<String, dynamic>? data,
+    List<int> seedIds,
+    String type,
+    T Function(Map<String, dynamic>) fromJson,
+  ) {
+    final Map<int, List<T>> out = <int, List<T>>{};
+    for (int i = 0; i < seedIds.length; i++) {
+      final Map<String, dynamic>? media =
+          data?[AniListQueries.recommendationAlias(i)] as Map<String, dynamic>?;
+      out[seedIds[i]] =
+          _recommendationMedia(media, type).map(fromJson).toList();
+    }
+    return out;
+  }
+
+  /// Recommendation nodes can point at deleted media (null) or cross media
+  /// types — both are dropped, keeping the server's rating order.
+  static List<Map<String, dynamic>> _recommendationMedia(
+    Map<String, dynamic>? media,
+    String type,
+  ) {
+    final Map<String, dynamic>? recommendations =
+        media?['recommendations'] as Map<String, dynamic>?;
+    final List<dynamic> nodes =
+        recommendations?['nodes'] as List<dynamic>? ?? <dynamic>[];
+    return <Map<String, dynamic>>[
+      for (final dynamic node in nodes)
+        if ((node as Map<String, dynamic>?)?['mediaRecommendation']
+            case final Map<String, dynamic> rec when rec['type'] == type)
+          rec,
+    ];
   }
 
   // AniList fuzzy dates: year is mandatory, month/day may be null/0.

--- a/lib/core/api/anilist/anilist_queries.dart
+++ b/lib/core/api/anilist/anilist_queries.dart
@@ -265,6 +265,76 @@ query ($page: Int, $perPage: Int, $ids: [Int]) {
 }
 ''';
 
+  // `mediaRecommendation.type` is selected because recommendations can cross
+  // media types (a manga recommended for an anime) — the parser filters on it.
+  static const String _animeRecommendationFields = '''
+type
+id
+title { romaji english native }
+coverImage { extraLarge large medium }
+bannerImage
+description(asHtml: false)
+genres
+tags { name }
+averageScore
+status
+startDate { year month day }
+episodes
+duration
+format
+source
+studios(isMain: true) { nodes { name } }
+nextAiringEpisode { episode }
+''';
+
+  static const String _mangaRecommendationFields = '''
+type
+id
+title { romaji english native }
+coverImage { extraLarge large medium }
+bannerImage
+description(asHtml: false)
+genres
+tags { name }
+averageScore
+status
+startDate { year month day }
+chapters
+volumes
+format
+staff(sort: RELEVANCE, perPage: 5) {
+  edges {
+    node { name { full } }
+    role
+  }
+}
+''';
+
+  /// One aliased `Media` block per seed — a whole seed set costs one request
+  /// against the 30/min limit. Ids are inlined (internal ints, never user text).
+  static String recommendationsBatch({
+    required List<int> ids,
+    required bool anime,
+  }) {
+    final String type = anime ? 'ANIME' : 'MANGA';
+    final String fields =
+        anime ? _animeRecommendationFields : _mangaRecommendationFields;
+    final StringBuffer buf = StringBuffer('query (\$perPage: Int) {\n');
+    for (int i = 0; i < ids.length; i++) {
+      buf
+        ..write('${recommendationAlias(i)}: Media(id: ${ids[i]}, type: $type) ')
+        ..write('{ recommendations(sort: RATING_DESC, perPage: \$perPage) ')
+        ..write('{ nodes { mediaRecommendation {\n')
+        ..write(fields)
+        ..write('} } } }\n');
+    }
+    buf.write('}');
+    return buf.toString();
+  }
+
+  /// Alias of the [i]-th seed's block in a [recommendationsBatch] response.
+  static String recommendationAlias(int i) => 's$i';
+
   // MediaListCollection returns every list (Watching/Completed/…) for a user
   // in a single response — no pagination at this level.
   static const String userAnimeList = r'''

--- a/lib/core/api/anilist_api.dart
+++ b/lib/core/api/anilist_api.dart
@@ -98,6 +98,21 @@ class AniListApi {
 
   Future<Anime?> getAnimeById(int id) => _media.getAnimeById(id);
 
+  /// Titles similar to [id] via `Media.recommendations`, rating-sorted,
+  /// seed excluded server-side. Keyless; up to 25 entries.
+  Future<List<Anime>> getAnimeRecommendations(int id) =>
+      _media.getAnimeRecommendations(id);
+
+  Future<List<Manga>> getMangaRecommendations(int id) =>
+      _media.getMangaRecommendations(id);
+
+  /// Per-seed recommendations for a whole seed set in one aliased request.
+  Future<Map<int, List<Anime>>> getAnimeRecommendationsBatch(List<int> ids) =>
+      _media.getAnimeRecommendationsBatch(ids);
+
+  Future<Map<int, List<Manga>>> getMangaRecommendationsBatch(List<int> ids) =>
+      _media.getMangaRecommendationsBatch(ids);
+
   Future<List<Manga>> getMangaByIds(
     List<int> ids, {
     void Function(Duration wait, int attempt)? onRateLimit,

--- a/lib/core/api/kitsu/kitsu_mapping_api.dart
+++ b/lib/core/api/kitsu/kitsu_mapping_api.dart
@@ -16,6 +16,12 @@ class KitsuMappingApi {
   /// `filter[externalSite]` value for AniDB ids.
   static const String siteAniDb = 'anidb';
 
+  /// `filter[externalSite]` / `externalSite` value for AniList anime ids.
+  static const String siteAniListAnime = 'anilist/anime';
+
+  /// Same for AniList manga ids.
+  static const String siteAniListManga = 'anilist/manga';
+
   /// Kitsu rejects `page[limit]` above 20 with a 400.
   static const int _batchLimit = 20;
 
@@ -66,6 +72,35 @@ class KitsuMappingApi {
       return out;
     } on DioException catch (e) {
       throw _client.handleDioException(e, 'Failed to resolve Kitsu mappings');
+    }
+  }
+
+  /// AniList id of a Kitsu title via its own `mappings` list, or null when
+  /// the title has no AniList mapping.
+  Future<int?> getAniListId({
+    required int kitsuId,
+    required bool manga,
+  }) async {
+    final String kind = manga ? 'manga' : 'anime';
+    final String site = manga ? siteAniListManga : siteAniListAnime;
+    try {
+      final Response<dynamic> resp = await _client.get(
+        '$kind/$kitsuId/mappings',
+        queryParameters: <String, dynamic>{'page[limit]': _batchLimit},
+      );
+      final Map<String, dynamic> data =
+          (resp.data as Map<String, dynamic>?) ?? <String, dynamic>{};
+      for (final Map<String, dynamic> mapping
+          in ((data['data'] as List<dynamic>?) ?? <dynamic>[])
+              .whereType<Map<String, dynamic>>()) {
+        final Map<String, dynamic>? attrs =
+            mapping['attributes'] as Map<String, dynamic>?;
+        if (attrs?['externalSite'] != site) continue;
+        return int.tryParse((attrs?['externalId'] as String?) ?? '');
+      }
+      return null;
+    } on DioException catch (e) {
+      throw _client.handleDioException(e, 'Failed to load Kitsu mappings');
     }
   }
 

--- a/lib/core/api/kitsu_api.dart
+++ b/lib/core/api/kitsu_api.dart
@@ -11,9 +11,8 @@ import 'kitsu/kitsu_manga_api.dart';
 import 'kitsu/kitsu_mapping_api.dart';
 export 'kitsu/kitsu_types.dart';
 
-/// Kitsu JSON:API facade (`https://kitsu.io/api/edge`, no auth).
-///
-/// An anime + manga catalog; both carry `DataSource.kitsu`.
+/// Kitsu JSON:API facade (`https://kitsu.io/api/edge`, no auth) — an anime +
+/// manga catalog; both carry `DataSource.kitsu`.
 class KitsuApi {
   KitsuApi({Dio? dio}) : _client = KitsuHttpClient(dio: dio) {
     _manga = KitsuMangaApi(_client);
@@ -87,6 +86,22 @@ class KitsuApi {
         externalSite: KitsuMappingApi.siteAniDb,
         externalIds: anidbIds,
       );
+
+  /// Resolves AniList ids to Kitsu anime — used to show AniList-sourced
+  /// recommendations as Kitsu titles (seasons + episode tracker).
+  Future<Map<int, Anime>> getAnimeByAniListIds(List<int> aniListIds) =>
+      _mappings.resolveAnime(
+        externalSite: KitsuMappingApi.siteAniListAnime,
+        externalIds: aniListIds,
+      );
+
+  /// AniList id of a Kitsu anime, or null without a mapping.
+  Future<int?> getAniListAnimeId(int kitsuId) =>
+      _mappings.getAniListId(kitsuId: kitsuId, manga: false);
+
+  /// AniList id of a Kitsu manga, or null without a mapping.
+  Future<int?> getAniListMangaId(int kitsuId) =>
+      _mappings.getAniListId(kitsuId: kitsuId, manga: true);
 
   void dispose() => _client.dispose();
 }

--- a/lib/features/collections/screens/item_detail_screen.dart
+++ b/lib/features/collections/screens/item_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:core/models/collected_item_info.dart';
 import 'package:core/models/collection.dart';
 import 'package:core/models/collection_item.dart';
 import 'package:core/models/custom_media.dart';
+import 'package:core/models/anime.dart';
 import 'package:core/models/data_source.dart';
 import 'package:core/models/item_status.dart';
 import 'package:core/models/manga.dart';
@@ -47,6 +48,7 @@ import '../widgets/episode_tracker_section.dart';
 import '../widgets/item_tags_section.dart';
 import '../widgets/anime_progress_section.dart';
 import '../widgets/book_progress_section.dart';
+import '../widgets/anime_similars_section.dart';
 import '../widgets/book_similars_section.dart';
 import '../widgets/manga_similars_section.dart';
 import '../widgets/custom_progress_section.dart';
@@ -790,15 +792,23 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
             book: item.book!,
             onAddBook: _addBookFromSimilars,
           ),
-        // Similar manga — MangaBaka and MangaDex each have a native
-        // recommendations endpoint seeded by the current title.
+        // Similar manga — MangaBaka and MangaDex have native recommendation
+        // endpoints; AniList / Kitsu seeds go through AniList's.
         if (settings.showRecommendations &&
             item.mediaType == MediaType.manga &&
-            (item.manga?.source == DataSource.mangabaka ||
-                item.manga?.source == DataSource.mangadex))
+            mangaSimilarsSources.contains(item.manga?.source))
           MangaSimilarsSection(
             seed: item.manga!,
             onAddManga: _addMangaFromSimilars,
+          ),
+        // Similar anime — AniList recommendations shown as Kitsu titles;
+        // a Kitsu seed is bridged to its AniList id first.
+        if (settings.showRecommendations &&
+            item.mediaType == MediaType.anime &&
+            item.anime != null)
+          AnimeSimilarsSection(
+            seed: item.anime!,
+            onAddAnime: _addAnimeFromSimilars,
           ),
       ],
       authorComment: item.authorComment,
@@ -1136,6 +1146,63 @@ class _ItemDetailScreenState extends ConsumerState<ItemDetailScreen> {
           mediaType: MediaType.manga,
           externalId: manga.id,
           source: manga.source,
+        );
+
+    if (!mounted) return;
+
+    context.showSnack(
+      success
+          ? l.searchAddedToNamed(title, collectionName)
+          : l.searchAlreadyInNamed(title, collectionName),
+      type: success ? SnackType.success : SnackType.info,
+    );
+  }
+
+  /// Adds an anime tapped in the "Similar" row to a chosen collection,
+  /// caching the full record first. Similars are always Kitsu entities.
+  Future<void> _addAnimeFromSimilars(Anime anime) async {
+    final Map<int, List<CollectedItemInfo>> ownMap =
+        await ref.read(collectedAnimeIdsProvider.future);
+    final Set<int?> alreadyIn = <CollectedItemInfo>[
+      ...?ownMap[anime.id],
+    ]
+        .where((CollectedItemInfo i) => i.source == anime.source)
+        .map((CollectedItemInfo i) => i.collectionId)
+        .toSet();
+
+    if (!mounted) return;
+    final S l = S.of(context);
+    final String title = anime.titleByLanguage(
+      ref.read(settingsNotifierProvider).animeMangaTitleLanguage,
+    );
+    final CollectionChoice? choice = await showCollectionPickerDialog(
+      context: context,
+      ref: ref,
+      title: l.searchAddToCollection,
+      alreadyInCollectionIds: alreadyIn,
+      showUncategorized: false,
+    );
+    if (choice == null || !mounted) return;
+
+    final int? collectionId;
+    final String collectionName;
+    switch (choice) {
+      case ChosenCollection(:final Collection collection):
+        collectionId = collection.id;
+        collectionName = collection.name;
+      case WithoutCollection():
+        collectionId = null;
+        collectionName = l.collectionsUncategorized;
+    }
+
+    await ref.read(databaseServiceProvider).animeDao.upsertAnime(anime);
+
+    final bool success = await ref
+        .read(collectionItemsNotifierProvider(collectionId).notifier)
+        .addItem(
+          mediaType: MediaType.anime,
+          externalId: anime.id,
+          source: anime.source,
         );
 
     if (!mounted) return;

--- a/lib/features/collections/widgets/anime_similars_section.dart
+++ b/lib/features/collections/widgets/anime_similars_section.dart
@@ -1,0 +1,127 @@
+import 'package:core/models/anime.dart';
+import 'package:core/models/collected_item_info.dart';
+import 'package:core/models/data_source.dart';
+import 'package:core/models/image_type.dart';
+import 'package:core/models/media_type.dart';
+import 'package:core/utils/cover_image_id.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api/anilist_api.dart';
+import '../../../core/api/kitsu_api.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/constants/media_type_theme.dart';
+import '../../search/widgets/item_details_sheet.dart';
+import '../../settings/providers/settings_provider.dart'
+    show settingsNotifierProvider;
+import '../providers/collections_provider.dart';
+import 'similars_poster_row.dart';
+
+/// AniList is the similarity engine (Kitsu has no such endpoint), but results
+/// are shown as Kitsu titles — only those carry seasons + the episode tracker.
+final AutoDisposeFutureProviderFamily<List<Anime>, _AnimeSeedKey>
+    _animeRecProvider =
+    FutureProvider.autoDispose.family<List<Anime>, _AnimeSeedKey>(
+  (Ref ref, _AnimeSeedKey seed) async {
+    final AniListApi aniList = ref.watch(aniListApiProvider);
+    final KitsuApi kitsu = ref.watch(kitsuApiProvider);
+    final int? aniListId = seed.source == DataSource.kitsu
+        ? await kitsu.getAniListAnimeId(seed.id)
+        : seed.id;
+    if (aniListId == null) return <Anime>[];
+    final List<Anime> recs = await aniList.getAnimeRecommendations(aniListId);
+    if (recs.isEmpty) return recs;
+    final Map<int, Anime> kitsuByAniListId = await kitsu.getAnimeByAniListIds(
+      <int>[for (final Anime a in recs) a.id],
+    );
+    // Keep the server's rating order; unmapped titles are dropped.
+    return <Anime>[
+      for (final Anime a in recs)
+        if (kitsuByAniListId[a.id] case final Anime k) k,
+    ];
+  },
+);
+
+typedef _AnimeSeedKey = ({DataSource source, int id});
+
+/// "Similar anime" row on an anime's detail page, seeded by the current
+/// title; hidden while loading, on failure or when nothing comes back.
+class AnimeSimilarsSection extends ConsumerWidget {
+  const AnimeSimilarsSection({
+    required this.seed,
+    this.onAddAnime,
+    super.key,
+  });
+
+  /// The anime being viewed; a Kitsu seed is bridged to its AniList id first.
+  final Anime seed;
+
+  /// Adds a tapped similar anime to a collection.
+  final void Function(Anime anime)? onAddAnime;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final _AnimeSeedKey seedKey = (source: seed.source, id: seed.id);
+    final AsyncValue<List<Anime>> async = ref.watch(_animeRecProvider(seedKey));
+
+    final Map<int, List<CollectedItemInfo>> ownedMap =
+        ref.watch(collectedAnimeIdsProvider).valueOrNull ??
+            const <int, List<CollectedItemInfo>>{};
+    // Recommendations are always Kitsu entities, so match owned by that
+    // source regardless of the seed's own source.
+    final Set<int> ownedIds = <int>{
+      for (final MapEntry<int, List<CollectedItemInfo>> e in ownedMap.entries)
+        if (e.value.any(
+          (CollectedItemInfo i) => i.source == DataSource.kitsu,
+        ))
+          e.key,
+    };
+    final String titleLanguage =
+        ref.watch(settingsNotifierProvider).animeMangaTitleLanguage;
+
+    return async.when(
+      data: (List<Anime> animes) {
+        if (animes.isEmpty) return const SizedBox.shrink();
+        return SimilarsPosterRow(
+          title: S.of(context).recommendationsTitle,
+          cards: <SimilarCardData>[
+            for (final Anime anime in animes)
+              (
+                title: anime.titleByLanguage(titleLanguage),
+                imageUrl: anime.coverUrl ?? '',
+                cacheImageType: ImageType.animeCover,
+                cacheImageId: coverImageId(
+                  mediaType: MediaType.anime,
+                  externalId: anime.id,
+                  source: anime.source,
+                ),
+                year: anime.releaseYear,
+                apiRating: anime.rating10,
+                isOwned: ownedIds.contains(anime.id),
+                placeholderIcon:
+                    MediaTypeTheme.placeholderIconFor(MediaType.anime),
+                source: anime.source,
+                externalUrl: anime.externalUrl,
+                onTap: () => _showAnime(context, ref, anime),
+              ),
+          ],
+        );
+      },
+      loading: () => const SimilarsPosterRowShimmer(),
+      error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+
+  void _showAnime(BuildContext context, WidgetRef ref, Anime anime) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext ctx) => ItemDetailsSheet.anime(
+        anime,
+        onAddToCollection: () => onAddAnime?.call(anime),
+        animeMangaTitleLanguage:
+            ref.read(settingsNotifierProvider).animeMangaTitleLanguage,
+      ),
+    );
+  }
+}

--- a/lib/features/collections/widgets/manga_similars_section.dart
+++ b/lib/features/collections/widgets/manga_similars_section.dart
@@ -1,53 +1,65 @@
-import '../../../shared/constants/platform_features.dart';
-
 import 'package:core/models/collected_item_info.dart';
 import 'package:core/models/data_source.dart';
+import 'package:core/models/image_type.dart';
 import 'package:core/models/manga.dart';
 import 'package:core/models/media_type.dart';
 import 'package:core/utils/cover_image_id.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/api/anilist_api.dart';
+import '../../../core/api/kitsu_api.dart';
 import '../../../core/api/mangabaka_api.dart';
 import '../../../core/api/mangadex_api.dart';
-import '../../../core/services/image_cache_service.dart';
 import '../../../l10n/app_localizations.dart';
-import '../../../shared/theme/app_colors.dart';
-import '../../../shared/theme/app_spacing.dart';
-import '../../../shared/theme/app_typography.dart';
-import '../../../shared/utils/url_launch.dart';
-import '../../../shared/widgets/media_poster_card.dart';
-import '../../../shared/widgets/scrollable_row_with_arrows.dart';
-import '../../../shared/widgets/shimmer_loading.dart';
+import '../../../shared/constants/media_type_theme.dart';
 import '../../search/widgets/item_details_sheet.dart';
 import '../../settings/providers/settings_provider.dart'
     show settingsNotifierProvider;
 import '../providers/collections_provider.dart';
+import 'similars_poster_row.dart';
 
-/// Recommendations for a seed, routed by its source. `autoDispose` evicts the
-/// entry when the card is left (and a first-fetch failure is not cached
-/// forever); the record key carries `source` so same-`id`/different-source
-/// seeds never collide.
+/// Manga sources the similars row supports; gates the section in the item
+/// detail screen.
+const Set<DataSource> mangaSimilarsSources = <DataSource>{
+  DataSource.mangabaka,
+  DataSource.mangadex,
+  DataSource.anilist,
+  DataSource.kitsu,
+};
+
+/// Recommendations for a seed, routed by its source; the record key carries
+/// `source` so same-`id`/different-source seeds never collide.
 final AutoDisposeFutureProviderFamily<List<Manga>, _MangaSeedKey>
     _mangaRecProvider =
     FutureProvider.autoDispose.family<List<Manga>, _MangaSeedKey>(
-  (Ref ref, _MangaSeedKey seed) {
+  (Ref ref, _MangaSeedKey seed) async {
     switch (seed.source) {
       case DataSource.mangadex:
-        if (seed.uuid.isEmpty) return Future<List<Manga>>.value(<Manga>[]);
+        if (seed.uuid.isEmpty) return <Manga>[];
         return ref.watch(mangaDexApiProvider).getRecommendations(seed.uuid);
-      default:
+      case DataSource.anilist:
+        return ref.watch(aniListApiProvider).getMangaRecommendations(seed.id);
+      case DataSource.kitsu:
+        // Both clients are read before the await: touching an autoDispose ref
+        // after the card unmounts mid-fetch would throw.
+        final KitsuApi kitsu = ref.watch(kitsuApiProvider);
+        final AniListApi aniList = ref.watch(aniListApiProvider);
+        final int? aniListId = await kitsu.getAniListMangaId(seed.id);
+        if (aniListId == null) return <Manga>[];
+        return aniList.getMangaRecommendations(aniListId);
+      case DataSource.mangabaka:
         return ref.watch(mangaBakaApiProvider).getRecommendations(seed.id);
+      default:
+        return <Manga>[];
     }
   },
 );
 
 typedef _MangaSeedKey = ({DataSource source, int id, String uuid});
 
-/// "Similar manga" row on a manga's detail page, seeded by the current title.
-/// MangaBaka uses `/series/mix`, MangaDex uses `/manga/{id}/recommendation`;
-/// mirrors the TMDB [RecommendationsSection]. Hidden while loading, on failure
-/// or when nothing comes back.
+/// "Similar manga" row on a manga's detail page, seeded by the current title;
+/// hidden while loading, on failure or when nothing comes back.
 class MangaSimilarsSection extends ConsumerWidget {
   const MangaSimilarsSection({
     required this.seed,
@@ -75,11 +87,13 @@ class MangaSimilarsSection extends ConsumerWidget {
     final Map<int, List<CollectedItemInfo>> ownedMap =
         ref.watch(collectedMangaIdsProvider).valueOrNull ??
             const <int, List<CollectedItemInfo>>{};
-    // Recommendations all share the seed's source, so match owned by source too
-    // (a MangaBaka id can equal a MangaDex hash id).
+    // Recommendations all share one source (AniList for a Kitsu seed), so
+    // match owned by it (a MangaBaka id can equal a MangaDex hash id).
+    final DataSource recSource =
+        seed.source == DataSource.kitsu ? DataSource.anilist : seed.source;
     final Set<int> ownedIds = <int>{
       for (final MapEntry<int, List<CollectedItemInfo>> e in ownedMap.entries)
-        if (e.value.any((CollectedItemInfo i) => i.source == seed.source))
+        if (e.value.any((CollectedItemInfo i) => i.source == recSource))
           e.key,
     };
     final String titleLanguage =
@@ -88,15 +102,32 @@ class MangaSimilarsSection extends ConsumerWidget {
     return async.when(
       data: (List<Manga> mangas) {
         if (mangas.isEmpty) return const SizedBox.shrink();
-        return _MangaRow(
+        return SimilarsPosterRow(
           title: S.of(context).recommendationsTitle,
-          mangas: mangas,
-          ownedIds: ownedIds,
-          titleLanguage: titleLanguage,
-          onTap: (Manga m) => _showManga(context, ref, m),
+          cards: <SimilarCardData>[
+            for (final Manga manga in mangas)
+              (
+                title: manga.titleByLanguage(titleLanguage),
+                imageUrl: manga.coverUrl ?? '',
+                cacheImageType: ImageType.mangaCover,
+                cacheImageId: coverImageId(
+                  mediaType: MediaType.manga,
+                  externalId: manga.id,
+                  source: manga.source,
+                ),
+                year: manga.releaseYear,
+                apiRating: manga.rating10,
+                isOwned: ownedIds.contains(manga.id),
+                placeholderIcon:
+                    MediaTypeTheme.placeholderIconFor(MediaType.manga),
+                source: manga.source,
+                externalUrl: manga.externalUrl,
+                onTap: () => _showManga(context, ref, manga),
+              ),
+          ],
         );
       },
-      loading: () => const _MangaRowShimmer(),
+      loading: () => const SimilarsPosterRowShimmer(),
       error: (_, _) => const SizedBox.shrink(),
     );
   }
@@ -111,147 +142,6 @@ class MangaSimilarsSection extends ConsumerWidget {
         animeMangaTitleLanguage:
             ref.read(settingsNotifierProvider).animeMangaTitleLanguage,
       ),
-    );
-  }
-}
-
-class _MangaRow extends StatefulWidget {
-  const _MangaRow({
-    required this.title,
-    required this.mangas,
-    required this.ownedIds,
-    required this.titleLanguage,
-    required this.onTap,
-  });
-
-  final String title;
-  final List<Manga> mangas;
-  final Set<int> ownedIds;
-  final String titleLanguage;
-  final void Function(Manga manga) onTap;
-
-  @override
-  State<_MangaRow> createState() => _MangaRowState();
-}
-
-class _MangaRowState extends State<_MangaRow> {
-  final ScrollController _scrollController = ScrollController();
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final bool compact = isCompactScreen(context);
-    final double posterWidth = compact ? 100 : 130;
-    final double rowHeight = AppSpacing.posterRowHeight(
-      posterWidth: posterWidth,
-      compact: compact,
-      textScaler: MediaQuery.textScalerOf(context),
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Text(
-          widget.title,
-          style: AppTypography.h3.copyWith(fontWeight: FontWeight.w600),
-        ),
-        const SizedBox(height: AppSpacing.sm),
-        SizedBox(
-          height: rowHeight,
-          child: ScrollableRowWithArrows(
-            controller: _scrollController,
-            height: rowHeight,
-            child: ListView.separated(
-              controller: _scrollController,
-              scrollDirection: Axis.horizontal,
-              clipBehavior: Clip.none,
-              padding: const EdgeInsets.symmetric(
-                vertical: AppSpacing.posterRowVerticalPadding,
-              ),
-              itemCount: widget.mangas.length,
-              separatorBuilder: (_, _) =>
-                  const SizedBox(width: AppSpacing.sm),
-              itemBuilder: (BuildContext context, int index) {
-                final Manga manga = widget.mangas[index];
-                return SizedBox(
-                  width: posterWidth,
-                  child: MediaPosterCard(
-                    variant:
-                        compact ? CardVariant.compact : CardVariant.grid,
-                    title: manga.titleByLanguage(widget.titleLanguage),
-                    imageUrl: manga.coverUrl ?? '',
-                    cacheImageType: ImageType.mangaCover,
-                    cacheImageId: coverImageId(
-                      mediaType: MediaType.manga,
-                      externalId: manga.id,
-                      source: manga.source,
-                    ),
-                    year: manga.releaseYear,
-                    apiRating: manga.rating10,
-                    splitRatings: true,
-                    isInCollection: widget.ownedIds.contains(manga.id),
-                    placeholderIcon: Icons.auto_stories,
-                    source: manga.source,
-                    onSourceTap: openUrlCallback(manga.externalUrl),
-                    onTap: () => widget.onTap(manga),
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _MangaRowShimmer extends StatelessWidget {
-  const _MangaRowShimmer();
-
-  @override
-  Widget build(BuildContext context) {
-    final bool compact = isCompactScreen(context);
-    final double posterWidth = compact ? 100 : 130;
-    final double rowHeight = AppSpacing.posterRowHeight(
-      posterWidth: posterWidth,
-      compact: compact,
-      textScaler: MediaQuery.textScalerOf(context),
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Container(
-          width: 150,
-          height: 20,
-          decoration: BoxDecoration(
-            color: AppColors.surfaceLight,
-            borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
-          ),
-        ),
-        const SizedBox(height: AppSpacing.sm),
-        SizedBox(
-          height: rowHeight,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(
-              vertical: AppSpacing.posterRowVerticalPadding,
-            ),
-            itemCount: 5,
-            separatorBuilder: (_, _) =>
-                const SizedBox(width: AppSpacing.sm),
-            itemBuilder: (_, _) => SizedBox(
-              width: posterWidth,
-              child: ShimmerPosterCard(compact: compact),
-            ),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/collections/widgets/similars_poster_row.dart
+++ b/lib/features/collections/widgets/similars_poster_row.dart
@@ -1,0 +1,165 @@
+import 'package:core/models/data_source.dart';
+import 'package:core/models/image_type.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/constants/platform_features.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/theme/app_spacing.dart';
+import '../../../shared/theme/app_typography.dart';
+import '../../../shared/utils/url_launch.dart';
+import '../../../shared/widgets/media_poster_card.dart';
+import '../../../shared/widgets/scrollable_row_with_arrows.dart';
+import '../../../shared/widgets/shimmer_loading.dart';
+
+/// One card of a [SimilarsPosterRow], already resolved to display values so
+/// the row stays media-type agnostic.
+typedef SimilarCardData = ({
+  String title,
+  String imageUrl,
+  ImageType cacheImageType,
+  String cacheImageId,
+  int? year,
+  double? apiRating,
+  bool isOwned,
+  IconData placeholderIcon,
+  DataSource source,
+  String? externalUrl,
+  VoidCallback onTap,
+});
+
+/// Titled horizontal poster carousel shared by the "Similar …" sections
+/// (anime / manga); pair with [SimilarsPosterRowShimmer] while loading.
+class SimilarsPosterRow extends StatefulWidget {
+  const SimilarsPosterRow({
+    required this.title,
+    required this.cards,
+    super.key,
+  });
+
+  final String title;
+  final List<SimilarCardData> cards;
+
+  @override
+  State<SimilarsPosterRow> createState() => _SimilarsPosterRowState();
+}
+
+class _SimilarsPosterRowState extends State<SimilarsPosterRow> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool compact = isCompactScreen(context);
+    final double posterWidth = compact ? 100 : 130;
+    final double rowHeight = AppSpacing.posterRowHeight(
+      posterWidth: posterWidth,
+      compact: compact,
+      textScaler: MediaQuery.textScalerOf(context),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          widget.title,
+          style: AppTypography.h3.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        // Clip.none inside lets hover scale / shadows use the row padding;
+        // this rect stops cards sliding out over neighbouring UI mid-scroll.
+        ClipRect(
+          child: SizedBox(
+            height: rowHeight,
+            child: ScrollableRowWithArrows(
+              controller: _scrollController,
+              height: rowHeight,
+              child: ListView.separated(
+                controller: _scrollController,
+                scrollDirection: Axis.horizontal,
+                clipBehavior: Clip.none,
+                padding: const EdgeInsets.symmetric(
+                  vertical: AppSpacing.posterRowVerticalPadding,
+                ),
+                itemCount: widget.cards.length,
+                separatorBuilder: (_, _) =>
+                    const SizedBox(width: AppSpacing.sm),
+                itemBuilder: (BuildContext context, int index) {
+                  final SimilarCardData card = widget.cards[index];
+                  return SizedBox(
+                    width: posterWidth,
+                    child: MediaPosterCard(
+                      variant: compact ? CardVariant.compact : CardVariant.grid,
+                      title: card.title,
+                      imageUrl: card.imageUrl,
+                      cacheImageType: card.cacheImageType,
+                      cacheImageId: card.cacheImageId,
+                      year: card.year,
+                      apiRating: card.apiRating,
+                      splitRatings: true,
+                      isInCollection: card.isOwned,
+                      placeholderIcon: card.placeholderIcon,
+                      source: card.source,
+                      onSourceTap: openUrlCallback(card.externalUrl),
+                      onTap: card.onTap,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Loading placeholder matching [SimilarsPosterRow]'s layout.
+class SimilarsPosterRowShimmer extends StatelessWidget {
+  const SimilarsPosterRowShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final bool compact = isCompactScreen(context);
+    final double posterWidth = compact ? 100 : 130;
+    final double rowHeight = AppSpacing.posterRowHeight(
+      posterWidth: posterWidth,
+      compact: compact,
+      textScaler: MediaQuery.textScalerOf(context),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          width: 150,
+          height: 20,
+          decoration: BoxDecoration(
+            color: AppColors.surfaceLight,
+            borderRadius: BorderRadius.circular(AppSpacing.radiusXs),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        SizedBox(
+          height: rowHeight,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(
+              vertical: AppSpacing.posterRowVerticalPadding,
+            ),
+            itemCount: 5,
+            separatorBuilder: (_, _) => const SizedBox(width: AppSpacing.sm),
+            itemBuilder: (_, _) => SizedBox(
+              width: posterWidth,
+              child: ShimmerPosterCard(compact: compact),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/recommendations/anime_taste_input.dart
+++ b/lib/features/recommendations/anime_taste_input.dart
@@ -1,0 +1,47 @@
+import 'package:core/models/anime.dart';
+import 'package:core/models/collection_item.dart';
+import 'package:core/models/data_source.dart';
+import 'package:core/models/media_type.dart';
+
+import 'engine/recommendation_models.dart';
+import 'taste_features.dart';
+
+/// Engine id for an anime title/candidate; the source keeps id spaces apart.
+String animeTasteId(DataSource source, int id) => 'anime:${source.name}:$id';
+
+/// Builds a [TasteTitle] from a completed collection item, or `null` when the
+/// item is not an AniList anime or has no usable genres/tags.
+TasteTitle? tasteTitleFromAnimeItem(CollectionItem item) {
+  final Anime? anime = item.anime;
+  if (item.mediaType != MediaType.anime || anime == null) return null;
+  if (anime.source != DataSource.anilist) return null;
+  return buildNameFeatureTitle(
+    id: animeTasteId(anime.source, anime.id),
+    label: item.overrideName ?? anime.title,
+    genres: anime.genres,
+    tags: anime.tags,
+    rating: item.userRating,
+    isFavorite: item.isFavorite,
+  );
+}
+
+/// Builds an anime candidate [TasteTitle], or `null` without genres/tags.
+TasteTitle? tasteTitleFromAnime(Anime anime) => buildNameFeatureTitle(
+      id: animeTasteId(anime.source, anime.id),
+      label: anime.title,
+      genres: anime.genres,
+      tags: anime.tags,
+      rating: null,
+      isFavorite: false,
+    );
+
+/// Owned-exclusion ids for every anime in the library; a Kitsu copy of an
+/// AniList candidate cannot be matched (different id spaces) and may surface.
+Set<String> ownedAnimeTasteIds(List<CollectionItem> items) => <String>{
+      for (final CollectionItem item in items)
+        if (item.mediaType == MediaType.anime)
+          // The raw column first: dataSource resolves through the media
+          // submodel and falls back to a per-type default when it's absent.
+          animeTasteId(item.source ?? item.dataSource, item.externalId),
+    };
+

--- a/lib/features/recommendations/manga_taste_input.dart
+++ b/lib/features/recommendations/manga_taste_input.dart
@@ -1,0 +1,55 @@
+import 'package:core/models/collection_item.dart';
+import 'package:core/models/data_source.dart';
+import 'package:core/models/manga.dart';
+import 'package:core/models/media_type.dart';
+
+import 'engine/recommendation_models.dart';
+import 'taste_features.dart';
+
+/// Manga sources with a similarity backend and genre/tag features. Kitsu
+/// manga carry neither in our model, so they cannot feed a profile.
+const Set<DataSource> mangaTasteSources = <DataSource>{
+  DataSource.mangabaka,
+  DataSource.mangadex,
+  DataSource.anilist,
+};
+
+/// Engine id for a manga title/candidate; the source keeps id spaces apart
+/// (a MangaBaka id can equal a MangaDex hash id).
+String mangaTasteId(DataSource source, int id) => 'manga:${source.name}:$id';
+
+/// Builds a [TasteTitle] from a completed collection item of [source], or
+/// `null` when the item is another source's manga or has no genres/tags.
+TasteTitle? tasteTitleFromMangaItem(CollectionItem item, DataSource source) {
+  final Manga? manga = item.manga;
+  if (item.mediaType != MediaType.manga || manga == null) return null;
+  if (manga.source != source) return null;
+  return buildNameFeatureTitle(
+    id: mangaTasteId(manga.source, manga.id),
+    label: item.overrideName ?? manga.title,
+    genres: manga.genres,
+    tags: manga.tags,
+    rating: item.userRating,
+    isFavorite: item.isFavorite,
+  );
+}
+
+/// Builds a manga candidate [TasteTitle], or `null` without genres/tags.
+TasteTitle? tasteTitleFromManga(Manga manga) => buildNameFeatureTitle(
+      id: mangaTasteId(manga.source, manga.id),
+      label: manga.title,
+      genres: manga.genres,
+      tags: manga.tags,
+      rating: null,
+      isFavorite: false,
+    );
+
+/// Engine ids of every manga already in the library, any source — used to
+/// exclude candidates already collected.
+Set<String> ownedMangaTasteIds(List<CollectionItem> items) => <String>{
+      for (final CollectionItem item in items)
+        if (item.mediaType == MediaType.manga)
+          // The raw column first: dataSource resolves through the media
+          // submodel and falls back to a per-type default when it's absent.
+          mangaTasteId(item.source ?? item.dataSource, item.externalId),
+    };

--- a/lib/features/recommendations/providers/recommendations_provider.dart
+++ b/lib/features/recommendations/providers/recommendations_provider.dart
@@ -1,16 +1,9 @@
-// Orchestration for the Recommendations tab: learn a taste profile from the
-// completed library, gather candidates (primarily TMDB recommendations/similar
-// of the titles you liked, topped up with discover-by-genre), exclude owned,
-// score them with the engine, and resolve the winners back to renderable items.
-//
-// autoDispose: the work (network + scoring) runs only while the tab is on
-// screen. The library is read once per run (not watched) so adding a pick
-// doesn't reload the list mid-browse; the refresh button or reopening the tab
-// recomputes fresh.
-
+import 'package:core/models/anime.dart';
 import 'package:core/models/collected_item_info.dart';
 import 'package:core/models/collection_item.dart';
+import 'package:core/models/data_source.dart';
 import 'package:core/models/item_status.dart';
+import 'package:core/models/manga.dart';
 import 'package:core/models/media_type.dart';
 import 'package:core/models/movie.dart';
 import 'package:core/models/tv_show.dart';
@@ -18,29 +11,33 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
+import '../../../core/api/anilist_api.dart';
+import '../../../core/api/mangabaka_api.dart';
+import '../../../core/api/mangadex_api.dart';
 import '../../../core/api/tmdb_api.dart';
 import '../../../core/database/database_service.dart';
 import '../../collections/providers/collections_provider.dart';
 import '../../home/providers/all_items_provider.dart';
 import '../../settings/providers/settings_provider.dart';
+import '../anime_taste_input.dart';
 import '../engine/recommendation_models.dart';
 import '../engine/recommender.dart';
+import '../manga_taste_input.dart';
 import '../tmdb_taste_input.dart';
 
 final Logger _log = Logger('Recommendations');
 
 /// How the Recommendations tab should render.
 enum RecommendationStatus {
-  /// No completed movie/TV titles with genres — nothing to learn from.
+  /// No completed titles with features in any domain — nothing to learn from.
   empty,
 
-  /// No TMDB API key configured, so candidates can't be fetched at all. Kept
-  /// separate from [noCandidates] so the message points at the real fix
-  /// instead of blaming the key when a key is present.
+  /// Only the movie/TV profile exists and the TMDB key is missing — kept
+  /// apart from [noCandidates] so the message points at the real fix.
   noApiKey,
 
-  /// A profile and a key exist, but the fetch came back with nothing usable —
-  /// a network error, or everything matching is already owned.
+  /// Profiles exist, but every fetch came back with nothing usable — a
+  /// network error, or everything matching is already owned.
   noCandidates,
 
   /// Recommendations are ready.
@@ -54,7 +51,8 @@ class RecommendedItem {
     required this.tasteId,
     required this.media,
     required this.mediaType,
-    required this.tmdbId,
+    required this.source,
+    required this.externalId,
     required this.title,
     required this.posterUrl,
     required this.year,
@@ -63,29 +61,32 @@ class RecommendedItem {
     required this.predictedRating,
   });
 
-  /// Engine id (`movie:<id>` / `tv:<id>`).
+  /// Engine id (`movie:<id>` / `tv:<id>` / `anime:<source>:<id>` / …).
   final String tasteId;
 
-  /// The underlying [Movie] / [TvShow], handed to the search add-to-collection
-  /// handlers so the pick can be added straight from here.
+  /// The underlying [Movie] / [TvShow] / [Anime] / [Manga], handed to the
+  /// search add-to-collection handlers so the pick can be added from here.
   final Object media;
 
-  /// [MediaType.movie] or [MediaType.tvShow].
+  /// The recommended title's media type.
   final MediaType mediaType;
 
-  /// TMDB id.
-  final int tmdbId;
+  /// Provider the candidate came from (TMDB / AniList / MangaBaka / …).
+  final DataSource source;
+
+  /// The title's id in [source]'s id space.
+  final int externalId;
 
   /// Display title.
   final String title;
 
-  /// Poster URL, or `null` when TMDB has no poster.
+  /// Poster URL, or `null` when the source has no poster.
   final String? posterUrl;
 
   /// Release / first-air year, or `null`.
   final int? year;
 
-  /// TMDB community rating (0–10), or `null`.
+  /// The source's community rating (0–10), or `null`.
   final double? apiRating;
 
   /// Engine match score.
@@ -94,10 +95,12 @@ class RecommendedItem {
   /// Predicted personal rating (1–10), or `null` when not predictable.
   final double? predictedRating;
 
-  /// TMDB page of the underlying [media].
+  /// External page of the underlying [media].
   String? get externalUrl => switch (media) {
         final Movie m => m.externalUrl,
         final TvShow t => t.externalUrl,
+        final Anime a => a.externalUrl,
+        final Manga m => m.externalUrl,
         _ => null,
       };
 }
@@ -137,9 +140,8 @@ class RecommendationResult {
   final List<RecommendationRowUi> rows;
 }
 
-/// How many genres (across clusters) to query candidates by. Generous enough to
-/// reach TV-only genre names (e.g. "Sci-Fi & Fantasy"), which tend to rank
-/// below movie genres in the clusters.
+/// Genres (across clusters) to query candidates by — generous enough to reach
+/// TV-only genre names, which tend to rank below movie genres in the clusters.
 const int _maxGenresToQuery = 8;
 
 /// How many candidate pages to pull per genre/domain before moving on.
@@ -162,23 +164,80 @@ const int _maxSeedTitles = 8;
 /// How many of each cluster's strongest titles to take as seeds.
 const int _seedsPerCluster = 2;
 
-/// Recommendations for the current library. See the file header.
+/// One independent pipeline per domain (movie/TV, anime, manga per source);
+/// rows concatenate, and a domain with nothing to say contributes none.
 final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
     FutureProvider.autoDispose<RecommendationResult>((Ref ref) async {
-  // Read once, don't watch: adding a recommended pick mutates the library, and
-  // watching would re-run the whole fetch+score pipeline (flashing the loading
-  // spinner) on every add. Refresh re-runs it on demand.
+  // Read once, don't watch: watching would re-run the whole fetch+score
+  // pipeline on every add. Refresh re-runs it on demand.
   final List<CollectionItem> library =
       ref.read(allItemsNotifierProvider).valueOrNull ??
           const <CollectionItem>[];
 
-  // Genres are matched by TMDB *id*, not by name, so the library and the
-  // candidates line up no matter which language each was cached or fetched in
-  // (see GenreKeyResolver). Both language maps feed each resolver; the
-  // content-language map drives the human-readable rationale captions.
-  // Watch only language + key presence: changing either should recompute
-  // (a key added at runtime flips hasKey false->true and refreshes the tab),
-  // but unrelated settings shouldn't re-run the whole pipeline.
+  // Watch only what should recompute the tab: anime/manga titles render in
+  // this language, so flipping it re-titles the rows.
+  final String titleLanguage = ref.watch(
+    settingsNotifierProvider
+        .select((SettingsState s) => s.animeMangaTitleLanguage),
+  );
+
+  // Domains hit unrelated backends — run them concurrently.
+  final (_MovieTvOutcome movieTv, _NicheOutcome anime, _NicheOutcome manga) =
+      await (
+    _movieTvDomain(ref, library),
+    _animeDomain(ref, library, titleLanguage),
+    _mangaDomain(ref, library, titleLanguage),
+  ).wait;
+
+  // Pin fetched results across tab unmounts; cheap no-fetch states stay
+  // uncached on purpose so they recompute per visit.
+  final bool movieTvFetched =
+      movieTv.status == RecommendationStatus.ready ||
+          movieTv.status == RecommendationStatus.noCandidates;
+  if (movieTvFetched || anime.hadProfile || manga.hadProfile) {
+    ref.keepAlive();
+  }
+
+  final List<RecommendationRowUi> rows = <RecommendationRowUi>[
+    ...movieTv.rows,
+    ...anime.rows,
+    ...manga.rows,
+  ];
+  if (rows.isNotEmpty) {
+    return RecommendationResult(status: RecommendationStatus.ready, rows: rows);
+  }
+  if (movieTv.status == RecommendationStatus.noApiKey) {
+    return const RecommendationResult.state(RecommendationStatus.noApiKey);
+  }
+  if (movieTv.status == RecommendationStatus.noCandidates ||
+      anime.hadProfile ||
+      manga.hadProfile) {
+    return const RecommendationResult.state(RecommendationStatus.noCandidates);
+  }
+  return const RecommendationResult.state(RecommendationStatus.empty);
+});
+
+typedef _MovieTvOutcome = ({
+  RecommendationStatus status,
+  List<RecommendationRowUi> rows,
+});
+
+/// Rows + a flag for the keyless domains: [hadProfile] separates "nothing to
+/// learn from" (empty) from "learned but found nothing" (noCandidates).
+typedef _NicheOutcome = ({
+  List<RecommendationRowUi> rows,
+  bool hadProfile,
+});
+
+const _NicheOutcome _nicheNothing =
+    (rows: <RecommendationRowUi>[], hadProfile: false);
+
+Future<_MovieTvOutcome> _movieTvDomain(
+  Ref ref,
+  List<CollectionItem> library,
+) async {
+  // Genres are matched by TMDB *id* (GenreKeyResolver) so library and
+  // candidates line up regardless of the language each was cached in.
   final ({String language, bool hasKey}) tmdbSettings = ref.watch(
     settingsNotifierProvider.select((SettingsState s) =>
         (language: s.tmdbLanguage, hasKey: s.hasTmdbKey)),
@@ -204,55 +263,50 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
   };
 
   // 1. Taste titles from completed movie/TV with genres, deduped by taste id.
-  // The same title can sit in several collections; learning it once keeps it
-  // from skewing IDF/weights and from appearing twice in a row's "because you
-  // liked" header. Merging keeps the strongest signal: favorite if any of the
-  // copies is, and the highest explicit rating.
-  final Map<String, TasteTitle> completedById = <String, TasteTitle>{};
-  for (final CollectionItem item in library) {
-    if (item.status != ItemStatus.completed) continue;
-    final TasteTitle? t = tasteTitleFromItem(
+  final List<TasteTitle> completed = _completedTitles(
+    library,
+    (CollectionItem item) => tasteTitleFromItem(
       item,
       movieGenres: movieGenres,
       tvGenres: tvGenres,
-    );
-    if (t == null) continue;
-    final TasteTitle? existing = completedById[t.id];
-    completedById[t.id] =
-        existing == null ? t : _mergeTasteSignals(existing, t);
-  }
-  final List<TasteTitle> completed = completedById.values.toList();
+    ),
+  );
   if (completed.isEmpty) {
-    return const RecommendationResult.state(RecommendationStatus.empty);
+    return (
+      status: RecommendationStatus.empty,
+      rows: const <RecommendationRowUi>[],
+
+    );
   }
 
   // 2. Learn the profile.
   final Recommender recommender = Recommender(completed);
   if (recommender.profile.isEmpty) {
     // Completed titles exist but none carry a positive signal.
-    return const RecommendationResult.state(RecommendationStatus.empty);
+    return (
+      status: RecommendationStatus.empty,
+      rows: const <RecommendationRowUi>[],
+
+    );
   }
 
   // 3. No key means candidates can't be fetched at all — report that plainly
   // rather than letting it fall through to the generic "nothing found".
   if (!tmdbSettings.hasKey) {
-    return const RecommendationResult.state(RecommendationStatus.noApiKey);
+    return (
+      status: RecommendationStatus.noApiKey,
+      rows: const <RecommendationRowUi>[],
+
+    );
   }
 
-  // Fetch candidates from TMDB by the profile's top genres. Use the shared
-  // client — the same one Search uses — instead of building a fresh one:
-  // SettingsNotifier keeps its key and request language live, so a key entered
-  // at runtime is picked up here too. A freshly built client could only read the
-  // startup-only apiKeysProvider snapshot, which stayed keyless whenever the key
-  // was added after launch — that left this tab perpetually "no candidates".
+  // The shared client, not a fresh one: only it picks up a TMDB key entered
+  // at runtime (a fresh Dio reads the startup-only apiKeysProvider snapshot).
   final TmdbApi tmdb = ref.watch(tmdbApiProvider);
   final Set<String> owned = ownedTasteIds(library);
   final _CandidatePool pool = _CandidatePool();
-  // Primary source — "recommended/similar to titles you liked". TMDB's per-title
-  // similarity is far less coarse than discover-by-genre, which (sorted by
-  // popularity) just surfaces the biggest title sharing a broad genre like
-  // "Sci-Fi & Fantasy" — that's the Dark + Wisting → House of the Dragon miss.
-  // Seeds are the strongest titles in each taste cluster.
+  // Per-title similarity first — far less coarse than discover-by-genre;
+  // seeds are the strongest titles in each taste cluster.
   await _fetchFromSeeds(
     tmdb: tmdb,
     seeds: _seedSelection(recommender.profile),
@@ -269,13 +323,6 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
     pool: pool,
   );
 
-  // The expensive network work is done — pin the result so it survives the
-  // screen unmounting (Personalization unloads on leave) and a revisit shows
-  // it instantly instead of re-fetching. The refresh button and the watched
-  // TMDB settings still invalidate it. Cheap pre-fetch states above stay
-  // uncached on purpose: they recompute per visit, picking up library changes.
-  ref.keepAlive();
-
   // 4. Vectorize candidates and score them.
   final Map<String, TasteTitle> candidateById = <String, TasteTitle>{};
   final Map<String, RecommendedItem Function(double score, double? predicted)>
@@ -290,7 +337,8 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
           tasteId: id,
           media: m,
           mediaType: MediaType.movie,
-          tmdbId: m.tmdbId,
+          source: DataSource.tmdb,
+          externalId: m.tmdbId,
           title: m.title,
           posterUrl: m.posterUrl,
           year: m.releaseYear,
@@ -307,7 +355,8 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
           tasteId: id,
           media: tv,
           mediaType: MediaType.tvShow,
-          tmdbId: tv.tmdbId,
+          source: DataSource.tmdb,
+          externalId: tv.tmdbId,
           title: tv.title,
           posterUrl: tv.posterUrl,
           year: tv.firstAirYear,
@@ -317,17 +366,258 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
         );
   });
 
-  if (candidateById.isEmpty) {
-    return const RecommendationResult.state(RecommendationStatus.noCandidates);
+  final List<RecommendationRowUi> rows = _resolveRows(
+    recommender: recommender,
+    candidateById: candidateById,
+    builderById: builderById,
+    genreLabel: (String g) => genreDisplay[g] ?? g,
+  );
+  return (
+    status: rows.isEmpty
+        ? RecommendationStatus.noCandidates
+        : RecommendationStatus.ready,
+    rows: rows,
+
+  );
+}
+
+/// Anime domain: AniList profile and AniList candidates — one tag vocabulary
+/// on both sides. Kitsu titles carry no genres/tags, so they can't join.
+Future<_NicheOutcome> _animeDomain(
+  Ref ref,
+  List<CollectionItem> library,
+  String titleLanguage,
+) async {
+  final List<TasteTitle> completed =
+      _completedTitles(library, tasteTitleFromAnimeItem);
+  if (completed.isEmpty) return _nicheNothing;
+
+  final Recommender recommender = Recommender(completed);
+  if (recommender.profile.isEmpty) return _nicheNothing;
+
+  // All seeds ride one aliased request — a single hit on AniList's rate limit.
+  final AniListApi aniList = ref.watch(aniListApiProvider);
+  final List<int> seedIds = <int>[
+    for (final String tasteId in _seedTasteIds(recommender.profile))
+      if (_idFromTasteId(tasteId) case final int id) id,
+  ];
+  final Map<int, List<Anime>> fetched = await _safeBatch(
+    () => aniList.getAnimeRecommendationsBatch(seedIds),
+  );
+
+  final Set<String> owned = ownedAnimeTasteIds(library);
+  final Map<String, Anime> pool = <String, Anime>{};
+  for (final Anime a in fetched.values.expand((List<Anime> l) => l)) {
+    final String id = animeTasteId(a.source, a.id);
+    if (owned.contains(id) || pool.containsKey(id)) continue;
+    pool[id] = a;
   }
 
+  final Map<String, TasteTitle> candidateById = <String, TasteTitle>{};
+  final Map<String, RecommendedItem Function(double, double?)> builderById =
+      <String, RecommendedItem Function(double, double?)>{};
+  pool.forEach((String id, Anime a) {
+    final TasteTitle? t = tasteTitleFromAnime(a);
+    if (t == null) return;
+    candidateById[id] = t;
+    builderById[id] = (double score, double? predicted) => RecommendedItem(
+          tasteId: id,
+          media: a,
+          mediaType: MediaType.anime,
+          source: a.source,
+          externalId: a.id,
+          title: a.titleByLanguage(titleLanguage),
+          posterUrl: a.coverUrl,
+          year: a.releaseYear,
+          apiRating: a.rating10,
+          score: score,
+          predictedRating: predicted,
+        );
+  });
+
+  return (
+    rows: _resolveRows(
+      recommender: recommender,
+      candidateById: candidateById,
+      builderById: builderById,
+      genreLabel: (String g) => g,
+    ),
+    hadProfile: true,
+  );
+}
+
+/// Manga domain: one profile per source (vocabularies never mix), candidates
+/// from that source's own similarity backend, rows appended per source.
+Future<_NicheOutcome> _mangaDomain(
+  Ref ref,
+  List<CollectionItem> library,
+  String titleLanguage,
+) async {
+  // Clients are read before any await: an autoDispose ref must not be touched
+  // once the tab unmounts mid-fetch.
+  final _MangaBackends backends = (
+    aniList: ref.watch(aniListApiProvider),
+    mangaBaka: ref.watch(mangaBakaApiProvider),
+    mangaDex: ref.watch(mangaDexApiProvider),
+  );
+  final Set<String> owned = ownedMangaTasteIds(library);
+  final List<RecommendationRowUi> rows = <RecommendationRowUi>[];
+  bool hadProfile = false;
+
+  for (final DataSource source in mangaTasteSources) {
+    final List<TasteTitle> completed = _completedTitles(
+      library,
+      (CollectionItem item) => tasteTitleFromMangaItem(item, source),
+    );
+    if (completed.isEmpty) continue;
+
+    // MangaDex is seeded by UUID, which lives only on the library item's
+    // externalUrl — harvested here so seeds can resolve it.
+    final Map<String, String> uuidByTasteId = <String, String>{
+      if (source == DataSource.mangadex)
+        for (final CollectionItem item in library)
+          if (item.manga case final Manga m
+              when m.source == DataSource.mangadex &&
+                  mangaDexUuidFromUrl(m.externalUrl).isNotEmpty)
+            mangaTasteId(m.source, m.id): mangaDexUuidFromUrl(m.externalUrl),
+    };
+
+    final Recommender recommender = Recommender(completed);
+    if (recommender.profile.isEmpty) continue;
+    hadProfile = true;
+
+    final List<List<Manga>> results = await _mangaSeedRecommendations(
+      backends,
+      source,
+      _seedTasteIds(recommender.profile),
+      uuidByTasteId,
+    );
+
+    final Map<String, Manga> pool = <String, Manga>{};
+    for (final Manga m in results.expand((List<Manga> l) => l)) {
+      final String id = mangaTasteId(m.source, m.id);
+      if (owned.contains(id) || pool.containsKey(id)) continue;
+      pool[id] = m;
+    }
+
+    final Map<String, TasteTitle> candidateById = <String, TasteTitle>{};
+    final Map<String, RecommendedItem Function(double, double?)> builderById =
+        <String, RecommendedItem Function(double, double?)>{};
+    pool.forEach((String id, Manga m) {
+      final TasteTitle? t = tasteTitleFromManga(m);
+      if (t == null) return;
+      candidateById[id] = t;
+      builderById[id] = (double score, double? predicted) => RecommendedItem(
+            tasteId: id,
+            media: m,
+            mediaType: MediaType.manga,
+            source: m.source,
+            externalId: m.id,
+            title: m.titleByLanguage(titleLanguage),
+            posterUrl: m.coverUrl,
+            year: m.releaseYear,
+            apiRating: m.rating10,
+            score: score,
+            predictedRating: predicted,
+          );
+    });
+
+    rows.addAll(
+      _resolveRows(
+        recommender: recommender,
+        candidateById: candidateById,
+        builderById: builderById,
+        genreLabel: (String g) => g,
+      ),
+    );
+  }
+
+  return (rows: rows, hadProfile: hadProfile);
+}
+
+typedef _MangaBackends = ({
+  AniListApi aniList,
+  MangaBakaApi mangaBaka,
+  MangaDexApi mangaDex,
+});
+
+/// AniList seeds ride one aliased request (rate-limit budget); MangaBaka /
+/// MangaDex have no batch endpoint and are queried per seed, concurrently.
+Future<List<List<Manga>>> _mangaSeedRecommendations(
+  _MangaBackends backends,
+  DataSource source,
+  List<String> seedTasteIds,
+  Map<String, String> uuidByTasteId,
+) async {
+  if (source == DataSource.anilist) {
+    final List<int> ids = <int>[
+      for (final String tasteId in seedTasteIds)
+        if (_idFromTasteId(tasteId) case final int id) id,
+    ];
+    final Map<int, List<Manga>> byId = await _safeBatch(
+      () => backends.aniList.getMangaRecommendationsBatch(ids),
+    );
+    return byId.values.toList();
+  }
+  return Future.wait(
+    <Future<List<Manga>>>[
+      for (final String tasteId in seedTasteIds)
+        _safeDiscover<Manga>(() {
+          if (source == DataSource.mangadex) {
+            final String? uuid = uuidByTasteId[tasteId];
+            if (uuid == null) return Future<List<Manga>>.value(const <Manga>[]);
+            return backends.mangaDex.getRecommendations(uuid);
+          }
+          final int? id = _idFromTasteId(tasteId);
+          if (id == null) return Future<List<Manga>>.value(const <Manga>[]);
+          return backends.mangaBaka.getRecommendations(id);
+        }),
+    ],
+  );
+}
+
+/// Like [_safeDiscover] for the aliased batch calls: a failure degrades to an
+/// empty map instead of erroring the tab.
+Future<Map<int, List<T>>> _safeBatch<T>(
+  Future<Map<int, List<T>>> Function() call,
+) async {
+  try {
+    return await call();
+  } on Object catch (error, stack) {
+    _log.warning('batch candidate fetch failed', error, stack);
+    return <int, List<T>>{};
+  }
+}
+
+/// Completed titles vectorized by [toTaste], deduped by taste id — a title in
+/// several collections must be learned once or it skews IDF and weights.
+List<TasteTitle> _completedTitles(
+  List<CollectionItem> library,
+  TasteTitle? Function(CollectionItem) toTaste,
+) {
+  final Map<String, TasteTitle> byId = <String, TasteTitle>{};
+  for (final CollectionItem item in library) {
+    if (item.status != ItemStatus.completed) continue;
+    final TasteTitle? t = toTaste(item);
+    if (t == null) continue;
+    final TasteTitle? existing = byId[t.id];
+    byId[t.id] = existing == null ? t : _mergeTasteSignals(existing, t);
+  }
+  return byId.values.toList();
+}
+
+/// Resolves engine rows to UI rows: strongest matches taken, then shown
+/// highest-rated first — match-score order looks shuffled against ratings.
+List<RecommendationRowUi> _resolveRows({
+  required Recommender recommender,
+  required Map<String, TasteTitle> candidateById,
+  required Map<String, RecommendedItem Function(double, double?)> builderById,
+  required String Function(String) genreLabel,
+}) {
+  if (candidateById.isEmpty) return const <RecommendationRowUi>[];
   final List<RecommendationRow> engineRows =
       recommender.recommend(candidateById.values.toList());
 
-  // 5. Resolve engine rows to UI rows. The engine ranks by match score; take
-  // the strongest matches, then present them highest-rated first (TMDB rating,
-  // predicted personal rating as tiebreak) so the row reads top-down instead of
-  // in match-score order, which looks shuffled against the visible ratings.
   final List<RecommendationRowUi> rows = <RecommendationRowUi>[];
   for (final RecommendationRow row in engineRows) {
     final List<RecommendedItem> items = <RecommendedItem>[];
@@ -343,25 +633,19 @@ final AutoDisposeFutureProvider<RecommendationResult> recommendationsProvider =
       rows.add(
         RecommendationRowUi(
           becauseTitles: row.becauseTitles,
-          // topGenres are id keys now; show their content-language names.
           genres: <String>[
-            for (final String g in row.topGenres) genreDisplay[g] ?? g,
+            for (final String g in row.topGenres) genreLabel(g),
           ],
           items: items,
         ),
       );
     }
   }
+  return rows;
+}
 
-  if (rows.isEmpty) {
-    return const RecommendationResult.state(RecommendationStatus.noCandidates);
-  }
-  return RecommendationResult(status: RecommendationStatus.ready, rows: rows);
-});
-
-/// Orders recommended items highest-rated first: TMDB rating, then predicted
-/// personal rating as a tiebreak, then engine match score. Items with no rating
-/// sort last so the row still leads with its rated, strongest picks.
+/// Source rating desc, predicted rating as tiebreak, then match score;
+/// unrated items sort last so the row leads with its strongest picks.
 @visibleForTesting
 int byRatingDesc(RecommendedItem a, RecommendedItem b) {
   final int byApi = _compareRatingDesc(a.apiRating, b.apiRating);
@@ -379,9 +663,8 @@ int _compareRatingDesc(double? a, double? b) {
   return b.compareTo(a);
 }
 
-/// Merges two taste entries for the same title sitting in several collections:
-/// favorite if either copy is, and the higher of any explicit ratings. Genres
-/// (features) and label are identical across copies, so [a]'s are kept.
+/// Keeps the strongest signal across copies of one title: favorite if either
+/// is, the higher rating; features and label are identical, so [a]'s are kept.
 TasteTitle _mergeTasteSignals(TasteTitle a, TasteTitle b) {
   return TasteTitle(
     id: a.id,
@@ -436,28 +719,34 @@ List<String> _topGenresForDiscovery(TasteProfile profile) {
 }
 
 /// The strongest titles in each cluster (members come pre-sorted by weight),
-/// as `(type, tmdbId)` seeds for similarity/recommendation lookups.
-List<({String type, int tmdbId})> _seedSelection(TasteProfile profile) {
-  final List<({String type, int tmdbId})> seeds =
-      <({String type, int tmdbId})>[];
+/// as taste ids for similarity/recommendation lookups.
+List<String> _seedTasteIds(TasteProfile profile) {
+  final List<String> seeds = <String>[];
   final Set<String> seen = <String>{};
   for (final TasteCluster c in profile.clusters) {
     for (final TasteTitle t in c.members.take(_seedsPerCluster)) {
-      if (!seen.add(t.id)) continue;
-      final ({String type, int tmdbId})? parsed = _parseTasteId(t.id);
-      if (parsed != null) seeds.add(parsed);
+      if (seen.add(t.id)) seeds.add(t.id);
     }
     if (seeds.length >= _maxSeedTitles) break;
   }
   return seeds.take(_maxSeedTitles).toList();
 }
 
-({String type, int tmdbId})? _parseTasteId(String id) {
-  final int sep = id.indexOf(':');
-  if (sep < 0) return null;
-  final int? tmdbId = int.tryParse(id.substring(sep + 1));
-  if (tmdbId == null) return null;
-  return (type: id.substring(0, sep), tmdbId: tmdbId);
+/// The trailing numeric segment of a taste id (`movie:603`,
+/// `anime:anilist:21`), or null when it isn't numeric.
+int? _idFromTasteId(String tasteId) =>
+    int.tryParse(tasteId.substring(tasteId.lastIndexOf(':') + 1));
+
+List<({String type, int tmdbId})> _seedSelection(TasteProfile profile) {
+  final List<({String type, int tmdbId})> seeds =
+      <({String type, int tmdbId})>[];
+  for (final String tasteId in _seedTasteIds(profile)) {
+    final int sep = tasteId.indexOf(':');
+    final int? tmdbId = _idFromTasteId(tasteId);
+    if (sep < 0 || tmdbId == null) continue;
+    seeds.add((type: tasteId.substring(0, sep), tmdbId: tmdbId));
+  }
+  return seeds;
 }
 
 /// Fills [pool] with TMDB recommendations + similar titles for each seed, run
@@ -500,9 +789,8 @@ Future<({List<Movie> movies, List<TvShow> tvShows})> _similarFor(
   return (movies: const <Movie>[], tvShows: <TvShow>[...recs, ...similar]);
 }
 
-/// Tops up [pool] with discover-by-genre, up to [_perDomainTarget] per domain.
-/// [topGenreIds] are genre id strings; each is queried in whichever domain
-/// (movie / TV) actually defines that id.
+/// Tops up [pool] with discover-by-genre up to [_perDomainTarget]; each genre
+/// id is queried in whichever domain (movie / TV) actually defines it.
 Future<void> _fetchByDiscover({
   required TmdbApi tmdb,
   required List<String> topGenreIds,
@@ -549,7 +837,7 @@ Future<void> _fetchByDiscover({
   }
 }
 
-/// Runs a TMDB list call, swallowing failures (network, rate limits) to an
+/// Runs a candidate list call, swallowing failures (network, rate limits) to an
 /// empty list so the tab degrades to "no candidates" instead of erroring.
 Future<List<T>> _safeDiscover<T>(Future<List<T>> Function() call) async {
   try {
@@ -565,20 +853,30 @@ Future<List<T>> _safeDiscover<T>(Future<List<T>> Function() call) async {
 final StateProvider<Set<int>> recommendationTargetCollectionsProvider =
     StateProvider<Set<int>>((Ref ref) => <int>{});
 
-/// Engine ids (movie/TV) currently in any collection, for marking recommended
-/// cards as added. Sourced from the collected-id providers rather than the
-/// all-items notifier so the screen can sticky-merge it: those providers carry
-/// their value across reloads, where the all-items notifier blanks through
-/// AsyncLoading and would flash every mark off.
+/// Engine ids currently in any collection, for the "added" card mark. The
+/// collected-id providers hold values across reloads; all-items would blank.
 final AutoDisposeFutureProvider<Set<String>>
     collectedRecommendationIdsProvider =
     FutureProvider.autoDispose<Set<String>>((Ref ref) async {
-  final Map<int, List<CollectedItemInfo>> movies =
-      await ref.watch(collectedMovieIdsProvider.future);
-  final Map<int, List<CollectedItemInfo>> tv =
-      await ref.watch(collectedTvShowIdsProvider.future);
+  final (
+    Map<int, List<CollectedItemInfo>> movies,
+    Map<int, List<CollectedItemInfo>> tv,
+    Map<int, List<CollectedItemInfo>> anime,
+    Map<int, List<CollectedItemInfo>> manga,
+  ) = await (
+    ref.watch(collectedMovieIdsProvider.future),
+    ref.watch(collectedTvShowIdsProvider.future),
+    ref.watch(collectedAnimeIdsProvider.future),
+    ref.watch(collectedMangaIdsProvider.future),
+  ).wait;
   return <String>{
     for (final int id in movies.keys) movieTasteId(id),
     for (final int id in tv.keys) tvTasteId(id),
+    for (final MapEntry<int, List<CollectedItemInfo>> e in anime.entries)
+      for (final CollectedItemInfo info in e.value)
+        animeTasteId(info.source, e.key),
+    for (final MapEntry<int, List<CollectedItemInfo>> e in manga.entries)
+      for (final CollectedItemInfo info in e.value)
+        mangaTasteId(info.source, e.key),
   };
 });

--- a/lib/features/recommendations/screens/recommendations_screen.dart
+++ b/lib/features/recommendations/screens/recommendations_screen.dart
@@ -1,10 +1,3 @@
-// Recommendations tab: content-based movie/TV suggestions learned from the
-// user's completed, rated and favorited titles. Rows are grouped by taste
-// cluster. A pinned collection-chips row lets the user pick target collections;
-// tapping a card then adds it straight into the selection, or — with nothing
-// selected — opens the same details sheet Search uses, so the pick can be added
-// without leaving the tab.
-
 import 'package:core/models/platform.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -32,18 +25,15 @@ class RecommendationsScreen extends ConsumerStatefulWidget {
 class _RecommendationsScreenState extends ConsumerState<RecommendationsScreen> {
   late final MediaHandlers _handlers;
 
-  /// Titles added to a collection from this screen this session — marked
-  /// locally so only the tapped card flips to "added". Driving this from the
-  /// library instead would blank every mark while the library reloads through
-  /// AsyncLoading on each add.
+  /// Titles added from this screen this session, marked locally — the library
+  /// blanks through AsyncLoading on each add and would flash every mark off.
   final Set<String> _added = <String>{};
 
   @override
   void initState() {
     super.initState();
-    // Recs only surface movies/TV, so the platform map (used only by the game
-    // handler) stays empty. The add target is read live from the recs-specific
-    // selection so a tap resolves the current chips at tap time.
+    // Recs never surface games, so the game handler's platform map stays
+    // empty; the add target is read live so a tap resolves current chips.
     _handlers = MediaHandlers(
       ref: ref,
       platformMap: () => const <int, Platform>{},
@@ -55,9 +45,8 @@ class _RecommendationsScreenState extends ConsumerState<RecommendationsScreen> {
   @override
   Widget build(BuildContext context) {
     final S l = S.of(context);
-    // Mark a card once its title lands in any collection — covers adds made
-    // through the details sheet, where the add happens out of band. Sticky
-    // union (never removes), so a collected-id reload can't blank a mark.
+    // Marks cards whose add happened out of band (details sheet). Sticky
+    // union — never removes — so a collected-id reload can't blank a mark.
     ref.listen<AsyncValue<Set<String>>>(collectedRecommendationIdsProvider, (
       AsyncValue<Set<String>>? _,
       AsyncValue<Set<String>> next,
@@ -135,6 +124,9 @@ class _RecommendationsScreenState extends ConsumerState<RecommendationsScreen> {
     AsyncValue<RecommendationResult> async,
   ) {
     return async.when(
+      // The refresh button invalidates the provider; without this the old
+      // rows keep showing through the reload and the tap looks like a no-op.
+      skipLoadingOnRefresh: false,
       loading: () => const Center(child: LogoLoader()),
       error: (Object error, StackTrace _) => Center(
         child: Padding(
@@ -206,14 +198,11 @@ class _RecommendationsScreenState extends ConsumerState<RecommendationsScreen> {
     );
   }
 
-  /// Routes the tap through the Search handlers: with target collections
-  /// selected it adds the pick straight in; otherwise it opens the details
-  /// sheet (the same window Search shows), where the user can add it.
+  /// With target collections selected the tap adds straight in; otherwise it
+  /// opens the same details sheet Search shows, where the user can add it.
   void _onItemTap(BuildContext context, RecommendedItem item) {
-    // A non-empty target selection means the tap adds straight in (see
-    // SimpleMediaHandler.onTap), so mark this one card locally. With nothing
-    // selected the tap opens the details sheet, where the add (if any) happens
-    // out of band — that card marks on the next refresh instead.
+    // Direct adds mark the card locally; a sheet add happens out of band and
+    // marks on the next collected-id refresh instead.
     final bool addsDirectly = ref
         .read(recommendationTargetCollectionsProvider)
         .isNotEmpty;

--- a/lib/features/recommendations/taste_features.dart
+++ b/lib/features/recommendations/taste_features.dart
@@ -1,0 +1,30 @@
+import 'engine/recommendation_config.dart';
+import 'engine/recommendation_models.dart';
+
+/// Shared vectorizer for name-keyed feature domains (anime / manga): genres
+/// and tags at equal weight; the engine's IDF handles discrimination.
+TasteTitle? buildNameFeatureTitle({
+  required String id,
+  required String label,
+  required List<String>? genres,
+  required List<String>? tags,
+  required double? rating,
+  required bool isFavorite,
+}) {
+  final Set<String> features = <String>{
+    for (final String g in genres ?? const <String>[])
+      if (g.trim().isNotEmpty) g,
+    for (final String t in tags ?? const <String>[])
+      if (t.trim().isNotEmpty) t,
+  };
+  if (features.isEmpty) return null;
+  return TasteTitle(
+    id: id,
+    label: label,
+    features: <String, double>{
+      for (final String f in features) f: RecommendationConfig.genreValue,
+    },
+    rating: rating,
+    isFavorite: isFavorite,
+  );
+}

--- a/lib/features/recommendations/widgets/recommendation_row.dart
+++ b/lib/features/recommendations/widgets/recommendation_row.dart
@@ -1,9 +1,9 @@
-import 'package:core/models/data_source.dart';
 import 'package:core/models/media_type.dart';
 import 'package:core/utils/cover_image_id.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/services/image_cache_service.dart';
+import '../../../shared/constants/media_type_theme.dart';
 import '../../../shared/constants/platform_features.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/theme/app_spacing.dart';
@@ -13,11 +13,8 @@ import '../../../shared/widgets/media_poster_card.dart';
 import '../../../shared/widgets/scrollable_row_with_arrows.dart';
 import '../providers/recommendations_provider.dart';
 
-/// A self-contained section card for one "because you liked …" group: a
-/// two-tier header (an uppercase reason label over the driver titles), the
-/// cluster's genres as chips, and a horizontal carousel of recommended titles.
-/// Each card shows the predicted personal rating (top-left badge) and the TMDB
-/// rating (subtitle). Tapping a card runs [onTap].
+/// Section card for one "because you liked …" group: reason header, the
+/// cluster's genre chips and a horizontal carousel of recommended titles.
 class RecommendationRowWidget extends StatefulWidget {
   /// Creates a recommendation row.
   const RecommendationRowWidget({
@@ -127,72 +124,98 @@ class _RecommendationRowWidgetState extends State<RecommendationRowWidget> {
             ),
           ),
           const SizedBox(height: AppSpacing.md),
-          SizedBox(
-            height: rowHeight,
-            child: ScrollableRowWithArrows(
-              controller: _scrollController,
+          // Clip.none inside lets hover scale / shadows use the row padding;
+          // this rect stops cards sliding out over the sidebar mid-scroll.
+          ClipRect(
+            child: SizedBox(
               height: rowHeight,
-              child: ListView.separated(
+              child: ScrollableRowWithArrows(
                 controller: _scrollController,
-                scrollDirection: Axis.horizontal,
-                clipBehavior: Clip.none,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSpacing.md,
-                  vertical: AppSpacing.posterRowVerticalPadding,
-                ),
-                itemCount: widget.items.length,
-                separatorBuilder: (_, _) =>
-                    const SizedBox(width: AppSpacing.md),
-                itemBuilder: (BuildContext context, int index) {
-                  final RecommendedItem item = widget.items[index];
-                  final bool isMovie = item.mediaType == MediaType.movie;
-                  final bool isOwned = widget.ownedIds.contains(item.tasteId);
-                  // Wrapper shape stays constant whether or not the item is
-                  // owned: toggling Opacity/IgnorePointer structurally would
-                  // re-parent the poster and reload its image. Opacity(1.0) is
-                  // a no-op paint, so non-owned cards pay nothing.
-                  return SizedBox(
-                    key: ValueKey<String>(item.tasteId),
-                    width: posterWidth,
-                    child: Opacity(
-                      opacity: isOwned ? 0.45 : 1.0,
-                      child: IgnorePointer(
-                        ignoring: isOwned,
-                        child: MediaPosterCard(
-                          variant: compact
-                              ? CardVariant.compact
-                              : CardVariant.grid,
-                          title: item.title,
-                          imageUrl: item.posterUrl ?? '',
-                          cacheImageType: isMovie
-                              ? ImageType.moviePoster
-                              : ImageType.tvShowPoster,
-                          cacheImageId: isMovie
-                              ? item.tmdbId.toString()
-                              : coverImageId(
-                                  mediaType: MediaType.tvShow,
-                                  externalId: item.tmdbId,
-                                ),
-                          mediaType: item.mediaType,
-                          year: item.year,
-                          // Predicted personal rating in the badge; TMDB rating
-                          // in the subtitle.
-                          userRating: item.predictedRating,
-                          apiRating: item.apiRating,
-                          splitRatings: true,
-                          // Already added: show the standard in-collection check.
-                          isInCollection: isOwned,
-                          placeholderIcon: isMovie
-                              ? Icons.movie_outlined
-                              : Icons.tv_outlined,
-                          source: DataSource.tmdb,
-                          onSourceTap: openUrlCallback(item.externalUrl),
-                          onTap: () => widget.onTap(item),
+                height: rowHeight,
+                child: ListView.separated(
+                  controller: _scrollController,
+                  scrollDirection: Axis.horizontal,
+                  clipBehavior: Clip.none,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.md,
+                    vertical: AppSpacing.posterRowVerticalPadding,
+                  ),
+                  itemCount: widget.items.length,
+                  separatorBuilder: (_, _) =>
+                      const SizedBox(width: AppSpacing.md),
+                  itemBuilder: (BuildContext context, int index) {
+                    final RecommendedItem item = widget.items[index];
+                    final bool isOwned = widget.ownedIds.contains(item.tasteId);
+                    // Movies cache by a bare id string for historical reasons;
+                    // every other type uses the shared coverImageId scheme.
+                    final ({ImageType type, String id}) cache =
+                        switch (item.mediaType) {
+                          MediaType.movie => (
+                            type: ImageType.moviePoster,
+                            id: item.externalId.toString(),
+                          ),
+                          MediaType.anime => (
+                            type: ImageType.animeCover,
+                            id: coverImageId(
+                              mediaType: MediaType.anime,
+                              externalId: item.externalId,
+                              source: item.source,
+                            ),
+                          ),
+                          MediaType.manga => (
+                            type: ImageType.mangaCover,
+                            id: coverImageId(
+                              mediaType: MediaType.manga,
+                              externalId: item.externalId,
+                              source: item.source,
+                            ),
+                          ),
+                          _ => (
+                            type: ImageType.tvShowPoster,
+                            id: coverImageId(
+                              mediaType: MediaType.tvShow,
+                              externalId: item.externalId,
+                            ),
+                          ),
+                        };
+                    // Constant wrapper shape: toggling Opacity/IgnorePointer
+                    // structurally would re-parent and reload the poster.
+                    return SizedBox(
+                      key: ValueKey<String>(item.tasteId),
+                      width: posterWidth,
+                      child: Opacity(
+                        opacity: isOwned ? 0.45 : 1.0,
+                        child: IgnorePointer(
+                          ignoring: isOwned,
+                          child: MediaPosterCard(
+                            variant: compact
+                                ? CardVariant.compact
+                                : CardVariant.grid,
+                            title: item.title,
+                            imageUrl: item.posterUrl ?? '',
+                            cacheImageType: cache.type,
+                            cacheImageId: cache.id,
+                            mediaType: item.mediaType,
+                            year: item.year,
+                            // Predicted personal rating in the badge; the
+                            // source's rating in the subtitle.
+                            userRating: item.predictedRating,
+                            apiRating: item.apiRating,
+                            splitRatings: true,
+                            // Already added: show the standard in-collection check.
+                            isInCollection: isOwned,
+                            placeholderIcon: MediaTypeTheme.placeholderIconFor(
+                              item.mediaType,
+                            ),
+                            source: item.source,
+                            onSourceTap: openUrlCallback(item.externalUrl),
+                            onTap: () => widget.onTap(item),
+                          ),
                         ),
                       ),
-                    ),
-                  );
-                },
+                    );
+                  },
+                ),
               ),
             ),
           ),

--- a/test/core/api/anilist/anilist_media_parser_test.dart
+++ b/test/core/api/anilist/anilist_media_parser_test.dart
@@ -95,4 +95,96 @@ void main() {
       );
     });
   });
+
+  Map<String, dynamic> recommendationsMedia(List<Map<String, dynamic>?> nodes) =>
+      <String, dynamic>{
+        'recommendations': <String, dynamic>{
+          'nodes': <Map<String, dynamic>?>[
+            for (final Map<String, dynamic>? rec in nodes)
+              <String, dynamic>{'mediaRecommendation': rec},
+          ],
+        },
+      };
+
+  Map<String, dynamic> recMedia(int id, String type, String title) =>
+      <String, dynamic>{
+        'type': type,
+        'id': id,
+        'title': <String, dynamic>{'romaji': title},
+      };
+
+  group('AniListMediaParser.recommendedAnimeBatch', () {
+    test('maps nodes per seed preserving order', () {
+      final Map<int, List<Anime>> r = AniListMediaParser.recommendedAnimeBatch(
+        <String, dynamic>{
+          's0': recommendationsMedia(<Map<String, dynamic>?>[
+            recMedia(11061, 'ANIME', 'Hunter x Hunter'),
+            recMedia(20, 'ANIME', 'Naruto'),
+          ]),
+          's1': recommendationsMedia(<Map<String, dynamic>?>[
+            recMedia(1, 'ANIME', 'Cowboy Bebop'),
+          ]),
+        },
+        <int>[21, 205],
+      );
+      expect(r[21]!.map((Anime a) => a.id), <int>[11061, 20]);
+      expect(r[21]!.first.title, 'Hunter x Hunter');
+      expect(r[205]!.single.id, 1);
+    });
+
+    test('drops null mediaRecommendation (deleted media)', () {
+      final Map<int, List<Anime>> r = AniListMediaParser.recommendedAnimeBatch(
+        <String, dynamic>{
+          's0': recommendationsMedia(<Map<String, dynamic>?>[
+            null,
+            recMedia(20, 'ANIME', 'Naruto'),
+          ]),
+        },
+        <int>[21],
+      );
+      expect(r[21]!.map((Anime a) => a.id), <int>[20]);
+    });
+
+    test('drops cross-type entries (a manga recommended for an anime)', () {
+      final Map<int, List<Anime>> r = AniListMediaParser.recommendedAnimeBatch(
+        <String, dynamic>{
+          's0': recommendationsMedia(<Map<String, dynamic>?>[
+            recMedia(30002, 'MANGA', 'Berserk'),
+            recMedia(20, 'ANIME', 'Naruto'),
+          ]),
+        },
+        <int>[21],
+      );
+      expect(r[21]!.map((Anime a) => a.id), <int>[20]);
+    });
+
+    test('null data or a deleted seed yields empty lists per seed', () {
+      expect(
+        AniListMediaParser.recommendedAnimeBatch(null, <int>[21])[21],
+        isEmpty,
+      );
+      // Seed s0 deleted server-side: its Media comes back null.
+      final Map<int, List<Anime>> r = AniListMediaParser.recommendedAnimeBatch(
+        <String, dynamic>{'s0': null},
+        <int>[21],
+      );
+      expect(r[21], isEmpty);
+    });
+  });
+
+  group('AniListMediaParser.recommendedMangaBatch', () {
+    test('maps nodes and keeps only MANGA entries', () {
+      final Map<int, List<Manga>> r = AniListMediaParser.recommendedMangaBatch(
+        <String, dynamic>{
+          's0': recommendationsMedia(<Map<String, dynamic>?>[
+            recMedia(30642, 'MANGA', 'Vinland Saga'),
+            recMedia(20, 'ANIME', 'Naruto'),
+            recMedia(30656, 'MANGA', 'Vagabond'),
+          ]),
+        },
+        <int>[30002],
+      );
+      expect(r[30002]!.map((Manga m) => m.id), <int>[30642, 30656]);
+    });
+  });
 }

--- a/test/core/api/anilist_api_test.dart
+++ b/test/core/api/anilist_api_test.dart
@@ -706,6 +706,108 @@ void main() {
       });
     });
 
+    group('recommendations', () {
+      Map<String, dynamic> recommendationsResponse(
+        Map<String, List<Map<String, dynamic>>> recsByAlias,
+      ) =>
+          <String, dynamic>{
+            'data': <String, dynamic>{
+              for (final MapEntry<String, List<Map<String, dynamic>>> e
+                  in recsByAlias.entries)
+                e.key: <String, dynamic>{
+                  'recommendations': <String, dynamic>{
+                    'nodes': <Map<String, dynamic>>[
+                      for (final Map<String, dynamic> rec in e.value)
+                        <String, dynamic>{'mediaRecommendation': rec},
+                    ],
+                  },
+                },
+            },
+          };
+
+      test('should inline the seed ids and pass the 25 perPage cap', () async {
+        when(() => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+            )).thenAnswer(
+          (_) async => makeResponse(
+            recommendationsResponse(<String, List<Map<String, dynamic>>>{}),
+          ),
+        );
+
+        await api.getAnimeRecommendationsBatch(<int>[21, 20]);
+
+        final Map<String, dynamic> body = verify(() => mockDio.post<dynamic>(
+              any(),
+              data: captureAny(named: 'data'),
+            )).captured.single as Map<String, dynamic>;
+        final String query = body['query'] as String;
+        expect(query, contains('s0: Media(id: 21, type: ANIME)'));
+        expect(query, contains('s1: Media(id: 20, type: ANIME)'));
+        final Map<String, dynamic> variables =
+            body['variables'] as Map<String, dynamic>;
+        expect(variables['perPage'], 25);
+      });
+
+      test('should map a single-seed call through the batch', () async {
+        when(() => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+            )).thenAnswer(
+          (_) async => makeResponse(
+            recommendationsResponse(<String, List<Map<String, dynamic>>>{
+              's0': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'type': 'ANIME',
+                  'id': 11061,
+                  'title': <String, dynamic>{'romaji': 'Hunter x Hunter'},
+                },
+              ],
+            }),
+          ),
+        );
+
+        final List<Anime> results = await api.getAnimeRecommendations(21);
+
+        expect(results, hasLength(1));
+        expect(results.single.id, 11061);
+      });
+
+      test('should map manga recommendations through the MANGA query',
+          () async {
+        when(() => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+            )).thenAnswer(
+          (_) async => makeResponse(
+            recommendationsResponse(<String, List<Map<String, dynamic>>>{
+              's0': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'type': 'MANGA',
+                  'id': 30642,
+                  'title': <String, dynamic>{'romaji': 'Vinland Saga'},
+                },
+              ],
+            }),
+          ),
+        );
+
+        final Map<int, List<Manga>> results =
+            await api.getMangaRecommendationsBatch(<int>[30002]);
+
+        expect(results[30002], hasLength(1));
+        expect(results[30002]!.single.id, 30642);
+      });
+
+      test('an empty seed list makes no request', () async {
+        expect(await api.getAnimeRecommendationsBatch(<int>[]), isEmpty);
+        verifyNever(() => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+            ));
+      });
+    });
+
     group('dispose', () {
       test('должен закрыть Dio клиент', () {
         when(() => mockDio.close()).thenReturn(null);

--- a/test/core/api/kitsu/kitsu_mapping_api_test.dart
+++ b/test/core/api/kitsu/kitsu_mapping_api_test.dart
@@ -228,4 +228,95 @@ void main() {
           ));
     });
   });
+
+  group('getAnimeByAniListIds', () {
+    test('filters mappings by the AniList anime site', () async {
+      stubGet(<Response<dynamic>>[
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[mapping('21', '12')],
+          'included': <Map<String, dynamic>>[animeResource('12')],
+        }),
+      ]);
+
+      final Map<int, Anime> result = await api.getAnimeByAniListIds(<int>[21]);
+
+      expect(result[21]?.id, 12);
+      final Map<String, dynamic> query = capturedQueries().single;
+      expect(query['filter[externalSite]'], 'anilist/anime');
+    });
+  });
+
+  group('getAniListId', () {
+    Map<String, dynamic> titleMapping(String site, String externalId) =>
+        <String, dynamic>{
+          'id': 'm-$externalId',
+          'type': 'mappings',
+          'attributes': <String, dynamic>{
+            'externalSite': site,
+            'externalId': externalId,
+          },
+        };
+
+    List<String> capturedPaths() => verify(() => mockDio.get<dynamic>(
+          captureAny(),
+          queryParameters: any(named: 'queryParameters'),
+          options: any(named: 'options'),
+        )).captured.cast<String>();
+
+    test('returns the AniList id from an anime mappings list', () async {
+      stubGet(<Response<dynamic>>[
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[
+            titleMapping('myanimelist/anime', '21'),
+            titleMapping('anilist/anime', '21'),
+            titleMapping('anidb', '69'),
+          ],
+        }),
+      ]);
+
+      final int? id = await api.getAniListAnimeId(12);
+
+      expect(id, 21);
+      expect(capturedPaths().single, 'anime/12/mappings');
+    });
+
+    test('uses the manga endpoint and site for a manga title', () async {
+      stubGet(<Response<dynamic>>[
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[
+            titleMapping('anilist/manga', '30008'),
+          ],
+        }),
+      ]);
+
+      final int? id = await api.getAniListMangaId(24);
+
+      expect(id, 30008);
+      expect(capturedPaths().single, 'manga/24/mappings');
+    });
+
+    test('returns null when the title has no AniList mapping', () async {
+      stubGet(<Response<dynamic>>[
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[
+            titleMapping('myanimelist/anime', '21'),
+          ],
+        }),
+      ]);
+
+      expect(await api.getAniListAnimeId(12), isNull);
+    });
+
+    test('ignores the anime site when looking up a manga', () async {
+      stubGet(<Response<dynamic>>[
+        makeResponse(<String, dynamic>{
+          'data': <Map<String, dynamic>>[
+            titleMapping('anilist/anime', '21'),
+          ],
+        }),
+      ]);
+
+      expect(await api.getAniListMangaId(12), isNull);
+    });
+  });
 }

--- a/test/features/collections/widgets/anime_similars_section_test.dart
+++ b/test/features/collections/widgets/anime_similars_section_test.dart
@@ -1,0 +1,202 @@
+import 'package:core/models/anime.dart';
+import 'package:core/models/collected_item_info.dart';
+import 'package:core/models/data_source.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/anilist_api.dart';
+import 'package:tonkatsu_box/core/api/kitsu_api.dart';
+import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
+import 'package:tonkatsu_box/features/collections/widgets/anime_similars_section.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  late MockAniListApi mockAniList;
+  late MockKitsuApi mockKitsu;
+
+  setUp(() {
+    mockAniList = MockAniListApi();
+    mockKitsu = MockKitsuApi();
+  });
+
+  final Anime aniListSeed = createTestAnime(id: 21);
+  final Anime kitsuSeed = createTestAnime(id: 12, source: DataSource.kitsu);
+
+  Anime kitsuAnime(int id, String title) =>
+      createTestAnime(id: id, source: DataSource.kitsu, title: title);
+
+  Future<void> pumpSection(
+    WidgetTester tester, {
+    Anime? seed,
+    Map<int, List<CollectedItemInfo>> ownedIds =
+        const <int, List<CollectedItemInfo>>{},
+  }) {
+    return tester.pumpApp(
+      SingleChildScrollView(
+        child: AnimeSimilarsSection(seed: seed ?? aniListSeed),
+      ),
+      overrides: <Override>[
+        aniListApiProvider.overrideWithValue(mockAniList),
+        kitsuApiProvider.overrideWithValue(mockKitsu),
+        collectedAnimeIdsProvider.overrideWith((Ref ref) async => ownedIds),
+      ],
+    );
+  }
+
+  group('AnimeSimilarsSection', () {
+    testWidgets(
+        'should render recommendations as Kitsu titles for an AniList seed',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getAnimeRecommendations(21)).thenAnswer(
+        (_) async => <Anime>[
+          createTestAnime(id: 11061, title: 'HxH (AniList)'),
+          createTestAnime(id: 20, title: 'Naruto (AniList)'),
+        ],
+      );
+      when(() => mockKitsu.getAnimeByAniListIds(<int>[11061, 20])).thenAnswer(
+        (_) async => <int, Anime>{
+          11061: kitsuAnime(6448, 'HxH (Kitsu)'),
+          20: kitsuAnime(11, 'Naruto (Kitsu)'),
+        },
+      );
+
+      await pumpSection(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('HxH (Kitsu)'), findsOneWidget);
+      expect(find.text('Naruto (Kitsu)'), findsOneWidget);
+      expect(find.text('HxH (AniList)'), findsNothing);
+      verifyNever(() => mockKitsu.getAniListAnimeId(any()));
+    });
+
+    testWidgets('should drop candidates without a Kitsu mapping',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getAnimeRecommendations(21)).thenAnswer(
+        (_) async => <Anime>[
+          createTestAnime(id: 11061, title: 'Mapped'),
+          createTestAnime(id: 999, title: 'Unmapped'),
+        ],
+      );
+      when(() => mockKitsu.getAnimeByAniListIds(<int>[11061, 999])).thenAnswer(
+        (_) async => <int, Anime>{11061: kitsuAnime(6448, 'Mapped (Kitsu)')},
+      );
+
+      await pumpSection(tester);
+
+      expect(find.text('Mapped (Kitsu)'), findsOneWidget);
+      expect(find.text('Unmapped'), findsNothing);
+    });
+
+    testWidgets('should bridge a Kitsu seed to its AniList id first',
+        (WidgetTester tester) async {
+      when(() => mockKitsu.getAniListAnimeId(12))
+          .thenAnswer((_) async => 21);
+      when(() => mockAniList.getAnimeRecommendations(21)).thenAnswer(
+        (_) async => <Anime>[createTestAnime(id: 20, title: 'Rec')],
+      );
+      when(() => mockKitsu.getAnimeByAniListIds(<int>[20])).thenAnswer(
+        (_) async => <int, Anime>{20: kitsuAnime(11, 'Rec (Kitsu)')},
+      );
+
+      await pumpSection(tester, seed: kitsuSeed);
+
+      expect(find.text('Rec (Kitsu)'), findsOneWidget);
+      verify(() => mockKitsu.getAniListAnimeId(12)).called(1);
+    });
+
+    testWidgets('should hide itself when a Kitsu seed has no AniList mapping',
+        (WidgetTester tester) async {
+      when(() => mockKitsu.getAniListAnimeId(12))
+          .thenAnswer((_) async => null);
+
+      await pumpSection(tester, seed: kitsuSeed);
+
+      expect(find.byType(ListView), findsNothing);
+      verifyNever(() => mockAniList.getAnimeRecommendations(any()));
+    });
+
+    testWidgets('should hide itself when there are no recommendations',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getAnimeRecommendations(21))
+          .thenAnswer((_) async => <Anime>[]);
+
+      await pumpSection(tester);
+
+      expect(find.byType(ListView), findsNothing);
+      verifyNever(() => mockKitsu.getAnimeByAniListIds(any()));
+    });
+
+    testWidgets('should hide itself when the request fails',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getAnimeRecommendations(21))
+          .thenThrow(Exception('network down'));
+
+      await pumpSection(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('should mark a Kitsu-owned similar anime as owned',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getAnimeRecommendations(21)).thenAnswer(
+        (_) async => <Anime>[
+          createTestAnime(id: 11061, title: 'A'),
+          createTestAnime(id: 20, title: 'B'),
+        ],
+      );
+      when(() => mockKitsu.getAnimeByAniListIds(<int>[11061, 20])).thenAnswer(
+        (_) async => <int, Anime>{
+          11061: kitsuAnime(6448, 'A (Kitsu)'),
+          20: kitsuAnime(11, 'B (Kitsu)'),
+        },
+      );
+
+      await pumpSection(
+        tester,
+        ownedIds: <int, List<CollectedItemInfo>>{
+          6448: <CollectedItemInfo>[
+            const CollectedItemInfo(
+              recordId: 1,
+              collectionId: 1,
+              collectionName: 'Watching',
+              source: DataSource.kitsu,
+            ),
+          ],
+        },
+      );
+
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('should ignore an owned id whose source is not Kitsu',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getAnimeRecommendations(21)).thenAnswer(
+        (_) async => <Anime>[createTestAnime(id: 11061, title: 'A')],
+      );
+      when(() => mockKitsu.getAnimeByAniListIds(<int>[11061])).thenAnswer(
+        (_) async => <int, Anime>{11061: kitsuAnime(6448, 'A (Kitsu)')},
+      );
+
+      await pumpSection(
+        tester,
+        ownedIds: <int, List<CollectedItemInfo>>{
+          6448: <CollectedItemInfo>[
+            const CollectedItemInfo(
+              recordId: 1,
+              collectionId: 1,
+              collectionName: 'Watching',
+              source: DataSource.anilist,
+            ),
+          ],
+        },
+      );
+
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+  });
+}

--- a/test/features/collections/widgets/manga_similars_section_test.dart
+++ b/test/features/collections/widgets/manga_similars_section_test.dart
@@ -1,5 +1,3 @@
-// Widget tests for MangaSimilarsSection — render / empty / error / owned badge.
-
 import 'package:core/models/collected_item_info.dart';
 import 'package:core/models/data_source.dart';
 import 'package:core/models/manga.dart';
@@ -7,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/anilist_api.dart';
+import 'package:tonkatsu_box/core/api/kitsu_api.dart';
 import 'package:tonkatsu_box/core/api/mangabaka_api.dart';
 import 'package:tonkatsu_box/core/api/mangadex_api.dart';
 import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
@@ -19,10 +19,14 @@ void main() {
 
   late MockMangaBakaApi mockApi;
   late MockMangaDexApi mockDexApi;
+  late MockAniListApi mockAniList;
+  late MockKitsuApi mockKitsu;
 
   setUp(() {
     mockApi = MockMangaBakaApi();
     mockDexApi = MockMangaDexApi();
+    mockAniList = MockAniListApi();
+    mockKitsu = MockKitsuApi();
   });
 
   final Manga mangaBakaSeed =
@@ -41,6 +45,8 @@ void main() {
       overrides: <Override>[
         mangaBakaApiProvider.overrideWithValue(mockApi),
         mangaDexApiProvider.overrideWithValue(mockDexApi),
+        aniListApiProvider.overrideWithValue(mockAniList),
+        kitsuApiProvider.overrideWithValue(mockKitsu),
         collectedMangaIdsProvider.overrideWith((Ref ref) async => ownedIds),
       ],
     );
@@ -153,6 +159,88 @@ void main() {
       expect(find.text('Vagabond'), findsOneWidget);
       verify(() => mockDexApi.getRecommendations('the-uuid')).called(1);
       verifyNever(() => mockApi.getRecommendations(any()));
+    });
+
+    testWidgets('routes an AniList seed to AniList recommendations',
+        (WidgetTester tester) async {
+      when(() => mockAniList.getMangaRecommendations(30002)).thenAnswer(
+        (_) async => <Manga>[createTestManga(id: 30642, title: 'Vinland Saga')],
+      );
+
+      await pumpSection(
+        tester,
+        seed: createTestManga(id: 30002).copyWith(source: DataSource.anilist),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Vinland Saga'), findsOneWidget);
+      verify(() => mockAniList.getMangaRecommendations(30002)).called(1);
+      verifyNever(() => mockApi.getRecommendations(any()));
+      verifyNever(() => mockKitsu.getAniListMangaId(any()));
+    });
+
+    testWidgets('bridges a Kitsu seed to AniList recommendations',
+        (WidgetTester tester) async {
+      when(() => mockKitsu.getAniListMangaId(24))
+          .thenAnswer((_) async => 30008);
+      when(() => mockAniList.getMangaRecommendations(30008)).thenAnswer(
+        (_) async => <Manga>[createTestManga(id: 30013, title: 'One Piece')],
+      );
+
+      await pumpSection(
+        tester,
+        seed: createTestManga(id: 24).copyWith(source: DataSource.kitsu),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('One Piece'), findsOneWidget);
+      verify(() => mockKitsu.getAniListMangaId(24)).called(1);
+    });
+
+    testWidgets('hides itself when a Kitsu seed has no AniList mapping',
+        (WidgetTester tester) async {
+      when(() => mockKitsu.getAniListMangaId(24))
+          .thenAnswer((_) async => null);
+
+      await pumpSection(
+        tester,
+        seed: createTestManga(id: 24).copyWith(source: DataSource.kitsu),
+      );
+
+      expect(find.byType(ListView), findsNothing);
+      verifyNever(() => mockAniList.getMangaRecommendations(any()));
+    });
+
+    testWidgets(
+        'marks an AniList-owned manga as owned for a Kitsu seed',
+        (WidgetTester tester) async {
+      when(() => mockKitsu.getAniListMangaId(24))
+          .thenAnswer((_) async => 30008);
+      when(() => mockAniList.getMangaRecommendations(30008)).thenAnswer(
+        (_) async => <Manga>[
+          createTestManga(id: 30013, title: 'One Piece')
+              .copyWith(source: DataSource.anilist),
+        ],
+      );
+
+      await pumpSection(
+        tester,
+        seed: createTestManga(id: 24).copyWith(source: DataSource.kitsu),
+        ownedIds: <int, List<CollectedItemInfo>>{
+          // Candidates are AniList entities, so owned matches AniList — not
+          // the seed's Kitsu source.
+          30013: <CollectedItemInfo>[
+            const CollectedItemInfo(
+              recordId: 1,
+              collectionId: 1,
+              collectionName: 'Reading',
+              source: DataSource.anilist,
+            ),
+          ],
+        },
+      );
+
+      expect(find.byIcon(Icons.check), findsOneWidget);
     });
   });
 }

--- a/test/features/recommendations/anime_taste_input_test.dart
+++ b/test/features/recommendations/anime_taste_input_test.dart
@@ -1,0 +1,117 @@
+import 'package:core/models/collection_item.dart';
+import 'package:core/models/data_source.dart';
+import 'package:core/models/item_status.dart';
+import 'package:core/models/media_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/recommendations/anime_taste_input.dart';
+import 'package:tonkatsu_box/features/recommendations/engine/recommendation_models.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('anime_taste_input', () {
+    test('animeTasteId carries the source', () {
+      expect(animeTasteId(DataSource.anilist, 21), 'anime:anilist:21');
+      expect(animeTasteId(DataSource.kitsu, 12), 'anime:kitsu:12');
+    });
+
+    group('tasteTitleFromAnimeItem', () {
+      test('should build features from genres and tags', () {
+        final CollectionItem item = createTestCollectionItem(
+          mediaType: MediaType.anime,
+          externalId: 21,
+          source: DataSource.anilist,
+          status: ItemStatus.completed,
+          userRating: 9,
+          isFavorite: true,
+          anime: createTestAnime(
+            id: 21,
+            genres: <String>['Action', 'Adventure'],
+            tags: <String>['Pirates', 'Shounen'],
+          ),
+        );
+
+        final TasteTitle? t = tasteTitleFromAnimeItem(item);
+
+        expect(t, isNotNull);
+        expect(t!.id, 'anime:anilist:21');
+        expect(
+          t.features.keys,
+          containsAll(<String>['Action', 'Adventure', 'Pirates', 'Shounen']),
+        );
+        expect(t.rating, 9);
+        expect(t.isFavorite, isTrue);
+      });
+
+      test('should return null for a Kitsu-sourced anime (no features)', () {
+        final CollectionItem item = createTestCollectionItem(
+          mediaType: MediaType.anime,
+          externalId: 12,
+          source: DataSource.kitsu,
+          anime: createTestAnime(
+            id: 12,
+            source: DataSource.kitsu,
+            genres: <String>['Action'],
+          ),
+        );
+
+        expect(tasteTitleFromAnimeItem(item), isNull);
+      });
+
+      test('should return null without genres and tags', () {
+        final CollectionItem item = createTestCollectionItem(
+          mediaType: MediaType.anime,
+          externalId: 21,
+          source: DataSource.anilist,
+          anime: createTestAnime(id: 21),
+        );
+
+        expect(tasteTitleFromAnimeItem(item), isNull);
+      });
+
+      test('should return null for other media types', () {
+        expect(
+          tasteTitleFromAnimeItem(
+            createTestCollectionItem(mediaType: MediaType.game),
+          ),
+          isNull,
+        );
+      });
+    });
+
+    group('tasteTitleFromAnime', () {
+      test('should vectorize a candidate without user signals', () {
+        final TasteTitle? t = tasteTitleFromAnime(
+          createTestAnime(id: 11061, genres: <String>['Action']),
+        );
+
+        expect(t!.id, 'anime:anilist:11061');
+        expect(t.rating, isNull);
+        expect(t.isFavorite, isFalse);
+      });
+    });
+
+    group('ownedAnimeTasteIds', () {
+      test('should collect anime of every source, and only anime', () {
+        final Set<String> owned = ownedAnimeTasteIds(<CollectionItem>[
+          createTestCollectionItem(
+            mediaType: MediaType.anime,
+            externalId: 21,
+            source: DataSource.anilist,
+          ),
+          createTestCollectionItem(
+            mediaType: MediaType.anime,
+            externalId: 12,
+            source: DataSource.kitsu,
+          ),
+          createTestCollectionItem(
+            mediaType: MediaType.movie,
+            externalId: 603,
+          ),
+        ]);
+
+        expect(owned, <String>{'anime:anilist:21', 'anime:kitsu:12'});
+      });
+    });
+  });
+}

--- a/test/features/recommendations/manga_taste_input_test.dart
+++ b/test/features/recommendations/manga_taste_input_test.dart
@@ -1,0 +1,78 @@
+import 'package:core/models/collection_item.dart';
+import 'package:core/models/data_source.dart';
+import 'package:core/models/media_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonkatsu_box/features/recommendations/engine/recommendation_models.dart';
+import 'package:tonkatsu_box/features/recommendations/manga_taste_input.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  group('manga_taste_input', () {
+    test('mangaTasteId carries the source', () {
+      expect(mangaTasteId(DataSource.mangabaka, 42), 'manga:mangabaka:42');
+      expect(mangaTasteId(DataSource.anilist, 30002), 'manga:anilist:30002');
+    });
+
+    group('tasteTitleFromMangaItem', () {
+      CollectionItem itemFor(DataSource source) => createTestCollectionItem(
+            mediaType: MediaType.manga,
+            externalId: 42,
+            source: source,
+            manga: createTestManga(id: 42).copyWith(
+              source: source,
+              genres: <String>['Action'],
+              tags: <String>['Dark Fantasy'],
+            ),
+          );
+
+      test('should build a title only for the requested source', () {
+        final CollectionItem item = itemFor(DataSource.mangabaka);
+
+        final TasteTitle? t =
+            tasteTitleFromMangaItem(item, DataSource.mangabaka);
+        expect(t, isNotNull);
+        expect(t!.id, 'manga:mangabaka:42');
+        expect(
+          t.features.keys,
+          containsAll(<String>['Action', 'Dark Fantasy']),
+        );
+
+        expect(tasteTitleFromMangaItem(item, DataSource.anilist), isNull);
+      });
+
+      test('should return null for other media types', () {
+        expect(
+          tasteTitleFromMangaItem(
+            createTestCollectionItem(mediaType: MediaType.book),
+            DataSource.mangabaka,
+          ),
+          isNull,
+        );
+      });
+    });
+
+    group('ownedMangaTasteIds', () {
+      test('should key owned manga by their own source', () {
+        final Set<String> owned = ownedMangaTasteIds(<CollectionItem>[
+          createTestCollectionItem(
+            mediaType: MediaType.manga,
+            externalId: 42,
+            source: DataSource.mangabaka,
+          ),
+          createTestCollectionItem(
+            mediaType: MediaType.manga,
+            externalId: 42,
+            source: DataSource.mangadex,
+          ),
+        ]);
+
+        // Same numeric id, different sources — both kept apart.
+        expect(
+          owned,
+          <String>{'manga:mangabaka:42', 'manga:mangadex:42'},
+        );
+      });
+    });
+  });
+}

--- a/test/features/recommendations/providers/recommendations_provider_test.dart
+++ b/test/features/recommendations/providers/recommendations_provider_test.dart
@@ -1,0 +1,275 @@
+import 'package:core/models/anime.dart';
+import 'package:core/models/collection_item.dart';
+import 'package:core/models/data_source.dart';
+import 'package:core/models/item_status.dart';
+import 'package:core/models/manga.dart';
+import 'package:core/models/media_type.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tonkatsu_box/core/api/anilist_api.dart';
+import 'package:tonkatsu_box/core/api/mangabaka_api.dart';
+import 'package:tonkatsu_box/core/api/mangadex_api.dart';
+import 'package:tonkatsu_box/core/api/tmdb_api.dart';
+import 'package:tonkatsu_box/core/database/database_service.dart';
+import 'package:tonkatsu_box/features/home/providers/all_items_provider.dart';
+import 'package:tonkatsu_box/features/recommendations/providers/recommendations_provider.dart';
+import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
+
+import '../../../helpers/test_helpers.dart';
+
+class _FakeAllItemsNotifier extends AllItemsNotifier {
+  _FakeAllItemsNotifier(this._items);
+
+  final List<CollectionItem> _items;
+
+  @override
+  AsyncValue<List<CollectionItem>> build() =>
+      AsyncData<List<CollectionItem>>(_items);
+}
+
+class _NoKeySettingsNotifier extends SettingsNotifier {
+  @override
+  SettingsState build() => const SettingsState();
+}
+
+void main() {
+  setUpAll(registerAllFallbacks);
+
+  late MockAniListApi mockAniList;
+  late MockMangaBakaApi mockMangaBaka;
+  late MockMangaDexApi mockMangaDex;
+  late MockTmdbApi mockTmdb;
+  late MockDatabaseService mockDb;
+  late MockMovieDao mockMovieDao;
+
+  setUp(() {
+    mockAniList = MockAniListApi();
+    mockMangaBaka = MockMangaBakaApi();
+    mockMangaDex = MockMangaDexApi();
+    mockTmdb = MockTmdbApi();
+    mockDb = MockDatabaseService();
+    mockMovieDao = MockMovieDao();
+    when(() => mockDb.movieDao).thenReturn(mockMovieDao);
+    when(() => mockMovieDao.getTmdbGenreMap(any(), lang: any(named: 'lang')))
+        .thenAnswer((_) async => <String, String>{});
+  });
+
+  ProviderContainer makeContainer(List<CollectionItem> library) {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        allItemsNotifierProvider
+            .overrideWith(() => _FakeAllItemsNotifier(library)),
+        settingsNotifierProvider.overrideWith(_NoKeySettingsNotifier.new),
+        databaseServiceProvider.overrideWithValue(mockDb),
+        aniListApiProvider.overrideWithValue(mockAniList),
+        mangaBakaApiProvider.overrideWithValue(mockMangaBaka),
+        mangaDexApiProvider.overrideWithValue(mockMangaDex),
+        tmdbApiProvider.overrideWithValue(mockTmdb),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  CollectionItem completedAnime({
+    required int id,
+    List<String> genres = const <String>['Action'],
+    List<String> tags = const <String>['Shounen'],
+  }) =>
+      createTestCollectionItem(
+        id: id,
+        mediaType: MediaType.anime,
+        externalId: id,
+        source: DataSource.anilist,
+        status: ItemStatus.completed,
+        userRating: 9,
+        isFavorite: true,
+        anime: createTestAnime(id: id, genres: genres, tags: tags),
+      );
+
+  Anime candidateAnime(int id) => createTestAnime(
+        id: id,
+        title: 'Candidate $id',
+        genres: <String>['Action'],
+        tags: <String>['Shounen'],
+      );
+
+  group('recommendationsProvider', () {
+    test('should build anime rows without a TMDB key (keyless domain)',
+        () async {
+      when(() => mockAniList.getAnimeRecommendationsBatch(any())).thenAnswer(
+        (_) async => <int, List<Anime>>{
+          21: <Anime>[candidateAnime(11061), candidateAnime(20)],
+        },
+      );
+
+      final ProviderContainer container = makeContainer(<CollectionItem>[
+        completedAnime(id: 21),
+      ]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      expect(result.status, RecommendationStatus.ready);
+      expect(result.rows, isNotEmpty);
+      final RecommendedItem item = result.rows.first.items.first;
+      expect(item.mediaType, MediaType.anime);
+      expect(item.source, DataSource.anilist);
+      verifyNever(() => mockTmdb.discoverMovies(
+            genreId: any(named: 'genreId'),
+            voteCountGte: any(named: 'voteCountGte'),
+            page: any(named: 'page'),
+          ));
+    });
+
+    test('should exclude anime the library already owns', () async {
+      when(() => mockAniList.getAnimeRecommendationsBatch(any())).thenAnswer(
+        (_) async => <int, List<Anime>>{
+          21: <Anime>[candidateAnime(11061), candidateAnime(20)],
+        },
+      );
+
+      final ProviderContainer container = makeContainer(<CollectionItem>[
+        completedAnime(id: 21),
+        // Candidate 20 is already collected (any status counts as owned).
+        createTestCollectionItem(
+          id: 2,
+          mediaType: MediaType.anime,
+          externalId: 20,
+          source: DataSource.anilist,
+          anime: createTestAnime(id: 20),
+        ),
+      ]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      final Iterable<int> ids = result.rows
+          .expand((RecommendationRowUi r) => r.items)
+          .map((RecommendedItem i) => i.externalId);
+      expect(ids, contains(11061));
+      expect(ids, isNot(contains(20)));
+    });
+
+    test('should build manga rows from a MangaBaka profile', () async {
+      when(() => mockMangaBaka.getRecommendations(any())).thenAnswer(
+        (_) async => <Manga>[
+          createTestManga(id: 7, title: 'Similar').copyWith(
+            source: DataSource.mangabaka,
+            genres: <String>['Action'],
+            tags: <String>['Seinen'],
+          ),
+        ],
+      );
+
+      final ProviderContainer container = makeContainer(<CollectionItem>[
+        createTestCollectionItem(
+          id: 1,
+          mediaType: MediaType.manga,
+          externalId: 42,
+          source: DataSource.mangabaka,
+          status: ItemStatus.completed,
+          userRating: 9,
+          isFavorite: true,
+          manga: createTestManga(id: 42).copyWith(
+            source: DataSource.mangabaka,
+            genres: <String>['Action'],
+            tags: <String>['Seinen'],
+          ),
+        ),
+      ]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      expect(result.status, RecommendationStatus.ready);
+      expect(result.rows.first.items.single.mediaType, MediaType.manga);
+      expect(result.rows.first.items.single.source, DataSource.mangabaka);
+      verifyNever(() => mockAniList.getMangaRecommendationsBatch(any()));
+      verifyNever(() => mockMangaDex.getRecommendations(any()));
+    });
+
+    test('should report empty for an empty library', () async {
+      final ProviderContainer container = makeContainer(<CollectionItem>[]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      expect(result.status, RecommendationStatus.empty);
+    });
+
+    test(
+        'should report noCandidates when a profile exists but the fetch '
+        'returns nothing', () async {
+      when(() => mockAniList.getAnimeRecommendationsBatch(any()))
+          .thenAnswer((_) async => <int, List<Anime>>{});
+
+      final ProviderContainer container = makeContainer(<CollectionItem>[
+        completedAnime(id: 21),
+      ]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      expect(result.status, RecommendationStatus.noCandidates);
+    });
+
+    test(
+        'should report noApiKey only when the movie/TV profile is the sole '
+        'one and the key is missing', () async {
+      final ProviderContainer container = makeContainer(<CollectionItem>[
+        createTestCollectionItem(
+          id: 1,
+          mediaType: MediaType.movie,
+          externalId: 603,
+          status: ItemStatus.completed,
+          userRating: 9,
+          isFavorite: true,
+          movie: createTestMovie(
+            tmdbId: 603,
+            genres: <String>['Action', 'Sci-Fi'],
+          ),
+        ),
+      ]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      expect(result.status, RecommendationStatus.noApiKey);
+    });
+
+    test('should survive a failing anime backend with manga rows intact',
+        () async {
+      when(() => mockAniList.getAnimeRecommendationsBatch(any()))
+          .thenThrow(Exception('AniList down'));
+      when(() => mockMangaBaka.getRecommendations(any())).thenAnswer(
+        (_) async => <Manga>[
+          createTestManga(id: 7, title: 'Similar').copyWith(
+            source: DataSource.mangabaka,
+            genres: <String>['Action'],
+          ),
+        ],
+      );
+
+      final ProviderContainer container = makeContainer(<CollectionItem>[
+        completedAnime(id: 21),
+        createTestCollectionItem(
+          id: 2,
+          mediaType: MediaType.manga,
+          externalId: 42,
+          source: DataSource.mangabaka,
+          status: ItemStatus.completed,
+          userRating: 9,
+          isFavorite: true,
+          manga: createTestManga(id: 42).copyWith(
+            source: DataSource.mangabaka,
+            genres: <String>['Action'],
+          ),
+        ),
+      ]);
+      final RecommendationResult result =
+          await container.read(recommendationsProvider.future);
+
+      expect(result.status, RecommendationStatus.ready);
+      expect(
+        result.rows.expand((RecommendationRowUi r) => r.items).single.mediaType,
+        MediaType.manga,
+      );
+    });
+  });
+}

--- a/test/features/recommendations/recommendations_sort_test.dart
+++ b/test/features/recommendations/recommendations_sort_test.dart
@@ -1,3 +1,4 @@
+import 'package:core/models/data_source.dart';
 import 'package:core/models/media_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/recommendations/providers/recommendations_provider.dart';
@@ -12,7 +13,8 @@ RecommendedItem _item(
       tasteId: 'movie:$title',
       media: Object(),
       mediaType: MediaType.movie,
-      tmdbId: 1,
+      source: DataSource.tmdb,
+      externalId: 1,
       title: title,
       posterUrl: null,
       year: null,

--- a/test/features/recommendations/recommended_item_test.dart
+++ b/test/features/recommendations/recommended_item_test.dart
@@ -1,3 +1,4 @@
+import 'package:core/models/data_source.dart';
 import 'package:core/models/media_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/recommendations/providers/recommendations_provider.dart';
@@ -9,7 +10,8 @@ void main() {
         tasteId: 'taste:1',
         media: media,
         mediaType: mediaType,
-        tmdbId: 1,
+        source: DataSource.tmdb,
+        externalId: 1,
         title: 'Dune',
         posterUrl: null,
         year: null,

--- a/test/features/recommendations/screens/recommendations_screen_test.dart
+++ b/test/features/recommendations/screens/recommendations_screen_test.dart
@@ -1,5 +1,7 @@
 import 'package:core/models/collection.dart';
+import 'package:core/models/data_source.dart';
 import 'package:core/models/media_type.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/collections/providers/collections_provider.dart';
@@ -22,7 +24,8 @@ RecommendedItem _item(String title) => RecommendedItem(
       tasteId: 'movie:$title',
       media: Object(),
       mediaType: MediaType.movie,
-      tmdbId: 1,
+      source: DataSource.tmdb,
+      externalId: 1,
       title: title,
       posterUrl: null,
       year: 2000,
@@ -112,6 +115,43 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.byType(RecommendationsEmptyState), findsNothing);
       expect(find.byType(RecommendationRowWidget), findsNWidgets(2));
+    });
+
+    testWidgets('refresh recomputes and shows the loader while reloading', (
+      WidgetTester tester,
+    ) async {
+      int runs = 0;
+      await tester.pumpApp(
+        const RecommendationsScreen(),
+        overrides: <Override>[
+          collectionsProvider
+              .overrideWith(() => _FakeCollectionsNotifier(<Collection>[])),
+          recommendationsProvider.overrideWith((Ref ref) async {
+            runs++;
+            // A real recompute takes time; without a turnaround the refresh
+            // would resolve within the same frame and never show the loader.
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            return RecommendationResult(
+              status: RecommendationStatus.ready,
+              rows: <RecommendationRowUi>[_row('A')],
+            );
+          }),
+          collectedRecommendationIdsProvider
+              .overrideWith((Ref ref) async => <String>{}),
+        ],
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(RecommendationRowWidget), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.refresh));
+      await tester.pump();
+
+      // The pipeline re-ran and the old rows gave way to the loader.
+      expect(runs, 2);
+      expect(find.byType(RecommendationRowWidget), findsNothing);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(RecommendationRowWidget), findsOneWidget);
     });
   });
 }

--- a/test/features/recommendations/widgets/recommendation_row_test.dart
+++ b/test/features/recommendations/widgets/recommendation_row_test.dart
@@ -1,3 +1,4 @@
+import 'package:core/models/data_source.dart';
 import 'package:core/models/media_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tonkatsu_box/features/recommendations/providers/recommendations_provider.dart';
@@ -10,7 +11,8 @@ RecommendedItem _item(String title) => RecommendedItem(
   tasteId: 'movie:$title',
   media: Object(),
   mediaType: MediaType.movie,
-  tmdbId: 1,
+  source: DataSource.tmdb,
+  externalId: 1,
   title: title,
   posterUrl: null,
   year: 2000,


### PR DESCRIPTION
Item cards get a "Similar" carousel for anime (AniList recommendations rendered as Kitsu titles, keeping seasons and the episode tracker) and the manga carousel now also covers AniList / Kitsu seeds. The Personalization tab learns two new keyless taste domains next to movies/TV: anime (AniList) and manga (per source — MangaBaka, MangaDex, AniList), computed concurrently with per-source tag vocabularies; seeds ride a single aliased GraphQL request against AniList's rate limit.