### PR TITLE
perf(app): keyed sorting, scoped selection rebuilds, batched platform…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,11 @@ Entries follow the [GNU Change Log style](https://www.gnu.org/prep/standards/htm
 
 ### Changed
 
+- **Performance improvements**
+
+  Faster sorting on large collections and smoother "All items" grid,
+  selection mode and scrolling.
+
 - **The collection banner carries the title and the back arrow**
 
   With rich collection view on, the plain title row above a collection is

--- a/lib/features/collections/providers/sort_utils.dart
+++ b/lib/features/collections/providers/sort_utils.dart
@@ -2,10 +2,28 @@ import 'package:core/models/collection_item.dart';
 import 'package:core/models/collection_sort_mode.dart';
 import 'package:core/utils/anime_manga_title_language.dart';
 
-int _compareByDisplayName(CollectionItem a, CollectionItem b, String lang) =>
-    a.displayName(lang).toLowerCase().compareTo(
-          b.displayName(lang).toLowerCase(),
-        );
+/// Item plus its precomputed lowercase name: a comparator recomputing
+/// `displayName` costs O(n·log n) calls, keying costs exactly n.
+typedef _Keyed = ({String name, CollectionItem item});
+
+int _byName(_Keyed a, _Keyed b) {
+  final int byName = a.name.compareTo(b.name);
+  // List.sort is unstable; id keeps duplicate names deterministic.
+  return byName != 0 ? byName : a.item.id.compareTo(b.item.id);
+}
+
+List<CollectionItem> _sortKeyed(
+  List<CollectionItem> items,
+  String lang,
+  int Function(_Keyed a, _Keyed b) compare,
+) {
+  final List<_Keyed> keyed = <_Keyed>[
+    for (final CollectionItem i in items)
+      (name: i.displayName(lang).toLowerCase(), item: i),
+  ];
+  keyed.sort(compare);
+  return <CollectionItem>[for (final _Keyed e in keyed) e.item];
+}
 
 /// Recent first; undated items sink last, kept stable by [tieBreaker].
 int _compareNullableDatesDesc(
@@ -28,85 +46,86 @@ List<CollectionItem> applySortMode(
   bool isDescending = false,
   String animeMangaTitleLanguage = AnimeMangaTitleLanguage.defaultId,
 }) {
-  final List<CollectionItem> sorted = List<CollectionItem>.of(items);
+  final String lang = animeMangaTitleLanguage;
+  final List<CollectionItem> sorted;
   switch (sortMode) {
     case CollectionSortMode.manual:
-      sorted.sort(
-        (CollectionItem a, CollectionItem b) =>
-            a.sortOrder.compareTo(b.sortOrder),
-      );
+      sorted = List<CollectionItem>.of(items)
+        ..sort(
+          (CollectionItem a, CollectionItem b) =>
+              a.sortOrder.compareTo(b.sortOrder),
+        );
       // Manual is never inverted: the order is user-defined.
       return sorted;
     case CollectionSortMode.addedDate:
-      sorted.sort(
-        (CollectionItem a, CollectionItem b) =>
-            b.addedAt.compareTo(a.addedAt),
-      );
+      sorted = List<CollectionItem>.of(items)
+        ..sort(
+          (CollectionItem a, CollectionItem b) =>
+              b.addedAt.compareTo(a.addedAt),
+        );
     case CollectionSortMode.status:
-      sorted.sort((CollectionItem a, CollectionItem b) {
-        final int cmp =
-            a.status.statusSortPriority.compareTo(b.status.statusSortPriority);
-        if (cmp != 0) return cmp;
-        return _compareByDisplayName(a, b, animeMangaTitleLanguage);
+      sorted = _sortKeyed(items, lang, (_Keyed a, _Keyed b) {
+        final int cmp = a.item.status.statusSortPriority
+            .compareTo(b.item.status.statusSortPriority);
+        return cmp != 0 ? cmp : _byName(a, b);
       });
     case CollectionSortMode.name:
-      sorted.sort(
-        (CollectionItem a, CollectionItem b) =>
-            _compareByDisplayName(a, b, animeMangaTitleLanguage),
-      );
+      sorted = _sortKeyed(items, lang, _byName);
     case CollectionSortMode.rating:
-      sorted.sort((CollectionItem a, CollectionItem b) {
+      sorted = _sortKeyed(items, lang, (_Keyed a, _Keyed b) {
         // User rating only (API rating is a separate mode); unrated items
         // sort last by name so the bucket stays stable across re-sorts.
-        final double? rA = a.userRating?.toDouble();
-        final double? rB = b.userRating?.toDouble();
-        if (rA == null && rB == null) {
-          return _compareByDisplayName(a, b, animeMangaTitleLanguage);
-        }
+        final double? rA = a.item.userRating?.toDouble();
+        final double? rB = b.item.userRating?.toDouble();
+        if (rA == null && rB == null) return _byName(a, b);
         if (rA == null) return 1;
         if (rB == null) return -1;
         final int byRating = rB.compareTo(rA);
-        return byRating != 0
-            ? byRating
-            : _compareByDisplayName(a, b, animeMangaTitleLanguage);
+        return byRating != 0 ? byRating : _byName(a, b);
       });
     case CollectionSortMode.favorite:
-      sorted.sort((CollectionItem a, CollectionItem b) {
-        if (a.isFavorite != b.isFavorite) {
-          return a.isFavorite ? -1 : 1;
+      sorted = _sortKeyed(items, lang, (_Keyed a, _Keyed b) {
+        if (a.item.isFavorite != b.item.isFavorite) {
+          return a.item.isFavorite ? -1 : 1;
         }
-        return _compareByDisplayName(a, b, animeMangaTitleLanguage);
+        return _byName(a, b);
       });
     case CollectionSortMode.externalRating:
-      sorted.sort((CollectionItem a, CollectionItem b) {
-        // Null ratings sort last.
-        if (a.apiRating == null && b.apiRating == null) return 0;
-        if (a.apiRating == null) return 1;
-        if (b.apiRating == null) return -1;
-        return b.apiRating!.compareTo(a.apiRating!);
-      });
+      sorted = List<CollectionItem>.of(items)
+        ..sort((CollectionItem a, CollectionItem b) {
+          // Null ratings sort last.
+          if (a.apiRating == null && b.apiRating == null) return 0;
+          if (a.apiRating == null) return 1;
+          if (b.apiRating == null) return -1;
+          return b.apiRating!.compareTo(a.apiRating!);
+        });
     case CollectionSortMode.lastActivity:
-      sorted.sort((CollectionItem a, CollectionItem b) {
-        // An item untouched since it was added has no activity date yet; fall
-        // back to its added date so fresh items don't sink below older ones.
-        final DateTime aAt = a.lastActivityAt ?? a.addedAt;
-        final DateTime bAt = b.lastActivityAt ?? b.addedAt;
-        return bAt.compareTo(aAt);
-      });
+      sorted = List<CollectionItem>.of(items)
+        ..sort((CollectionItem a, CollectionItem b) {
+          // An item untouched since it was added has no activity date yet;
+          // fall back to added so fresh items don't sink below older ones.
+          final DateTime aAt = a.lastActivityAt ?? a.addedAt;
+          final DateTime bAt = b.lastActivityAt ?? b.addedAt;
+          return bAt.compareTo(aAt);
+        });
     case CollectionSortMode.startDate:
-      sorted.sort(
-        (CollectionItem a, CollectionItem b) => _compareNullableDatesDesc(
-          a.startedAt,
-          b.startedAt,
-          () => _compareByDisplayName(a, b, animeMangaTitleLanguage),
+      sorted = _sortKeyed(
+        items,
+        lang,
+        (_Keyed a, _Keyed b) => _compareNullableDatesDesc(
+          a.item.startedAt,
+          b.item.startedAt,
+          () => _byName(a, b),
         ),
       );
     case CollectionSortMode.completionDate:
-      sorted.sort(
-        (CollectionItem a, CollectionItem b) => _compareNullableDatesDesc(
-          a.completedAt,
-          b.completedAt,
-          () => _compareByDisplayName(a, b, animeMangaTitleLanguage),
+      sorted = _sortKeyed(
+        items,
+        lang,
+        (_Keyed a, _Keyed b) => _compareNullableDatesDesc(
+          a.item.completedAt,
+          b.item.completedAt,
+          () => _byName(a, b),
         ),
       );
   }

--- a/lib/features/collections/widgets/collection_items_view.dart
+++ b/lib/features/collections/widgets/collection_items_view.dart
@@ -401,14 +401,17 @@ class CollectionItemsView extends ConsumerWidget {
           ? (bool hasFocus) => onItemFocusChanged!(item, hasFocus)
           : null,
     );
-    if (!canEdit) return card;
-    return SelectablePosterCard(
-      isSelected: isSelected,
-      selectionActive: selectionActive,
-      onToggleSelect: () => ref
-          .read(collectionSelectionProvider(collectionId).notifier)
-          .toggle(item.id),
-      child: card,
+    // Hover/animation inside one card must not invalidate the grid's layer.
+    if (!canEdit) return RepaintBoundary(child: card);
+    return RepaintBoundary(
+      child: SelectablePosterCard(
+        isSelected: isSelected,
+        selectionActive: selectionActive,
+        onToggleSelect: () => ref
+            .read(collectionSelectionProvider(collectionId).notifier)
+            .toggle(item.id),
+        child: card,
+      ),
     );
   }
 

--- a/lib/features/home/providers/all_items_provider.dart
+++ b/lib/features/home/providers/all_items_provider.dart
@@ -256,11 +256,8 @@ final FutureProvider<List<Platform>> allItemsPlatformsProvider =
   if (uniqueIds.isEmpty) return <Platform>[];
 
   final DatabaseService db = ref.read(databaseServiceProvider);
-  final List<Platform> platforms = <Platform>[];
-  for (final int id in uniqueIds) {
-    final Platform? p = await db.gameDao.getPlatformById(id);
-    if (p != null) platforms.add(p);
-  }
+  final List<Platform> platforms =
+      await db.gameDao.getPlatformsByIds(uniqueIds.toList());
   platforms.sort(
     (Platform a, Platform b) => a.name.compareTo(b.name),
   );

--- a/lib/features/home/screens/all_items_screen.dart
+++ b/lib/features/home/screens/all_items_screen.dart
@@ -79,35 +79,18 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
     final bool favoriteOnly = ref.watch(homeFavoriteFilterProvider);
     final String searchQuery = ref.watch(homeSearchQueryProvider);
 
-    final Set<int> selection = ref.watch(allItemsSelectionProvider);
     final List<CollectionItem> allItems =
         itemsAsync.valueOrNull ?? const <CollectionItem>[];
     final List<CollectionItem> visibleItems =
         _applyFilter(
             allItems, filterStatuses, favoriteOnly, tagsMap, searchQuery);
-    final List<CollectionItem> selectedItems = selection.isEmpty
-        ? const <CollectionItem>[]
-        : <CollectionItem>[
-            for (final CollectionItem i in allItems)
-              if (selection.contains(i.id)) i,
-          ];
 
     return Column(
       children: <Widget>[
         _buildMediaTypeBar(
             itemsAsync, filterStatuses, favoriteOnly, tagsMap, searchQuery),
         SubfilterBar(groups: _subfilterGroups(itemsAsync)),
-        if (selectedItems.isNotEmpty)
-          BulkActionBar(
-            items: selectedItems,
-            visibleCount: visibleItems.length,
-            onSelectAllVisible: () => ref
-                .read(allItemsSelectionProvider.notifier)
-                .selectAll(visibleItems.map((CollectionItem i) => i.id)),
-            onClearSelection: () => ref
-                .read(allItemsSelectionProvider.notifier)
-                .clear(),
-          ),
+        _AllItemsBulkBar(allItems: allItems, visibleItems: visibleItems),
         Expanded(
           child: itemsAsync.when(
             data: (List<CollectionItem> items) {
@@ -511,72 +494,19 @@ class _AllItemsScreenState extends ConsumerState<AllItemsScreen> {
                   (BuildContext context, int index) {
                     final CollectionItem item = groups[i].items[index];
                     final List<int>? tagIds = itemTags[item.id];
-                    final Tag? tag = orderedTags.primaryFor(tagIds);
-                    final int tagCount = tagIds?.length ?? 0;
-                    final Set<int> selection =
-                        ref.watch(allItemsSelectionProvider);
-                    final bool isSelected = selection.contains(item.id);
-                    final ItemCardProgress? progress =
-                        itemCardProgress(item) ?? trackerCardProgress(ref, item);
-                    final MediaPosterCard card = MediaPosterCard(
+                    return _AllItemsCard(
                       key: ValueKey<int>(item.id),
+                      item: item,
                       variant: isLandscape ||
                               isCompactScreen(context)
                           ? CardVariant.compact
                           : CardVariant.grid,
-                      title: item.cardTitle(ref.displayNameOf(item)),
-                      imageUrl: item.thumbnailUrl ?? '',
-                      cacheImageType:
-                          _imageTypeFor(item.mediaType, item.platformId),
-                      cacheImageId: item.coverImageId,
-                      userRating: item.userRating,
-                      apiRating: item.apiRating,
-                      splitRatings: true,
-                      year: _yearFor(item),
-                      platformLabel: item.platform?.displayName,
-                      platformColor: item.platform?.familyColor,
-                      platformOverlayAsset:
-                          ref.watch(settingsNotifierProvider).resolveOverlay(
-                            platformOverlay: item.platform?.overlayAsset,
-                            mediaTypeOverlay: item.mediaType.overlayAsset,
-                          ),
-                      mediaType: item.displayMediaType,
-                      typeLabelOverride: item.formatLabel,
-                      status: item.status,
-                      progress: progress,
-                      isFavorite: item.isFavorite,
-                      showFavorite: true,
-                      enableHoverScale: !isSelected,
-                      onToggleFavorite: selection.isEmpty
-                          ? () => ref
-                              .read(allItemsNotifierProvider.notifier)
-                              .toggleFavorite(item.id)
-                          : null,
-                      tagName: tag?.name,
-                      tagColor: tag?.color,
-                      tagTextColor: tag?.textColor,
-                      tagMoreCount: tagCount > 1 ? tagCount - 1 : 0,
-                      source: item.dataSource,
-                      onSourceTap: openUrlCallback(item.externalUrl),
-                      onTap: selection.isEmpty
-                          ? () => _showItemDetails(item, collectionNames)
-                          : () => ref
-                              .read(allItemsSelectionProvider.notifier)
-                              .toggle(item.id),
-                      onSecondaryTap: (Offset pos) =>
+                      tag: orderedTags.primaryFor(tagIds),
+                      tagCount: tagIds?.length ?? 0,
+                      onShowDetails: () =>
+                          _showItemDetails(item, collectionNames),
+                      onShowContextMenu: (Offset pos) =>
                           _showItemContextMenu(pos, item),
-                      onLongPress: () => ref
-                          .read(allItemsSelectionProvider.notifier)
-                          .toggle(item.id),
-                    );
-                    return SelectablePosterCard(
-                      key: ValueKey<int>(item.id),
-                      isSelected: isSelected,
-                      selectionActive: selection.isNotEmpty,
-                      onToggleSelect: () => ref
-                          .read(allItemsSelectionProvider.notifier)
-                          .toggle(item.id),
-                      child: card,
                     );
                   },
                   childCount: groups[i].items.length,
@@ -994,4 +924,123 @@ class _CollectionGroup {
   final String name;
   final List<CollectionItem> items;
   final bool isUncategorized;
+}
+
+/// Watches the selection itself so a toggle never rebuilds the screen
+/// (and its O(n) grouping) — only the bar.
+class _AllItemsBulkBar extends ConsumerWidget {
+  const _AllItemsBulkBar({
+    required this.allItems,
+    required this.visibleItems,
+  });
+
+  final List<CollectionItem> allItems;
+  final List<CollectionItem> visibleItems;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Set<int> selection = ref.watch(allItemsSelectionProvider);
+    if (selection.isEmpty) return const SizedBox.shrink();
+    final List<CollectionItem> selectedItems = <CollectionItem>[
+      for (final CollectionItem i in allItems)
+        if (selection.contains(i.id)) i,
+    ];
+    return BulkActionBar(
+      items: selectedItems,
+      visibleCount: visibleItems.length,
+      onSelectAllVisible: () => ref
+          .read(allItemsSelectionProvider.notifier)
+          .selectAll(visibleItems.map((CollectionItem i) => i.id)),
+      onClearSelection: () =>
+          ref.read(allItemsSelectionProvider.notifier).clear(),
+    );
+  }
+}
+
+/// Scopes selection/settings/tracker watches to one card: bool-valued
+/// `select`s rebuild only the card whose value actually changed.
+class _AllItemsCard extends ConsumerWidget {
+  const _AllItemsCard({
+    required this.item,
+    required this.variant,
+    required this.tag,
+    required this.tagCount,
+    required this.onShowDetails,
+    required this.onShowContextMenu,
+    super.key,
+  });
+
+  final CollectionItem item;
+  final CardVariant variant;
+  final Tag? tag;
+  final int tagCount;
+  final VoidCallback onShowDetails;
+  final void Function(Offset position) onShowContextMenu;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bool isSelected = ref.watch(
+      allItemsSelectionProvider.select((Set<int> s) => s.contains(item.id)),
+    );
+    final bool selectionActive = ref.watch(
+      allItemsSelectionProvider.select((Set<int> s) => s.isNotEmpty),
+    );
+    final String? overlayAsset = ref.watch(
+      settingsNotifierProvider.select(
+        (SettingsState s) => s.resolveOverlay(
+          platformOverlay: item.platform?.overlayAsset,
+          mediaTypeOverlay: item.mediaType.overlayAsset,
+        ),
+      ),
+    );
+    final ItemCardProgress? progress =
+        itemCardProgress(item) ?? trackerCardProgress(ref, item);
+    void toggle() =>
+        ref.read(allItemsSelectionProvider.notifier).toggle(item.id);
+    return RepaintBoundary(
+      child: SelectablePosterCard(
+        isSelected: isSelected,
+        selectionActive: selectionActive,
+        onToggleSelect: toggle,
+        child: MediaPosterCard(
+          variant: variant,
+          title: item.cardTitle(ref.displayNameOf(item)),
+          imageUrl: item.thumbnailUrl ?? '',
+          cacheImageType: _AllItemsScreenState._imageTypeFor(
+            item.mediaType,
+            item.platformId,
+          ),
+          cacheImageId: item.coverImageId,
+          userRating: item.userRating,
+          apiRating: item.apiRating,
+          splitRatings: true,
+          year: _AllItemsScreenState._yearFor(item),
+          platformLabel: item.platform?.displayName,
+          platformColor: item.platform?.familyColor,
+          platformOverlayAsset: overlayAsset,
+          mediaType: item.displayMediaType,
+          typeLabelOverride: item.formatLabel,
+          status: item.status,
+          progress: progress,
+          isFavorite: item.isFavorite,
+          showFavorite: true,
+          enableHoverScale: !isSelected,
+          onToggleFavorite: selectionActive
+              ? null
+              : () => ref
+                  .read(allItemsNotifierProvider.notifier)
+                  .toggleFavorite(item.id),
+          tagName: tag?.name,
+          tagColor: tag?.color,
+          tagTextColor: tag?.textColor,
+          tagMoreCount: tagCount > 1 ? tagCount - 1 : 0,
+          source: item.dataSource,
+          onSourceTap: openUrlCallback(item.externalUrl),
+          onTap: selectionActive ? toggle : onShowDetails,
+          onSecondaryTap: onShowContextMenu,
+          onLongPress: toggle,
+        ),
+      ),
+    );
+  }
 }

--- a/packages/core/test/models/db_field_coverage_test.dart
+++ b/packages/core/test/models/db_field_coverage_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+// A forgotten `toDb` entry compiles fine and the field silently never reaches
+// the database — so constructor parameters are checked against toDb keys here.
+
+/// Constructor parameters deliberately absent from `toDb`: joined models
+/// hydrated separately, or in-memory state that is never persisted.
+const Map<String, Set<String>> _notStored = <String, Set<String>>{
+  'CollectionItem': <String>{
+    'game',
+    'movie',
+    'tvShow',
+    'visualNovel',
+    'anime',
+    'manga',
+    'book',
+    'audioItem',
+    'customMedia',
+    'platform',
+  },
+  // Joined media plus override_name read from collection_items.
+  'CanvasItem': <String>{
+    'game',
+    'movie',
+    'tvShow',
+    'visualNovel',
+    'anime',
+    'manga',
+    'book',
+    'audioItem',
+    'customMedia',
+    'overrideName',
+  },
+  // Transient: fetched with search, never stored.
+  'Game': <String>{'timeToBeat'},
+  // Insert-only rows: the id column is autoincrement.
+  'ItemMark': <String>{'id'},
+};
+
+/// Columns whose name does not follow the `camelCase → snake_case` rule.
+const Map<String, Map<String, String>> _keyOverrides =
+    <String, Map<String, String>>{
+  'Book': <String, String>{'isbn10': 'isbn_10', 'isbn13': 'isbn_13'},
+  // GROUP is an SQL keyword.
+  'MangaDexTag': <String, String>{'group': 'tag_group'},
+  'TierDefinition': <String, String>{'colorValue': 'color'},
+};
+
+String _snake(String name) => name.replaceAllMapped(
+      RegExp('[A-Z]'),
+      (Match m) => '_${m[0]!.toLowerCase()}',
+    );
+
+Set<String> _stringLiterals(AstNode node) {
+  final Set<String> found = <String>{};
+  void walk(AstNode n) {
+    if (n is SimpleStringLiteral) found.add(n.value);
+    n.childEntities.whereType<AstNode>().forEach(walk);
+  }
+
+  walk(node);
+  return found;
+}
+
+void main() {
+  test('toDb mentions every stored constructor parameter', () {
+    final List<String> failures = <String>[];
+    final Directory dir = Directory(p.join('lib', 'models'));
+    for (final File file in dir.listSync().whereType<File>()) {
+      if (!file.path.endsWith('.dart')) continue;
+      final CompilationUnit unit = parseFile(
+        path: p.normalize(file.absolute.path),
+        featureSet: FeatureSet.latestLanguageVersion(),
+      ).unit;
+      for (final ClassDeclaration cls
+          in unit.declarations.whereType<ClassDeclaration>()) {
+        final String className = cls.name.lexeme;
+        MethodDeclaration? toDb;
+        ConstructorDeclaration? ctor;
+        for (final ClassMember member in cls.members) {
+          if (member is MethodDeclaration && member.name.lexeme == 'toDb') {
+            toDb = member;
+          }
+          if (member is ConstructorDeclaration &&
+              member.name == null &&
+              member.factoryKeyword == null) {
+            ctor = member;
+          }
+        }
+        if (toDb == null || ctor == null) continue;
+
+        final Set<String> keys = _stringLiterals(toDb.body);
+        for (final FormalParameter param in ctor.parameters.parameters) {
+          final String? name = param.name?.lexeme;
+          if (name == null) continue;
+          if (_notStored[className]?.contains(name) ?? false) continue;
+          final String key = _keyOverrides[className]?[name] ?? _snake(name);
+          if (!keys.contains(key)) {
+            failures.add(
+              '$className.$name: toDb() never mentions "$key" '
+              '(${p.basename(file.path)})',
+            );
+          }
+        }
+      }
+    }
+    expect(
+      failures,
+      isEmpty,
+      reason: 'Fields that never reach the database:\n${failures.join('\n')}',
+    );
+  });
+}

--- a/test/features/collections/providers/sort_utils_test.dart
+++ b/test/features/collections/providers/sort_utils_test.dart
@@ -780,5 +780,90 @@ void main() {
         expect(result.last.itemName, 'Zelda');
       });
     });
+
+    group('детерминизм при дубликатах имён', () {
+      test('name: одинаковые имена упорядочены по id', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 3, name: 'Same'),
+          _makeItem(id: 1, name: 'Same'),
+          _makeItem(id: 2, name: 'Same'),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.name,
+        );
+
+        expect(
+          result.map((CollectionItem i) => i.id).toList(),
+          <int>[1, 2, 3],
+        );
+      });
+
+      test('status: одинаковый статус и имя упорядочены по id', () {
+        final List<CollectionItem> items = <CollectionItem>[
+          _makeItem(id: 2, name: 'Same', status: ItemStatus.planned),
+          _makeItem(id: 1, name: 'Same', status: ItemStatus.planned),
+        ];
+
+        final List<CollectionItem> result = applySortMode(
+          items,
+          CollectionSortMode.status,
+        );
+
+        expect(
+          result.map((CollectionItem i) => i.id).toList(),
+          <int>[1, 2],
+        );
+      });
+    });
+
+    group('эффективность', () {
+      test('name: displayName вызывается не более одного раза на элемент',
+          () {
+        _CountingItem.displayNameCalls = 0;
+        final List<CollectionItem> items = <CollectionItem>[
+          for (int i = 0; i < 100; i++)
+            _CountingItem(id: i, name: 'Item ${(i * 37) % 100}'),
+        ];
+
+        applySortMode(items, CollectionSortMode.name);
+
+        expect(_CountingItem.displayNameCalls, lessThanOrEqualTo(100));
+      });
+
+      test('status: displayName вызывается не более одного раза на элемент',
+          () {
+        _CountingItem.displayNameCalls = 0;
+        final List<CollectionItem> items = <CollectionItem>[
+          for (int i = 0; i < 100; i++)
+            _CountingItem(id: i, name: 'Item ${(i * 37) % 100}'),
+        ];
+
+        applySortMode(items, CollectionSortMode.status);
+
+        expect(_CountingItem.displayNameCalls, lessThanOrEqualTo(100));
+      });
+    });
   });
+}
+
+class _CountingItem extends CollectionItem {
+  _CountingItem({required super.id, required String name})
+      : super(
+          collectionId: 1,
+          mediaType: MediaType.game,
+          externalId: 0,
+          status: ItemStatus.notStarted,
+          addedAt: DateTime(2024),
+          game: Game(id: 0, name: name),
+        );
+
+  static int displayNameCalls = 0;
+
+  @override
+  String displayName(String animeMangaTitleLanguage) {
+    displayNameCalls++;
+    return super.displayName(animeMangaTitleLanguage);
+  }
 }

--- a/test/features/home/providers/all_items_provider_test.dart
+++ b/test/features/home/providers/all_items_provider_test.dart
@@ -751,11 +751,16 @@ void main() {
       ];
       when(() => mockRepo.getAllItemsWithData())
           .thenAnswer((_) async => items);
-      when(() => mockGameDao.getPlatformById(19)).thenAnswer(
-        (_) async => const model.Platform(id: 19, name: 'Super Nintendo'),
-      );
-      when(() => mockGameDao.getPlatformById(24)).thenAnswer(
-        (_) async => const model.Platform(id: 24, name: 'Game Boy Advance'),
+      when(() => mockGameDao.getPlatformsByIds(any())).thenAnswer(
+        (Invocation inv) async {
+          final List<int> ids = inv.positionalArguments.first as List<int>;
+          return <model.Platform>[
+            if (ids.contains(19))
+              const model.Platform(id: 19, name: 'Super Nintendo'),
+            if (ids.contains(24))
+              const model.Platform(id: 24, name: 'Game Boy Advance'),
+          ];
+        },
       );
 
       final ProviderContainer container = createContainer();
@@ -787,8 +792,14 @@ void main() {
       ];
       when(() => mockRepo.getAllItemsWithData())
           .thenAnswer((_) async => items);
-      when(() => mockGameDao.getPlatformById(19)).thenAnswer(
-        (_) async => const model.Platform(id: 19, name: 'Super Nintendo'),
+      when(() => mockGameDao.getPlatformsByIds(any())).thenAnswer(
+        (Invocation inv) async {
+          final List<int> ids = inv.positionalArguments.first as List<int>;
+          return <model.Platform>[
+            if (ids.contains(19))
+              const model.Platform(id: 19, name: 'Super Nintendo'),
+          ];
+        },
       );
 
       final ProviderContainer container = createContainer();
@@ -810,8 +821,14 @@ void main() {
       ];
       when(() => mockRepo.getAllItemsWithData())
           .thenAnswer((_) async => items);
-      when(() => mockGameDao.getPlatformById(19)).thenAnswer(
-        (_) async => const model.Platform(id: 19, name: 'Super Nintendo'),
+      when(() => mockGameDao.getPlatformsByIds(any())).thenAnswer(
+        (Invocation inv) async {
+          final List<int> ids = inv.positionalArguments.first as List<int>;
+          return <model.Platform>[
+            if (ids.contains(19))
+              const model.Platform(id: 19, name: 'Super Nintendo'),
+          ];
+        },
       );
 
       final ProviderContainer container = createContainer();

--- a/test/features/home/screens/all_items_screen_test.dart
+++ b/test/features/home/screens/all_items_screen_test.dart
@@ -17,6 +17,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tonkatsu_box/core/database/database_service.dart';
 import 'package:tonkatsu_box/data/repositories/collection_repository.dart';
 import 'package:tonkatsu_box/features/collections/providers/episode_tracker_provider.dart';
+import 'package:tonkatsu_box/features/collections/widgets/bulk_action_bar.dart';
 import 'package:tonkatsu_box/features/home/screens/all_items_screen.dart';
 import 'package:tonkatsu_box/features/settings/providers/profile_provider.dart';
 import 'package:tonkatsu_box/features/settings/providers/settings_provider.dart';
@@ -140,19 +141,24 @@ void main() {
         .thenAnswer((_) async => <TvSeason>[]);
     final MockGameDao mockGameDao = MockGameDao();
     when(() => mockDb.gameDao).thenReturn(mockGameDao);
-    when(() => mockGameDao.getPlatformById(19)).thenAnswer(
-      (_) async => const model.Platform(
-        id: 19,
-        name: 'Super Nintendo',
-        abbreviation: 'SNES',
-      ),
-    );
-    when(() => mockGameDao.getPlatformById(24)).thenAnswer(
-      (_) async => const model.Platform(
-        id: 24,
-        name: 'Game Boy Advance',
-        abbreviation: 'GBA',
-      ),
+    when(() => mockGameDao.getPlatformsByIds(any())).thenAnswer(
+      (Invocation inv) async {
+        final List<int> ids = inv.positionalArguments.first as List<int>;
+        return <model.Platform>[
+          if (ids.contains(19))
+            const model.Platform(
+              id: 19,
+              name: 'Super Nintendo',
+              abbreviation: 'SNES',
+            ),
+          if (ids.contains(24))
+            const model.Platform(
+              id: 24,
+              name: 'Game Boy Advance',
+              abbreviation: 'GBA',
+            ),
+        ];
+      },
     );
   });
 
@@ -196,6 +202,30 @@ void main() {
       expect(find.text('TV Shows'), findsOneWidget);
       expect(find.text('Animation'), findsOneWidget);
       expect(find.text('Visual Novels'), findsOneWidget);
+    });
+
+    testWidgets('long-press выделяет элемент и передаёт его в BulkActionBar',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BulkActionBar), findsNothing);
+
+      await tester.ensureVisible(find.text('Steins;Gate'));
+      await tester.longPress(find.text('Steins;Gate'));
+      await tester.pumpAndSettle();
+
+      // Bulk actions must receive exactly the selected item, from the
+      // unfiltered list — this is what move/clone will operate on.
+      final BulkActionBar bar =
+          tester.widget<BulkActionBar>(find.byType(BulkActionBar));
+      expect(bar.items.map((CollectionItem i) => i.id).toList(), <int>[5]);
+
+      // A second tap toggles the item off; the bar leaves with the selection.
+      await tester.tap(find.text('Steins;Gate'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BulkActionBar), findsNothing);
     });
 
     testWidgets('показывает счётчики на сегментах после загрузки',


### PR DESCRIPTION
… lookup

Sort keys are computed once per item instead of inside the comparator, with a deterministic id tie-breaker for duplicate names. The All Items card watches selection through bool-valued selects so a toggle rebuilds one card instead of the screen; the bulk bar owns its own selection watch. Platform chips load via one getPlatformsByIds call instead of a per-id loop. Grid cards are wrapped in RepaintBoundary. A new core test checks every model constructor parameter against its toDb keys.