### PR TITLE
feat(settings): copy button for the Simkl pairing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,6 +413,20 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
   * packages/core/test/utils/stable_id_test.dart: New. Golden vectors pin the
     id contract; io and web variants must agree.
 
+### Changed
+
+- **Copy the Simkl pairing code with one tap**
+
+  The code block on the Simkl import screen gets a copy button, so the code no
+  longer has to be retyped by hand into simkl.com/pin.
+
+  * lib/features/settings/content/simkl_import_content.dart
+    (_SimklImportContentState._buildPinBlock,
+    _SimklImportContentState._copyPin): Copy button next to the code, with a
+    confirmation snack.
+  * lib/l10n/app_en.arb, app_ru.arb, app_es.arb, app_fr.arb, app_pt.arb,
+    app_zh.arb (simklPinCopied): New string.
+
 ### Removed
 
 - **Drop orphaned widgets left behind by earlier redesigns**

--- a/lib/features/settings/content/simkl_import_content.dart
+++ b/lib/features/settings/content/simkl_import_content.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:core/models/collection.dart';
 import 'package:core/models/universal_import_result.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -334,14 +335,28 @@ class _SimklImportContentState extends ConsumerState<SimklImportContent> {
               borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
               border: Border.all(color: AppColors.surfaceBorder),
             ),
-            child: Center(
-              child: SelectableText(
-                pin.userCode,
-                style: AppTypography.h3.copyWith(
-                  fontFamily: 'monospace',
-                  letterSpacing: 8,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Flexible(
+                  child: SelectableText(
+                    pin.userCode,
+                    style: AppTypography.h3.copyWith(
+                      fontFamily: 'monospace',
+                      letterSpacing: 8,
+                    ),
+                  ),
                 ),
-              ),
+                IconButton(
+                  onPressed: () => _copyPin(pin.userCode),
+                  icon: const Icon(Icons.copy, size: 18),
+                  tooltip: l.copy,
+                  visualDensity: VisualDensity.compact,
+                  constraints: const BoxConstraints(),
+                  padding: const EdgeInsets.all(AppSpacing.xs),
+                  color: AppColors.textSecondary,
+                ),
+              ],
             ),
           ),
           const SizedBox(height: AppSpacing.sm),
@@ -663,6 +678,12 @@ class _SimklImportContentState extends ConsumerState<SimklImportContent> {
         ],
       ),
     );
+  }
+
+
+  void _copyPin(String userCode) {
+    Clipboard.setData(ClipboardData(text: userCode));
+    context.showSnack(S.of(context).simklPinCopied);
   }
 
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2460,6 +2460,7 @@
   "simklGetPin": "Get code",
   "simklGetNewPin": "Get a new code",
   "simklPinPrompt": "Enter this code at simkl.com/pin:",
+  "simklPinCopied": "Code copied",
   "simklOpenPinPage": "Open simkl.com/pin",
   "simklWaitingConfirmation": "Waiting for confirmation…",
   "simklPinExpired": "The code has expired.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2430,6 +2430,7 @@
   "simklGetPin": "Obtener código",
   "simklGetNewPin": "Obtener un código nuevo",
   "simklPinPrompt": "Introduce este código en simkl.com/pin:",
+  "simklPinCopied": "Código copiado",
   "simklOpenPinPage": "Abrir simkl.com/pin",
   "simklWaitingConfirmation": "Esperando confirmación…",
   "simklPinExpired": "El código ha caducado.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2430,6 +2430,7 @@
   "simklGetPin": "Obtenir le code",
   "simklGetNewPin": "Obtenir un nouveau code",
   "simklPinPrompt": "Saisissez ce code sur simkl.com/pin :",
+  "simklPinCopied": "Code copié",
   "simklOpenPinPage": "Ouvrir simkl.com/pin",
   "simklWaitingConfirmation": "En attente de confirmation…",
   "simklPinExpired": "Le code a expiré.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9752,6 +9752,12 @@ abstract class S {
   /// **'Enter this code at simkl.com/pin:'**
   String get simklPinPrompt;
 
+  /// No description provided for @simklPinCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Code copied'**
+  String get simklPinCopied;
+
   /// No description provided for @simklOpenPinPage.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5503,6 +5503,9 @@ class SEn extends S {
   String get simklPinPrompt => 'Enter this code at simkl.com/pin:';
 
   @override
+  String get simklPinCopied => 'Code copied';
+
+  @override
   String get simklOpenPinPage => 'Open simkl.com/pin';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5574,6 +5574,9 @@ class SEs extends S {
   String get simklPinPrompt => 'Introduce este código en simkl.com/pin:';
 
   @override
+  String get simklPinCopied => 'Código copiado';
+
+  @override
   String get simklOpenPinPage => 'Abrir simkl.com/pin';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5591,6 +5591,9 @@ class SFr extends S {
   String get simklPinPrompt => 'Saisissez ce code sur simkl.com/pin :';
 
   @override
+  String get simklPinCopied => 'Code copié';
+
+  @override
   String get simklOpenPinPage => 'Ouvrir simkl.com/pin';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -5555,6 +5555,9 @@ class SPt extends S {
   String get simklPinPrompt => 'Digite este código em simkl.com/pin:';
 
   @override
+  String get simklPinCopied => 'Código copiado';
+
+  @override
   String get simklOpenPinPage => 'Abrir simkl.com/pin';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -5599,6 +5599,9 @@ class SRu extends S {
   String get simklPinPrompt => 'Введите этот код на simkl.com/pin:';
 
   @override
+  String get simklPinCopied => 'Код скопирован';
+
+  @override
   String get simklOpenPinPage => 'Открыть simkl.com/pin';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5223,6 +5223,9 @@ class SZh extends S {
   String get simklPinPrompt => '在 simkl.com/pin 输入此代码：';
 
   @override
+  String get simklPinCopied => '代码已复制';
+
+  @override
   String get simklOpenPinPage => '打开 simkl.com/pin';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2857,6 +2857,7 @@
   "simklGetPin": "Obter código",
   "simklGetNewPin": "Obter um novo código",
   "simklPinPrompt": "Digite este código em simkl.com/pin:",
+  "simklPinCopied": "Código copiado",
   "simklOpenPinPage": "Abrir simkl.com/pin",
   "simklWaitingConfirmation": "Aguardando confirmação…",
   "simklPinExpired": "O código expirou.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -2091,6 +2091,7 @@
   "simklGetPin": "Получить код",
   "simklGetNewPin": "Получить новый код",
   "simklPinPrompt": "Введите этот код на simkl.com/pin:",
+  "simklPinCopied": "Код скопирован",
   "simklOpenPinPage": "Открыть simkl.com/pin",
   "simklWaitingConfirmation": "Ждём подтверждения…",
   "simklPinExpired": "Срок действия кода истёк.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2425,6 +2425,7 @@
   "simklGetPin": "获取代码",
   "simklGetNewPin": "获取新代码",
   "simklPinPrompt": "在 simkl.com/pin 输入此代码：",
+  "simklPinCopied": "代码已复制",
   "simklOpenPinPage": "打开 simkl.com/pin",
   "simklWaitingConfirmation": "等待确认…",
   "simklPinExpired": "代码已过期。",

--- a/test/features/settings/content/simkl_import_content_test.dart
+++ b/test/features/settings/content/simkl_import_content_test.dart
@@ -1,5 +1,6 @@
 import 'package:core/models/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -58,6 +59,32 @@ void main() {
   S loc(WidgetTester tester) =>
       S.of(tester.element(find.byType(SimklImportContent)));
 
+  /// Drives the client-id form until the PIN block is on screen.
+  Future<SharedPreferences> pumpPinBlock(WidgetTester tester) async {
+    when(() => mockSimkl.requestPin()).thenAnswer((_) async => const SimklPin(
+          userCode: 'AB12C',
+          verificationUrl: 'https://simkl.com/pin',
+          expiresIn: 900,
+          // Long enough that no poll tick fires during the test.
+          interval: 600,
+        ));
+    final SharedPreferences prefs = await pumpContent(tester);
+
+    await tester.enterText(
+      find.ancestor(
+        of: find.text(loc(tester).simklClientIdLabel),
+        matching: find.byType(TextField),
+      ),
+      'my-client-id',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(loc(tester).simklGetPin));
+    // The PIN block spins an indeterminate bar, so it never settles.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    return prefs;
+  }
+
   group('SimklImportContent', () {
     testWidgets('renders the disconnected form without exceptions',
         (WidgetTester tester) async {
@@ -90,27 +117,7 @@ void main() {
 
     testWidgets('shows the PIN code once the user supplies a client id',
         (WidgetTester tester) async {
-      when(() => mockSimkl.requestPin()).thenAnswer((_) async => const SimklPin(
-            userCode: 'AB12C',
-            verificationUrl: 'https://simkl.com/pin',
-            expiresIn: 900,
-            // Long enough that no poll tick fires during the test.
-            interval: 600,
-          ));
-      final SharedPreferences prefs = await pumpContent(tester);
-
-      await tester.enterText(
-        find.ancestor(
-          of: find.text(loc(tester).simklClientIdLabel),
-          matching: find.byType(TextField),
-        ),
-        'my-client-id',
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.text(loc(tester).simklGetPin));
-      // The PIN block spins an indeterminate bar, so it never settles.
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 50));
+      final SharedPreferences prefs = await pumpPinBlock(tester);
 
       expect(find.text('AB12C'), findsOneWidget);
       expect(tester.takeException(), isNull);
@@ -119,6 +126,37 @@ void main() {
       expect(prefs.getString(SettingsKeys.simklClientId), 'my-client-id');
 
       // Dispose the tree so the poll timer is cancelled before teardown.
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
+    testWidgets('copies the PIN code when the copy button is tapped',
+        (WidgetTester tester) async {
+      final List<MethodCall> platformCalls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          platformCalls.add(call);
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+      await pumpPinBlock(tester);
+
+      await tester.tap(find.byTooltip(loc(tester).copy));
+      await tester.pump();
+
+      final Iterable<MethodCall> copies = platformCalls
+          .where((MethodCall call) => call.method == 'Clipboard.setData');
+      expect(copies, hasLength(1));
+      expect(
+        (copies.first.arguments as Map<Object?, Object?>)['text'],
+        'AB12C',
+      );
+      expect(tester.takeException(), isNull);
+
       await tester.pumpWidget(const SizedBox.shrink());
     });
 


### PR DESCRIPTION
The PIN block gets a copy button with a confirmation snack, so the code does not have to be retyped by hand into simkl.com/pin.